### PR TITLE
Fix failing API tests - again

### DIFF
--- a/test/Elastic.Apm.Tests/ApiTests/ConvenientApiSpanTests.cs
+++ b/test/Elastic.Apm.Tests/ApiTests/ConvenientApiSpanTests.cs
@@ -22,10 +22,10 @@ namespace Elastic.Apm.Tests.ApiTests
 	{
 		private const string ExceptionMessage = "Foo";
 		private const string SpanName = "TestSpan";
-		private const int SpanSleepLength = 150;
+		private const int SpanSleepLength = 450;
 		private const string SpanType = "TestSpan";
 		private const string TransactionName = "ConvenientApiTest";
-		private const int TransactionSleepLength = 130;
+		private const int TransactionSleepLength = 600;
 		private const string TransactionType = "Test";
 
 		/// <summary>
@@ -545,7 +545,7 @@ namespace Elastic.Apm.Tests.ApiTests
 
 			agent.Tracer.CaptureTransaction(TransactionName, TransactionType, t =>
 			{
-				Thread.Sleep(SpanSleepLength);
+				Thread.Sleep(TransactionSleepLength);
 				action(t);
 			});
 
@@ -560,7 +560,8 @@ namespace Elastic.Apm.Tests.ApiTests
 			Assert.Equal(SpanName, payloadSender.SpansOnFirstTransaction[0].Name);
 			Assert.Equal(SpanType, payloadSender.SpansOnFirstTransaction[0].Type);
 
-			Assert.True(payloadSender.Payloads[0].Transactions[0].Duration >= TransactionSleepLength + SpanSleepLength);
+			var duration = payloadSender.Payloads[0].Transactions[0].Duration;
+			Assert.True(duration >= TransactionSleepLength + SpanSleepLength, $"Expected {duration} to be greater or equal to: {TransactionSleepLength + SpanSleepLength}");
 
 			return payloadSender;
 		}
@@ -575,7 +576,7 @@ namespace Elastic.Apm.Tests.ApiTests
 
 			agent.Tracer.CaptureTransaction(TransactionName, TransactionType, t =>
 			{
-				Thread.Sleep(SpanSleepLength);
+				Thread.Sleep(TransactionSleepLength);
 				action(t);
 			});
 
@@ -585,7 +586,8 @@ namespace Elastic.Apm.Tests.ApiTests
 			Assert.Equal(TransactionName, payloadSender.Payloads[0].Transactions[0].Name);
 			Assert.Equal(TransactionType, payloadSender.Payloads[0].Transactions[0].Type);
 
-			Assert.True(payloadSender.Payloads[0].Transactions[0].Duration >= TransactionSleepLength + SpanSleepLength);
+			var duration = payloadSender.Payloads[0].Transactions[0].Duration;
+			Assert.True(duration >= TransactionSleepLength + SpanSleepLength, $"Expected {duration} to be greater or equal to: {TransactionSleepLength + SpanSleepLength}");
 
 			Assert.NotEmpty(payloadSender.SpansOnFirstTransaction);
 

