### PR TITLE
Adding docs

### DIFF
--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -22,7 +22,7 @@ To adapt the Elastic APM agent to your needs, you can configure it using environ
 | `http://localhost:8200` | List
 |============
 
-The URLs for your APM Servers. The URLs must be fully qualified, including protocol (`http` or `https`) and port. To add multiple servers separate them with comma (`,`).
+The URLs for your APM Servers. The URLs must be fully qualified, including protocol (`http` or `https`) and port. To add multiple servers, separate them with a comma (`,`).
 
 
 NOTE: Providing multiple URLs only works with APM Server v6.5+.

--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -1,0 +1,28 @@
+[[configuration]]
+== Configuration
+
+To adapt the Elastic APM agent to your needs, you can configure it using environment variables.
+
+
+[[config-reporter]]
+=== Reporter configuration options
+[float]
+[[config-server-urls]]
+==== `server_urls`
+
+[options="header"]
+|============
+| Environment variable name
+| `ELASTIC_APM_SERVER_URLS`
+|============
+
+[options="header"]
+|============
+| Default                 | Type
+| `http://localhost:8200` | List
+|============
+
+The URLs for your APM Servers. The URLs must be fully qualified, including protocol (`http` or `https`) and port. To add multiple servers separate them with comma (`,`).
+
+
+NOTE: Providing multiple URLs only works if intake API v2 is enabled.

--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -25,4 +25,4 @@ To adapt the Elastic APM agent to your needs, you can configure it using environ
 The URLs for your APM Servers. The URLs must be fully qualified, including protocol (`http` or `https`) and port. To add multiple servers separate them with comma (`,`).
 
 
-NOTE: Providing multiple URLs only works if intake API v2 is enabled.
+NOTE: Providing multiple URLs only works with APM Server v6.5+.

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -1,0 +1,13 @@
+= APM .NET Agent Reference (Prototype)
+:branch: current
+include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
+
+ifdef::env-github[]
+NOTE: For the best reading experience,
+please view this documentation at https://www.elastic.co/guide/en/apm/agent/dotnet[elastic.co]
+endif::[]
+
+ifndef::env-github[]
+include::./intro.asciidoc[Introduction]
+include::./configuration.asciidoc[Configuration]
+endif::[]

--- a/docs/intro.asciidoc
+++ b/docs/intro.asciidoc
@@ -21,8 +21,5 @@ To instrument other events, you can use custom spans.
 [float]
 [[additional-components]]
 === Additional Components
-The agent is only one of multiple components you need to get started with APM.
-Please also have a look at the documentation for
-
-* {apm-server-ref}/index.html[APM Server]
-* {ref}/index.html[Elasticsearch]
+APM Agents work in conjunction with the {apm-server-ref}/index.html[APM Server], {ref}/index.html[Elasticsearch], and {kibana-ref}/index.html[Kibana].
+Please view the {apm-get-started-ref}/index.html[APM Overview] for details on how these components work together.

--- a/docs/intro.asciidoc
+++ b/docs/intro.asciidoc
@@ -1,0 +1,25 @@
+ifdef::env-github[]
+NOTE: For the best reading experience,
+please view this documentation at https://www.elastic.co/guide/en/apm/agent/dotnet[elastic.co]
+endif::[]
+
+[[intro]]
+
+== Introduction
+
+Welcome to the APM .NET Agent documentation.
+
+Elastic APM automatically measures the performance of your application and tracks errors.
+For example, it records spans for database queries and transactions for incoming HTTP requests.
+
+Spans are grouped in transactions - by default one for each incoming HTTP request.
+But it's possible to create custom transactions not associated with an HTTP request.
+
+By default the agent comes with support for ASP.NET Core out-of-the-box.
+To instrument other events, you can use custom spans.
+
+The agent is only one of multiple components you need to get started with APM.
+Please also have a look at the documentation for
+
+* {apm-server-ref}/index.html[APM Server]
+* {ref}/index.html[Elasticsearch]

--- a/docs/intro.asciidoc
+++ b/docs/intro.asciidoc
@@ -18,6 +18,9 @@ But it's possible to create custom transactions not associated with an HTTP requ
 By default the agent comes with support for ASP.NET Core out-of-the-box.
 To instrument other events, you can use custom spans.
 
+[float]
+[[additional-components]]
+=== Additional Components
 The agent is only one of multiple components you need to get started with APM.
 Please also have a look at the documentation for
 


### PR DESCRIPTION
Adding the very first doc files.

My goal is to have the infrastructure including the `configuration.asciidoc` in place. With this configs can be documented as they get implemented.

@bmorelli25 This builds locally. Can you please see if this is ok? 

Plus there is this sentence in `configuration.asciidoc`:
> To add multiple servers separate them with comma (`,`).

Not sure that's the right way to write it... Any feedback on that?

Thx! 