### PR TITLE
ASP.NET Core span tests

### DIFF
--- a/sample/ApiSamples/Program.cs
+++ b/sample/ApiSamples/Program.cs
@@ -70,8 +70,13 @@ namespace ApiSamples
 		public static void SampleCustomTransactionWithConvenientApi() => Agent.Tracer.CaptureTransaction("TestTransaction", "TestType",
 			t =>
 			{
+				t.Context.Tags["fooTransaction"] = "barTransaction";
 				Thread.Sleep(10);
-				t.CaptureSpan("TestSpan", "TestSpanName", () => { Thread.Sleep(20); });
+				t.CaptureSpan("TestSpan", "TestSpanName", (s) =>
+				{
+					Thread.Sleep(20);
+					s.Tags["fooSpan"] = "barSpan";
+				});
 			});
 	}
 }

--- a/src/Elastic.Apm.AspNetCore/ApmMiddleware.cs
+++ b/src/Elastic.Apm.AspNetCore/ApmMiddleware.cs
@@ -35,25 +35,22 @@ namespace Elastic.Apm.AspNetCore
 			var transaction = _tracer.StartTransaction($"{context.Request.Method} {context.Request.Path}",
 				Transaction.TypeRequest);
 
-			transaction.Context = new Context
+			transaction.Context.Request = new Request
 			{
-				Request = new Request
+				Method = context.Request.Method,
+				Socket = new Socket
 				{
-					Method = context.Request.Method,
-					Socket = new Socket
-					{
-						Encrypted = context.Request.IsHttps,
-						RemoteAddress = context.Connection?.RemoteIpAddress?.ToString()
-					},
-					Url = new Url
-					{
-						Full = context.Request?.Path.Value,
-						HostName = context.Request.Host.Host,
-						Protocol = GetProtocolName(context.Request.Protocol),
-						Raw = context.Request?.Path.Value //TODO
-					},
-					HttpVersion = GetHttpVersion(context.Request.Protocol)
-				}
+					Encrypted = context.Request.IsHttps,
+					RemoteAddress = context.Connection?.RemoteIpAddress?.ToString()
+				},
+				Url = new Url
+				{
+					Full = context.Request?.Path.Value,
+					HostName = context.Request.Host.Host,
+					Protocol = GetProtocolName(context.Request.Protocol),
+					Raw = context.Request?.Path.Value //TODO
+				},
+				HttpVersion = GetHttpVersion(context.Request.Protocol)
 			};
 
 			try

--- a/src/Elastic.Apm.AspNetCore/DiagnosticListener/AspNetCoreDiagnosticListener.cs
+++ b/src/Elastic.Apm.AspNetCore/DiagnosticListener/AspNetCoreDiagnosticListener.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Reflection;
 using Elastic.Apm.DiagnosticSource;
 using Elastic.Apm.Logging;