--- a/test/Elastic.Apm.Tests/ApiTests/ConvenientApiSpanTests.cs
+++ b/test/Elastic.Apm.Tests/ApiTests/ConvenientApiSpanTests.cs
@@ -22,10 +22,10 @@ namespace Elastic.Apm.Tests.ApiTests
 	{
 		private const string ExceptionMessage = "Foo";
 		private const string SpanName = "TestSpan";
-		private const int SpanSleepLength = 450;
+		private const int SpanSleepLength = 30;
 		private const string SpanType = "TestSpan";
 		private const string TransactionName = "ConvenientApiTest";
-		private const int TransactionSleepLength = 600;
+		private const int TransactionSleepLength = 60;
 		private const string TransactionType = "Test";
 
 		/// <summary>
@@ -486,7 +486,10 @@ namespace Elastic.Apm.Tests.ApiTests
 			Assert.Equal(TransactionName, payloadSender.Payloads[0].Transactions[0].Name);
 			Assert.Equal(TransactionType, payloadSender.Payloads[0].Transactions[0].Type);
 
-			Assert.True(payloadSender.Payloads[0].Transactions[0].Duration >= TransactionSleepLength + SpanSleepLength);
+			//`await Task.Delay` is inaccurate, so we enable 10% error in the test
+			var expectedTransactionLength = (TransactionSleepLength + SpanSleepLength) - (TransactionSleepLength * 0.1 + SpanSleepLength * 0.1);
+			var duration = payloadSender.Payloads[0].Transactions[0].Duration;
+			Assert.True(duration >= expectedTransactionLength, $"Expected {duration} to be greater or equal to: {expectedTransactionLength}");
 
 			Assert.NotEmpty(payloadSender.SpansOnFirstTransaction);
 
@@ -524,8 +527,10 @@ namespace Elastic.Apm.Tests.ApiTests
 			Assert.Equal(TransactionName, payloadSender.Payloads[0].Transactions[0].Name);
 			Assert.Equal(TransactionType, payloadSender.Payloads[0].Transactions[0].Type);
 
-			var duration = payloadSender.FirstTransaction.Duration;
-			Assert.True(duration >= TransactionSleepLength + SpanSleepLength, $"Expected {duration} to be greater or equal to: {TransactionSleepLength + SpanSleepLength}");
+			//`await Task.Delay` is inaccurate, so we enable 10% error in the test
+			var expectedTransactionLength = (TransactionSleepLength + SpanSleepLength) - (TransactionSleepLength * 0.1 + SpanSleepLength * 0.1);
+			var duration = payloadSender.Payloads[0].Transactions[0].Duration;
+			Assert.True(duration >= expectedTransactionLength, $"Expected {duration} to be greater or equal to: {expectedTransactionLength}");
 
 			Assert.NotEmpty(payloadSender.SpansOnFirstTransaction);
 
@@ -560,8 +565,10 @@ namespace Elastic.Apm.Tests.ApiTests
 			Assert.Equal(SpanName, payloadSender.SpansOnFirstTransaction[0].Name);
 			Assert.Equal(SpanType, payloadSender.SpansOnFirstTransaction[0].Type);
 
+			//`await Task.Delay` is inaccurate, so we enable 10% error in the test
+			var expectedTransactionLength = (TransactionSleepLength + SpanSleepLength) - (TransactionSleepLength * 0.1 + SpanSleepLength * 0.1);
 			var duration = payloadSender.Payloads[0].Transactions[0].Duration;
-			Assert.True(duration >= TransactionSleepLength + SpanSleepLength, $"Expected {duration} to be greater or equal to: {TransactionSleepLength + SpanSleepLength}");
+			Assert.True(duration >= expectedTransactionLength, $"Expected {duration} to be greater or equal to: {expectedTransactionLength}");
 
 			return payloadSender;
 		}
@@ -586,8 +593,10 @@ namespace Elastic.Apm.Tests.ApiTests
 			Assert.Equal(TransactionName, payloadSender.Payloads[0].Transactions[0].Name);
 			Assert.Equal(TransactionType, payloadSender.Payloads[0].Transactions[0].Type);
 
+			//`await Task.Delay` is inaccurate, so we enable 10% error in the test
+			var expectedTransactionLength = (TransactionSleepLength + SpanSleepLength) - (TransactionSleepLength * 0.1 + SpanSleepLength * 0.1);
 			var duration = payloadSender.Payloads[0].Transactions[0].Duration;
-			Assert.True(duration >= TransactionSleepLength + SpanSleepLength, $"Expected {duration} to be greater or equal to: {TransactionSleepLength + SpanSleepLength}");
+			Assert.True(duration >= expectedTransactionLength, $"Expected {duration} to be greater or equal to: {expectedTransactionLength}");
 
 			Assert.NotEmpty(payloadSender.SpansOnFirstTransaction);
 

