### PR TITLE
Public cleanup

### DIFF
--- a/sample/SampleAspNetCoreApp/SampleAspNetCoreApp.csproj
+++ b/sample/SampleAspNetCoreApp/SampleAspNetCoreApp.csproj
@@ -2,6 +2,9 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.1</TargetFramework>
+    <SignAssembly>true</SignAssembly>
+    <AssemblyOriginatorKeyFile>..\..\elasticapm.snk</AssemblyOriginatorKeyFile>
+    <DelaySign>false</DelaySign>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Elastic.Apm.AspNetCore/ApmMiddleware.cs
+++ b/src/Elastic.Apm.AspNetCore/ApmMiddleware.cs
@@ -16,12 +16,12 @@ using Microsoft.AspNetCore.Http;
 namespace Elastic.Apm.AspNetCore
 {
 	// ReSharper disable once ClassNeverInstantiated.Global
-	public class ApmMiddleware
+	internal class ApmMiddleware
 	{
 		private readonly RequestDelegate _next;
-		private readonly ITracer _tracer;
+		private readonly Tracer _tracer;
 
-		public ApmMiddleware(RequestDelegate next, ITracer tracer)
+		public ApmMiddleware(RequestDelegate next, Tracer tracer)
 		{
 			_next = next;
 			_tracer = tracer;
@@ -29,7 +29,7 @@ namespace Elastic.Apm.AspNetCore
 
 		public async Task InvokeAsync(HttpContext context)
 		{
-			var transaction = _tracer.StartTransaction($"{context.Request.Method} {context.Request.Path}",
+			var transaction = _tracer.StartTransactionInternal($"{context.Request.Method} {context.Request.Path}",
 				ApiConstants.TypeRequest);
 
 			transaction.Context.Request = new Request

--- a/src/Elastic.Apm.AspNetCore/Config/MicrosoftExtensionsConfig.cs
+++ b/src/Elastic.Apm.AspNetCore/Config/MicrosoftExtensionsConfig.cs
@@ -10,7 +10,7 @@ namespace Elastic.Apm.AspNetCore.Config
 	/// An agent-config provider based on Microsoft.Extensions.Configuration.IConfiguration.
 	/// It uses environment variables as fallback
 	/// </summary>
-	public class MicrosoftExtensionsConfig : AbstractConfigurationReader, IConfigurationReader
+	internal class MicrosoftExtensionsConfig : AbstractConfigurationReader, IConfigurationReader
 	{
 		private readonly IConfiguration _configuration;
 

--- a/src/Elastic.Apm.AspNetCore/DiagnosticListener/AspNetCoreDiagnosticListener.cs
+++ b/src/Elastic.Apm.AspNetCore/DiagnosticListener/AspNetCoreDiagnosticListener.cs
@@ -6,14 +6,13 @@ using Elastic.Apm.Logging;
 
 namespace Elastic.Apm.AspNetCore.DiagnosticListener
 {
-	public class AspNetCoreDiagnosticListener : IDiagnosticListener
+	internal class AspNetCoreDiagnosticListener : IDiagnosticListener
 	{
 		private readonly AbstractLogger _logger;
 
 		public AspNetCoreDiagnosticListener(IApmAgent agent) => _logger = agent.Logger;
 
 		public string Name => "Microsoft.AspNetCore";
-		public IDisposable SourceSubscription { get; set; }
 
 		public void OnCompleted() { }
 

--- a/src/Elastic.Apm.EntityFrameworkCore/EfCoreDiagnosticListener.cs
+++ b/src/Elastic.Apm.EntityFrameworkCore/EfCoreDiagnosticListener.cs
@@ -12,14 +12,13 @@ namespace Elastic.Apm.EntityFrameworkCore
 {
 	internal class EfCoreDiagnosticListener : IDiagnosticListener
 	{
-		private readonly ConcurrentDictionary<Guid, ISpan> _spans = new ConcurrentDictionary<Guid, ISpan>();
+		private readonly ConcurrentDictionary<Guid, Span> _spans = new ConcurrentDictionary<Guid, Span>();
 
 		public EfCoreDiagnosticListener(IApmAgent agent) => Logger = agent.Logger;
 
 		private AbstractLogger Logger { get; }
 
 		public string Name => "Microsoft.EntityFrameworkCore";
-		public IDisposable SourceSubscription { get; set; }
 
 		public void OnCompleted() { }
 
@@ -32,7 +31,7 @@ namespace Elastic.Apm.EntityFrameworkCore
 				case string k when k == RelationalEventId.CommandExecuting.Name && Agent.TransactionContainer.Transactions.Value != null:
 					if (kv.Value is CommandEventData commandEventData)
 					{
-						var newSpan = Agent.TransactionContainer.Transactions.Value.StartSpan(
+						var newSpan = Agent.TransactionContainer.Transactions.Value.StartSpanInternal(
 							commandEventData.Command.CommandText, ApiConstants.TypeDb);
 
 						_spans.TryAdd(commandEventData.CommandId, newSpan);

--- a/src/Elastic.Apm/Agent.cs
+++ b/src/Elastic.Apm/Agent.cs
@@ -54,6 +54,8 @@ namespace Elastic.Apm
 
 		internal readonly CompositeDisposable Disposables = new CompositeDisposable();
 		public void Dispose() => Disposables?.Dispose();
+
+		internal Tracer TracerInternal => Tracer as Tracer;
 	}
 
 	public static class Agent

--- a/src/Elastic.Apm/AgentComponents.cs
+++ b/src/Elastic.Apm/AgentComponents.cs
@@ -18,7 +18,7 @@ namespace Elastic.Apm
 			ConfigurationReader = configurationReader ?? new EnvironmentConfigurationReader(Logger);
 			Service = service ?? Service.GetDefaultService(ConfigurationReader);
 			PayloadSender = payloadSender ?? new PayloadSender(Logger, ConfigurationReader);
-			Tracer = new Tracer(Logger, Service, PayloadSender);
+			TracerInternal = new Tracer(Logger, Service, PayloadSender);
 			TransactionContainer = new TransactionContainer();
 		}
 
@@ -28,7 +28,9 @@ namespace Elastic.Apm
 
 		public IConfigurationReader ConfigurationReader { get; }
 
-		public ITracer Tracer { get; }
+		public ITracer Tracer => TracerInternal;
+
+		internal Tracer TracerInternal { get; }
 
 		internal TransactionContainer TransactionContainer { get; }
 

--- a/src/Elastic.Apm/Api/IError.cs
+++ b/src/Elastic.Apm/Api/IError.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Collections.Generic;
+
+namespace Elastic.Apm.Api
+{
+	public interface IError
+	{
+		List<IErrorDetail> Errors { get; set; }
+	}
+
+	public interface IErrorDetail
+	{
+		string Culprit { get; set; }
+		ICapturedException Exception { get; set; }
+		Guid Id { get; }
+	}
+
+	public interface ICapturedException
+	{
+		/// <summary>
+		/// The exception message, see: <see cref="Exception.Message"/>
+		/// </summary>
+		string Message { get; set; }
+
+		/// <summary>
+		/// The type of the exception class
+		/// </summary>
+		string Type { get; set; }
+	}
+}

--- a/src/Elastic.Apm/Api/ISpan.cs
+++ b/src/Elastic.Apm/Api/ISpan.cs
@@ -14,11 +14,6 @@ namespace Elastic.Apm.Api
 		string Action { get; set; }
 
 		/// <summary>
-		/// Any other arbitrary data captured by the agent, optionally provided by the user.
-		/// </summary>
-		IContext Context { get; }
-
-		/// <summary>
 		/// The duration of the span.
 		/// If it's not set (its HasValue property is false) then the value
 		/// is automatically calculated when <see cref="End" /> is called.
@@ -35,8 +30,6 @@ namespace Elastic.Apm.Api
 		/// The name of the span.
 		/// </summary>
 		string Name { get; set; }
-
-		List<Stacktrace> StackTrace { get; set; }
 
 		/// <summary>
 		/// Offset relative to the transaction's timestamp identifying the start of the span, in milliseconds.
@@ -85,26 +78,5 @@ namespace Elastic.Apm.Api
 		/// It is illegal to call any methods on a span instance which has already ended.
 		/// </summary>
 		void End();
-	}
-
-	public interface IContext
-	{
-		IDb Db { get; set; }
-		IHttp Http { get; set; }
-		Dictionary<string, string> Tags { get; }
-	}
-
-	public interface IDb
-	{
-		string Instance { get; set; }
-		string Statement { get; set; }
-		string Type { get; set; }
-	}
-
-	public interface IHttp
-	{
-		string Method { get; set; }
-		int StatusCode { get; set; }
-		string Url { get; set; }
 	}
 }

--- a/src/Elastic.Apm/Api/ITransaction.cs
+++ b/src/Elastic.Apm/Api/ITransaction.cs
@@ -9,11 +9,6 @@ namespace Elastic.Apm.Api
 	public interface ITransaction
 	{
 		/// <summary>
-		/// Any arbitrary contextual information regarding the event, captured by the agent, optionally provided by the user.
-		/// </summary>
-		Context Context { get; }
-
-		/// <summary>
 		/// The duration of the transaction.
 		/// If it's not set (its HasValue property is false) then the value
 		/// is automatically calculated when <see cref="End" /> is called.
@@ -35,15 +30,10 @@ namespace Elastic.Apm.Api
 		/// <value>The result.</value>
 		string Result { get; set; }
 
-		//TODO: probably won't need with intake v2
-		ISpan[] Spans { get; }
-
 		/// <summary>
 		/// A flat mapping of user-defined tags with string values.
 		/// </summary>
 		Dictionary<string, string> Tags { get; }
-
-		string Timestamp { get; }
 
 		/// <summary>
 		/// The type of the transaction.

--- a/src/Elastic.Apm/Api/Tracer.cs
+++ b/src/Elastic.Apm/Api/Tracer.cs
@@ -24,8 +24,10 @@ namespace Elastic.Apm.Api
 			_sender = payloadSender;
 		}
 
-
 		public ITransaction StartTransaction(string name, string type)
+			=> StartTransactionInternal(name, type);
+
+		internal Transaction StartTransactionInternal(string name, string type)
 		{
 			var retVal = new Transaction(_logger, name, type, _sender)
 			{

--- a/src/Elastic.Apm/Config/EnvironmentConfigurationReader.cs
+++ b/src/Elastic.Apm/Config/EnvironmentConfigurationReader.cs
@@ -4,7 +4,7 @@ using Elastic.Apm.Logging;
 
 namespace Elastic.Apm.Config
 {
-	public class EnvironmentConfigurationReader : AbstractConfigurationReader, IConfigurationReader
+	internal class EnvironmentConfigurationReader : AbstractConfigurationReader, IConfigurationReader
 	{
 		internal const string Origin = "environment";
 

--- a/src/Elastic.Apm/DiagnosticListeners/HttpDiagnosticListener.cs
+++ b/src/Elastic.Apm/DiagnosticListeners/HttpDiagnosticListener.cs
@@ -14,16 +14,17 @@ using Elastic.Apm.Model.Payload;
 
 namespace Elastic.Apm.DiagnosticListeners
 {
+	/// <inheritdoc />
 	/// <summary>
-	/// Captures web requests initiated by <see cref="System.Net.Http.HttpClient" />
+	/// Captures web requests initiated by <see cref="T:System.Net.Http.HttpClient" />
 	/// </summary>
-	public class HttpDiagnosticListener : IDiagnosticListener
+	internal class HttpDiagnosticListener : IDiagnosticListener
 	{
 
 		/// <summary>
 		/// Keeps track of ongoing requests
 		/// </summary>
-		internal readonly ConcurrentDictionary<HttpRequestMessage, ISpan> ProcessingRequests = new ConcurrentDictionary<HttpRequestMessage, ISpan>();
+		internal readonly ConcurrentDictionary<HttpRequestMessage, Span> ProcessingRequests = new ConcurrentDictionary<HttpRequestMessage, Span>();
 
 		public HttpDiagnosticListener(IApmAgent components) =>
 			(Logger, ConfigurationReader) = (components.Logger, components.ConfigurationReader);
@@ -32,7 +33,6 @@ namespace Elastic.Apm.DiagnosticListeners
 		private IConfigurationReader ConfigurationReader { get; }
 
 		public string Name => "HttpHandlerDiagnosticListener";
-		public IDisposable SourceSubscription { get; set; }
 
 		public void OnCompleted() { }
 
@@ -61,7 +61,7 @@ namespace Elastic.Apm.DiagnosticListeners
 
 					transaction = Agent.TransactionContainer.Transactions.Value;
 
-					var span = transaction.StartSpan($"{request?.Method} {request?.RequestUri?.Host}", ApiConstants.TypeExternal,
+					var span = transaction.StartSpanInternal($"{request?.Method} {request?.RequestUri?.Host}", ApiConstants.TypeExternal,
 						ApiConstants.SubtypeHttp);
 
 					if (ProcessingRequests.TryAdd(request, span))

--- a/src/Elastic.Apm/DiagnosticSource/DiagnosticInitializer.cs
+++ b/src/Elastic.Apm/DiagnosticSource/DiagnosticInitializer.cs
@@ -9,7 +9,7 @@ namespace Elastic.Apm.DiagnosticSource
 		private readonly IEnumerable<IDiagnosticListener> _listeners;
 		private IDisposable _sourceSubscription;
 
-		public DiagnosticInitializer(IEnumerable<IDiagnosticListener> listeners) => _listeners = listeners;
+		internal DiagnosticInitializer(IEnumerable<IDiagnosticListener> listeners) => _listeners = listeners;
 
 		public void OnCompleted() { }
 

--- a/src/Elastic.Apm/DiagnosticSource/IDiagnosticListener.cs
+++ b/src/Elastic.Apm/DiagnosticSource/IDiagnosticListener.cs
@@ -7,18 +7,12 @@ namespace Elastic.Apm.DiagnosticSource
 	/// Common interface for every diagnostic listener
 	/// The DiagnosticInitializer works through this interface with the different listeners
 	/// </summary>
-	public interface IDiagnosticListener : IObserver<KeyValuePair<string, object>>
+	internal interface IDiagnosticListener : IObserver<KeyValuePair<string, object>>
 	{
 		/// <summary>
 		/// Represents the component associated with the event.
 		/// </summary>
 		/// <value>The name.</value>
 		string Name { get; }
-
-		/// <summary>
-		/// Reference to the source subscription.
-		/// This is set by <see cref="DiagnosticInitializer"/>
-		/// </summary>
-		IDisposable SourceSubscription { get; set; }
 	}
 }

--- a/src/Elastic.Apm/Helpers/StacktraceHelper.cs
+++ b/src/Elastic.Apm/Helpers/StacktraceHelper.cs
@@ -7,14 +7,14 @@ using Elastic.Apm.Model.Payload;
 
 namespace Elastic.Apm.Helpers
 {
-	public static class StacktraceHelper
+	internal static class StacktraceHelper
 	{
 		/// <summary>
 		/// Turns a System.Diagnostic.StackFrame[] into a <see cref="Stacktrace" /> list which can be reported to the APM Server
 		/// </summary>
 		/// <param name="capturingFor">Just for logging.</param>
 		/// <returns>A prepared List that can be passed to the APM server</returns>
-		public static List<Stacktrace> GenerateApmStackTrace(StackFrame[] frames, AbstractLogger logger, string capturingFor)
+		internal static List<Stacktrace> GenerateApmStackTrace(StackFrame[] frames, AbstractLogger logger, string capturingFor)
 		{
 			var retVal = new List<Stacktrace>(frames.Length);
 

--- a/src/Elastic.Apm/Logging/AbstractLogger.cs
+++ b/src/Elastic.Apm/Logging/AbstractLogger.cs
@@ -12,7 +12,7 @@
 		/// they need to write it (e.g. into a file, to the console)
 		/// </summary>
 		/// <param name="logline">This line that must be logged - it already contains the prefix and the loglevel</param>
-		protected abstract void PrintLogline(string logline);
+		protected abstract void PrintLogLine(string logLine);
 
 		private string GetPrefixString(LogLevel logLevel, string prefix) =>
 			string.IsNullOrWhiteSpace(prefix) ? $"{logLevel.ToString()} " : $"{logLevel.ToString()} {prefix}: ";
@@ -25,25 +25,25 @@
 		internal void LogInfo(string info) => LogInfo(null, info);
 		internal void LogInfo(string prefix, string info)
 		{
-			if (LogLevel >= LogLevel.Info) PrintLogline($"{GetPrefixString(LogLevel.Info, prefix)}{info}");
+			if (LogLevel >= LogLevel.Info) PrintLogLine($"{GetPrefixString(LogLevel.Info, prefix)}{info}");
 		}
 
 		internal void LogWarning(string warning) => LogWarning(null, warning);
 		internal void LogWarning(string prefix, string warning)
 		{
-			if (LogLevel >= LogLevel.Warning) PrintLogline($"{GetPrefixString(LogLevel.Warning, prefix)}{warning}");
+			if (LogLevel >= LogLevel.Warning) PrintLogLine($"{GetPrefixString(LogLevel.Warning, prefix)}{warning}");
 		}
 
 		internal void LogError(string error) => LogError(null, error);
 		internal void LogError(string prefix, string error)
 		{
-			if (LogLevel >= LogLevel.Error) PrintLogline($"{GetPrefixString(LogLevel.Error, prefix)}{error}");
+			if (LogLevel >= LogLevel.Error) PrintLogLine($"{GetPrefixString(LogLevel.Error, prefix)}{error}");
 		}
 
 		internal void LogDebug(string debug) => LogDebug(null, debug);
 		internal void LogDebug(string prefix, string debug)
 		{
-			if (LogLevel >= LogLevel.Debug) PrintLogline($"{GetPrefixString(LogLevel.Debug, prefix)}{debug}");
+			if (LogLevel >= LogLevel.Debug) PrintLogLine($"{GetPrefixString(LogLevel.Debug, prefix)}{debug}");
 		}
 	}
 }

--- a/src/Elastic.Apm/Logging/ConsoleLogger.cs
+++ b/src/Elastic.Apm/Logging/ConsoleLogger.cs
@@ -4,10 +4,10 @@ namespace Elastic.Apm.Logging
 {
 	internal class ConsoleLogger : AbstractLogger
 	{
-		protected ConsoleLogger(LogLevel level) : base(level) { }
+		private ConsoleLogger(LogLevel level) : base(level) { }
 
-		protected override void PrintLogline(string logline) => Console.WriteLine(logline);
+		protected override void PrintLogLine(string logLine) => Console.WriteLine(logLine);
 
-		public static ConsoleLogger Instance { get; } = new ConsoleLogger(LogLevelDefault);
+		internal static ConsoleLogger Instance { get; } = new ConsoleLogger(LogLevelDefault);
 	}
 }

--- a/src/Elastic.Apm/Model/Payload/Context.cs
+++ b/src/Elastic.Apm/Model/Payload/Context.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 
 namespace Elastic.Apm.Model.Payload
 {
-	public class Context
+	internal class Context
 	{
 		public Request Request { get; set; }
 

--- a/src/Elastic.Apm/Model/Payload/Error.cs
+++ b/src/Elastic.Apm/Model/Payload/Error.cs
@@ -17,12 +17,12 @@ namespace Elastic.Apm.Model.Payload
 				Id = Guid.NewGuid();
 			}
 
-			public Context Context { get; set; }
+			internal Context Context { get; set; }
 			public string Culprit { get; set; }
 			public CapturedException Exception { get; set; }
-			public Guid Id { get; }
-			public string Timestamp { get; }
-			public Trans Transaction { get; set; }
+			internal Guid Id { get; }
+			private string Timestamp { get; }
+			internal Trans Transaction { get; set; }
 
 			public class Trans
 			{
@@ -33,17 +33,23 @@ namespace Elastic.Apm.Model.Payload
 
 	public class CapturedException
 	{
-		public string Code { get; set; } //TODO
+		internal string Code { get; set; } //TODO
 
-		public bool Handled { get; set; }
+		internal bool Handled { get; set; }
 
+		/// <summary>
+		/// The exception message, see: <see cref="Exception.Message"/>
+		/// </summary>
 		public string Message { get; set; }
 
-		public string Module { get; set; }
+		internal string Module { get; set; }
 
 		[JsonProperty("Stacktrace")]
-		public List<Stacktrace> StacktTrace { get; set; }
+		internal List<Stacktrace> StacktTrace { get; set; }
 
+		/// <summary>
+		/// The type of the exception class
+		/// </summary>
 		public string Type { get; set; }
 	}
 }

--- a/src/Elastic.Apm/Model/Payload/Error.cs
+++ b/src/Elastic.Apm/Model/Payload/Error.cs
@@ -1,17 +1,18 @@
 ﻿using System;
 using System.Collections.Generic;
+using Elastic.Apm.Api;
 using Newtonsoft.Json;
 
 namespace Elastic.Apm.Model.Payload
 {
-	public class Error
+	internal class Error : IError
 	{
-		public List<Err> Errors { get; set; }
+		public List<IErrorDetail> Errors { get; set; }
 		public Service Service { get; set; }
 
-		public class Err
+		public class ErrorDetail : IErrorDetail
 		{
-			public Err()
+			public ErrorDetail()
 			{
 				Timestamp = DateTimeOffset.UtcNow.ToString("yyyy-MM-ddTHH:mm:ss.FFFZ");
 				Id = Guid.NewGuid();
@@ -19,33 +20,33 @@ namespace Elastic.Apm.Model.Payload
 
 			internal Context Context { get; set; }
 			public string Culprit { get; set; }
-			public CapturedException Exception { get; set; }
-			internal Guid Id { get; }
-			private string Timestamp { get; }
-			internal Trans Transaction { get; set; }
+			public ICapturedException Exception { get; set; }
+			public Guid Id { get; }
+			public string Timestamp { get; }
+			public TransactionReference Transaction { get; set; }
 
-			public class Trans
+			public class TransactionReference
 			{
 				public Guid Id { get; set; }
 			}
 		}
 	}
 
-	public class CapturedException
+	internal class CapturedException : ICapturedException
 	{
 		internal string Code { get; set; } //TODO
 
-		internal bool Handled { get; set; }
+		public bool Handled { get; set; }
 
 		/// <summary>
 		/// The exception message, see: <see cref="Exception.Message"/>
 		/// </summary>
 		public string Message { get; set; }
 
-		internal string Module { get; set; }
+		public string Module { get; set; }
 
 		[JsonProperty("Stacktrace")]
-		internal List<Stacktrace> StacktTrace { get; set; }
+		public List<Stacktrace> StacktTrace { get; set; }
 
 		/// <summary>
 		/// The type of the exception class

--- a/src/Elastic.Apm/Model/Payload/IPayload.cs
+++ b/src/Elastic.Apm/Model/Payload/IPayload.cs
@@ -1,0 +1,11 @@
+using System.Collections.Generic;
+using Elastic.Apm.Api;
+
+namespace Elastic.Apm.Model.Payload
+{
+	public interface IPayload
+	{
+		Service Service { get; set; }
+		List<ITransaction> Transactions { get; set; }
+	}
+}

--- a/src/Elastic.Apm/Model/Payload/Payload.cs
+++ b/src/Elastic.Apm/Model/Payload/Payload.cs
@@ -1,9 +1,17 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using Elastic.Apm.Api;
 
 namespace Elastic.Apm.Model.Payload
 {
-	public class Payload
+	public interface IPayload
+	{
+		 Service Service { get; set; }
+
+		 List<ITransaction> Transactions { get; set; }
+	}
+
+	internal class Payload : IPayload
 	{
 		public Service Service { get; set; }
 

--- a/src/Elastic.Apm/Model/Payload/Payload.cs
+++ b/src/Elastic.Apm/Model/Payload/Payload.cs
@@ -1,16 +1,8 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using Elastic.Apm.Api;
 
 namespace Elastic.Apm.Model.Payload
 {
-	public interface IPayload
-	{
-		 Service Service { get; set; }
-
-		 List<ITransaction> Transactions { get; set; }
-	}
-
 	internal class Payload : IPayload
 	{
 		public Service Service { get; set; }

--- a/src/Elastic.Apm/Model/Payload/Request.cs
+++ b/src/Elastic.Apm/Model/Payload/Request.cs
@@ -2,7 +2,7 @@
 
 namespace Elastic.Apm.Model.Payload
 {
-	public class Request
+	internal class Request
 	{
 		public string HttpVersion { get; set; }
 
@@ -11,7 +11,7 @@ namespace Elastic.Apm.Model.Payload
 		public Url Url { get; set; }
 	}
 
-	public class Socket
+	internal class Socket
 	{
 		public bool Encrypted { get; set; }
 
@@ -19,7 +19,7 @@ namespace Elastic.Apm.Model.Payload
 		public string RemoteAddress { get; set; }
 	}
 
-	public class Url
+	internal class Url
 	{
 		public string Full { get; set; }
 		public string HostName { get; set; }

--- a/src/Elastic.Apm/Model/Payload/Response.cs
+++ b/src/Elastic.Apm/Model/Payload/Response.cs
@@ -2,7 +2,7 @@
 
 namespace Elastic.Apm.Model.Payload
 {
-	public class Response
+	internal class Response
 	{
 		public bool Finished { get; set; }
 

--- a/src/Elastic.Apm/Model/Payload/Span.cs
+++ b/src/Elastic.Apm/Model/Payload/Span.cs
@@ -25,6 +25,10 @@ namespace Elastic.Apm.Model.Payload
 		}
 
 		public string Action { get; set; }
+
+		/// <summary>
+		/// Any other arbitrary data captured by the agent, optionally provided by the user.
+		/// </summary>
 		public IContext Context => _context.Value;
 
 		/// <inheritdoc />
@@ -79,14 +83,34 @@ namespace Elastic.Apm.Model.Payload
 		}
 	}
 
-	public class Db : IDb
+	internal interface IContext
+	{
+		IDb Db { get; set; }
+		IHttp Http { get; set; }
+		Dictionary<string, string> Tags { get; }
+	}
+
+	internal interface IDb
+	{
+		string Statement { get; set; }
+		string Type { get; set; }
+	}
+
+	internal interface IHttp
+	{
+		string Method { get; set; }
+		int StatusCode { get; set; }
+		string Url { get; set; }
+	}
+
+	internal class Db : IDb
 	{
 		public string Instance { get; set; }
 		public string Statement { get; set; }
 		public string Type { get; set; }
 	}
 
-	public class Http : IHttp
+	internal class Http : IHttp
 	{
 		public string Method { get; set; }
 		public int StatusCode { get; set; }

--- a/src/Elastic.Apm/Model/Payload/Stacktrace.cs
+++ b/src/Elastic.Apm/Model/Payload/Stacktrace.cs
@@ -2,7 +2,7 @@
 
 namespace Elastic.Apm.Model.Payload
 {
-	public class Stacktrace
+	internal class Stacktrace
 	{
 		[JsonProperty("Filename")]
 		public string FileName { get; set; }

--- a/src/Elastic.Apm/Model/Payload/Transaction.cs
+++ b/src/Elastic.Apm/Model/Payload/Transaction.cs
@@ -33,6 +33,9 @@ namespace Elastic.Apm.Model.Payload
 			Id = Guid.NewGuid();
 		}
 
+		/// <summary>
+		/// Any arbitrary contextual information regarding the event, captured by the agent, optionally provided by the user.
+		/// </summary>
 		public Context Context => _context.Value;
 
 		/// <inheritdoc />
@@ -88,7 +91,11 @@ namespace Elastic.Apm.Model.Payload
 		}
 
 		public ISpan StartSpan(string name, string type, string subType = null, string action = null)
+			=> StartSpanInternal(name, type, subType, action);
+
+		internal Span StartSpanInternal(string name, string type, string subType = null, string action = null)
 		{
+
 			var retVal = new Span(name, type, this);
 
 			if (!string.IsNullOrEmpty(subType)) retVal.Subtype = subType;

--- a/src/Elastic.Apm/Model/Payload/Transaction.cs
+++ b/src/Elastic.Apm/Model/Payload/Transaction.cs
@@ -111,16 +111,19 @@ namespace Elastic.Apm.Model.Payload
 		public void CaptureException(Exception exception, string culprit = null, bool isHandled = false)
 		{
 			var capturedCulprit = string.IsNullOrEmpty(culprit) ? "PublicAPI-CaptureException" : culprit;
-			var error = new Error.Err
+
+			var capturedException = new CapturedException
+			{
+				Message = exception.Message,
+				Type = exception.GetType().FullName,
+				Handled = isHandled
+			};
+
+			var error = new Error.ErrorDetail()
 			{
 				Culprit = capturedCulprit,
-				Exception = new CapturedException
-				{
-					Message = exception.Message,
-					Type = exception.GetType().FullName,
-					Handled = isHandled
-				},
-				Transaction = new Error.Err.Trans
+				Exception = capturedException,
+				Transaction = new Error.ErrorDetail.TransactionReference()
 				{
 					Id = Id
 				}
@@ -128,25 +131,26 @@ namespace Elastic.Apm.Model.Payload
 
 			if (!string.IsNullOrEmpty(exception.StackTrace))
 			{
-				error.Exception.StacktTrace
+				capturedException.StacktTrace
 					= StacktraceHelper.GenerateApmStackTrace(new StackTrace(exception).GetFrames(), _logger,
 						"failed capturing stacktrace");
 			}
 
 			error.Context = Context;
-			_sender.QueueError(new Error { Errors = new List<Error.Err> { error }, Service = Service });
+			_sender.QueueError(new Error { Errors = new List<IErrorDetail> { error }, Service = Service });
 		}
 
 		public void CaptureError(string message, string culprit, StackFrame[] frames)
 		{
-			var error = new Error.Err
+			var capturedException = new CapturedException
+			{
+				Message = message
+			};
+			var error = new Error.ErrorDetail
 			{
 				Culprit = culprit,
-				Exception = new CapturedException
-				{
-					Message = message
-				},
-				Transaction = new Error.Err.Trans
+				Exception = capturedException,
+				Transaction = new Error.ErrorDetail.TransactionReference()
 				{
 					Id = Id
 				}
@@ -154,12 +158,12 @@ namespace Elastic.Apm.Model.Payload
 
 			if (frames != null)
 			{
-				error.Exception.StacktTrace
+				capturedException.StacktTrace
 					= StacktraceHelper.GenerateApmStackTrace(frames, _logger, "failed capturing stacktrace");
 			}
 
 			error.Context = Context;
-			_sender.QueueError(new Error { Errors = new List<Error.Err> { error }, Service = Service });
+			_sender.QueueError(new Error { Errors = new List<IErrorDetail> { error }, Service = Service });
 		}
 
 		public void CaptureSpan(string name, string type, Action<ISpan> capturedAction, string subType = null, string action = null)

--- a/src/Elastic.Apm/Report/IPayloadSender.cs
+++ b/src/Elastic.Apm/Report/IPayloadSender.cs
@@ -1,10 +1,11 @@
-﻿using Elastic.Apm.Model.Payload;
+﻿using Elastic.Apm.Api;
+using Elastic.Apm.Model.Payload;
 
 namespace Elastic.Apm.Report
 {
 	public interface IPayloadSender
 	{
-		void QueueError(Error error);
+		void QueueError(IError error);
 
 		void QueuePayload(IPayload payload);
 	}

--- a/src/Elastic.Apm/Report/IPayloadSender.cs
+++ b/src/Elastic.Apm/Report/IPayloadSender.cs
@@ -6,6 +6,6 @@ namespace Elastic.Apm.Report
 	{
 		void QueueError(Error error);
 
-		void QueuePayload(Payload payload);
+		void QueuePayload(IPayload payload);
 	}
 }

--- a/src/Elastic.Apm/Report/PayloadSender.cs
+++ b/src/Elastic.Apm/Report/PayloadSender.cs
@@ -21,15 +21,15 @@ namespace Elastic.Apm.Report
 		private readonly AbstractLogger _logger;
 		private readonly Uri _serverUrlBase;
 
-		public PayloadSender(AbstractLogger logger, IConfigurationReader configurationReader)
+		internal PayloadSender(AbstractLogger logger, IConfigurationReader configurationReader)
 		{
 			_logger = logger;
 			_serverUrlBase = configurationReader.ServerUrls.First();
-			_workerThread = new Thread(StartWork)
+			var workerThread = new Thread(StartWork)
 			{
 				IsBackground = true
 			};
-			_workerThread.Start();
+			workerThread.Start();
 		}
 
 		/// <summary>
@@ -37,16 +37,11 @@ namespace Elastic.Apm.Report
 		/// </summary>
 		private BlockingCollection<object> _payloads = new BlockingCollection<object>();
 
-		/// <summary>
-		/// The work of sending data back to the server is done on this thread
-		/// </summary>
-		private readonly Thread _workerThread;
-
-		public void QueuePayload(Payload payload) => _payloads.Add(payload);
+		public void QueuePayload(IPayload payload) => _payloads.Add(payload);
 
 		public void QueueError(Error error) => _payloads.Add(error);
 
-		public async void StartWork()
+		private async void StartWork()
 		{
 			var httpClient = new HttpClient
 			{
@@ -63,23 +58,20 @@ namespace Elastic.Apm.Report
 						new JsonSerializerSettings { ContractResolver = new CamelCasePropertyNamesContractResolver() });
 					var content = new StringContent(json, Encoding.UTF8, "application/json");
 
-					HttpResponseMessage result = null;
 					switch (item)
 					{
-						case Payload p:
-							result = await httpClient.PostAsync(Consts.IntakeV1Transactions, content);
+						case Payload _:
+							await httpClient.PostAsync(Consts.IntakeV1Transactions, content);
 							break;
-						case Error e:
-							result = await httpClient.PostAsync(Consts.IntakeV1Errors, content);
+						case Error _:
+							await httpClient.PostAsync(Consts.IntakeV1Errors, content);
 							break;
 					}
-
-					var isSucc = result.IsSuccessStatusCode;
-					var str = await result.Content.ReadAsStringAsync();
 				}
 				catch (Exception e)
 				{
-					switch (item) {
+					switch (item)
+					{
 						case Payload p:
 							_logger.LogWarning($"Failed sending transaction {p.Transactions.FirstOrDefault()?.Name}");
 							_logger.LogDebug($"{e.GetType().Name}: {e.Message}");
@@ -91,6 +83,7 @@ namespace Elastic.Apm.Report
 					}
 				}
 			}
+			// ReSharper disable once FunctionNeverReturns
 		}
 
 		public void Dispose()

--- a/src/Elastic.Apm/Report/PayloadSender.cs
+++ b/src/Elastic.Apm/Report/PayloadSender.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Net.Http;
 using System.Text;
 using System.Threading;
+using Elastic.Apm.Api;
 using Elastic.Apm.Config;
 using Elastic.Apm.Logging;
 using Elastic.Apm.Model.Payload;
@@ -39,7 +40,7 @@ namespace Elastic.Apm.Report
 
 		public void QueuePayload(IPayload payload) => _payloads.Add(payload);
 
-		public void QueueError(Error error) => _payloads.Add(error);
+		public void QueueError(IError error) => _payloads.Add(error);
 
 		private async void StartWork()
 		{

--- a/test/Elastic.Apm.AspNetCore.Tests/AspNetCoreDiagnosticListenerTest.cs
+++ b/test/Elastic.Apm.AspNetCore.Tests/AspNetCoreDiagnosticListenerTest.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Net.Http;
 using System.Threading.Tasks;
+using Elastic.Apm.Model.Payload;
 using Elastic.Apm.Tests.Mocks;
 using Microsoft.AspNetCore.Mvc.Testing;
 using SampleAspNetCoreApp;
@@ -42,9 +43,9 @@ namespace Elastic.Apm.AspNetCore.Tests
 				Assert.Equal("This is a test exception!", capturedPayload.Errors[0].Errors[0].Exception.Message);
 				Assert.Equal(typeof(Exception).FullName, capturedPayload.Errors[0].Errors[0].Exception.Type);
 
-				Assert.Equal("/Home/TriggerError", capturedPayload.Errors[0].Errors[0].Context.Request.Url.Full);
-				Assert.Equal(HttpMethod.Get.Method, capturedPayload.Errors[0].Errors[0].Context.Request.Method);
-				Assert.False(capturedPayload.Errors[0].Errors[0].Exception.Handled);
+				Assert.Equal("/Home/TriggerError", capturedPayload.FirstErrorDetail.Context.Request.Url.Full);
+				Assert.Equal(HttpMethod.Get.Method, capturedPayload.FirstErrorDetail.Context.Request.Method);
+				Assert.False((capturedPayload.FirstErrorDetail.Exception as CapturedException)?.Handled);
 			}
 		}
 	}

--- a/test/Elastic.Apm.AspNetCore.Tests/AspNetCoreMiddlewareTests.cs
+++ b/test/Elastic.Apm.AspNetCore.Tests/AspNetCoreMiddlewareTests.cs
@@ -52,7 +52,7 @@ namespace Elastic.Apm.AspNetCore.Tests
 			Assembly.CreateQualifiedName("ASP.NET Core", payload.Service.Framework.Name);
 			Assembly.CreateQualifiedName(Assembly.Load("Microsoft.AspNetCore").GetName().Version.ToString(), payload.Service.Framework.Version);
 
-			var transaction = _capturedPayload.Payloads[0].Transactions[0];
+			var transaction = _capturedPayload.FirstTransaction;
 
 			//test transaction
 			Assert.Equal($"{response.RequestMessage.Method} {response.RequestMessage.RequestUri.AbsolutePath}", transaction.Name);
@@ -88,10 +88,10 @@ namespace Elastic.Apm.AspNetCore.Tests
 			Assert.True(response.IsSuccessStatusCode);
 
 			var transaction = _capturedPayload.Payloads[0].Transactions[0];
-			Assert.NotEmpty(transaction.Spans);
+			Assert.NotEmpty(_capturedPayload.SpansOnFirstTransaction);
 
 			//one of the spans is a DB call:
-			Assert.Contains(transaction.Spans, n => n.Context.Db != null);
+			Assert.Contains(_capturedPayload.SpansOnFirstTransaction, n => n.Context.Db != null);
 		}
 
 		/// <summary>

--- a/test/Elastic.Apm.AspNetCore.Tests/DiagnosticListenerTests.cs
+++ b/test/Elastic.Apm.AspNetCore.Tests/DiagnosticListenerTests.cs
@@ -83,8 +83,8 @@ namespace Elastic.Apm.AspNetCore.Tests
 				Assert.Single(_capturedPayload.Payloads);
 				Assert.Single(_capturedPayload.Payloads[0].Transactions);
 
-				Assert.NotEmpty(_capturedPayload.Payloads[0].Transactions[0].Spans);
-				Assert.Contains(_capturedPayload.Payloads[0].Transactions[0].Spans, n => n.Context.Db != null );
+				Assert.NotEmpty(_capturedPayload.SpansOnFirstTransaction);
+				Assert.Contains(_capturedPayload.SpansOnFirstTransaction, n => n.Context.Db != null );
 			} //here we unsubsribe, so no errors should be captured after this line.
 
 			_capturedPayload.Payloads.Clear();
@@ -95,7 +95,7 @@ namespace Elastic.Apm.AspNetCore.Tests
 			Assert.Single(_capturedPayload.Payloads);
 			Assert.Single(_capturedPayload.Payloads[0].Transactions);
 
-			Assert.Empty(_capturedPayload.Payloads[0].Transactions[0].Spans);
+			Assert.Empty(_capturedPayload.SpansOnFirstTransaction);
 		}
 
 		public void Dispose()

--- a/test/Elastic.Apm.Tests/ApiTests/ApiTests.cs
+++ b/test/Elastic.Apm.Tests/ApiTests/ApiTests.cs
@@ -152,11 +152,11 @@ namespace Elastic.Apm.Tests.ApiTests
 			span.End();
 			transaction.End();
 			Assert.NotEmpty(payloadSender.Payloads);
-			Assert.NotEmpty(payloadSender.Payloads[0].Transactions[0].Spans);
+			Assert.NotEmpty(payloadSender.SpansOnFirstTransaction);
 
-			Assert.Equal(spanName, payloadSender.Payloads[0].Transactions[0].Spans[0].Name);
-			Assert.True(payloadSender.Payloads[0].Transactions[0].Spans[0].Duration >= 5);
-			Assert.True(payloadSender.Payloads[0].Transactions[0].Spans[0].Id >= 5);
+			Assert.Equal(spanName, payloadSender.SpansOnFirstTransaction[0].Name);
+			Assert.True(payloadSender.SpansOnFirstTransaction[0].Duration >= 5);
+			Assert.True(payloadSender.SpansOnFirstTransaction[0].Id >= 5);
 			Assert.NotNull(payloadSender.Payloads[0].Service);
 		}
 
@@ -181,7 +181,7 @@ namespace Elastic.Apm.Tests.ApiTests
 
 			transaction.End(); //Ends transaction, but doesn't end span.
 			Assert.NotEmpty(payloadSender.Payloads);
-			Assert.Empty(payloadSender.Payloads[0].Transactions[0].Spans);
+			Assert.Empty(payloadSender.SpansOnFirstTransaction);
 
 			Assert.NotNull(payloadSender.Payloads[0].Service);
 		}
@@ -205,11 +205,11 @@ namespace Elastic.Apm.Tests.ApiTests
 			transaction.End();
 
 			Assert.NotEmpty(payloadSender.Payloads);
-			Assert.NotEmpty(payloadSender.Payloads[0].Transactions[0].Spans);
+			Assert.NotEmpty(payloadSender.SpansOnFirstTransaction);
 
-			Assert.Equal(ApiConstants.TypeDb, payloadSender.Payloads[0].Transactions[0].Spans[0].Type);
-			Assert.Equal(ApiConstants.SubtypeMssql, payloadSender.Payloads[0].Transactions[0].Spans[0].Subtype);
-			Assert.Equal(ApiConstants.ActionQuery, payloadSender.Payloads[0].Transactions[0].Spans[0].Action);
+			Assert.Equal(ApiConstants.TypeDb, payloadSender.SpansOnFirstTransaction[0].Type);
+			Assert.Equal(ApiConstants.SubtypeMssql, payloadSender.SpansOnFirstTransaction[0].Subtype);
+			Assert.Equal(ApiConstants.ActionQuery, payloadSender.SpansOnFirstTransaction[0].Action);
 
 			Assert.NotNull(payloadSender.Payloads[0].Service);
 		}
@@ -344,16 +344,16 @@ namespace Elastic.Apm.Tests.ApiTests
 			Assert.Equal(exceptionMessage, payloadSender.Errors[0].Errors[0].Exception.Message);
 
 			Assert.Equal("barTransaction1", payloadSender.Payloads[0].Transactions[0].Tags["fooTransaction1"]);
-			Assert.Equal("barTransaction1", payloadSender.Payloads[0].Transactions[0].Context.Tags["fooTransaction1"]);
+			Assert.Equal("barTransaction1", payloadSender.FirstTransaction.Context.Tags["fooTransaction1"]);
 
 			Assert.Equal("barTransaction2", payloadSender.Payloads[0].Transactions[0].Tags["fooTransaction2"]);
-			Assert.Equal("barTransaction2", payloadSender.Payloads[0].Transactions[0].Context.Tags["fooTransaction2"]);
+			Assert.Equal("barTransaction2", payloadSender.FirstTransaction.Context.Tags["fooTransaction2"]);
 
-			Assert.Equal("barSpan1", payloadSender.Payloads[0].Transactions[0].Spans[0].Tags["fooSpan1"]);
-			Assert.Equal("barSpan1", payloadSender.Payloads[0].Transactions[0].Spans[0].Context.Tags["fooSpan1"]);
+			Assert.Equal("barSpan1", payloadSender.SpansOnFirstTransaction[0].Tags["fooSpan1"]);
+			Assert.Equal("barSpan1", payloadSender.SpansOnFirstTransaction[0].Context.Tags["fooSpan1"]);
 
-			Assert.Equal("barSpan2", payloadSender.Payloads[0].Transactions[0].Spans[0].Tags["fooSpan2"]);
-			Assert.Equal("barSpan2", payloadSender.Payloads[0].Transactions[0].Spans[0].Context.Tags["fooSpan2"]);
+			Assert.Equal("barSpan2", payloadSender.SpansOnFirstTransaction[0].Tags["fooSpan2"]);
+			Assert.Equal("barSpan2", payloadSender.SpansOnFirstTransaction[0].Context.Tags["fooSpan2"]);
 		}
 	}
 }

--- a/test/Elastic.Apm.Tests/ApiTests/ConvenientApiSpanTests.cs
+++ b/test/Elastic.Apm.Tests/ApiTests/ConvenientApiSpanTests.cs
@@ -406,10 +406,10 @@ namespace Elastic.Apm.Tests.ApiTests
 				});
 
 			//According to the Intake API tags are stored on the Context (and not on Spans.Tags directly).
-			Assert.Equal("bar", payloadSender.Payloads[0].Transactions[0].Spans[0].Context.Tags["foo"]);
+			Assert.Equal("bar", payloadSender.SpansOnFirstTransaction[0].Context.Tags["foo"]);
 
 			//Also make sure the tag is visible directly on Span.Tags.
-			Assert.Equal("bar", payloadSender.Payloads[0].Transactions[0].Spans[0].Tags["foo"]);
+			Assert.Equal("bar", payloadSender.SpansOnFirstTransaction[0].Tags["foo"]);
 		}
 
 		/// <summary>
@@ -430,10 +430,10 @@ namespace Elastic.Apm.Tests.ApiTests
 				});
 
 			//According to the Intake API tags are stored on the Context (and not on Spans.Tags directly).
-			Assert.Equal("bar", payloadSender.Payloads[0].Transactions[0].Spans[0].Context.Tags["foo"]);
+			Assert.Equal("bar", payloadSender.SpansOnFirstTransaction[0].Context.Tags["foo"]);
 
 			//Also make sure the tag is visible directly on Span.Tags.
-			Assert.Equal("bar", payloadSender.Payloads[0].Transactions[0].Spans[0].Tags["foo"]);
+			Assert.Equal("bar", payloadSender.SpansOnFirstTransaction[0].Tags["foo"]);
 		}
 
 		/// <summary>
@@ -460,10 +460,10 @@ namespace Elastic.Apm.Tests.ApiTests
 				});
 
 			//According to the Intake API tags are stored on the Context (and not on Spans.Tags directly).
-			Assert.Equal("bar", payloadSender.Payloads[0].Transactions[0].Spans[0].Context.Tags["foo"]);
+			Assert.Equal("bar", payloadSender.SpansOnFirstTransaction[0].Context.Tags["foo"]);
 
 			//Also make sure the tag is visible directly on Span.Tags.
-			Assert.Equal("bar", payloadSender.Payloads[0].Transactions[0].Spans[0].Tags["foo"]);
+			Assert.Equal("bar", payloadSender.SpansOnFirstTransaction[0].Tags["foo"]);
 		}
 
 		/// <summary>
@@ -488,10 +488,10 @@ namespace Elastic.Apm.Tests.ApiTests
 
 			Assert.True(payloadSender.Payloads[0].Transactions[0].Duration >= TransactionSleepLength + SpanSleepLength);
 
-			Assert.NotEmpty(payloadSender.Payloads[0].Transactions[0].Spans);
+			Assert.NotEmpty(payloadSender.SpansOnFirstTransaction);
 
-			Assert.Equal(SpanName, payloadSender.Payloads[0].Transactions[0].Spans[0].Name);
-			Assert.Equal(SpanType, payloadSender.Payloads[0].Transactions[0].Spans[0].Type);
+			Assert.Equal(SpanName, payloadSender.SpansOnFirstTransaction[0].Name);
+			Assert.Equal(SpanType, payloadSender.SpansOnFirstTransaction[0].Type);
 
 
 			Assert.NotEmpty(payloadSender.Errors);
@@ -526,10 +526,10 @@ namespace Elastic.Apm.Tests.ApiTests
 
 			Assert.True(payloadSender.Payloads[0].Transactions[0].Duration >= TransactionSleepLength + SpanSleepLength);
 
-			Assert.NotEmpty(payloadSender.Payloads[0].Transactions[0].Spans);
+			Assert.NotEmpty(payloadSender.SpansOnFirstTransaction);
 
-			Assert.Equal(SpanName, payloadSender.Payloads[0].Transactions[0].Spans[0].Name);
-			Assert.Equal(SpanType, payloadSender.Payloads[0].Transactions[0].Spans[0].Type);
+			Assert.Equal(SpanName, payloadSender.SpansOnFirstTransaction[0].Name);
+			Assert.Equal(SpanType, payloadSender.SpansOnFirstTransaction[0].Type);
 
 			return payloadSender;
 		}
@@ -554,10 +554,10 @@ namespace Elastic.Apm.Tests.ApiTests
 			Assert.Equal(TransactionName, payloadSender.Payloads[0].Transactions[0].Name);
 			Assert.Equal(TransactionType, payloadSender.Payloads[0].Transactions[0].Type);
 
-			Assert.NotEmpty(payloadSender.Payloads[0].Transactions[0].Spans);
+			Assert.NotEmpty(payloadSender.SpansOnFirstTransaction);
 
-			Assert.Equal(SpanName, payloadSender.Payloads[0].Transactions[0].Spans[0].Name);
-			Assert.Equal(SpanType, payloadSender.Payloads[0].Transactions[0].Spans[0].Type);
+			Assert.Equal(SpanName, payloadSender.SpansOnFirstTransaction[0].Name);
+			Assert.Equal(SpanType, payloadSender.SpansOnFirstTransaction[0].Type);
 
 			Assert.True(payloadSender.Payloads[0].Transactions[0].Duration >= TransactionSleepLength + SpanSleepLength);
 
@@ -586,10 +586,10 @@ namespace Elastic.Apm.Tests.ApiTests
 
 			Assert.True(payloadSender.Payloads[0].Transactions[0].Duration >= TransactionSleepLength + SpanSleepLength);
 
-			Assert.NotEmpty(payloadSender.Payloads[0].Transactions[0].Spans);
+			Assert.NotEmpty(payloadSender.SpansOnFirstTransaction);
 
-			Assert.Equal(SpanName, payloadSender.Payloads[0].Transactions[0].Spans[0].Name);
-			Assert.Equal(SpanType, payloadSender.Payloads[0].Transactions[0].Spans[0].Type);
+			Assert.Equal(SpanName, payloadSender.SpansOnFirstTransaction[0].Name);
+			Assert.Equal(SpanType, payloadSender.SpansOnFirstTransaction[0].Type);
 
 			Assert.NotEmpty(payloadSender.Errors);
 			Assert.NotEmpty(payloadSender.Errors[0].Errors);

--- a/test/Elastic.Apm.Tests/ApiTests/ConvenientApiTransactionTests.cs
+++ b/test/Elastic.Apm.Tests/ApiTests/ConvenientApiTransactionTests.cs
@@ -407,7 +407,7 @@ namespace Elastic.Apm.Tests.ApiTests
 				});
 
 			//According to the Intake API tags are stored on the Context (and not on Transaction.Tags directly).
-			Assert.Equal("bar", payloadSender.Payloads[0].Transactions[0].Context.Tags["foo"]);
+			Assert.Equal("bar", payloadSender.FirstTransaction.Context.Tags["foo"]);
 
 			//Also make sure the tag is visible directly on Transaction.Tags.
 			Assert.Equal("bar", payloadSender.Payloads[0].Transactions[0].Tags["foo"]);
@@ -431,7 +431,7 @@ namespace Elastic.Apm.Tests.ApiTests
 				});
 
 			//According to the Intake API tags are stored on the Context (and not on Transaction.Tags directly).
-			Assert.Equal("bar", payloadSender.Payloads[0].Transactions[0].Context.Tags["foo"]);
+			Assert.Equal("bar", payloadSender.FirstTransaction.Context.Tags["foo"]);
 
 			//Also make sure the tag is visible directly on Transaction.Tags.
 			Assert.Equal("bar", payloadSender.Payloads[0].Transactions[0].Tags["foo"]);
@@ -461,7 +461,7 @@ namespace Elastic.Apm.Tests.ApiTests
 				});
 
 			//According to the Intake API tags are stored on the Context (and not on Transaction.Tags directly).