-using Microsoft.AspNetCore.Http;
 
 namespace Elastic.Apm.AspNetCore.DiagnosticListener
 {

--- a/src/Elastic.Apm.EntityFrameworkCore/EfCoreDiagnosticListener.cs
+++ b/src/Elastic.Apm.EntityFrameworkCore/EfCoreDiagnosticListener.cs
@@ -42,14 +42,11 @@ namespace Elastic.Apm.EntityFrameworkCore
 					{
 						if (_spans.TryRemove(commandExecutedEventData.CommandId, out var span))
 						{
-							span.Context = new Span.ContextC
+							span.Context.Db = new Db
 							{
-								Db = new Db
-								{
-									Statement = commandExecutedEventData.Command.CommandText,
-									Instance = commandExecutedEventData.Command.Connection.Database,
-									Type = "sql"
-								}
+								Statement = commandExecutedEventData.Command.CommandText,
+								Instance = commandExecutedEventData.Command.Connection.Database,
+								Type = "sql"
 							};
 							span.Duration = commandExecutedEventData.Duration.TotalMilliseconds;
 

--- a/src/Elastic.Apm/Api/ISpan.cs
+++ b/src/Elastic.Apm/Api/ISpan.cs
@@ -13,7 +13,10 @@ namespace Elastic.Apm.Api
 		/// </summary>
 		string Action { get; set; }
 
-		IContext Context { get; set; }
+		/// <summary>
+		/// Any other arbitrary data captured by the agent, optionally provided by the user.
+		/// </summary>
+		IContext Context { get; }
 
 		/// <summary>
 		/// The duration of the span.
@@ -45,6 +48,11 @@ namespace Elastic.Apm.Api
 		/// Examples: 'http', 'mssql'.
 		/// </summary>
 		string Subtype { get; set; }
+
+		/// <summary>
+		/// A flat mapping of user-defined tags with string values.
+		/// </summary>
+		Dictionary<string, string> Tags { get; }
 
 		/// <summary>
 		/// UUID of the enclosing transaction.
@@ -83,6 +91,7 @@ namespace Elastic.Apm.Api
 	{
 		IDb Db { get; set; }
 		IHttp Http { get; set; }
+		Dictionary<string, string> Tags { get; }
 	}
 
 	public interface IDb

--- a/src/Elastic.Apm/Api/ITransaction.cs
+++ b/src/Elastic.Apm/Api/ITransaction.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Threading.Tasks;
@@ -12,7 +11,7 @@ namespace Elastic.Apm.Api
 		/// <summary>
 		/// Any arbitrary contextual information regarding the event, captured by the agent, optionally provided by the user.
 		/// </summary>
-		Context Context { get; set; }
+		Context Context { get; }
 
 		/// <summary>
 		/// The duration of the transaction.
@@ -38,6 +37,11 @@ namespace Elastic.Apm.Api
 
 		//TODO: probably won't need with intake v2
 		ISpan[] Spans { get; }
+
+		/// <summary>
+		/// A flat mapping of user-defined tags with string values.
+		/// </summary>
+		Dictionary<string, string> Tags { get; }
 
 		string Timestamp { get; }
 
@@ -101,7 +105,8 @@ namespace Elastic.Apm.Api
 		/// <param name="subType">The subtype of the span.</param>
 		/// <param name="action">The action of the span.</param>
 		/// <typeparam name="T">The return type of the code that you want to capture as span.</typeparam>
-		/// <returns>The result of the
+		/// <returns>
+		/// The result of the
 		/// <param name="func"></param>
 		/// .
 		/// </returns>

--- a/src/Elastic.Apm/DiagnosticListeners/HttpDiagnosticListener.cs
+++ b/src/Elastic.Apm/DiagnosticListeners/HttpDiagnosticListener.cs
@@ -64,13 +64,10 @@ namespace Elastic.Apm.DiagnosticListeners
 
 					if (ProcessingRequests.TryAdd(request, span))
 					{
-						span.Context = new Span.ContextC
+						span.Context.Http = new Http
 						{
-							Http = new Http
-							{
-								Url = request?.RequestUri?.ToString(),
-								Method = request?.Method?.Method
-							}
+							Url = request?.RequestUri?.ToString(),
+							Method = request?.Method?.Method
 						};
 
 						var frames = new StackTrace().GetFrames();

--- a/src/Elastic.Apm/Model/Payload/Context.cs
+++ b/src/Elastic.Apm/Model/Payload/Context.cs
@@ -1,9 +1,16 @@
-﻿namespace Elastic.Apm.Model.Payload
+﻿using System;
+using System.Collections.Generic;
+
+namespace Elastic.Apm.Model.Payload
 {
 	public class Context
 	{
 		public Request Request { get; set; }
 
 		public Response Response { get; set; }
+
+		private readonly Lazy<Dictionary<string, string>> tags = new Lazy<Dictionary<string, string>>();
+
+		public Dictionary<string, string> Tags => tags.Value;
 	}
 }

--- a/src/Elastic.Apm/Model/Payload/Span.cs
+++ b/src/Elastic.Apm/Model/Payload/Span.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using Elastic.Apm.Api;
 using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
 
 namespace Elastic.Apm.Model.Payload
 {
@@ -18,6 +17,8 @@ namespace Elastic.Apm.Model.Payload
 
 		public const string TypeDb = "db";
 		public const string TypeExternal = "external";
+
+		private readonly Lazy<ContextImpl> _context = new Lazy<ContextImpl>();
 
 		private readonly DateTimeOffset _start;
 
@@ -34,8 +35,7 @@ namespace Elastic.Apm.Model.Payload
 		}
 
 		public string Action { get; set; }
-
-		public IContext Context { get; set; }
+		public IContext Context => _context.Value;
 
 		/// <inheritdoc />
 		/// <summary>
@@ -56,6 +56,9 @@ namespace Elastic.Apm.Model.Payload
 		public decimal Start { get; set; }
 
 		public string Subtype { get; set; }
+
+		public Dictionary<string, string> Tags => Context.Tags;
+
 		internal Transaction Transaction;
 
 		public Guid TransactionId => Transaction.Id;
@@ -75,10 +78,13 @@ namespace Elastic.Apm.Model.Payload
 		public void CaptureError(string message, string culprit, StackFrame[] frames)
 			=> Transaction?.CaptureError(message, culprit, frames);
 
-		public class ContextC : IContext
+		private class ContextImpl : IContext
 		{
 			public IDb Db { get; set; }
 			public IHttp Http { get; set; }
+
+			private readonly Lazy<Dictionary<string, string>> _tags = new Lazy<Dictionary<string, string>>();
+			public Dictionary<string, string> Tags => _tags.Value;
 		}
 	}
 

--- a/src/Elastic.Apm/Model/Payload/Transaction.cs
+++ b/src/Elastic.Apm/Model/Payload/Transaction.cs
@@ -17,10 +17,8 @@ namespace Elastic.Apm.Model.Payload
 		private readonly IPayloadSender _sender;
 		public const string TypeRequest = "request";
 		internal readonly DateTimeOffset Start;
-    
-		private readonly Lazy<Context> _context = new Lazy<Context>();
 
-		public Transaction(string name, string type)
+		private readonly Lazy<Context> _context = new Lazy<Context>();
 
 		public Transaction(IApmAgent agent, string name, string type)
 			: this(agent.Logger, name, type, agent.PayloadSender) { }

--- a/src/Elastic.Apm/Model/Payload/Transaction.cs
+++ b/src/Elastic.Apm/Model/Payload/Transaction.cs
@@ -17,6 +17,10 @@ namespace Elastic.Apm.Model.Payload
 		private readonly IPayloadSender _sender;
 		public const string TypeRequest = "request";
 		internal readonly DateTimeOffset Start;
+    
+		private readonly Lazy<Context> _context = new Lazy<Context>();
+
+		public Transaction(string name, string type)
 
 		public Transaction(IApmAgent agent, string name, string type)
 			: this(agent.Logger, name, type, agent.PayloadSender) { }
@@ -31,7 +35,7 @@ namespace Elastic.Apm.Model.Payload
 			Id = Guid.NewGuid();
 		}
 
-		public Context Context { get; set; }
+		public Context Context => _context.Value;
 
 		/// <inheritdoc />
 		/// <summary>
@@ -56,11 +60,13 @@ namespace Elastic.Apm.Model.Payload
 
 		internal Service Service;
 
+		//TODO: probably won't need with intake v2
+		public ISpan[] Spans => SpansInternal.ToArray();
+
 		//TODO: measure! What about List<T> with lock() in our case?
 		internal BlockingCollection<Span> SpansInternal = new BlockingCollection<Span>();
 
-		//TODO: probably won't need with intake v2
-		public ISpan[] Spans => SpansInternal.ToArray();
+		public Dictionary<string, string> Tags => Context.Tags;
 
 		public string Timestamp => Start.ToString("yyyy-MM-ddTHH:mm:ss.FFFZ");
 


### PR DESCRIPTION
In #63 [this](https://github.com/elastic/apm-agent-dotnet/pull/63#discussion_r247145009) should have been found by a test. So this PR adds a test that makes sure that once the DiagnosticListeners are passed to `ApmMiddleware` the agent really captures spans within the request. 