--- a/test/Elastic.Apm.Tests/ApiTests/ConvenientApiSpanTests.cs
+++ b/test/Elastic.Apm.Tests/ApiTests/ConvenientApiSpanTests.cs
@@ -22,10 +22,10 @@ namespace Elastic.Apm.Tests.ApiTests
 	{
 		private const string ExceptionMessage = "Foo";
 		private const string SpanName = "TestSpan";
-		private const int SpanSleepLength = 33;
+		private const int SpanSleepLength = 150;
 		private const string SpanType = "TestSpan";
 		private const string TransactionName = "ConvenientApiTest";
-		private const int TransactionSleepLength = 32;
+		private const int TransactionSleepLength = 130;
 		private const string TransactionType = "Test";
 
 		/// <summary>

--- a/test/Elastic.Apm.Tests/ApiTests/ConvenientApiSpanTests.cs
+++ b/test/Elastic.Apm.Tests/ApiTests/ConvenientApiSpanTests.cs
@@ -22,10 +22,10 @@ namespace Elastic.Apm.Tests.ApiTests
 	{
 		private const string ExceptionMessage = "Foo";
 		private const string SpanName = "TestSpan";
-		private const int SpanSleepLength = 30;
+		private const int SpanSleepLength = 450;
 		private const string SpanType = "TestSpan";
 		private const string TransactionName = "ConvenientApiTest";
-		private const int TransactionSleepLength = 60;
+		private const int TransactionSleepLength = 300;
 		private const string TransactionType = "Test";
 
 		/// <summary>

--- a/test/Elastic.Apm.Tests/ApiTests/ConvenientApiTransactionTests.cs
+++ b/test/Elastic.Apm.Tests/ApiTests/ConvenientApiTransactionTests.cs
@@ -21,7 +21,7 @@ namespace Elastic.Apm.Tests.ApiTests
 	public class ConvenientApiTransactionTests
 	{
 		private const string ExceptionMessage = "Foo";
-		private const int SleepLength = 150;
+		private const int SleepLength = 450;
 		private const string TransactionName = "ConvenientApiTest";
 		private const string TransactionType = "Test";
 
@@ -504,8 +504,8 @@ namespace Elastic.Apm.Tests.ApiTests
 			Assert.Equal(TransactionName, payloadSender.Payloads[0].Transactions[0].Name);
 			Assert.Equal(TransactionType, payloadSender.Payloads[0].Transactions[0].Type);
 
-			Assert.True(payloadSender.Payloads[0].Transactions[0].Duration >= SleepLength);
-
+			var duration = payloadSender.Payloads[0].Transactions[0].Duration;
+			Assert.True(duration >= SleepLength, $"Expected {duration} to be greater or equal to: {SleepLength}");
 
 			Assert.NotEmpty(payloadSender.Errors);
 			Assert.NotEmpty(payloadSender.Errors[0].Errors);
@@ -531,7 +531,8 @@ namespace Elastic.Apm.Tests.ApiTests
 			Assert.Equal(TransactionName, payloadSender.Payloads[0].Transactions[0].Name);
 			Assert.Equal(TransactionType, payloadSender.Payloads[0].Transactions[0].Type);
 
-			Assert.True(payloadSender.Payloads[0].Transactions[0].Duration >= SleepLength);
+			var duration = payloadSender.Payloads[0].Transactions[0].Duration;
+			Assert.True(duration >= SleepLength, $"Expected {duration} to be greater or equal to: {SleepLength}");
 
 			return payloadSender;
 		}

--- a/test/Elastic.Apm.Tests/ApiTests/ConvenientApiTransactionTests.cs
+++ b/test/Elastic.Apm.Tests/ApiTests/ConvenientApiTransactionTests.cs
@@ -379,8 +379,10 @@ namespace Elastic.Apm.Tests.ApiTests
 			Assert.Equal(TransactionName, payloadSender.Payloads[0].Transactions[0].Name);
 			Assert.Equal(TransactionType, payloadSender.Payloads[0].Transactions[0].Type);
 
-			Assert.True(payloadSender.Payloads[0].Transactions[0].Duration >= SleepLength);
-
+			//`await Task.Delay` is inaccurate, so we enable 10% error in the test
+			var expectedTransactionLength = SleepLength - (SleepLength * 0.1);
+			var duration = payloadSender.Payloads[0].Transactions[0].Duration;
+			Assert.True(duration >= expectedTransactionLength, $"Expected {duration} to be greater or equal to: {expectedTransactionLength}");
 
 			Assert.NotEmpty(payloadSender.Errors);
 			Assert.NotEmpty(payloadSender.Errors[0].Errors);

--- a/test/Elastic.Apm.Tests/ApiTests/ConvenientApiTransactionTests.cs
+++ b/test/Elastic.Apm.Tests/ApiTests/ConvenientApiTransactionTests.cs
@@ -483,8 +483,11 @@ namespace Elastic.Apm.Tests.ApiTests
 			Assert.Equal(TransactionName, payloadSender.Payloads[0].Transactions[0].Name);
 			Assert.Equal(TransactionType, payloadSender.Payloads[0].Transactions[0].Type);
 
-			var duration = payloadSender.FirstTransaction.Duration;
-			Assert.True(duration >= SleepLength, $"Expected {duration} to be greater or equal to: {SleepLength}");
+			//`await Task.Delay` is inaccurate, so we enable 10% error in the test
+			var expectedTransactionLength = SleepLength - (SleepLength * 0.1);
+			var duration = payloadSender.Payloads[0].Transactions[0].Duration;
+			Assert.True(duration >= expectedTransactionLength, $"Expected {duration} to be greater or equal to: {expectedTransactionLength}");
+
 			return payloadSender;
 		}
 
@@ -504,8 +507,10 @@ namespace Elastic.Apm.Tests.ApiTests
 			Assert.Equal(TransactionName, payloadSender.Payloads[0].Transactions[0].Name);
 			Assert.Equal(TransactionType, payloadSender.Payloads[0].Transactions[0].Type);
 
+			//`await Task.Delay` is inaccurate, so we enable 10% error in the test
+			var expectedTransactionLength = SleepLength - (SleepLength * 0.1);
 			var duration = payloadSender.Payloads[0].Transactions[0].Duration;
-			Assert.True(duration >= SleepLength, $"Expected {duration} to be greater or equal to: {SleepLength}");
+			Assert.True(duration >= expectedTransactionLength, $"Expected {duration} to be greater or equal to: {expectedTransactionLength}");
 
 			Assert.NotEmpty(payloadSender.Errors);
 			Assert.NotEmpty(payloadSender.Errors[0].Errors);
@@ -531,8 +536,10 @@ namespace Elastic.Apm.Tests.ApiTests
 			Assert.Equal(TransactionName, payloadSender.Payloads[0].Transactions[0].Name);
 			Assert.Equal(TransactionType, payloadSender.Payloads[0].Transactions[0].Type);
 
+			//`await Task.Delay` is inaccurate, so we enable 10% error in the test
+			var expectedTransactionLength = SleepLength - (SleepLength * 0.1);
 			var duration = payloadSender.Payloads[0].Transactions[0].Duration;
-			Assert.True(duration >= SleepLength, $"Expected {duration} to be greater or equal to: {SleepLength}");
+			Assert.True(duration >= expectedTransactionLength, $"Expected {duration} to be greater or equal to: {expectedTransactionLength}");
 
 			return payloadSender;
 		}
