### PR TITLE
Add SecretToken configuration value

### DIFF
--- a/src/Elastic.Apm.AspNetCore/Config/MicrosoftExtensionsConfig.cs
+++ b/src/Elastic.Apm.AspNetCore/Config/MicrosoftExtensionsConfig.cs
@@ -14,11 +14,12 @@ namespace Elastic.Apm.AspNetCore.Config
 	{
 		internal const string Origin = "Configuration Provider";
 
-		public static (string LevelSubKey, string Level, string Urls, string ServiceName) Keys = (
+		public static (string LevelSubKey, string Level, string Urls, string ServiceName, string SecretToken) Keys = (
 			LevelSubKey: "LogLevel",
 			Level: "ElasticApm:LogLevel",
 			Urls: "ElasticApm:ServerUrls",
-			ServiceName: "ElasticApm:ServiceName"
+			ServiceName: "ElasticApm:ServiceName",
+			SecretToken: "ElasticApm:SecretToken"
 		);
 
 		private readonly IConfiguration _configuration;
@@ -49,6 +50,8 @@ namespace Elastic.Apm.AspNetCore.Config
 		public IReadOnlyList<Uri> ServerUrls => ParseServerUrls(ReadFallBack(Keys.Urls, ConfigConsts.ConfigKeys.Urls));
 
 		public string ServiceName => ParseServiceName(ReadFallBack(Keys.ServiceName, ConfigConsts.ConfigKeys.ServiceName));
+
+		public string SecretToken => ParseSecretToken(ReadFallBack(Keys.SecretToken, ConfigConsts.ConfigKeys.SecretToken));
 
 		private ConfigurationKeyValue Read(string key) => Kv(key, _configuration[key], Origin);
 

--- a/src/Elastic.Apm/AgentComponents.cs
+++ b/src/Elastic.Apm/AgentComponents.cs
@@ -18,7 +18,7 @@ namespace Elastic.Apm
 			Logger = logger ?? ConsoleLogger.Instance;
 			ConfigurationReader = configurationReader ?? new EnvironmentConfigurationReader(Logger);
 			Service = service ?? Service.GetDefaultService(ConfigurationReader);
-			PayloadSender = payloadSender ?? new PayloadSender(Logger, ConfigurationReader);
+			PayloadSender = payloadSender ?? new PayloadSender(Logger, ConfigurationReader, null);
 			TracerInternal = new Tracer(Logger, Service, PayloadSender);
 			TransactionContainer = new TransactionContainer();
 		}

--- a/src/Elastic.Apm/AgentComponents.cs
+++ b/src/Elastic.Apm/AgentComponents.cs
@@ -18,7 +18,7 @@ namespace Elastic.Apm
 			Logger = logger ?? ConsoleLogger.Instance;
 			ConfigurationReader = configurationReader ?? new EnvironmentConfigurationReader(Logger);
 			Service = service ?? Service.GetDefaultService(ConfigurationReader);
-			PayloadSender = payloadSender ?? new PayloadSender(Logger, ConfigurationReader, null);
+			PayloadSender = payloadSender ?? new PayloadSender(Logger, ConfigurationReader);
 			TracerInternal = new Tracer(Logger, Service, PayloadSender);
 			TransactionContainer = new TransactionContainer();
 		}

--- a/src/Elastic.Apm/Config/AbstractConfigurationReader.cs
+++ b/src/Elastic.Apm/Config/AbstractConfigurationReader.cs
@@ -18,6 +18,12 @@ namespace Elastic.Apm.Config
 		protected internal static LogLevel ParseLogLevel(string value) =>
 			Enum.TryParse<LogLevel>(value, out var logLevel) ? logLevel : AbstractLogger.LogLevelDefault;
 