-			Assert.Equal("bar", payloadSender.Payloads[0].Transactions[0].Context.Tags["foo"]);
+			Assert.Equal("bar", payloadSender.FirstTransaction.Context.Tags["foo"]);
 
 			//Also make sure the tag is visible directly on Transaction.Tags.
 			Assert.Equal("bar", payloadSender.Payloads[0].Transactions[0].Tags["foo"]);

--- a/test/Elastic.Apm.Tests/BasicAgentTests.cs
+++ b/test/Elastic.Apm.Tests/BasicAgentTests.cs
@@ -1,7 +1,13 @@
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using System.Threading;
 using Elastic.Apm.Tests.Mocks;
 using Xunit;
+
+[assembly:
+	InternalsVisibleTo(
+		"Elastic.Apm.AspNetCore.Tests, PublicKey=002400000480000094000000060200000024000052534131000400000100010051df3e4d8341d66c6dfbf35b2fda3627d08073156ed98eef81122b94e86ef2e44e7980202d21826e367db9f494c265666ae30869fb4cd1a434d171f6b634aa67fa8ca5b9076d55dc3baa203d3a23b9c1296c9f45d06a45cf89520bef98325958b066d8c626db76dd60d0508af877580accdd0e9f88e46b6421bf09a33de53fe1")]
+
 
 namespace Elastic.Apm.Tests
 {

--- a/test/Elastic.Apm.Tests/HttpDiagnosticListenerTest.cs
+++ b/test/Elastic.Apm.Tests/HttpDiagnosticListenerTest.cs
@@ -174,7 +174,7 @@ namespace Elastic.Apm.Tests
 		[Fact]
 		public async Task TestSimpleOutgoingHttpRequest()
 		{
-			var (listener, payloadSender, _) = RegisterListenerAndStartTransaction();
+			var (listener, _, _) = RegisterListenerAndStartTransaction();
 
 			using (listener)
 			using (var localServer = new LocalServer())
@@ -196,9 +196,9 @@ namespace Elastic.Apm.Tests
 		/// the response code correctly
 		/// </summary>
 		[Fact]
-		public async Task TestNotSuccesfulOutgoingHttpPostRequest()
+		public async Task TestNotSuccessfulOutgoingHttpPostRequest()
 		{
-			var (listener, payloadSender, _) = RegisterListenerAndStartTransaction();
+			var (listener, _, _) = RegisterListenerAndStartTransaction();
 
 			using(listener)
 			using (var localServer = new LocalServer(ctx => { ctx.Response.StatusCode = 500; }))
@@ -323,7 +323,7 @@ namespace Elastic.Apm.Tests
 		[Fact]
 		public async Task HttpRequestDuration()
 		{
-			var (listener, payloadSender, _) = RegisterListenerAndStartTransaction();
+			var (listener, _, _) = RegisterListenerAndStartTransaction();
 
 			using(listener)
 			using (var localServer = new LocalServer(ctx =>
@@ -348,7 +348,7 @@ namespace Elastic.Apm.Tests
 		[Fact]
 		public async Task HttpRequestSpanGuid()
 		{
-			var (listener, payloadSender, _) = RegisterListenerAndStartTransaction();
+			var (listener, _, _) = RegisterListenerAndStartTransaction();
 
 			using(listener)
 			using (var localServer = new LocalServer())

--- a/test/Elastic.Apm.Tests/HttpDiagnosticListenerTest.cs
+++ b/test/Elastic.Apm.Tests/HttpDiagnosticListenerTest.cs
@@ -67,7 +67,8 @@ namespace Elastic.Apm.Tests
 		public void OnNextWithStartAndStop()
 		{
 			var logger = new TestLogger();
-			var agent = new ApmAgent(new TestAgentComponents(logger));
+			var payloadSender = new MockPayloadSender();
+			var agent = new ApmAgent(new TestAgentComponents(logger, payloadSender: payloadSender));
 			StartTransaction(agent);
 			var listener = new HttpDiagnosticListener(agent);
 
@@ -80,8 +81,8 @@ namespace Elastic.Apm.Tests
 			listener.OnNext(new KeyValuePair<string, object>("System.Net.Http.HttpRequestOut.Stop", new { Request = request, Response = response }));
 			Assert.Empty(listener.ProcessingRequests);
 
-			Assert.Equal(request.RequestUri.ToString(), Agent.TransactionContainer.Transactions.Value.Spans[0].Context.Http.Url);
-			Assert.Equal(HttpMethod.Get.ToString(), Agent.TransactionContainer.Transactions.Value.Spans[0].Context.Http.Method);
+			Assert.Equal(request.RequestUri.ToString(), (Agent.TransactionContainer.Transactions.Value.Spans[0] as Span)?.Context.Http.Url);
+			Assert.Equal(HttpMethod.Get.ToString(), (Agent.TransactionContainer.Transactions.Value.Spans[0] as Span)?.Context.Http.Method);
 		}
 
 		/// <summary>
@@ -173,7 +174,7 @@ namespace Elastic.Apm.Tests
 		[Fact]
 		public async Task TestSimpleOutgoingHttpRequest()
 		{
-			var (listener, _, _) = RegisterListenerAndStartTransaction();
+			var (listener, payloadSender, _) = RegisterListenerAndStartTransaction();
 
 			using (listener)
 			using (var localServer = new LocalServer())
@@ -182,11 +183,11 @@ namespace Elastic.Apm.Tests
 				var res = await httpClient.GetAsync(localServer.Uri);
 
 				Assert.True(res.IsSuccessStatusCode);
-				Assert.Equal(localServer.Uri, Agent.TransactionContainer.Transactions.Value.Spans[0].Context.Http.Url);
+				Assert.Equal(localServer.Uri, (Agent.TransactionContainer.Transactions.Value.Spans[0] as Span)?.Context.Http.Url);
 			}
 
-			Assert.Equal(200, Agent.TransactionContainer.Transactions.Value.Spans[0].Context.Http.StatusCode);
-			Assert.Equal(HttpMethod.Get.ToString(), Agent.TransactionContainer.Transactions.Value.Spans[0].Context.Http.Method);
+			Assert.Equal(200, (Agent.TransactionContainer.Transactions.Value.Spans[0] as Span)?.Context.Http.StatusCode);
+			Assert.Equal(HttpMethod.Get.ToString(), (Agent.TransactionContainer.Transactions.Value.Spans[0] as Span)?.Context.Http.Method);
 		}
 
 		/// <summary>
@@ -197,7 +198,7 @@ namespace Elastic.Apm.Tests
 		[Fact]
 		public async Task TestNotSuccesfulOutgoingHttpPostRequest()
 		{
-			var (listener, _, _) = RegisterListenerAndStartTransaction();
+			var (listener, payloadSender, _) = RegisterListenerAndStartTransaction();
 
 			using(listener)
 			using (var localServer = new LocalServer(ctx => { ctx.Response.StatusCode = 500; }))
@@ -206,11 +207,11 @@ namespace Elastic.Apm.Tests
 				var res = await httpClient.PostAsync(localServer.Uri, new StringContent("foo"));
 
 				Assert.False(res.IsSuccessStatusCode);
-				Assert.Equal(localServer.Uri, Agent.TransactionContainer.Transactions.Value.Spans[0].Context.Http.Url);
+				Assert.Equal(localServer.Uri, (Agent.TransactionContainer.Transactions.Value.Spans[0] as Span)?.Context.Http.Url);
 			}
 
-			Assert.Equal(500, Agent.TransactionContainer.Transactions.Value.Spans[0].Context.Http.StatusCode);
-			Assert.Equal(HttpMethod.Post.ToString(), Agent.TransactionContainer.Transactions.Value.Spans[0].Context.Http.Method);
+			Assert.Equal(500, (Agent.TransactionContainer.Transactions.Value.Spans[0] as Span)?.Context.Http.StatusCode);
+			Assert.Equal(HttpMethod.Post.ToString(), (Agent.TransactionContainer.Transactions.Value.Spans[0] as Span)?.Context.Http.Method);
 		}
 
 		/// <summary>
@@ -322,7 +323,7 @@ namespace Elastic.Apm.Tests
 		[Fact]
 		public async Task HttpRequestDuration()
 		{
-			var (listener, _, _) = RegisterListenerAndStartTransaction();
+			var (listener, payloadSender, _) = RegisterListenerAndStartTransaction();
 
 			using(listener)
 			using (var localServer = new LocalServer(ctx =>
@@ -335,7 +336,7 @@ namespace Elastic.Apm.Tests
 				var res = await httpClient.GetAsync(localServer.Uri);
 
 				Assert.True(res.IsSuccessStatusCode);
-				Assert.Equal(localServer.Uri, Agent.TransactionContainer.Transactions.Value.Spans[0].Context.Http.Url);
+				Assert.Equal(localServer.Uri, (Agent.TransactionContainer.Transactions.Value.Spans[0] as Span)?.Context.Http.Url);
 			}
 
 			Assert.True(Agent.TransactionContainer.Transactions.Value.Spans[0].Duration > 0);
@@ -347,7 +348,7 @@ namespace Elastic.Apm.Tests
 		[Fact]
 		public async Task HttpRequestSpanGuid()
 		{
-			var (listener, _, _) = RegisterListenerAndStartTransaction();
+			var (listener, payloadSender, _) = RegisterListenerAndStartTransaction();
 
 			using(listener)
 			using (var localServer = new LocalServer())
@@ -356,7 +357,7 @@ namespace Elastic.Apm.Tests
 				var res = await httpClient.GetAsync(localServer.Uri);
 
 				Assert.True(res.IsSuccessStatusCode);
-				Assert.Equal(localServer.Uri, Agent.TransactionContainer.Transactions.Value.Spans[0].Context.Http.Url);
+				Assert.Equal(localServer.Uri, (Agent.TransactionContainer.Transactions.Value.Spans[0] as Span)?.Context.Http.Url);
 			}
 
 			Assert.True(Agent.TransactionContainer.Transactions.Value.Spans[0].Id > 0);
@@ -390,10 +391,12 @@ namespace Elastic.Apm.Tests
 			});
 
 			Assert.NotEmpty(mockPayloadSender.Payloads[0].Transactions);
-			Assert.Empty(mockPayloadSender.Payloads[0].Transactions[0].Spans);
+			Assert.Empty(mockPayloadSender.SpansOnFirstTransaction);
 		}
 
-		/// <summary> Make sure HttpDiagnosticSubscriber does not report spans after its disposed</summary>
+		/// <summary>
+		/// Make sure HttpDiagnosticSubscriber does not report spans after its disposed
+		/// </summary>
 		[Fact]
 		public async Task SubscriptionOnlyRegistersSpansDuringItsLifeTime()
 		{
@@ -409,12 +412,13 @@ namespace Elastic.Apm.Tests
 				using (agent.Subscribe(new HttpDiagnosticsSubscriber()))
 				{
 					var res = await httpClient.GetAsync(localServer.Uri);
+					Assert.True(res.IsSuccessStatusCode);
 					res = await httpClient.GetAsync(localServer.Uri);
 					Assert.True(res.IsSuccessStatusCode);
 				}
 				spans = Agent.TransactionContainer.Transactions.Value.Spans;
 				Assert.True(spans.Length == 2, $"Expected 2 but spans has count: {spans.Length}");
-				foreach (var i in Enumerable.Range(0, 10))
+				foreach (var _ in Enumerable.Range(0, 10))
 					await httpClient.GetAsync(localServer.Uri);
 
 				Assert.True(localServer.SeenRequests > 10, "Make sure we actually performed more than 1 request to our local server");
@@ -452,10 +456,10 @@ namespace Elastic.Apm.Tests
 				});
 
 				Assert.NotEmpty(mockPayloadSender.Payloads[0].Transactions);
-				Assert.NotEmpty(mockPayloadSender.Payloads[0].Transactions[0].Spans);
+				Assert.NotEmpty(mockPayloadSender.SpansOnFirstTransaction);
 
-				Assert.NotNull(mockPayloadSender.Payloads[0].Transactions[0].Spans[0].Context.Http);
-				Assert.Equal(url, mockPayloadSender.Payloads[0].Transactions[0].Spans[0].Context.Http.Url);
+				Assert.NotNull(mockPayloadSender.SpansOnFirstTransaction[0].Context.Http);
+				Assert.Equal(url, mockPayloadSender.SpansOnFirstTransaction[0].Context.Http.Url);
 			}
 		}
 
@@ -507,22 +511,22 @@ namespace Elastic.Apm.Tests
 			});
 
 			Assert.NotNull(mockPayloadSender.Payloads[0].Transactions[0]);
