### PR TITLE
Docs: version links

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -1,5 +1,6 @@
 = APM .NET Agent Reference (Prototype)
 :branch: current
+:server-branch: 6.5
 include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 
 ifdef::env-github[]

--- a/docs/intro.asciidoc
+++ b/docs/intro.asciidoc
@@ -21,5 +21,5 @@ To instrument other events, you can use custom spans.
 [float]
 [[additional-components]]
 === Additional Components
-APM Agents work in conjunction with the {apm-server-ref}/index.html[APM Server], {ref}/index.html[Elasticsearch], and {kibana-ref}/index.html[Kibana].
-Please view the {apm-get-started-ref}/index.html[APM Overview] for details on how these components work together.
+APM Agents work in conjunction with the {apm-server-ref-v}/index.html[APM Server], {ref}/index.html[Elasticsearch], and {kibana-ref}/index.html[Kibana].
+Please view the {apm-overview-ref-v}/index.html[APM Overview] for details on how these components work together.


### PR DESCRIPTION
Versions dotnet master links to APM Server and APM Overview v6.5 per elastic/apm/issues/19.