### PR TITLE
Fix null logger in AbstractConfigurationReader

### DIFF
--- a/sample/SampleAspNetCoreApp/appsettings.json
+++ b/sample/SampleAspNetCoreApp/appsettings.json
@@ -6,9 +6,9 @@
   },
   "AllowedHosts": "*"//,
   //Settings for the elastic APM Agent
-  //"ElasticApm":
-  //  {
-  //    "LogLevel":  "Debug",
-  //    "ServerUrls":  "myServer"
-  //  }
+//  "ElasticApm":
+//    {
+//      "LogLevel":  "Debug",
+//      "ServerUrls":  "http://localhost:8200"
+//    }
 }

--- a/src/Elastic.Apm.AspNetCore/ApmMiddlewareExtension.cs
+++ b/src/Elastic.Apm.AspNetCore/ApmMiddlewareExtension.cs
@@ -6,6 +6,7 @@ using Elastic.Apm.AspNetCore.Config;
 using Elastic.Apm.AspNetCore.DiagnosticListener;
 using Elastic.Apm.Config;
 using Elastic.Apm.DiagnosticSource;
+using Elastic.Apm.Logging;
 using Elastic.Apm.Model.Payload;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.Configuration;
@@ -34,13 +35,14 @@ namespace Elastic.Apm.AspNetCore
 			params IDiagnosticsSubscriber[] subscribers
 		)
 		{
+			var logger = ConsoleLogger.Instance;
 			var configReader = configuration == null
-				? new EnvironmentConfigurationReader()
-				: new MicrosoftExtensionsConfig(configuration) as IConfigurationReader;
+				? new EnvironmentConfigurationReader(logger)
+				: new MicrosoftExtensionsConfig(configuration, logger) as IConfigurationReader;
 
 			var service = GetService(configReader);
 
-			var config = new AgentComponents(configurationReader: configReader, service: service);
+			var config = new AgentComponents(configurationReader: configReader, service: service, logger: logger);
 			Agent.Setup(config);
 			return UseElasticApm(builder, Agent.Instance, subscribers);
 		}

--- a/src/Elastic.Apm.AspNetCore/Config/MicrosoftExtensionsConfig.cs
+++ b/src/Elastic.Apm.AspNetCore/Config/MicrosoftExtensionsConfig.cs
@@ -23,7 +23,7 @@ namespace Elastic.Apm.AspNetCore.Config
 
 		private readonly IConfiguration _configuration;
 