-			Assert.Empty(mockPayloadSender.Payloads[0].Transactions[0].Spans);
+			Assert.Empty(mockPayloadSender.SpansOnFirstTransaction);
 		}
 
 		private (IDisposable, MockPayloadSender, ApmAgent) RegisterListenerAndStartTransaction()
 		{
 			var payloadSender = new MockPayloadSender();
 			var agent = new ApmAgent(new TestAgentComponents(payloadSender: payloadSender));
-			var subscriber = new HttpDiagnosticsSubscriber();
-			var sub = agent.Subscribe(subscriber);
+			var sub = agent.Subscribe(new HttpDiagnosticsSubscriber());
 			StartTransaction(agent);
 
 			return (sub, payloadSender, agent);
 		}
 
 		private void StartTransaction(ApmAgent agent)
-			=> Agent.TransactionContainer.Transactions.Value =
-				new Transaction(agent, $"{nameof(TestSimpleOutgoingHttpRequest)}", ApiConstants.TypeRequest);
+			//	=> agent.TransactionContainer.Transactions.Value =
+			//		new Transaction(agent, $"{nameof(TestSimpleOutgoingHttpRequest)}", ApiConstants.TypeRequest);
+			=> agent.Tracer.StartTransaction($"{nameof(TestSimpleOutgoingHttpRequest)}", ApiConstants.TypeRequest);
 	}
 }

