### PR TITLE
[APM-CI] set packages version

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -72,11 +72,11 @@ pipeline {
                 set -euxo pipefail
                 
                 # install tools
-                dotnet tool install -g dotnet-xunit-to-junit
+                dotnet tool install -g dotnet-xunit-to-junit --version 0.3.1
                 for i in $(find . -name '*.??proj') 
                 do 
                   dotnet add "$i" package XunitXml.TestLogger --version 2.0.0
-                  dotnet add "$i" package coverlet.msbuild
+                  dotnet add "$i" package coverlet.msbuild --version 2.5.0
                 done
                 
                 # build

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -74,11 +74,11 @@ pipeline {
               set -euxo pipefail
               
               # install tools
-              dotnet tool install -g dotnet-xunit-to-junit
+              dotnet tool install -g dotnet-xunit-to-junit --version 0.3.1
               for i in $(find . -name '*.??proj') 
               do 
                 dotnet add "$i" package XunitXml.TestLogger --version 2.0.0
-                dotnet add "$i" package coverlet.msbuild
+                dotnet add "$i" package coverlet.msbuild --version 2.5.0
               done
               
               # build


### PR DESCRIPTION
There is a new [dotnet-xunit-to-junit](https://www.nuget.org/packages/dotnet-xunit-to-junit/) release and it is not compatible with the current framework we use, thus I fixed the current version we use.