-		public MicrosoftExtensionsConfig(IConfiguration configuration, AbstractLogger logger = null) : base(logger)
+		public MicrosoftExtensionsConfig(IConfiguration configuration, AbstractLogger logger = null) : base(logger ?? ConsoleLogger.Instance)
 		{
 			_configuration = configuration;
 			_configuration.GetSection("ElasticApm")

--- a/src/Elastic.Apm.AspNetCore/Config/MicrosoftExtensionsConfig.cs
+++ b/src/Elastic.Apm.AspNetCore/Config/MicrosoftExtensionsConfig.cs
@@ -23,7 +23,7 @@ namespace Elastic.Apm.AspNetCore.Config
 
 		private readonly IConfiguration _configuration;
 
-		public MicrosoftExtensionsConfig(IConfiguration configuration, AbstractLogger logger = null) : base(logger ?? ConsoleLogger.Instance)
+		public MicrosoftExtensionsConfig(IConfiguration configuration, AbstractLogger logger) : base(logger)
 		{
 			_configuration = configuration;
 			_configuration.GetSection("ElasticApm")

--- a/src/Elastic.Apm/Agent.cs
+++ b/src/Elastic.Apm/Agent.cs
@@ -60,8 +60,8 @@ namespace Elastic.Apm
 
 	public static class Agent
 	{
-		private static readonly Lazy<ApmAgent> Lazy = new Lazy<ApmAgent>(() => new ApmAgent(_config));
-		private static AgentComponents _config;
+		private static readonly Lazy<ApmAgent> Lazy = new Lazy<ApmAgent>(() => new ApmAgent(_components));
+		private static AgentComponents _components;
 
 
 		public static IConfigurationReader Config => Lazy.Value.ConfigurationReader;
@@ -94,7 +94,7 @@ namespace Elastic.Apm
 		{
 			if (Lazy.IsValueCreated) throw new Exception("The singleton APM agent has already been instantiated and can no longer be configured");
 
-			_config = agentComponents;
+			_components = agentComponents;
 		}
 	}
 }

--- a/src/Elastic.Apm/Config/AbstractConfigurationReader.cs
+++ b/src/Elastic.Apm/Config/AbstractConfigurationReader.cs
@@ -10,7 +10,7 @@ namespace Elastic.Apm.Config
 	{
 		protected AbstractConfigurationReader(AbstractLogger logger) => Logger = logger;
 
-		internal AbstractLogger Logger { get; }
+		protected AbstractLogger Logger { get; }
 
 		protected static ConfigurationKeyValue Kv(string key, string value, string origin) =>
 			new ConfigurationKeyValue(key, value, origin);

--- a/src/Elastic.Apm/Config/AbstractConfigurationReader.cs
+++ b/src/Elastic.Apm/Config/AbstractConfigurationReader.cs
@@ -10,7 +10,7 @@ namespace Elastic.Apm.Config
 	{
 		protected AbstractConfigurationReader(AbstractLogger logger) => Logger = logger;
 
-		protected AbstractLogger Logger { get; }
+		internal AbstractLogger Logger { get; }
 
 		protected static ConfigurationKeyValue Kv(string key, string value, string origin) =>
 			new ConfigurationKeyValue(key, value, origin);
@@ -24,7 +24,7 @@ namespace Elastic.Apm.Config
 
 			if (Enum.TryParse<LogLevel>(kv.Value, out var logLevel)) return logLevel;
 
-			Logger?.LogError("Config",
+			Logger.LogError("Config",
 				$"Failed parsing log level from {kv.ReadFrom}: {kv.Key}, value: {kv.Value}. Defaulting to log level 'Error'");
 
 			return AbstractLogger.LogLevelDefault;
@@ -45,7 +45,7 @@ namespace Elastic.Apm.Config
 					continue;
 				}
 
-				Logger?.LogError(name, $"Failed parsing server URL from {kv.ReadFrom}: {kv.Key}, value: {u}");
+				Logger.LogError(name, $"Failed parsing server URL from {kv.ReadFrom}: {kv.Key}, value: {u}");
 			}
 
 			return list.Count == 0 ? LogAndReturnDefault().AsReadOnly() : list.AsReadOnly();
@@ -53,7 +53,7 @@ namespace Elastic.Apm.Config
 			List<Uri> LogAndReturnDefault()
 			{
 				list.Add(ConfigConsts.DefaultServerUri);
-				Logger?.LogDebug(name, $"Using default ServerUrl: {ConfigConsts.DefaultServerUri}");
+				Logger.LogDebug(name, $"Using default ServerUrl: {ConfigConsts.DefaultServerUri}");
 				return list;
 			}
 
@@ -73,7 +73,7 @@ namespace Elastic.Apm.Config
 			var retVal = kv.Value;
 			if (string.IsNullOrEmpty(retVal))
 			{
-				Logger?.LogInfo("Config", "The agent was started without a service name. The service name will be automatically calculated.");
+				Logger.LogInfo("Config", "The agent was started without a service name. The service name will be automatically calculated.");
 				retVal = Assembly.GetEntryAssembly()?.GetName().Name;
 			}
 
@@ -95,7 +95,7 @@ namespace Elastic.Apm.Config
 
 			if (string.IsNullOrEmpty(retVal))
 			{
-				Logger?.LogError("Config", "Failed calculating service name, the service name will be \'unknown\'." +
+				Logger.LogError("Config", "Failed calculating service name, the service name will be \'unknown\'." +
 					$" You can fix this by setting the service name to a specific value (e.g. by using the environment variable {ConfigConsts.ConfigKeys.ServiceName})");
 				retVal = "unknown";
 			}

--- a/src/Elastic.Apm/Config/EnvironmentConfigurationReader.cs
+++ b/src/Elastic.Apm/Config/EnvironmentConfigurationReader.cs
@@ -8,8 +8,7 @@ namespace Elastic.Apm.Config
 	{
 		internal const string Origin = "environment";
 
-
-		public EnvironmentConfigurationReader(AbstractLogger logger = null) : base(logger) { }
+		public EnvironmentConfigurationReader(AbstractLogger logger = null) : base(logger ?? ConsoleLogger.Instance) { }
 
 		public LogLevel LogLevel => ParseLogLevel(Read(ConfigConsts.ConfigKeys.Level));
 

--- a/src/Elastic.Apm/Config/EnvironmentConfigurationReader.cs
+++ b/src/Elastic.Apm/Config/EnvironmentConfigurationReader.cs
@@ -8,7 +8,7 @@ namespace Elastic.Apm.Config
 	{
 		internal const string Origin = "environment";
 
-		public EnvironmentConfigurationReader(AbstractLogger logger = null) : base(logger ?? ConsoleLogger.Instance) { }
+		public EnvironmentConfigurationReader(AbstractLogger logger) : base(logger) { }
 
 		public LogLevel LogLevel => ParseLogLevel(Read(ConfigConsts.ConfigKeys.Level));
 

--- a/src/Elastic.Apm/Consts.cs
+++ b/src/Elastic.Apm/Consts.cs
@@ -3,7 +3,7 @@
 	internal static class Consts
 	{
 		public static string IntakeV1Errors = "v1/errors";
-		public static string IntakeV1Transactions = "/v1/transactions";
+		public static string IntakeV1Transactions = "v1/transactions";
 
 		public static string AgentName => "dotNet";
 	}

--- a/src/Elastic.Apm/DiagnosticSource/DiagnosticInitializer.cs
+++ b/src/Elastic.Apm/DiagnosticSource/DiagnosticInitializer.cs
@@ -19,8 +19,10 @@ namespace Elastic.Apm.DiagnosticSource
 		public void OnNext(DiagnosticListener value)
 		{
 			foreach (var listener in _listeners)
+			{
 				if (value.Name == listener.Name)
 					_sourceSubscription = value.Subscribe(listener);
+			}
 		}
 
 		public void Dispose() => _sourceSubscription?.Dispose();

--- a/test/Elastic.Apm.Tests/ApiTests/ConvenientApiSpanTests.cs
+++ b/test/Elastic.Apm.Tests/ApiTests/ConvenientApiSpanTests.cs
@@ -524,7 +524,8 @@ namespace Elastic.Apm.Tests.ApiTests
 			Assert.Equal(TransactionName, payloadSender.Payloads[0].Transactions[0].Name);
 			Assert.Equal(TransactionType, payloadSender.Payloads[0].Transactions[0].Type);
 
-			Assert.True(payloadSender.Payloads[0].Transactions[0].Duration >= TransactionSleepLength + SpanSleepLength);
+			var duration = payloadSender.FirstTransaction.Duration;
+			Assert.True(duration >= TransactionSleepLength + SpanSleepLength, $"Expected {duration} to be greater or equal to: {TransactionSleepLength + SpanSleepLength}");
 
 			Assert.NotEmpty(payloadSender.SpansOnFirstTransaction);
 

--- a/test/Elastic.Apm.Tests/ConfigTest.cs
+++ b/test/Elastic.Apm.Tests/ConfigTest.cs
@@ -208,5 +208,16 @@ namespace Elastic.Apm.Tests
 					mscorlibToken[3], elasticToken[4], mscorlibToken[5], elasticToken[6], mscorlibToken[7]
 				}));
 		}
+
+		/// <summary>
+		/// Makes sure that even if the <see cref="EnvironmentConfigurationReader" /> is initialized without a logger
+		/// it still defaults to some kind of logger.
+		/// </summary>
+		[Fact]
+		public void LoggerNotNull()
+		{
+			var config = new EnvironmentConfigurationReader();
+			Assert.NotNull(config.Logger);
+		}
 	}
 }


### PR DESCRIPTION
Addresses #80. 

Summary: 

- Defining server urls without protocol is still not allowed, that's defined by the [documentation](https://github.com/elastic/apm-agent-dotnet/blob/master/docs/configuration.asciidoc#serverurls) and this is also what other agents do. (I guess mainly because it's hard to default to something... should it be `http`? `https`?)
- If this happens (or the entered value is invalid from another reason) the agent prints a log line with something like this:
`Error MicrosoftExtensionsConfig: Failed parsing server URL from Configuration Provider: ElasticApm:ServerUrls, value: localhost:8200`
- This was already implemented, but did not work, because the `Logger` was `null` on the `AbstractConfigurationReader`. This is fixed now.
- Plus added tests. 