--- a/test/Elastic.Apm.Tests/Mocks/MockPayloadSender.cs
+++ b/test/Elastic.Apm.Tests/Mocks/MockPayloadSender.cs
@@ -1,16 +1,24 @@
 ﻿using System.Collections.Generic;
+using Elastic.Apm.Api;
 using Elastic.Apm.Model.Payload;
 using Elastic.Apm.Report;
 
 namespace Elastic.Apm.Tests.Mocks
 {
-	public class MockPayloadSender : IPayloadSender
+	internal class MockPayloadSender : IPayloadSender
 	{
 		public readonly List<Error> Errors = new List<Error>();
-		public readonly List<Payload> Payloads = new List<Payload>();
+		public readonly List<IPayload> Payloads = new List<IPayload>();
 
 		public void QueueError(Error error) => Errors.Add(error);
+		public void QueuePayload(IPayload payload) => Payloads.Add(payload);
 
-		public void QueuePayload(Payload payload) => Payloads.Add(payload);
+		public Span[] SpansOnFirstTransaction => (Payloads[0].Transactions[0] as Transaction)?.Spans as Span[];
+		public Transaction FirstTransaction => Payloads[0].Transactions[0] as Transaction;
+
+		/// <summary>
+		/// The 1. Span on the 1. Transaction
+		/// </summary>
+		public Span FirstSpan => (Payloads[0].Transactions[0] as Transaction)?.Spans[0] as Span;
 	}
 }

