### PR TITLE
Duration fix

### DIFF
--- a/src/Elastic.Apm/Api/ITransaction.cs
+++ b/src/Elastic.Apm/Api/ITransaction.cs
@@ -13,7 +13,7 @@ namespace Elastic.Apm.Api
 		/// is automatically calculated when <see cref="End" /> is called.
 		/// </summary>
 		/// <value>The duration.</value>
-		long? Duration { get; set; } //TODO datatype?
+		double? Duration { get; set; }
 
 		Guid Id { get; }
 

--- a/src/Elastic.Apm/Model/Payload/Transaction.cs
+++ b/src/Elastic.Apm/Model/Payload/Transaction.cs
@@ -45,7 +45,7 @@ namespace Elastic.Apm.Model.Payload
 		/// is automatically calculated when <see cref="End" /> is called.
 		/// </summary>
 		/// <value>The duration.</value>
-		public long? Duration { get; set; } //TODO datatype?, TODO: Greg, imo should be internal, TBD!
+		public double? Duration { get; set; } //TODO datatype?, TODO: Greg, imo should be internal, TBD!
 
 		public Guid Id { get; }
 
@@ -76,7 +76,7 @@ namespace Elastic.Apm.Model.Payload
 
 		public void End()
 		{
-			if (!Duration.HasValue) Duration = (long)(DateTimeOffset.UtcNow - Start).TotalMilliseconds;
+			if (!Duration.HasValue) Duration = (DateTimeOffset.UtcNow - Start).TotalMilliseconds;
 
 			_sender.QueuePayload(new Payload
 			{

--- a/test/Elastic.Apm.Tests/ApiTests/ConvenientApiSpanTests.cs
+++ b/test/Elastic.Apm.Tests/ApiTests/ConvenientApiSpanTests.cs
@@ -22,10 +22,10 @@ namespace Elastic.Apm.Tests.ApiTests
 	{
 		private const string ExceptionMessage = "Foo";
 		private const string SpanName = "TestSpan";
-		private const int SpanSleepLength = 20;
+		private const int SpanSleepLength = 25;
 		private const string SpanType = "TestSpan";
 		private const string TransactionName = "ConvenientApiTest";
-		private const int TransactionSleepLength = 10;
+		private const int TransactionSleepLength = 20;
 		private const string TransactionType = "Test";
 
 		/// <summary>

--- a/test/Elastic.Apm.Tests/ApiTests/ConvenientApiTransactionTests.cs
+++ b/test/Elastic.Apm.Tests/ApiTests/ConvenientApiTransactionTests.cs
@@ -21,7 +21,7 @@ namespace Elastic.Apm.Tests.ApiTests
 	public class ConvenientApiTransactionTests
 	{
 		private const string ExceptionMessage = "Foo";
-		private const int SleepLength = 10;
+		private const int SleepLength = 20;
 		private const string TransactionName = "ConvenientApiTest";
 		private const string TransactionType = "Test";
 


### PR DESCRIPTION
Fixes  #94.

- Change `ITransaction.Duration` from `long` to `double`. 
- Adapts `await Task.Delay()` to OS`s timer.

More detail on #94. 
