### PR TITLE
Explicit version for AspNetCore.App on .net core sample app,

### DIFF
--- a/sample/SampleAspNetCoreApp/SampleAspNetCoreApp.csproj
+++ b/sample/SampleAspNetCoreApp/SampleAspNetCoreApp.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.App" />
+    <PackageReference Include="Microsoft.AspNetCore.App" Version="2.1.2" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="2.1.4" />
   </ItemGroup>
 


### PR DESCRIPTION
On a clean checkout this was causing a NU1107 version conflict.

> C:\Projects\elastic\apm-agent-dotnet\sample\SampleAspNetCoreApp\SampleAspNetCoreApp.csproj : error NU1107: Version conflict detected for Microsoft.EntityFrameworkCore. Reference the package directly from the project to resolve this issue.  [C:\Projects\elastic\apm-agent-dotnet\ElasticApmAgent.sln]
C:\Projects\elastic\apm-agent-dotnet\sample\SampleAspNetCoreApp\SampleAspNetCoreApp.csproj : error NU1107:  SampleAspNetCoreApp -> Microsoft.EntityFrameworkCore.Sqlite 2.1.4 -> Microsoft.EntityFrameworkCore.Sqlite.Core 2.1.4 -> Microsoft.EntityFrameworkCore.Relational 2.1.4 -> Microsoft.EntityFrameworkCore (>= 2.1.4)  [C:\Projects\elastic\apm-agent-dotnet\ElasticApmAgent.sln]
C:\Projects\elastic\apm-agent-dotnet\sample\SampleAspNetCoreApp\SampleAspNetCoreApp.csproj : error NU1107:  SampleAspNetCoreApp -> Microsoft.AspNetCore.App 2.1.0 -> Microsoft.EntityFrameworkCore (= 2.1.0). [C:\Projects\elastic\apm-agent-dotnet\ElasticApmAgent.sln]

For repeatable builds specifying the version should be the default.