--- a/test/Elastic.Apm.Tests/Mocks/MockPayloadSender.cs
+++ b/test/Elastic.Apm.Tests/Mocks/MockPayloadSender.cs
@@ -7,14 +7,16 @@ namespace Elastic.Apm.Tests.Mocks
 {
 	internal class MockPayloadSender : IPayloadSender
 	{
-		public readonly List<Error> Errors = new List<Error>();
+		public readonly List<IError> Errors = new List<IError>();
 		public readonly List<IPayload> Payloads = new List<IPayload>();
 
-		public void QueueError(Error error) => Errors.Add(error);
+		public void QueueError(IError error) => Errors.Add(error);
 		public void QueuePayload(IPayload payload) => Payloads.Add(payload);
 
 		public Span[] SpansOnFirstTransaction => (Payloads[0].Transactions[0] as Transaction)?.Spans as Span[];
 		public Transaction FirstTransaction => Payloads[0].Transactions[0] as Transaction;
+
+		public Error.ErrorDetail FirstErrorDetail => Errors[0].Errors[0] as Error.ErrorDetail;
 
 		/// <summary>
 		/// The 1. Span on the 1. Transaction

--- a/test/Elastic.Apm.Tests/Mocks/TestLogger.cs
+++ b/test/Elastic.Apm.Tests/Mocks/TestLogger.cs
@@ -11,6 +11,6 @@ namespace Elastic.Apm.Tests.Mocks
 
 		public List<string> Lines { get; } = new List<string>();
 
-		protected override void PrintLogline(string logline) => Lines.Add(logline);
+		protected override void PrintLogLine(string logline) => Lines.Add(logline);
 	}
 }


### PR DESCRIPTION
The purpose of this change is to make sure that the agent initially only has a minimal public API surface. Therefore lots of public things became internal. The intention is to avoid braking changes later. #77 

- `IDiagnosticListener` and all its implementors became internal. `IDiagnosticsSubscriber` and its implementors remain public. This way from the user's perspective it's easier to know how to subscribe: just use the subscribers, and don't care about the listeners, that's handled internally.
- Lots of classes from `Elastic.Apm.Model.Payload` became internal.
- Introduced `IError` interface, mainly because the `Error` class leaked lots of internal information that is not relevant to users.
- Removed a couple of properties from `ITransaction` and `ISpan`, which could potentially cause problems when users set data that is not accepted by the server. Those properties are available on `Transaction` and `Span`.
- Due to the previous point I added `internal Span StartSpanInternal` to `Transaction` and `internal Transaction StartTransactionInternal` to `Tracer`. These can be used in agent dlls to access properties that are not on the public interface.

- Plus added code signing to `SampleAspNetCoreApp.csproj` to avoid build warnings. (It is referenced from a test project, which is signed, so it also should be signed, which it is from now on). 