### PR TITLE
Add GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/Bug_report.md
+++ b/.github/ISSUE_TEMPLATE/Bug_report.md
@@ -1,0 +1,18 @@
+---
+name: Bug report
+about: Create a report to help us improve
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Use this config '...'
+2. Then call '....'
+3. Then do '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.

--- a/.github/ISSUE_TEMPLATE/Feature_request.md
+++ b/.github/ISSUE_TEMPLATE/Feature_request.md
@@ -1,0 +1,17 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATE/Question.md
+++ b/.github/ISSUE_TEMPLATE/Question.md
@@ -1,0 +1,7 @@
+---
+name: Question
+about: Please use the discuss forum (https://discuss.elastic.co/c/apm) to ask questions
+
+---
+
+Please use the [discuss forum](https://discuss.elastic.co/c/apm) to ask questions. 


### PR DESCRIPTION
- Copied from the https://github.com/elastic/apm-agent-java repo. 
- One change compared to the java: we don't have troubleshooting documentation, so I removed that part for now.
