### PR TITLE
[docs] Add release banner and prototype warning

### DIFF
--- a/docs/intro.asciidoc
+++ b/docs/intro.asciidoc
@@ -7,6 +7,9 @@ endif::[]
 
 == Introduction
 
+WARNING: **This project is currently a prototype.
+Use it at your own risk.**
+
 Welcome to the APM .NET Agent documentation.
 
 Elastic APM automatically measures the performance of your application and tracks errors.

--- a/docs/page_header.html
+++ b/docs/page_header.html
@@ -1,0 +1,1 @@
+You are looking at preliminary documentation for a future release.


### PR DESCRIPTION
Adds a warning and banner indicating this agent has not yet been released officially. 
<img width="797" alt="screen shot 2019-02-04 at 5 26 42 pm" src="https://user-images.githubusercontent.com/5618806/52241562-109c4300-28a2-11e9-8561-b68a38c08e53.png">
