### PR TITLE
Feature/gh 34 dependency version

### DIFF
--- a/src/Elastic.Apm.AspNetCore/Elastic.Apm.AspNetCore.csproj
+++ b/src/Elastic.Apm.AspNetCore/Elastic.Apm.AspNetCore.csproj
@@ -11,8 +11,8 @@
   </ItemGroup>
   <ItemGroup>
   <!-- We should probably lower the version number -->
-    <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.1.1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="2.0.2" />
+    <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="2.0.0" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Config\" />

--- a/src/Elastic.Apm.EntityFrameworkCore/EfCoreDiagnosticListener.cs
+++ b/src/Elastic.Apm.EntityFrameworkCore/EfCoreDiagnosticListener.cs
@@ -22,7 +22,7 @@ namespace Elastic.Apm.EntityFrameworkCore
             switch (kv.Key)
             {
                 case string k when k == RelationalEventId.CommandExecuting.Name:
-                    if (kv.Value is CommandEventData commandEventData)
+                    if (TransactionContainer.Transactions.Value != null && kv.Value is CommandEventData commandEventData)
                     {
                         var newSpan = TransactionContainer.Transactions.Value.StartSpan(
                                             commandEventData.Command.CommandText, Span.TYPE_DB);


### PR DESCRIPTION
I changed the aspnet core dependency versions to 2.0.0 to allow projects that were freshly created when 2.0.0 aspnetcore was shipped the ability to work with Elastic.Apm.AspNetCore