### PR TITLE
Prevent EfCoreDiagnosticListener Null Ref Exception #32

### DIFF
--- a/src/Elastic.Apm.EntityFrameworkCore/EfCoreDiagnosticListener.cs
+++ b/src/Elastic.Apm.EntityFrameworkCore/EfCoreDiagnosticListener.cs
@@ -21,8 +21,8 @@ namespace Elastic.Apm.EntityFrameworkCore
         {
             switch (kv.Key)
             {
-                case string k when k == RelationalEventId.CommandExecuting.Name:
-                    if (TransactionContainer.Transactions.Value != null && kv.Value is CommandEventData commandEventData)
+                case string k when k == RelationalEventId.CommandExecuting.Name && TransactionContainer.Transactions.Value != null:
+                    if (kv.Value is CommandEventData commandEventData)
                     {
                         var newSpan = TransactionContainer.Transactions.Value.StartSpan(
                                             commandEventData.Command.CommandText, Span.TYPE_DB);
@@ -30,7 +30,7 @@ namespace Elastic.Apm.EntityFrameworkCore
                         _spans.TryAdd(commandEventData.CommandId, newSpan);
                     }
                     break;
-                case string k when k == RelationalEventId.CommandExecuted.Name:
+                case string k when k == RelationalEventId.CommandExecuted.Name && TransactionContainer.Transactions.Value != null:
                     if (kv.Value is CommandExecutedEventData commandExecutedEventData)
                     {
                         if (_spans.TryRemove(commandExecutedEventData.CommandId, out Span span))

--- a/src/Elastic.Apm.EntityFrameworkCore/EfCoreDiagnosticListener.cs
+++ b/src/Elastic.Apm.EntityFrameworkCore/EfCoreDiagnosticListener.cs
@@ -22,7 +22,7 @@ namespace Elastic.Apm.EntityFrameworkCore
             switch (kv.Key)
             {
                 case string k when k == RelationalEventId.CommandExecuting.Name:
-                    if (kv.Value is CommandEventData commandEventData)
+                    if (TransactionContainer.Transactions.Value != null && kv.Value is CommandEventData commandEventData)
                     {
                         var newSpan = TransactionContainer.Transactions.Value.StartSpan(
                                             commandEventData.Command.CommandText, Span.TYPE_DB);


### PR DESCRIPTION
Added null check to verify that we have a reference to an active transaction before we attempt to create a new span from it. #32 