### PR TITLE
Proposal for Elastic.Apm.Agent instantiation

### DIFF
--- a/sample/SampleAspNetCoreApp/Startup.cs
+++ b/sample/SampleAspNetCoreApp/Startup.cs
@@ -1,4 +1,5 @@
-﻿using Elastic.Apm.AspNetCore;
+﻿using Elastic.Apm;
+using Elastic.Apm.AspNetCore;
 using Elastic.Apm.DiagnosticSource;
 using Elastic.Apm.EntityFrameworkCore;
 using Microsoft.AspNetCore.Builder;
@@ -39,8 +40,8 @@ namespace SampleAspNetCoreApp
 		public void Configure(IApplicationBuilder app, IHostingEnvironment env)
 		{
 			app.UseElasticApm(Configuration);
-			new ElasticCoreListeners().Start();
-			new ElasticEntityFrameworkCoreListener().Start();
+			new ElasticCoreListeners().Start(Agent.Config.Logger);
+			new ElasticEntityFrameworkCoreListener().Start(Agent.Config.Logger);
 
 			if (env.IsDevelopment())
 				app.UseDeveloperExceptionPage();

--- a/src/Elastic.Apm.AspNetCore/Config/MicrosoftExtensionsConfig.cs
+++ b/src/Elastic.Apm.AspNetCore/Config/MicrosoftExtensionsConfig.cs
@@ -1,4 +1,7 @@
 ﻿using Elastic.Apm.Config;
+using Elastic.Apm.Logging;
+using Elastic.Apm.Model.Payload;
+using Elastic.Apm.Report;
 using Microsoft.Extensions.Configuration;
 
 namespace Elastic.Apm.AspNetCore.Config
@@ -11,7 +14,12 @@ namespace Elastic.Apm.AspNetCore.Config
 	{
 		private readonly IConfiguration _configuration;
 
-		public MicrosoftExtensionsConfig(IConfiguration configuration)
+		public MicrosoftExtensionsConfig(
+			IConfiguration configuration,
+			AbstractLogger logger = null,
+			Service service = null,
+			IPayloadSender sender = null
+			) : base(logger, service, sender)
 		{
 			_configuration = configuration;
 			_configuration.GetSection("ElasticApm")

--- a/src/Elastic.Apm.AspNetCore/DiagnosticListener/AspNetCoreDiagnosticListener.cs
+++ b/src/Elastic.Apm.AspNetCore/DiagnosticListener/AspNetCoreDiagnosticListener.cs
@@ -11,8 +11,7 @@ namespace Elastic.Apm.AspNetCore.DiagnosticListener
 	{
 		private readonly AbstractLogger _logger;
 
-		public AspNetCoreDiagnosticListener()
-			=> _logger = Agent.CreateLogger(Name);
+		public AspNetCoreDiagnosticListener(AbstractLogger logger) => _logger = logger;
 
 		public string Name => "Microsoft.AspNetCore";
 

--- a/src/Elastic.Apm.EntityFrameworkCore/EfCoreDiagnosticListener.cs
+++ b/src/Elastic.Apm.EntityFrameworkCore/EfCoreDiagnosticListener.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Data;
 using Elastic.Apm.Api;
 using Elastic.Apm.DiagnosticSource;
+using Elastic.Apm.Logging;
 using Elastic.Apm.Model.Payload;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 
@@ -12,6 +13,11 @@ namespace Elastic.Apm.EntityFrameworkCore
 	internal class EfCoreDiagnosticListener : IDiagnosticListener
 	{
 		private readonly ConcurrentDictionary<Guid, ISpan> _spans = new ConcurrentDictionary<Guid, ISpan>();
+
+		public EfCoreDiagnosticListener(AbstractLogger logger) => Logger = logger;
+
+		private AbstractLogger Logger { get; }
+
 		public string Name => "Microsoft.EntityFrameworkCore";
 
 		public void OnCompleted() { }

--- a/src/Elastic.Apm.EntityFrameworkCore/ElasticEntityFrameworkCoreListener.cs
+++ b/src/Elastic.Apm.EntityFrameworkCore/ElasticEntityFrameworkCoreListener.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Diagnostics;
 using Elastic.Apm.DiagnosticSource;
+using Elastic.Apm.Logging;
 
 namespace Elastic.Apm.EntityFrameworkCore
 {
@@ -12,8 +13,8 @@ namespace Elastic.Apm.EntityFrameworkCore
 		/// <summary>
 		/// Start listening for EF Core diagnosticsource events
 		/// </summary>
-		public void Start() => DiagnosticListener
+		public void Start(AbstractLogger logger) => DiagnosticListener
 			.AllListeners
-			.Subscribe(new DiagnosticInitializer(new List<IDiagnosticListener> { new EfCoreDiagnosticListener() }));
+			.Subscribe(new DiagnosticInitializer(new [] { new EfCoreDiagnosticListener(logger) }));
 	}
 }

--- a/src/Elastic.Apm/Api/ITracer.cs
+++ b/src/Elastic.Apm/Api/ITracer.cs
@@ -12,12 +12,6 @@ namespace Elastic.Apm.Api
 		ITransaction CurrentTransaction { get; }
 
 		/// <summary>
-		/// Identifies the monitored service. If this remains unset the agent
-		/// automatically populates it based on the entry assembly.
-		/// </summary>
-		Service Service { get; set; }
-
-		/// <summary>
 		/// This is a convenient method which starts and ends a transaction and captures unhandled exceptions
 		/// and schedules it to be reported to the APM Server.
 		/// </summary>

--- a/src/Elastic.Apm/Config/AbstractAgentConfig.cs
+++ b/src/Elastic.Apm/Config/AbstractAgentConfig.cs
@@ -1,6 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Reflection;
 using Elastic.Apm.Logging;
+using Elastic.Apm.Model.Payload;
+using Elastic.Apm.Report;
 
 namespace Elastic.Apm.Config
 {
@@ -18,34 +21,44 @@ namespace Elastic.Apm.Config
 		/// </returns>
 		protected abstract (string value, string configType, string configKey) ReadServerUrls();
 
-		public AbstractLogger Logger { get; set; }
+		protected AbstractAgentConfig(AbstractLogger logger, Service service, IPayloadSender payloadSender)
+		{
+			Logger = logger;
+			Service = service;
+			PayloadSender = payloadSender ?? new PayloadSender(logger, () => this.ServerUrls[0]);
+		}
+
+		public AbstractLogger Logger { get; }
+
+		public IPayloadSender PayloadSender { get; }
 
 		protected LogLevel? LogLevelBackingField;
 
-		public LogLevel LogLevel
-		{
-			get
-			{
-				if (LogLevelBackingField.HasValue) return LogLevelBackingField.Value;
+		protected LogLevel? logLevel;
+        public LogLevel LogLevel
+        {
+            get
+            {
+                if (!logLevel.HasValue)
+                {
+                    (var logLevelStr, var configType, var configKey) = ReadLogLevel();
 
-				var (logLevelStr, configType, configKey) = ReadLogLevel();
+                    (var parsedLogLevel, var isError) = ParseLogLevel(logLevelStr);
 
-				var (parsedLogLevel, isError) = ParseLogLevel(logLevelStr);
+                    if(isError)
+                    {
+                        logLevel = LogLevel.Error;
+                        Logger?.LogError("Config", $"Failed parsing log level from {configType}: {configKey}, value: {logLevelStr}. Defaulting to log level 'Error'");
+                    }
+                    else
+                    {
+                        logLevel = parsedLogLevel.HasValue ? parsedLogLevel : LogLevel.Error;
+                    }
+                }
 
-				if (isError)
-				{
-					LogLevelBackingField = LogLevel.Error;
-					Logger?.LogError(
-						$"Failed parsing log level from {configType}: {configKey}, value: {logLevelStr}. Defaulting to log level 'Error'");
-				}
-				else
-					LogLevelBackingField = parsedLogLevel ?? LogLevel.Error;
-
-				return LogLevelBackingField.Value;
-			}
-
-			set => LogLevelBackingField = value;
-		}
+                return logLevel.Value;
+            }
+        }
 
 		private readonly List<Uri> _serverUrls = new List<Uri>();
 
@@ -73,8 +86,9 @@ namespace Elastic.Apm.Config
 					}
 					catch (Exception e)
 					{
-						Logger?.LogError($"Failed parsing server URL from {configType}: {configKey}, value: {url}");
-						Logger?.LogDebug($"{e.GetType().Name}: {e.Message}");
+						var name = GetType().Name;
+						Logger?.LogError(name, $"Failed parsing server URL from {configType}: {configKey}, value: {url}");
+						Logger?.LogDebug(name, $"{e.GetType().Name}: {e.Message}");
 					}
 				}
 
@@ -90,7 +104,36 @@ namespace Elastic.Apm.Config
 			}
 		}
 
-		protected (LogLevel? level, bool error) ParseLogLevel(string logLevelStr)
+		/// <summary>
+		/// Identifies the monitored service. If this remains unset the agent
+		/// automatically populates it based on the entry assembly.
+		/// </summary>
+		/// <value>The service.</value>
+		private Service _service;
+		public Service Service
+		{
+			get => _service ?? (_service = new Service
+			{
+				Name = Assembly.GetEntryAssembly()?.GetName().Name,
+				Agent = new Service.AgentC
+				{
+					Name = Consts.AgentName,
+					Version = Consts.AgentVersion
+				}
+			});
+			private set => _service = value;
+		}
+
+		protected static LogLevel LogLevelOrDefault(string logLevelStr)
+		{
+			if (string.IsNullOrEmpty(logLevelStr)) return AbstractLogger.LogLevelDefault;
+
+			if (Enum.TryParse(logLevelStr, out LogLevel parsedLogLevel)) return parsedLogLevel;
+
+			return AbstractLogger.LogLevelDefault;
+		}
+
+		protected static (LogLevel? level, bool error) ParseLogLevel(string logLevelStr)
 		{
 			if (string.IsNullOrEmpty(logLevelStr)) return (null, false);
 

--- a/src/Elastic.Apm/Config/EnvironmentVariableConfig.cs
+++ b/src/Elastic.Apm/Config/EnvironmentVariableConfig.cs
@@ -1,9 +1,15 @@
 ﻿using System;
+using Elastic.Apm.Logging;
+using Elastic.Apm.Model.Payload;
+using Elastic.Apm.Report;
 
 namespace Elastic.Apm.Config
 {
 	internal class EnvironmentVariableConfig : AbstractAgentConfig
 	{
+		public EnvironmentVariableConfig(AbstractLogger logger = null, Service service = null, IPayloadSender sender = null)
+			: base(logger, service, sender) { }
+
 		protected override (string value, string configType, string configKey) ReadServerUrls() => (
 			Environment.GetEnvironmentVariable(EnvVarConsts.ServerUrls), "environment variable", EnvVarConsts.ServerUrls);
 

--- a/src/Elastic.Apm/DiagnosticSource/ElasticCoreListeners.cs
+++ b/src/Elastic.Apm/DiagnosticSource/ElasticCoreListeners.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Diagnostics;
 using Elastic.Apm.DiagnosticListeners;
+using Elastic.Apm.Logging;
 
 namespace Elastic.Apm.DiagnosticSource
 {
@@ -12,8 +13,8 @@ namespace Elastic.Apm.DiagnosticSource
 		/// <summary>
 		/// Start listening for diagnosticsource events. Only listens for sources that are part of the Agent.Core package.
 		/// </summary>
-		public void Start() => DiagnosticListener
+		public void Start(AbstractLogger logger) => DiagnosticListener
 			.AllListeners
-			.Subscribe(new DiagnosticInitializer(new List<IDiagnosticListener> { new HttpDiagnosticListener() }));
+			.Subscribe(new DiagnosticInitializer(new [] { new HttpDiagnosticListener(logger) }));
 	}
 }

--- a/src/Elastic.Apm/Logging/AbstractLogger.cs
+++ b/src/Elastic.Apm/Logging/AbstractLogger.cs
@@ -14,32 +14,36 @@
 		/// <param name="logline">This line that must be logged - it already contains the prefix and the loglevel</param>
 		protected abstract void PrintLogline(string logline);
 
-		/// <summary>
-		/// Every log message is prefixed with this string
-		/// </summary>
-		/// <value>The prefix.</value>
-		internal string Prefix { get; set; }
+		private string GetPrefixString(LogLevel logLevel, string prefix) =>
+			string.IsNullOrWhiteSpace(prefix) ? $"{logLevel.ToString()} " : $"{logLevel.ToString()} {prefix}: ";
 
-		private string GetPrefixString(LogLevel logLevel) => $"{logLevel.ToString()} {Prefix}: ";
+		protected AbstractLogger(LogLevel level) => LogLevel = level;
 
-		internal void LogInfo(string info)
+		public LogLevel LogLevel { get; }
+		protected internal static LogLevel LogLevelDefault { get; } = LogLevel.Error;
+
+		internal void LogInfo(string info) => LogInfo(null, info);
+		internal void LogInfo(string prefix, string info)
 		{
-			if (Agent.Config.LogLevel >= LogLevel.Info) PrintLogline($"{GetPrefixString(LogLevel.Info)}{info}");
+			if (LogLevel >= LogLevel.Info) PrintLogline($"{GetPrefixString(LogLevel.Info, prefix)}{info}");
 		}
 
-		internal void LogWarning(string warning)
+		internal void LogWarning(string warning) => LogWarning(null, warning);
+		internal void LogWarning(string prefix, string warning)
 		{
-			if (Agent.Config.LogLevel >= LogLevel.Warning) PrintLogline($"{GetPrefixString(LogLevel.Warning)}{warning}");
+			if (LogLevel >= LogLevel.Warning) PrintLogline($"{GetPrefixString(LogLevel.Warning, prefix)}{warning}");
 		}
 
-		internal void LogError(string error)
+		internal void LogError(string error) => LogError(null, error);
+		internal void LogError(string prefix, string error)
 		{
-			if (Agent.Config.LogLevel >= LogLevel.Error) PrintLogline($"{GetPrefixString(LogLevel.Error)}{error}");
+			if (LogLevel >= LogLevel.Error) PrintLogline($"{GetPrefixString(LogLevel.Error, prefix)}{error}");
 		}
 
-		internal void LogDebug(string debugInfo)
+		internal void LogDebug(string debug) => LogDebug(null, debug);
+		internal void LogDebug(string prefix, string debug)
 		{
-			if (Agent.Config.LogLevel >= LogLevel.Debug) PrintLogline($"{GetPrefixString(LogLevel.Debug)}{debugInfo}");
+			if (LogLevel >= LogLevel.Debug) PrintLogline($"{GetPrefixString(LogLevel.Debug, prefix)}{debug}");
 		}
 	}
 }

--- a/src/Elastic.Apm/Logging/ConsoleLogger.cs
+++ b/src/Elastic.Apm/Logging/ConsoleLogger.cs
@@ -4,9 +4,7 @@ namespace Elastic.Apm.Logging
 {
 	internal class ConsoleLogger : AbstractLogger
 	{
-		public ConsoleLogger() => Prefix = string.Empty;
-
-		public ConsoleLogger(string prefix) => Prefix = prefix;
+		protected ConsoleLogger(LogLevel level) : base(level) { }
 
 		protected override void PrintLogline(string logline) => Console.WriteLine(logline);
 	}

--- a/src/Elastic.Apm/Report/PayloadSender.cs
+++ b/src/Elastic.Apm/Report/PayloadSender.cs
@@ -18,15 +18,13 @@ namespace Elastic.Apm.Report
 	/// </summary>
 	internal class PayloadSender : IDisposable, IPayloadSender
 	{
-		private readonly AbstractAgentConfig _agentConfig;
 		private readonly AbstractLogger _logger;
-		private readonly Uri _serverUrlBase;
+		private readonly Func<Uri> _serverUrlBaseGetter;
 
-		public PayloadSender()
+		public PayloadSender(AbstractLogger logger, Func<Uri> serverUrlBase)
 		{
-			_agentConfig = Agent.Config;
-			_logger = Agent.CreateLogger(nameof(PayloadSender));
-			_serverUrlBase = _agentConfig.ServerUrls[0];
+			_logger = logger;
+			_serverUrlBaseGetter = serverUrlBase;
 			_workerThread = new Thread(StartWork)
 			{
 				IsBackground = true
@@ -54,7 +52,7 @@ namespace Elastic.Apm.Report
 		{
 			var httpClient = new HttpClient
 			{
-				BaseAddress = _serverUrlBase
+				BaseAddress = _serverUrlBaseGetter()
 			};
 
 			while (true)

--- a/test/Elastic.Apm.AspNetCore.Tests/AspNetCoreDiagnosticListenerTest.cs
+++ b/test/Elastic.Apm.AspNetCore.Tests/AspNetCoreDiagnosticListenerTest.cs
@@ -30,8 +30,9 @@ namespace Elastic.Apm.AspNetCore.Tests
 		[Fact]
 		public async Task TestErrorInAspNetCore()
 		{
-			var capturedPayload = new MockPayloadSender();
-			var client = Helper.GetClient(capturedPayload, _factory);
+			var agent = new ApmAgent(new TestAgentConfiguration());
+			var capturedPayload = agent.Config.PayloadSender as MockPayloadSender;
+			var client = Helper.GetClient(agent, _factory);
 
 			var response = await client.GetAsync("/Home/TriggerError");
 

--- a/test/Elastic.Apm.AspNetCore.Tests/AspNetCoreMiddlewareTests.cs
+++ b/test/Elastic.Apm.AspNetCore.Tests/AspNetCoreMiddlewareTests.cs
@@ -29,8 +29,9 @@ namespace Elastic.Apm.AspNetCore.Tests
 		[InlineData("/Home/About")]
 		public async Task HomeAboutTransactionTest(string url)
 		{
-			var capturedPayload = new MockPayloadSender();
-			var client = Helper.GetClient(capturedPayload, _factory);
+			var agent = new ApmAgent(new TestAgentConfiguration());
+			var capturedPayload = agent.Config.PayloadSender as MockPayloadSender;
+			var client = Helper.GetClient(agent, _factory);
 
 			var response = await client.GetAsync(url);
 
@@ -77,8 +78,9 @@ namespace Elastic.Apm.AspNetCore.Tests
 		[Fact]
 		public async Task FailingRequestWithoutConfiguredExceptionPage()
 		{
-			var capturedPayload = new MockPayloadSender();
-			var client = Helper.GetClientWithoutExceptionPage(capturedPayload, _factory);
+			var agent = new ApmAgent(new TestAgentConfiguration());
+			var capturedPayload = agent.Config.PayloadSender as MockPayloadSender;
+			var client = Helper.GetClientWithoutExceptionPage(agent, _factory);
 
 			await Assert.ThrowsAsync<Exception>(async () => { await client.GetAsync("Home/TriggerError"); });
 

--- a/test/Elastic.Apm.AspNetCore.Tests/Helper.cs
+++ b/test/Elastic.Apm.AspNetCore.Tests/Helper.cs
@@ -16,15 +16,15 @@ namespace Elastic.Apm.AspNetCore.Tests
 {
 	public static class Helper
 	{
-		internal static HttpClient GetClient<T>(MockPayloadSender payloadSender, WebApplicationFactory<T> factory) where T : class
+		internal static HttpClient GetClient<T>(ApmAgent agent, WebApplicationFactory<T> factory) where T : class
 			=> factory
 				.WithWebHostBuilder(n =>
 				{
 					n.Configure(app =>
 					{
-						app.UseElasticApm(payloadSender: payloadSender);
-						new ElasticCoreListeners().Start();
-						new ElasticEntityFrameworkCoreListener().Start();
+						app.UseElasticApm(agent);
+						new ElasticCoreListeners().Start(agent.Config.Logger);
+						new ElasticEntityFrameworkCoreListener().Start(agent.Config.Logger);
 
 						app.UseDeveloperExceptionPage();
 
@@ -46,15 +46,15 @@ namespace Elastic.Apm.AspNetCore.Tests
 				})
 				.CreateClient();
 
-		internal static HttpClient GetClientWithoutExceptionPage<T>(MockPayloadSender payloadSender, WebApplicationFactory<T> factory) where T : class
+		internal static HttpClient GetClientWithoutExceptionPage<T>(ApmAgent agent, WebApplicationFactory<T> factory) where T : class
 			=> factory
 				.WithWebHostBuilder(n =>
 				{
 					n.Configure(app =>
 					{
-						app.UseElasticApm(payloadSender: payloadSender);
-						new ElasticCoreListeners().Start();
-						new ElasticEntityFrameworkCoreListener().Start();
+						app.UseElasticApm(agent);
+						new ElasticCoreListeners().Start(agent.Config.Logger);
+						new ElasticEntityFrameworkCoreListener().Start(agent.Config.Logger);
 
 						app.UseMvc(routes =>
 						{

--- a/test/Elastic.Apm.AspNetCore.Tests/MicrosoftExtensionsConfigTests.cs
+++ b/test/Elastic.Apm.AspNetCore.Tests/MicrosoftExtensionsConfigTests.cs
@@ -6,6 +6,7 @@ using Elastic.Apm.Logging;
 using Elastic.Apm.Tests;
 using Elastic.Apm.Tests.Mocks;
 using Microsoft.Extensions.Configuration;
+using Microsoft.VisualStudio.TestPlatform.Common.ExtensionFramework;
 using Xunit;
 
 namespace Elastic.Apm.AspNetCore.Tests
@@ -25,9 +26,9 @@ namespace Elastic.Apm.AspNetCore.Tests
 		[Fact]
 		public void ReadValidConfigsFromAppSettingsJson()
 		{
-			Agent.Config = new MicrosoftExtensionsConfig(GetConfig($"TestConfigs{Path.DirectorySeparatorChar}appsettings_valid.json"));
-			Assert.Equal(LogLevel.Debug, Agent.Config.LogLevel);
-			Assert.Equal(new Uri("http://myServerFromTheConfigFile:8080"), Agent.Config.ServerUrls[0]);
+			var config = new MicrosoftExtensionsConfig(GetConfig($"TestConfigs{Path.DirectorySeparatorChar}appsettings_valid.json"));
+			Assert.Equal(LogLevel.Debug, config.LogLevel);
+			Assert.Equal(new Uri("http://myServerFromTheConfigFile:8080"), config.ServerUrls[0]);
 		}
 
 		/// <summary>
@@ -37,14 +38,13 @@ namespace Elastic.Apm.AspNetCore.Tests
 		[Fact]
 		public void ReadInvalidLogLevelConfigFromAppsettingsJson()
 		{
-			Agent.SetLoggerType<TestLogger>();
-
-			Agent.Config = new MicrosoftExtensionsConfig(GetConfig($"TestConfigs{Path.DirectorySeparatorChar}appsettings_invalid.json"));
-			Assert.Equal(LogLevel.Error, Agent.Config.LogLevel);
+			var logger = new TestLogger();
+			var config = new MicrosoftExtensionsConfig(GetConfig($"TestConfigs{Path.DirectorySeparatorChar}appsettings_invalid.json"), logger);
+			Assert.Equal(LogLevel.Error, config.LogLevel);
 
 			Assert.Equal(
 				$"Error Config: Failed parsing log level from IConfiguration: {MicrosoftExtensionConfigConsts.LogLevel}, value: DbeugMisspelled. Defaulting to log level 'Error'",
-				(Agent.Config.Logger as TestLogger)?.Lines[0]);
+				logger.Lines[0]);
 		}
 
 		/// <summary>
@@ -54,14 +54,13 @@ namespace Elastic.Apm.AspNetCore.Tests
 		[Fact]
 		public void ReadInvalidServerUrlsConfigFromAppsettingsJson()
 		{
-			Agent.SetLoggerType<TestLogger>();
-
-			Agent.Config = new MicrosoftExtensionsConfig(GetConfig($"TestConfigs{Path.DirectorySeparatorChar}appsettings_invalid.json"));
-			Assert.Equal(LogLevel.Error, Agent.Config.LogLevel);
+			var logger = new TestLogger();
+			var config = new MicrosoftExtensionsConfig(GetConfig($"TestConfigs{Path.DirectorySeparatorChar}appsettings_invalid.json"), logger);
+			Assert.Equal(LogLevel.Error, config.LogLevel);
 
 			Assert.Equal(
 				$"Error Config: Failed parsing log level from IConfiguration: {MicrosoftExtensionConfigConsts.LogLevel}, value: DbeugMisspelled. Defaulting to log level 'Error'",
-				(Agent.Config.Logger as TestLogger)?.Lines[0]);
+				logger.Lines[0]);
 		}
 
 		/// <summary>
@@ -74,13 +73,13 @@ namespace Elastic.Apm.AspNetCore.Tests
 			Environment.SetEnvironmentVariable(EnvVarConsts.LogLevel, "Debug");
 			var serverUrl = "http://myServerFromEnvVar.com:1234";
 			Environment.SetEnvironmentVariable(EnvVarConsts.ServerUrls, serverUrl);
-			var config = new ConfigurationBuilder()
+			var configBuilder = new ConfigurationBuilder()
 				.AddEnvironmentVariables()
 				.Build();
 
-			Agent.Config = new MicrosoftExtensionsConfig(config);
-			Assert.Equal(LogLevel.Debug, Agent.Config.LogLevel);
-			Assert.Equal(new Uri(serverUrl), Agent.Config.ServerUrls[0]);
+			var config = new MicrosoftExtensionsConfig(configBuilder);
+			Assert.Equal(LogLevel.Debug, config.LogLevel);
+			Assert.Equal(new Uri(serverUrl), config.ServerUrls[0]);
 		}
 
 		private IConfiguration GetConfig(string path)

--- a/test/Elastic.Apm.Tests/ApiTests/ConvenientApiSpanTests.cs
+++ b/test/Elastic.Apm.Tests/ApiTests/ConvenientApiSpanTests.cs
@@ -371,14 +371,13 @@ namespace Elastic.Apm.Tests.ApiTests
 		[Fact]
 		public async Task CancelledAsyncTask()
 		{
-			var payloadSender = new MockPayloadSender();
-			Agent.PayloadSender = payloadSender;
+			var agent = new ApmAgent(new TestAgentConfiguration());
 
 			var cancellationTokenSource = new CancellationTokenSource();
 			var token = cancellationTokenSource.Token;
 			cancellationTokenSource.Cancel();
 
-			await Agent.Tracer.CaptureTransaction(TransactionName, TransactionType, async t =>
+			await agent.Tracer.CaptureTransaction(TransactionName, TransactionType, async t =>
 			{
 				await Assert.ThrowsAsync<OperationCanceledException>(async () =>
 				{
@@ -398,9 +397,9 @@ namespace Elastic.Apm.Tests.ApiTests
 		private async Task AssertWith1TransactionAnd1ErrorAnd1SpanAsync(Func<ITransaction, Task> func)
 		{
 			var payloadSender = new MockPayloadSender();
-			Agent.PayloadSender = payloadSender;
+			var agent = new ApmAgent(new TestAgentConfiguration(payloadSender: payloadSender));
 
-			await Agent.Tracer.CaptureTransaction(TransactionName, TransactionType, async t =>
+			await agent.Tracer.CaptureTransaction(TransactionName, TransactionType, async t =>
 			{
 				await Task.Delay(TransactionSleepLength);
 				await func(t);
@@ -434,9 +433,9 @@ namespace Elastic.Apm.Tests.ApiTests
 		private async Task AssertWith1TransactionAnd1SpanAsync(Func<ITransaction, Task> func)
 		{
 			var payloadSender = new MockPayloadSender();
-			Agent.PayloadSender = payloadSender;
+			var agent = new ApmAgent(new TestAgentConfiguration(payloadSender: payloadSender));
 
-			await Agent.Tracer.CaptureTransaction(TransactionName, TransactionType, async t =>
+			await agent.Tracer.CaptureTransaction(TransactionName, TransactionType, async t =>
 			{
 				await Task.Delay(TransactionSleepLength);
 				await func(t);
@@ -462,9 +461,9 @@ namespace Elastic.Apm.Tests.ApiTests
 		private void AssertWith1TransactionAnd1Span(Action<ITransaction> action)
 		{
 			var payloadSender = new MockPayloadSender();
-			Agent.PayloadSender = payloadSender;
+			var agent = new ApmAgent(new TestAgentConfiguration(payloadSender: payloadSender));
 
-			Agent.Tracer.CaptureTransaction(TransactionName, TransactionType, t =>
+			agent.Tracer.CaptureTransaction(TransactionName, TransactionType, t =>
 			{
 				Thread.Sleep(SpanSleepLength);
 				action(t);
@@ -489,10 +488,11 @@ namespace Elastic.Apm.Tests.ApiTests
 		/// </summary>
 		private void AssertWith1TransactionAnd1SpanAnd1Error(Action<ITransaction> action)
 		{
-			var payloadSender = new MockPayloadSender();
-			Agent.PayloadSender = payloadSender;
 
-			Agent.Tracer.CaptureTransaction(TransactionName, TransactionType, t =>
+			var payloadSender = new MockPayloadSender();
+			var agent = new ApmAgent(new TestAgentConfiguration(payloadSender: payloadSender));
+
+			agent.Tracer.CaptureTransaction(TransactionName, TransactionType, t =>
 			{
 				Thread.Sleep(SpanSleepLength);
 				action(t);

--- a/test/Elastic.Apm.Tests/ApiTests/ConvenientApiTransactionTests.cs
+++ b/test/Elastic.Apm.Tests/ApiTests/ConvenientApiTransactionTests.cs
@@ -25,8 +25,7 @@ namespace Elastic.Apm.Tests.ApiTests
 		private const string TransactionName = "ConvenientApiTest";
 		private const string TransactionType = "Test";
 
-		public ConvenientApiTransactionTests()
-			=> TestHelper.ResetAgentAndEnvVars();
+		public ConvenientApiTransactionTests() => TestHelper.ResetAgentAndEnvVars();
 
 		/// <summary>
 		/// Tests the <see cref="Tracer.CaptureTransaction(string,string,System.Action)" /> method.
@@ -34,12 +33,11 @@ namespace Elastic.Apm.Tests.ApiTests
 		/// and it makes sure that the transaction is captured by the agent.
 		/// </summary>
 		[Fact]
-		public void SimpleAction()
-			=> AssertWith1Transaction(() =>
-			{
-				Agent.Tracer.CaptureTransaction(TransactionName, TransactionType,
-					() => { Thread.Sleep(SleepLength); });
-			});
+		public void SimpleAction() => AssertWith1Transaction((agent) =>
+		{
+			agent.Tracer.CaptureTransaction(TransactionName, TransactionType,
+				() => { Thread.Sleep(SleepLength); });
+		});
 
 		/// <summary>
 		/// Tests the <see cref="Tracer.CaptureTransaction(string,string,System.Action)" /> method with an exception.
@@ -47,18 +45,17 @@ namespace Elastic.Apm.Tests.ApiTests
 		/// and it makes sure that the transaction and the exception are captured by the agent.
 		/// </summary>
 		[Fact]
-		public void SimpleActionWithException()
-			=> AssertWith1TransactionAnd1Error(() =>
+		public void SimpleActionWithException() => AssertWith1TransactionAnd1Error((agent) =>
+		{
+			Assert.Throws<InvalidOperationException>(() =>
 			{
-				Assert.Throws<InvalidOperationException>(() =>
+				agent.Tracer.CaptureTransaction(TransactionName, TransactionType, new Action(() =>
 				{
-					Agent.Tracer.CaptureTransaction(TransactionName, TransactionType, new Action(() =>
-					{
-						Thread.Sleep(SleepLength);
-						throw new InvalidOperationException(ExceptionMessage);
-					}));
-				});
+					Thread.Sleep(SleepLength);
+					throw new InvalidOperationException(ExceptionMessage);
+				}));
 			});
+		});
 
 		/// <summary>
 		/// Tests the <see cref="Tracer.CaptureTransaction(string,string,System.Action{ITransaction})" /> method.
@@ -68,16 +65,15 @@ namespace Elastic.Apm.Tests.ApiTests
 		/// is not null
 		/// </summary>
 		[Fact]
-		public void SimpleActionWithParameter()
-			=> AssertWith1Transaction(() =>
-			{
-				Agent.Tracer.CaptureTransaction(TransactionName, TransactionType,
-					t =>
-					{
-						Assert.NotNull(t);
-						Thread.Sleep(SleepLength);
-					});
-			});
+		public void SimpleActionWithParameter() => AssertWith1Transaction((agent) =>
+		{
+			agent.Tracer.CaptureTransaction(TransactionName, TransactionType,
+				t =>
+				{
+					Assert.NotNull(t);
+					Thread.Sleep(SleepLength);
+				});
+		});
 
 		/// <summary>
 		/// Tests the <see cref="Tracer.CaptureTransaction(string,string,System.Action{ITransaction})" /> method with an exception.
@@ -87,19 +83,18 @@ namespace Elastic.Apm.Tests.ApiTests
 		/// <see cref="Action{ITransaction}" /> parameter is not null
 		/// </summary>
 		[Fact]
-		public void SimpleActionWithExceptionAndParameter()
-			=> AssertWith1TransactionAnd1Error(() =>
+		public void SimpleActionWithExceptionAndParameter() => AssertWith1TransactionAnd1Error((agent) =>
+		{
+			Assert.Throws<InvalidOperationException>(() =>
 			{
-				Assert.Throws<InvalidOperationException>(() =>
+				agent.Tracer.CaptureTransaction(TransactionName, TransactionType, new Action<ITransaction>(t =>
 				{
-					Agent.Tracer.CaptureTransaction(TransactionName, TransactionType, new Action<ITransaction>(t =>
-					{
-						Assert.NotNull(t);
-						Thread.Sleep(SleepLength);
-						throw new InvalidOperationException(ExceptionMessage);
-					}));
-				});
+					Assert.NotNull(t);
+					Thread.Sleep(SleepLength);
+					throw new InvalidOperationException(ExceptionMessage);
+				}));
 			});
+		});
 
 		/// <summary>
 		/// Tests the <see cref="Tracer.CaptureTransaction{T}(string,string,System.Func{T})" /> method.
@@ -107,17 +102,16 @@ namespace Elastic.Apm.Tests.ApiTests
 		/// and it makes sure that the transaction is captured by the agent and the return value is correct.
 		/// </summary>
 		[Fact]
-		public void SimpleActionWithReturnType()
-			=> AssertWith1Transaction(() =>
+		public void SimpleActionWithReturnType() => AssertWith1Transaction((agent) =>
+		{
+			var res = agent.Tracer.CaptureTransaction(TransactionName, TransactionType, () =>
 			{
-				var res = Agent.Tracer.CaptureTransaction(TransactionName, TransactionType, () =>
-				{
-					Thread.Sleep(SleepLength);
-					return 42;
-				});
-
-				Assert.Equal(42, res);
+				Thread.Sleep(SleepLength);
+				return 42;
 			});
+
+			Assert.Equal(42, res);
+		});
 
 		/// <summary>
 		/// Tests the <see cref="Tracer.CaptureTransaction{T}(string,string,System.Func{ITransaction,T})" /> method.
@@ -127,19 +121,18 @@ namespace Elastic.Apm.Tests.ApiTests
 		/// <see cref="Action{ITransaction}" /> is not null.
 		/// </summary>
 		[Fact]
-		public void SimpleActionWithReturnTypeAndParameter()
-			=> AssertWith1Transaction(() =>
-			{
-				var res = Agent.Tracer.CaptureTransaction(TransactionName, TransactionType,
-					t =>
-					{
-						Assert.NotNull(t);
-						Thread.Sleep(SleepLength);
-						return 42;
-					});
+		public void SimpleActionWithReturnTypeAndParameter() => AssertWith1Transaction((agent) =>
+		{
+			var res = agent.Tracer.CaptureTransaction(TransactionName, TransactionType,
+				t =>
+				{
+					Assert.NotNull(t);
+					Thread.Sleep(SleepLength);
+					return 42;
+				});
 
-				Assert.Equal(42, res);
-			});
+			Assert.Equal(42, res);
+		});
 
 		/// <summary>
 		/// Tests the <see cref="Tracer.CaptureTransaction{T}(string,string,System.Func{ITransaction,T})" /> method with an
@@ -150,26 +143,25 @@ namespace Elastic.Apm.Tests.ApiTests
 		/// <see cref="Action{ITransaction}" /> is not null.
 		/// </summary>
 		[Fact]
-		public void SimpleActionWithReturnTypeAndExceptionAndParameter()
-			=> AssertWith1TransactionAnd1Error(() =>
+		public void SimpleActionWithReturnTypeAndExceptionAndParameter() => AssertWith1TransactionAnd1Error((agent) =>
+		{
+			Assert.Throws<InvalidOperationException>(() =>
 			{
-				Assert.Throws<InvalidOperationException>(() =>
+				var result = agent.Tracer.CaptureTransaction(TransactionName, TransactionType, t =>
 				{
-					var result = Agent.Tracer.CaptureTransaction(TransactionName, TransactionType, t =>
-					{
-						Assert.NotNull(t);
-						Thread.Sleep(SleepLength);
+					Assert.NotNull(t);
+					Thread.Sleep(SleepLength);
 
-						if (new Random().Next(1) == 0) //avoid unreachable code warning.
-							throw new InvalidOperationException(ExceptionMessage);
+					if (new Random().Next(1) == 0) //avoid unreachable code warning.
+						throw new InvalidOperationException(ExceptionMessage);
 
-						return 42;
-					});
-
-					Assert.True(false); //Should not be executed because the agent isn't allowed to catch an exception.
-					Assert.Equal(42, result); //But if it'd not throw it'd be 42.
+					return 42;
 				});
+
+				Assert.True(false); //Should not be executed because the agent isn't allowed to catch an exception.
+				Assert.Equal(42, result); //But if it'd not throw it'd be 42.
 			});
+		});
 
 		/// <summary>
 		/// Tests the <see cref="Tracer.CaptureTransaction{T}(string,string,System.Func{T})" /> method with an exception.
@@ -178,25 +170,24 @@ namespace Elastic.Apm.Tests.ApiTests
 		/// and it makes sure that the transaction and the error are captured by the agent.
 		/// </summary>
 		[Fact]
-		public void SimpleActionWithReturnTypeAndException()
-			=> AssertWith1TransactionAnd1Error(() =>
+		public void SimpleActionWithReturnTypeAndException() => AssertWith1TransactionAnd1Error((agent) =>
+		{
+			Assert.Throws<InvalidOperationException>(() =>
 			{
-				Assert.Throws<InvalidOperationException>(() =>
+				var result = agent.Tracer.CaptureTransaction(TransactionName, TransactionType, () =>
 				{
-					var result = Agent.Tracer.CaptureTransaction(TransactionName, TransactionType, () =>
-					{
-						Thread.Sleep(SleepLength);
+					Thread.Sleep(SleepLength);
 
-						if (new Random().Next(1) == 0) //avoid unreachable code warning.
-							throw new InvalidOperationException(ExceptionMessage);
+					if (new Random().Next(1) == 0) //avoid unreachable code warning.
+						throw new InvalidOperationException(ExceptionMessage);
 
-						return 42;
-					});
-
-					Assert.True(false); //Should not be executed because the agent isn't allowed to catch an exception.
-					Assert.Equal(42, result); //But if it'd not throw it'd be 42.
+					return 42;
 				});
+
+				Assert.True(false); //Should not be executed because the agent isn't allowed to catch an exception.
+				Assert.Equal(42, result); //But if it'd not throw it'd be 42.
 			});
+		});
 
 		/// <summary>
 		/// Tests the <see cref="Tracer.CaptureTransaction(string,string,System.Func{Task})" /> method.
@@ -204,9 +195,9 @@ namespace Elastic.Apm.Tests.ApiTests
 		/// and it makes sure that the transaction is captured.
 		/// </summary>
 		[Fact]
-		public async Task AsyncTask() => await AssertWith1TransactionAsync(async () =>
+		public async Task AsyncTask() => await AssertWith1TransactionAsync(async (agent) =>
 		{
-			await Agent.Tracer.CaptureTransaction(TransactionName, TransactionType,
+			await agent.Tracer.CaptureTransaction(TransactionName, TransactionType,
 				async () => { await Task.Delay(SleepLength); });
 		});
 
@@ -216,18 +207,17 @@ namespace Elastic.Apm.Tests.ApiTests
 		/// and it makes sure that the transaction and the error are captured.
 		/// </summary>
 		[Fact]
-		public async Task AsyncTaskWithException()
-			=> await AssertWith1TransactionAnd1ErrorAsync(async () =>
+		public async Task AsyncTaskWithException() => await AssertWith1TransactionAnd1ErrorAsync(async (agent) =>
+		{
+			await Assert.ThrowsAsync<InvalidOperationException>(async () =>
 			{
-				await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+				await agent.Tracer.CaptureTransaction(TransactionName, TransactionType, async () =>
 				{
-					await Agent.Tracer.CaptureTransaction(TransactionName, TransactionType, async () =>
-					{
-						await Task.Delay(SleepLength);
-						throw new InvalidOperationException(ExceptionMessage);
-					});
+					await Task.Delay(SleepLength);
+					throw new InvalidOperationException(ExceptionMessage);
 				});
 			});
+		});
 
 		/// <summary>
 		/// Tests the <see cref="Tracer.CaptureTransaction(string,string,System.Func{ITransaction, Task})" /> method.
@@ -236,16 +226,15 @@ namespace Elastic.Apm.Tests.ApiTests
 		/// and it makes sure that the transaction is captured and the <see cref="Action{ITransaction}" /> parameter is not null.
 		/// </summary>
 		[Fact]
-		public async Task AsyncTaskWithParameter()
-			=> await AssertWith1TransactionAsync(async () =>
-			{
-				await Agent.Tracer.CaptureTransaction(TransactionName, TransactionType,
-					async t =>
-					{
-						Assert.NotNull(t);
-						await Task.Delay(SleepLength);
-					});
-			});
+		public async Task AsyncTaskWithParameter() => await AssertWith1TransactionAsync(async (agent) =>
+		{
+			await agent.Tracer.CaptureTransaction(TransactionName, TransactionType,
+				async t =>
+				{
+					Assert.NotNull(t);
+					await Task.Delay(SleepLength);
+				});
+		});
 
 		/// <summary>
 		/// Tests the <see cref="Tracer.CaptureTransaction(string,string,System.Func{ITransaction, Task})" /> method with an
@@ -256,19 +245,18 @@ namespace Elastic.Apm.Tests.ApiTests
 		/// is not null.
 		/// </summary>
 		[Fact]
-		public async Task AsyncTaskWithExceptionAndParameter()
-			=> await AssertWith1TransactionAnd1ErrorAsync(async () =>
+		public async Task AsyncTaskWithExceptionAndParameter() => await AssertWith1TransactionAnd1ErrorAsync(async (agent) =>
+		{
+			await Assert.ThrowsAsync<InvalidOperationException>(async () =>
 			{
-				await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+				await agent.Tracer.CaptureTransaction(TransactionName, TransactionType, async t =>
 				{
-					await Agent.Tracer.CaptureTransaction(TransactionName, TransactionType, async t =>
-					{
-						Assert.NotNull(t);
-						await Task.Delay(SleepLength);
-						throw new InvalidOperationException(ExceptionMessage);
-					});
+					Assert.NotNull(t);
+					await Task.Delay(SleepLength);
+					throw new InvalidOperationException(ExceptionMessage);
 				});
 			});
+		});
 
 		/// <summary>
 		/// Tests the <see cref="Tracer.CaptureTransaction{T}(string,string,System.Func{Task{T}})" /> method.
@@ -276,16 +264,15 @@ namespace Elastic.Apm.Tests.ApiTests
 		/// and it makes sure that the transaction is captured by the agent and the return value is correct.
 		/// </summary>
 		[Fact]
-		public async Task AsyncTaskWithReturnType()
-			=> await AssertWith1TransactionAsync(async () =>
+		public async Task AsyncTaskWithReturnType() => await AssertWith1TransactionAsync(async (agent) =>
+		{
+			var res = await agent.Tracer.CaptureTransaction(TransactionName, TransactionType, async () =>
 			{
-				var res = await Agent.Tracer.CaptureTransaction(TransactionName, TransactionType, async () =>
-				{
-					await Task.Delay(SleepLength);
-					return 42;
-				});
-				Assert.Equal(42, res);
+				await Task.Delay(SleepLength);
+				return 42;
 			});
+			Assert.Equal(42, res);
+		});
 
 		/// <summary>
 		/// Tests the <see cref="Tracer.CaptureTransaction{T}(string,string,System.Func{ITransaction,Task{T}})" /> method.
@@ -295,19 +282,18 @@ namespace Elastic.Apm.Tests.ApiTests
 		/// <see cref="ITransaction" /> is not null.
 		/// </summary>
 		[Fact]
-		public async Task AsyncTaskWithReturnTypeAndParameter()
-			=> await AssertWith1TransactionAsync(async () =>
-			{
-				var res = await Agent.Tracer.CaptureTransaction(TransactionName, TransactionType,
-					async t =>
-					{
-						Assert.NotNull(t);
-						await Task.Delay(SleepLength);
-						return 42;
-					});
+		public async Task AsyncTaskWithReturnTypeAndParameter() => await AssertWith1TransactionAsync(async (agent) =>
+		{
+			var res = await agent.Tracer.CaptureTransaction(TransactionName, TransactionType,
+				async t =>
+				{
+					Assert.NotNull(t);
+					await Task.Delay(SleepLength);
+					return 42;
+				});
 
-				Assert.Equal(42, res);
-			});
+			Assert.Equal(42, res);
+		});
 
 		/// <summary>
 		/// Tests the <see cref="Tracer.CaptureTransaction{T}(string,string,System.Func{ITransaction,Task{T}})" /> method with an
@@ -318,26 +304,25 @@ namespace Elastic.Apm.Tests.ApiTests
 		/// <see cref="Action{ITransaction}" /> is not null.
 		/// </summary>
 		[Fact]
-		public async Task AsyncTaskWithReturnTypeAndExceptionAndParameter()
-			=> await AssertWith1TransactionAnd1ErrorAsync(async () =>
+		public async Task AsyncTaskWithReturnTypeAndExceptionAndParameter() => await AssertWith1TransactionAnd1ErrorAsync(async (agent) =>
+		{
+			await Assert.ThrowsAsync<InvalidOperationException>(async () =>
 			{
-				await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+				var result = await agent.Tracer.CaptureTransaction(TransactionName, TransactionType, async t =>
 				{
-					var result = await Agent.Tracer.CaptureTransaction(TransactionName, TransactionType, async t =>
-					{
-						Assert.NotNull(t);
-						await Task.Delay(SleepLength);
+					Assert.NotNull(t);
+					await Task.Delay(SleepLength);
 
-						if (new Random().Next(1) == 0) //avoid unreachable code warning.
-							throw new InvalidOperationException(ExceptionMessage);
+					if (new Random().Next(1) == 0) //avoid unreachable code warning.
+						throw new InvalidOperationException(ExceptionMessage);
 
-						return 42;
-					});
-
-					Assert.True(false); //Should not be executed because the agent isn't allowed to catch an exception.
-					Assert.Equal(42, result); //But if it'd not throw it'd be 42.
+					return 42;
 				});
+
+				Assert.True(false); //Should not be executed because the agent isn't allowed to catch an exception.
+				Assert.Equal(42, result); //But if it'd not throw it'd be 42.
 			});
+		});
 
 		/// <summary>
 		/// Tests the <see cref="Tracer.CaptureTransaction{T}(string,string,System.Func{Task{T}})" /> method with an exception.
@@ -346,25 +331,24 @@ namespace Elastic.Apm.Tests.ApiTests
 		/// and it makes sure that the transaction and the error are captured by the agent.
 		/// </summary>
 		[Fact]
-		public async Task AsyncTaskWithReturnTypeAndException()
-			=> await AssertWith1TransactionAnd1ErrorAsync(async () =>
+		public async Task AsyncTaskWithReturnTypeAndException() => await AssertWith1TransactionAnd1ErrorAsync(async (agent) =>
+		{
+			await Assert.ThrowsAsync<InvalidOperationException>(async () =>
 			{
-				await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+				var result = await agent.Tracer.CaptureTransaction(TransactionName, TransactionType, async () =>
 				{
-					var result = await Agent.Tracer.CaptureTransaction(TransactionName, TransactionType, async () =>
-					{
-						await Task.Delay(SleepLength);
+					await Task.Delay(SleepLength);
 
-						if (new Random().Next(1) == 0) //avoid unreachable code warning.
-							throw new InvalidOperationException(ExceptionMessage);
+					if (new Random().Next(1) == 0) //avoid unreachable code warning.
+						throw new InvalidOperationException(ExceptionMessage);
 
-						return 42;
-					});
-
-					Assert.True(false); //Should not be executed because the agent isn't allowed to catch an exception.
-					Assert.Equal(42, result); //But if it'd not throw it'd be 42.
+					return 42;
 				});
+
+				Assert.True(false); //Should not be executed because the agent isn't allowed to catch an exception.
+				Assert.Equal(42, result); //But if it'd not throw it'd be 42.
 			});
+		});
 
 		/// <summary>
 		/// Wraps a cancelled task into the CaptureTransaction method and
@@ -374,7 +358,7 @@ namespace Elastic.Apm.Tests.ApiTests
 		public async Task CancelledAsyncTask()
 		{
 			var payloadSender = new MockPayloadSender();
-			Agent.PayloadSender = payloadSender;
+			var agent = new ApmAgent(new TestAgentConfiguration(payloadSender: payloadSender));
 
 			var cancellationTokenSource = new CancellationTokenSource();
 			var token = cancellationTokenSource.Token;
@@ -382,7 +366,7 @@ namespace Elastic.Apm.Tests.ApiTests
 
 			await Assert.ThrowsAsync<OperationCanceledException>(async () =>
 			{
-				await Agent.Tracer.CaptureTransaction(TransactionName, TransactionType,
+				await agent.Tracer.CaptureTransaction(TransactionName, TransactionType,
 					async () =>
 					{
 						// ReSharper disable once MethodSupportsCancellation, we want to delay before we throw the exception
@@ -410,12 +394,12 @@ namespace Elastic.Apm.Tests.ApiTests
 		/// <summary>
 		/// Asserts on 1 transaction with async code
 		/// </summary>
-		private async Task AssertWith1TransactionAsync(Func<Task> func)
+		private async Task AssertWith1TransactionAsync(Func<ApmAgent, Task> func)
 		{
 			var payloadSender = new MockPayloadSender();
-			Agent.PayloadSender = payloadSender;
+			var agent = new ApmAgent(new TestAgentConfiguration(payloadSender: payloadSender));
 
-			await func();
+			await func(agent);
 
 			Assert.NotEmpty(payloadSender.Payloads);
 			Assert.NotEmpty(payloadSender.Payloads[0].Transactions);
@@ -429,12 +413,12 @@ namespace Elastic.Apm.Tests.ApiTests
 		/// <summary>
 		/// Asserts on 1 async transaction and 1 error
 		/// </summary>
-		private async Task AssertWith1TransactionAnd1ErrorAsync(Func<Task> func)
+		private async Task AssertWith1TransactionAnd1ErrorAsync(Func<ApmAgent, Task> func)
 		{
 			var payloadSender = new MockPayloadSender();
-			Agent.PayloadSender = payloadSender;
+			var agent = new ApmAgent(new TestAgentConfiguration(payloadSender: payloadSender));
 
-			await func();
+			await func(agent);
 
 			Assert.NotEmpty(payloadSender.Payloads);
 			Assert.NotEmpty(payloadSender.Payloads[0].Transactions);
@@ -455,12 +439,12 @@ namespace Elastic.Apm.Tests.ApiTests
 		/// <summary>
 		/// Asserts on 1 transaction
 		/// </summary>
-		private void AssertWith1Transaction(Action action)
+		private void AssertWith1Transaction(Action<ApmAgent> action)
 		{
 			var payloadSender = new MockPayloadSender();
-			Agent.PayloadSender = payloadSender;
+			var agent = new ApmAgent(new TestAgentConfiguration(payloadSender: payloadSender));
 
-			action();
+			action(agent);
 
 			Assert.NotEmpty(payloadSender.Payloads);
 			Assert.NotEmpty(payloadSender.Payloads[0].Transactions);
@@ -474,12 +458,12 @@ namespace Elastic.Apm.Tests.ApiTests
 		/// <summary>
 		/// Asserts on 1 transaction and 1 error
 		/// </summary>
-		private void AssertWith1TransactionAnd1Error(Action action)
+		private void AssertWith1TransactionAnd1Error(Action<ApmAgent> action)
 		{
 			var payloadSender = new MockPayloadSender();
-			Agent.PayloadSender = payloadSender;
+			var agent = new ApmAgent(new TestAgentConfiguration(payloadSender: payloadSender));
 
-			action();
+			action(agent);
 
 			Assert.NotEmpty(payloadSender.Payloads);
 			Assert.NotEmpty(payloadSender.Payloads[0].Transactions);

--- a/test/Elastic.Apm.Tests/LoggerTest.cs
+++ b/test/Elastic.Apm.Tests/LoggerTest.cs
@@ -6,66 +6,57 @@ namespace Elastic.Apm.Tests
 {
 	public class LoggerTest
 	{
-		private readonly TestLogger _logger;
-
-		public LoggerTest()
-		{
-			TestHelper.ResetAgentAndEnvVars();
-
-			Agent.SetLoggerType<TestLogger>();
-			_logger = (TestLogger)Agent.CreateLogger("Test");
-		}
-
 		[Fact]
 		public void TestLogError()
 		{
-			LogWithLevel(LogLevel.Error);
+			var logger = LogWithLevel(LogLevel.Error);
 
-			Assert.Single(_logger.Lines);
-			Assert.Equal("Error Test: Error log", (_logger).Lines[0]);
+			Assert.Single(logger.Lines);
+			Assert.Equal("Error Test: Error log", logger.Lines[0]);
 		}
 
 		[Fact]
 		public void TestLogWarning()
 		{
-			LogWithLevel(LogLevel.Warning);
+			var logger =LogWithLevel(LogLevel.Warning);
 
-			Assert.Equal(2, (_logger).Lines.Count);
-			Assert.Equal("Error Test: Error log", (_logger).Lines[0]);
-			Assert.Equal("Warning Test: Warning log", (_logger).Lines[1]);
+			Assert.Equal(2, logger.Lines.Count);
+			Assert.Equal("Error Test: Error log", logger.Lines[0]);
+			Assert.Equal("Warning Test: Warning log", logger.Lines[1]);
 		}
 
 		[Fact]
 		public void TestLogInfo()
 		{
-			LogWithLevel(LogLevel.Info);
+			var logger =LogWithLevel(LogLevel.Info);
 
-			Assert.Equal(3, (_logger).Lines.Count);
-			Assert.Equal("Error Test: Error log", (_logger).Lines[0]);
-			Assert.Equal("Warning Test: Warning log", (_logger).Lines[1]);
-			Assert.Equal("Info Test: Info log", (_logger).Lines[2]);
+			Assert.Equal(3, logger.Lines.Count);
+			Assert.Equal("Error Test: Error log", logger.Lines[0]);
+			Assert.Equal("Warning Test: Warning log", logger.Lines[1]);
+			Assert.Equal("Info Test: Info log", logger.Lines[2]);
 		}
 
 		[Fact]
 		public void TestLogDebug()
 		{
-			LogWithLevel(LogLevel.Debug);
+			var logger = LogWithLevel(LogLevel.Debug);
 
-			Assert.Equal(4, (_logger).Lines.Count);
-			Assert.Equal("Error Test: Error log", (_logger).Lines[0]);
-			Assert.Equal("Warning Test: Warning log", (_logger).Lines[1]);
-			Assert.Equal("Info Test: Info log", (_logger).Lines[2]);
-			Assert.Equal("Debug Test: Debug log", (_logger).Lines[3]);
+			Assert.Equal(4, logger.Lines.Count);
+			Assert.Equal("Error Test: Error log", logger.Lines[0]);
+			Assert.Equal("Warning Test: Warning log", logger.Lines[1]);
+			Assert.Equal("Info Test: Info log", logger.Lines[2]);
+			Assert.Equal("Debug Test: Debug log", logger.Lines[3]);
 		}
 
-		private void LogWithLevel(LogLevel logLevel)
+		private TestLogger LogWithLevel(LogLevel logLevel)
 		{
-			Agent.Config.LogLevel = logLevel;
+			var logger = new TestLogger(logLevel);
 
-			_logger.LogError("Error log");
-			_logger.LogWarning("Warning log");
-			_logger.LogInfo("Info log");
-			_logger.LogDebug("Debug log");
+			logger.LogError("Test", "Error log");
+			logger.LogWarning("Test", "Warning log");
+			logger.LogInfo("Test", "Info log");
+			logger.LogDebug("Test", "Debug log");
+			return logger;
 		}
 	}
 }

--- a/test/Elastic.Apm.Tests/Mocks/TestAgentConfiguration.cs
+++ b/test/Elastic.Apm.Tests/Mocks/TestAgentConfiguration.cs
@@ -1,0 +1,29 @@
+using Elastic.Apm.Config;
+using Elastic.Apm.Logging;
+using Elastic.Apm.Model.Payload;
+using Elastic.Apm.Report;
+
+namespace Elastic.Apm.Tests.Mocks
+{
+	public class TestAgentConfiguration : AbstractAgentConfig
+	{
+		private readonly string _serverUrls;
+		private readonly string _logLevel;
+
+		public TestAgentConfiguration(
+			string serverUrls = null,
+			string logLevel = "Debug",
+			AbstractLogger logger = null,
+			Service service = null,
+			IPayloadSender payloadSender = null
+		) : base(logger ?? new TestLogger(LogLevelOrDefault(logLevel)), service, payloadSender ?? new MockPayloadSender())
+		{
+			_serverUrls = serverUrls;
+			_logLevel = logLevel;
+		}
+
+		protected override (string value, string configType, string configKey) ReadLogLevel() => (_logLevel, "test", EnvVarConsts.LogLevel);
+
+		protected override (string value, string configType, string configKey) ReadServerUrls() => (_serverUrls, "test", EnvVarConsts.ServerUrls);
+	}
+}

--- a/test/Elastic.Apm.Tests/Mocks/TestLogger.cs
+++ b/test/Elastic.Apm.Tests/Mocks/TestLogger.cs
@@ -5,6 +5,10 @@ namespace Elastic.Apm.Tests.Mocks
 {
 	public class TestLogger : AbstractLogger
 	{
+		public TestLogger() : base(LogLevelDefault) { }
+
+		public TestLogger(LogLevel level) : base(level) { }
+
 		public List<string> Lines { get; } = new List<string>();
 
 		protected override void PrintLogline(string logline) => Lines.Add(logline);


### PR DESCRIPTION
This reworks `Elastic.Apm.Agent` making it static class holding a lazy singleton instance of `ApmAgent` which is `internal`.

There is now an `Elastic.Apm.Setup()` method that allows you to control the lazy instantiation which will throw if the singleton materialized already and can no longer be configured. This is in favor of having too many (internal) static property setters.

This also allows all other components to explicitly declare their dependencies in the constructor without referring to the static singleton directly. To me this was a `ServiceLocator` in disguise and so this PR introduces several constructors.

All the tests now instantiate a local `ApmAgent` and can test in isolation.

`Elastic.Apm.Agent` no longer has all the `CreateLogger` and `SetLoggerMethods()`. I refactored to make the tests pass but once #61 is settled on this could be cleaned up even further.