@@ -553,8 +560,11 @@ namespace Elastic.Apm.Tests.ApiTests
 			Assert.Equal(TransactionName, payloadSender.Payloads[0].Transactions[0].Name);
 			Assert.Equal(TransactionType, payloadSender.Payloads[0].Transactions[0].Type);
 
-			Assert.True(payloadSender.Payloads[0].Transactions[0].Duration >= SleepLength);
 
+			//`await Task.Delay` is inaccurate, so we enable 10% error in the test
+			var expectedTransactionLength = SleepLength - (SleepLength * 0.1);
+			var duration = payloadSender.Payloads[0].Transactions[0].Duration;
+			Assert.True(duration >= expectedTransactionLength, $"Expected {duration} to be greater or equal to: {expectedTransactionLength}");
 
 			Assert.NotEmpty(payloadSender.Errors);
 			Assert.NotEmpty(payloadSender.Errors[0].Errors);

--- a/test/Elastic.Apm.Tests/ApiTests/ConvenientApiTransactionTests.cs
+++ b/test/Elastic.Apm.Tests/ApiTests/ConvenientApiTransactionTests.cs
@@ -21,7 +21,7 @@ namespace Elastic.Apm.Tests.ApiTests
 	public class ConvenientApiTransactionTests
 	{
 		private const string ExceptionMessage = "Foo";
-		private const int SleepLength = 32;
+		private const int SleepLength = 150;
 		private const string TransactionName = "ConvenientApiTest";
 		private const string TransactionType = "Test";
 


### PR DESCRIPTION
It looks like the timers on the VMs in CI have a very low resolution. ~~Therefore we wait even longer in the API tests.~~ 

Update: waiting longer does not help, we enable 10% error due to this inaccuracy in `await Task.Delay`. I think it's fine, we don't wanna measure in these tests with a super high accuracy, the point is that if we have a 10ms wait in the code than the duration should be around 10ms.. (and not 0 or 1..., but e.g. 9,12ms due to this inaccuracy is imo fine)


Solves #94