+		protected string ParseSecretToken(ConfigurationKeyValue kv)
+		{
+			if (kv == null || string.IsNullOrEmpty(kv.Value)) return null;
+			return kv.Value;
+		}
+
 		protected LogLevel ParseLogLevel(ConfigurationKeyValue kv)
 		{
 			if (kv == null || string.IsNullOrEmpty(kv.Value)) return AbstractLogger.LogLevelDefault;

--- a/src/Elastic.Apm/Config/ConfigConsts.cs
+++ b/src/Elastic.Apm/Config/ConfigConsts.cs
@@ -4,10 +4,11 @@ namespace Elastic.Apm.Config
 {
 	public static class ConfigConsts
 	{
-		internal static (string Level, string Urls, string ServiceName) ConfigKeys = (
+		internal static (string Level, string Urls, string ServiceName, string SecretToken) ConfigKeys = (
 			Level: "ELASTIC_APM_LOG_LEVEL",
 			Urls: "ELASTIC_APM_SERVER_URLS",
-			ServiceName: "ELASTIC_APM_SERVICE_NAME"
+			ServiceName: "ELASTIC_APM_SERVICE_NAME",
+			SecretToken: "ELASTIC_APM_SECRET_TOKEN"
 		);
 
 		public static Uri DefaultServerUri => new Uri("http://localhost:8200");

--- a/src/Elastic.Apm/Config/EnvironmentConfigurationReader.cs
+++ b/src/Elastic.Apm/Config/EnvironmentConfigurationReader.cs
@@ -14,6 +14,8 @@ namespace Elastic.Apm.Config
 
 		public IReadOnlyList<Uri> ServerUrls => ParseServerUrls(Read(ConfigConsts.ConfigKeys.Urls));
 
+		public string SecretToken => ParseSecretToken(Read(ConfigConsts.ConfigKeys.SecretToken));
+
 		public string ServiceName => ParseServiceName(Read(ConfigConsts.ConfigKeys.ServiceName));
 
 		private static ConfigurationKeyValue Read(string key) =>

--- a/src/Elastic.Apm/Config/IAgentConfigReader.cs
+++ b/src/Elastic.Apm/Config/IAgentConfigReader.cs
@@ -9,5 +9,6 @@ namespace Elastic.Apm.Config
 		LogLevel LogLevel { get; }
 		IReadOnlyList<Uri> ServerUrls { get; }
 		string ServiceName { get; }
+		string SecretToken { get; }
 	}
 }

--- a/src/Elastic.Apm/Report/PayloadSender.cs
+++ b/src/Elastic.Apm/Report/PayloadSender.cs
@@ -2,6 +2,7 @@ using System;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
+using System.Net.Http.Headers;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks.Dataflow;
@@ -33,7 +34,7 @@ namespace Elastic.Apm.Report
 
 		static PayloadSender() => ServicePointManager.DnsRefreshTimeout = DnsTimeout;
 
-		internal PayloadSender(AbstractLogger logger, IConfigurationReader configurationReader)
+		internal PayloadSender(AbstractLogger logger, IConfigurationReader configurationReader, HttpMessageHandler handler)
 		{
 			_logger = logger;
 			_settings = new JsonSerializerSettings { ContractResolver = new CamelCasePropertyNamesContractResolver() };
@@ -44,10 +45,16 @@ namespace Elastic.Apm.Report
 			servicePoint.ConnectionLeaseTimeout = DnsTimeout;
 			servicePoint.ConnectionLimit = 20;
 
-			_httpClient = new HttpClient
+			_httpClient = new HttpClient(handler ?? new HttpClientHandler())
 			{
-				BaseAddress = serverUrlBase
+				BaseAddress = serverUrlBase,
 			};
+
+			if (configurationReader.SecretToken != null)
+			{
+				_httpClient.DefaultRequestHeaders.Authorization =
+					new AuthenticationHeaderValue("Bearer", configurationReader.SecretToken);
+			}
 
 			var workerThread = new Thread(StartWork)
 			{

--- a/src/Elastic.Apm/Report/PayloadSender.cs
+++ b/src/Elastic.Apm/Report/PayloadSender.cs
@@ -34,7 +34,7 @@ namespace Elastic.Apm.Report
 
 		static PayloadSender() => ServicePointManager.DnsRefreshTimeout = DnsTimeout;
 
-		internal PayloadSender(AbstractLogger logger, IConfigurationReader configurationReader, HttpMessageHandler handler)
+		internal PayloadSender(AbstractLogger logger, IConfigurationReader configurationReader, HttpMessageHandler handler = null)
 		{
 			_logger = logger;
 			_settings = new JsonSerializerSettings { ContractResolver = new CamelCasePropertyNamesContractResolver() };

--- a/test/Elastic.Apm.AspNetCore.Tests/MicrosoftExtensionsConfigTests.cs
+++ b/test/Elastic.Apm.AspNetCore.Tests/MicrosoftExtensionsConfigTests.cs
@@ -77,6 +77,8 @@ namespace Elastic.Apm.AspNetCore.Tests
 			Environment.SetEnvironmentVariable(ConfigConsts.ConfigKeys.Urls, serverUrl);
 			var serviceName = "MyServiceName123";
 			Environment.SetEnvironmentVariable(ConfigConsts.ConfigKeys.ServiceName, serviceName);
+			var secretToken = "SecretToken";
+			Environment.SetEnvironmentVariable(ConfigConsts.ConfigKeys.SecretToken, secretToken);
 			var configBuilder = new ConfigurationBuilder()
 				.AddEnvironmentVariables()
 				.Build();
@@ -85,6 +87,7 @@ namespace Elastic.Apm.AspNetCore.Tests
 			Assert.Equal(LogLevel.Debug, config.LogLevel);
 			Assert.Equal(new Uri(serverUrl), config.ServerUrls[0]);
 			Assert.Equal(serviceName, config.ServiceName);
+			Assert.Equal(secretToken, config.SecretToken);
 		}
 
 		/// <summary>

--- a/test/Elastic.Apm.Tests/ConfigTest.cs
+++ b/test/Elastic.Apm.Tests/ConfigTest.cs
@@ -89,6 +89,14 @@ namespace Elastic.Apm.Tests
 		}
 
 		[Fact]
+		public void SecretTokenSimpleTest()
+		{
+			var secretToken = "secretToken";
+			var agent = new ApmAgent(new TestAgentComponents(secretToken: secretToken));
+			Assert.Equal(secretToken, agent.ConfigurationReader.SecretToken);
+		}
+
+		[Fact]
 		public void DefaultLogLevelTest() => Assert.Equal(LogLevel.Error, Agent.Config.LogLevel);
 
 		[Fact]

--- a/test/Elastic.Apm.Tests/Mocks/MockHttpMessageHandler.cs
+++ b/test/Elastic.Apm.Tests/Mocks/MockHttpMessageHandler.cs
@@ -1,0 +1,17 @@
+using System;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Elastic.Apm.Tests.Mocks {
+	public class MockHttpMessageHandler : DelegatingHandler
+	{
+		private readonly Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> _sendAsync;
+
+		public MockHttpMessageHandler(Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> sendAsync) => 
+			_sendAsync = sendAsync ?? throw new ArgumentNullException(nameof(sendAsync));
+
+		protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken) => 
+			_sendAsync(request, cancellationToken);
+	}
+}

--- a/test/Elastic.Apm.Tests/Mocks/TestAgentComponents.cs
+++ b/test/Elastic.Apm.Tests/Mocks/TestAgentComponents.cs
@@ -11,12 +11,14 @@ namespace Elastic.Apm.Tests.Mocks
 			string logLevel = "Debug",
 			string serverUrls = null,
 			Service service = null,
+			string secretToken = null,
 			IPayloadSender payloadSender = null
 		)
 			: this(new TestAgentConfigurationReader(
 				new TestLogger(AbstractConfigurationReader.ParseLogLevel(logLevel)),
 				logLevel: logLevel,
-				serverUrls: serverUrls
+				serverUrls: serverUrls,
+				secretToken: secretToken
 			), service, payloadSender) { }
 
 		public TestAgentComponents(AbstractLogger logger, string serverUrls = null, Service service = null,

--- a/test/Elastic.Apm.Tests/Mocks/TestAgentConfigurationReader.cs
+++ b/test/Elastic.Apm.Tests/Mocks/TestAgentConfigurationReader.cs
@@ -12,18 +12,21 @@ namespace Elastic.Apm.Tests.Mocks
 		private readonly string _logLevel;
 		private readonly string _serverUrls;
 		private readonly string _serviceName;
+		private readonly string _secretToken;
 
 		public TestAgentConfigurationReader(
 			AbstractLogger logger,
 			string serverUrls = null,
 			string logLevel = "Debug",
-			string serviceName = null
+			string serviceName = null,
+			string secretToken = null
 		) : base(logger)
 		{
 			Logger = logger;
 			_serverUrls = serverUrls;
 			_logLevel = logLevel;
 			_serviceName = serviceName;
+			_secretToken = secretToken;
 		}
 
 		public new AbstractLogger Logger { get; }
@@ -31,5 +34,6 @@ namespace Elastic.Apm.Tests.Mocks
 		public LogLevel LogLevel => ParseLogLevel(Kv(ConfigConsts.ConfigKeys.Level, _logLevel, Origin));
 		public IReadOnlyList<Uri> ServerUrls => ParseServerUrls(Kv(ConfigConsts.ConfigKeys.Urls, _serverUrls, Origin));
 		public string ServiceName => ParseServiceName(Kv(ConfigConsts.ConfigKeys.ServiceName, _serviceName, Origin));
+		public string SecretToken => ParseSecretToken(Kv(ConfigConsts.ConfigKeys.SecretToken, _secretToken, Origin));
 	}
 }


### PR DESCRIPTION
This PR adds a SecretToken configuration value to allow
the agent to be used with Elasticsearch Service in Elastic Cloud.
The value assigned to the SecretToken configuration value will be
set as the value of a Bearer token Authorization header on
PayloadSender.

Closes #107