### PR TITLE
PayloadSender improvements

### DIFF
--- a/src/Elastic.Apm/Elastic.Apm.csproj
+++ b/src/Elastic.Apm/Elastic.Apm.csproj
@@ -21,5 +21,6 @@
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
     <!-- TODO: Are we ok with this reference/version? -->
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="4.0.0" />
+    <PackageReference Include="System.Threading.Tasks.Dataflow" Version="4.9.0" />
   </ItemGroup>
 </Project>

--- a/src/Elastic.Apm/Report/PayloadSender.cs
+++ b/src/Elastic.Apm/Report/PayloadSender.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Concurrent;
 using System.Linq;
 using System.Net;
@@ -29,12 +29,7 @@ namespace Elastic.Apm.Report
 
 		private static readonly int DnsTimeout = (int)TimeSpan.FromMinutes(1).TotalMilliseconds;
 
-		static PayloadSender()
-		{
-			ServicePointManager.DnsRefreshTimeout = DnsTimeout;
-			ServicePointManager.DefaultConnectionLimit = 20;
-		}
-
+		static PayloadSender() => ServicePointManager.DnsRefreshTimeout = DnsTimeout;
 
 		internal PayloadSender(AbstractLogger logger, IConfigurationReader configurationReader)
 		{
@@ -42,7 +37,10 @@ namespace Elastic.Apm.Report
 			_settings = new JsonSerializerSettings { ContractResolver = new CamelCasePropertyNamesContractResolver() };
 
 			var serverUrlBase = configurationReader.ServerUrls.First();
-			ServicePointManager.FindServicePoint(serverUrlBase).ConnectionLeaseTimeout = DnsTimeout;
+			var servicePoint = ServicePointManager.FindServicePoint(serverUrlBase);
+
+			servicePoint.ConnectionLeaseTimeout = DnsTimeout;
+			servicePoint.ConnectionLimit = 20;
 
 			_httpClient = new HttpClient
 			{

--- a/test/Elastic.Apm.Tests/ApiTests/ConvenientApiTransactionTests.cs
+++ b/test/Elastic.Apm.Tests/ApiTests/ConvenientApiTransactionTests.cs
@@ -483,7 +483,8 @@ namespace Elastic.Apm.Tests.ApiTests
 			Assert.Equal(TransactionName, payloadSender.Payloads[0].Transactions[0].Name);
 			Assert.Equal(TransactionType, payloadSender.Payloads[0].Transactions[0].Type);
 
-			Assert.True(payloadSender.Payloads[0].Transactions[0].Duration >= SleepLength);
+			var duration = payloadSender.FirstTransaction.Duration;
+			Assert.True(duration >= SleepLength, $"Expected {duration} to be greater or equal to: {SleepLength}");
 			return payloadSender;
 		}
 


### PR DESCRIPTION
* Reuse http client (with DNS timeouts)
* Reuse json .NET ContractResolver
* Move to `BatchBlock<>` from `TPL Dataflow` over `BlockingCollection<>` (`System.Threading.Channels` also has similar constructs). 