### PR TITLE
Feature/add custom

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -90,7 +90,7 @@ pipeline {
                       for i in $(find . -name '*.csproj')
                       do
                         dotnet add "$i" package XunitXml.TestLogger --version 2.0.0
-                        dotnet add "$i" package coverlet.msbuild --version 2.5.0
+                        dotnet add "$i" package coverlet.msbuild --version 2.5.1
                       done
                       '''
 
@@ -101,7 +101,10 @@ pipeline {
                       # run tests
                       dotnet test -v n -r target -d target/diag.log --logger:"xunit" --no-build \
                         /p:CollectCoverage=true /p:CoverletOutputFormat=cobertura \
-                        /p:CoverletOutput=target/Coverage/ || echo -e "\033[31;49mTests FAILED\033[0m"
+                        /p:CoverletOutput=target/Coverage/ \
+                        /p:Exclude='"[Elastic.Apm.Tests]*,[SampleAspNetCoreApp*]*,[xunit*]*"' \
+                        /p:Threshold=0 /p:ThresholdType=branch /p:ThresholdStat=total \
+                        || echo -e "\033[31;49mTests FAILED\033[0m"
                       '''
 
                       sh label: 'Convert Test Results to junit format', script: '''#!/bin/bash
@@ -183,13 +186,13 @@ pipeline {
                         Get-ChildItem -Path . -Recurse -Filter *.csproj |
                         Foreach-Object {
                           & dotnet add $_.FullName package XunitXml.TestLogger --version 2.0.0
-                          & dotnet add $_.FullName package coverlet.msbuild --version 2.5.0
+                          & dotnet add $_.FullName package coverlet.msbuild --version 2.5.1
                         }
                         '''
 
                         bat label: 'Build', script:'dotnet build'
 
-                        bat label: 'Test & Coverage', script: 'dotnet test -v n -r target -d target\\diag.log --logger:xunit --no-build /p:CollectCoverage=true /p:CoverletOutputFormat=cobertura /p:CoverletOutput=target\\Coverage\\'
+                        bat label: 'Test & Coverage', script: 'dotnet test -v n -r target -d target\\diag.log --logger:xunit --no-build /p:CollectCoverage=true /p:CoverletOutputFormat=cobertura /p:CoverletOutput=target\\Coverage\\ /p:Exclude=\\"[Elastic.Apm.Tests]*,[SampleAspNetCoreApp*]*,[xunit*]*\\" /p:Threshold=0 /p:ThresholdType=branch /p:ThresholdStat=total'
 
                         powershell label: 'Convert Test Results to junit format', script: '''
                         [System.Environment]::SetEnvironmentVariable("PATH", $Env:Path + ";" + $Env:USERPROFILE + "\\.dotnet\\tools")

--- a/src/Elastic.Apm.AspNetCore/ApmMiddleware.cs
+++ b/src/Elastic.Apm.AspNetCore/ApmMiddleware.cs
@@ -32,7 +32,7 @@ namespace Elastic.Apm.AspNetCore
 			var transaction = _tracer.StartTransactionInternal($"{context.Request.Method} {context.Request.Path}",
 				ApiConstants.TypeRequest);
 
-			var transactionRequest = transaction.Context.Request.Value;
+			var transactionRequest = transaction.Context.Request;
 
 			transactionRequest.Method = context.Request.Method;
 			transactionRequest.Socket = new Socket
@@ -60,8 +60,8 @@ namespace Elastic.Apm.AspNetCore
 				transaction.Result =
 					$"{GetProtocolName(context.Request.Protocol)} {context.Response.StatusCode.ToString()[0]}xx";
 
-				transaction.Context.Response.Value.Finished = context.Response.HasStarted;
-				transaction.Context.Response.Value.StatusCode = context.Response.StatusCode;
+				transaction.Context.Response.Finished = context.Response.HasStarted;
+				transaction.Context.Response.StatusCode = context.Response.StatusCode;
 
 				transaction.End();
 			}

--- a/src/Elastic.Apm/Api/IRequest.cs
+++ b/src/Elastic.Apm/Api/IRequest.cs
@@ -1,0 +1,11 @@
+using Elastic.Apm.Model.Payload;
+
+namespace Elastic.Apm.Api
+{
+	public interface IRequest
+	{
+		string HttpVersion { get; set; }
+		string Method { get; set; }
+		string Body { get; set; }
+	}
+}

--- a/src/Elastic.Apm/Api/IRequest.cs
+++ b/src/Elastic.Apm/Api/IRequest.cs
@@ -6,6 +6,6 @@ namespace Elastic.Apm.Api
 	{
 		string HttpVersion { get; set; }
 		string Method { get; set; }
-		string Body { get; set; }
+		object Body { get; set; }
 	}
 }

--- a/src/Elastic.Apm/Api/ISpan.cs
+++ b/src/Elastic.Apm/Api/ISpan.cs
@@ -47,6 +47,11 @@ namespace Elastic.Apm.Api
 		Dictionary<string, string> Tags { get; }
 
 		/// <summary>
+		/// A list of user defined custom fields.
+		/// </summary>
+		Dictionary<string, object> Custom { get; }
+
+		/// <summary>
 		/// UUID of the enclosing transaction.
 		/// </summary>
 		Guid TransactionId { get; }

--- a/src/Elastic.Apm/Api/ISpan.cs
+++ b/src/Elastic.Apm/Api/ISpan.cs
@@ -47,11 +47,6 @@ namespace Elastic.Apm.Api
 		Dictionary<string, string> Tags { get; }
 
 		/// <summary>
-		/// A list of user defined custom fields.
-		/// </summary>
-		Dictionary<string, object> Custom { get; }
-
-		/// <summary>
 		/// UUID of the enclosing transaction.
 		/// </summary>
 		Guid TransactionId { get; }

--- a/src/Elastic.Apm/Api/ITransaction.cs
+++ b/src/Elastic.Apm/Api/ITransaction.cs
@@ -41,11 +41,6 @@ namespace Elastic.Apm.Api
 		Dictionary<string, string> Tags { get; }
 
 		/// <summary>
-		/// A list of user defined custom fields.
-		/// </summary>
-		Dictionary<string, object> Custom { get; }
-
-		/// <summary>
 		/// The type of the transaction.
 		/// Example: 'request'
 		/// </summary>

--- a/src/Elastic.Apm/Api/ITransaction.cs
+++ b/src/Elastic.Apm/Api/ITransaction.cs
@@ -35,6 +35,11 @@ namespace Elastic.Apm.Api
 		Dictionary<string, string> Tags { get; }
 
 		/// <summary>
+		/// A list of user defined custom fields.
+		/// </summary>
+		Dictionary<string, object> Custom { get; }
+
+		/// <summary>
 		/// The type of the transaction.
 		/// Example: 'request'
 		/// </summary>

--- a/src/Elastic.Apm/Api/ITransaction.cs
+++ b/src/Elastic.Apm/Api/ITransaction.cs
@@ -9,9 +9,14 @@ namespace Elastic.Apm.Api
 	public interface ITransaction
 	{
 		/// <summary>
-		/// Any arbitrary contextual information regarding the event, captured by the agent, optionally provided by the user.
+		/// If a log record was generated as a result of a http request, the http interface can be used to collect this information.
 		/// </summary>
 		IRequest Request { get; }
+
+		/// <summary>
+		/// User identification
+		/// </summary>
+		IUser User { get; }
 
 		/// <summary>
 		/// The duration of the transaction.

--- a/src/Elastic.Apm/Api/ITransaction.cs
+++ b/src/Elastic.Apm/Api/ITransaction.cs
@@ -2,11 +2,17 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Threading.Tasks;
+using Elastic.Apm.Model.Payload;
 
 namespace Elastic.Apm.Api
 {
 	public interface ITransaction
 	{
+		/// <summary>
+		/// Any arbitrary contextual information regarding the event, captured by the agent, optionally provided by the user.
+		/// </summary>
+		IRequest Request { get; }
+
 		/// <summary>
 		/// The duration of the transaction.
 		/// If it's not set (its HasValue property is false) then the value

--- a/src/Elastic.Apm/Api/IUser.cs
+++ b/src/Elastic.Apm/Api/IUser.cs
@@ -1,0 +1,9 @@
+namespace Elastic.Apm.Api
+{
+	public interface IUser
+	{
+		string Id { get; set; }
+		string Email { get; set; }
+		string UserName { get; set; }
+	}
+}

--- a/src/Elastic.Apm/Elastic.Apm.csproj
+++ b/src/Elastic.Apm/Elastic.Apm.csproj
@@ -21,18 +21,18 @@
     <PackageTags>apm, monitoring, elastic, elasticapm, analytics, sdk</PackageTags>
   </PropertyGroup>
   <ItemGroup>
-    <Folder Include="Report\" />
-    <Folder Include="DiagnosticSource\" />
-    <Folder Include="DiagnosticListeners\" />
-    <Folder Include="Logging\" />
-    <Folder Include="Config\" />
-    <Folder Include="Helpers\" />
-    <Folder Include="Api\" />
+    <Folder Include="Report\"/>
+    <Folder Include="DiagnosticSource\"/>
+    <Folder Include="DiagnosticListeners\"/>
+    <Folder Include="Logging\"/>
+    <Folder Include="Config\"/>
+    <Folder Include="Helpers\"/>
+    <Folder Include="Api\"/>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
+    <PackageReference Include="Newtonsoft.Json" Version="11.0.2"/>
     <!-- TODO: Are we ok with this reference/version? -->
-    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="4.0.0" />
-    <PackageReference Include="System.Threading.Tasks.Dataflow" Version="4.9.0" />
+    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="4.0.0"/>
+    <PackageReference Include="System.Threading.Tasks.Dataflow" Version="4.9.0"/>
   </ItemGroup>
 </Project>

--- a/src/Elastic.Apm/Elastic.Apm.csproj
+++ b/src/Elastic.Apm/Elastic.Apm.csproj
@@ -21,18 +21,18 @@
     <PackageTags>apm, monitoring, elastic, elasticapm, analytics, sdk</PackageTags>
   </PropertyGroup>
   <ItemGroup>
-    <Folder Include="Report\"/>
-    <Folder Include="DiagnosticSource\"/>
-    <Folder Include="DiagnosticListeners\"/>
-    <Folder Include="Logging\"/>
-    <Folder Include="Config\"/>
-    <Folder Include="Helpers\"/>
-    <Folder Include="Api\"/>
+    <Folder Include="Report\" />
+    <Folder Include="DiagnosticSource\" />
+    <Folder Include="DiagnosticListeners\" />
+    <Folder Include="Logging\" />
+    <Folder Include="Config\" />
+    <Folder Include="Helpers\" />
+    <Folder Include="Api\" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="11.0.2"/>
+    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
     <!-- TODO: Are we ok with this reference/version? -->
-    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="4.0.0"/>
-    <PackageReference Include="System.Threading.Tasks.Dataflow" Version="4.9.0"/>
+    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="4.0.0" />
+    <PackageReference Include="System.Threading.Tasks.Dataflow" Version="4.9.0" />
   </ItemGroup>
 </Project>

--- a/src/Elastic.Apm/Helpers/StringExtensions.cs
+++ b/src/Elastic.Apm/Helpers/StringExtensions.cs
@@ -2,17 +2,14 @@ namespace Elastic.Apm.Helpers
 {
 	internal static class StringExtensions
 	{
-		internal static string TrimToLength(this string input, int maxLength)
+		private static string TrimToLength(this string input, int maxLength)
 		{
 			if (input.Length > maxLength)
-				input = $"{input.Substring(0, Consts.PropertyMaxLength-3)}...";
+				input = $"{input.Substring(0, Consts.PropertyMaxLength - 3)}...";
 
 			return input;
 		}
 
-		internal static string TrimToMaxLength(this string input)
-		{
-			return input.TrimToLength(Consts.PropertyMaxLength);
-		}
+		internal static string TrimToMaxLength(this string input) => input.TrimToLength(Consts.PropertyMaxLength);
 	}
 }

--- a/src/Elastic.Apm/Helpers/StringExtensions.cs
+++ b/src/Elastic.Apm/Helpers/StringExtensions.cs
@@ -1,10 +1,18 @@
 namespace Elastic.Apm.Helpers
 {
-	public static class StringExtensions
+	internal static class StringExtensions
 	{
-		public static string TrimToLength(this string input)
+		internal static string TrimToLength(this string input, int maxLength)
 		{
-			return "";
+			if (input.Length > maxLength)
+				input = $"{input.Substring(0, Consts.PropertyMaxLength-3)}...";
+
+			return input;
+		}
+
+		internal static string TrimToMaxLength(this string input)
+		{
+			return input.TrimToLength(Consts.PropertyMaxLength);
 		}
 	}
 }

--- a/src/Elastic.Apm/Helpers/StringExtensions.cs
+++ b/src/Elastic.Apm/Helpers/StringExtensions.cs
@@ -1,0 +1,10 @@
+namespace Elastic.Apm.Helpers
+{
+	public static class StringExtensions
+	{
+		public static string TrimToLength(this string input)
+		{
+			return "";
+		}
+	}
+}

--- a/src/Elastic.Apm/Model/Payload/Context.cs
+++ b/src/Elastic.Apm/Model/Payload/Context.cs
@@ -8,7 +8,13 @@ namespace Elastic.Apm.Model.Payload
 		private readonly Lazy<Dictionary<string, string>> _tags = new Lazy<Dictionary<string, string>>();
 		private Request _request;
 		private Response _response;
+		private User _user;
 
+		public User User
+		{
+			get => _user ?? (_user = new User());
+			set => _user = value;
+		}
 		public Request Request
 		{
 			get => _request ?? (_request = new Request());

--- a/src/Elastic.Apm/Model/Payload/Context.cs
+++ b/src/Elastic.Apm/Model/Payload/Context.cs
@@ -6,26 +6,10 @@ namespace Elastic.Apm.Model.Payload
 	internal class Context
 	{
 		private readonly Lazy<Dictionary<string, string>> _tags = new Lazy<Dictionary<string, string>>();
-		private Request _request;
-		private Response _response;
-		private User _user;
+		public Lazy<User> User { get; set; }
+		public Lazy<Request> Request { get; set; }
 
-		public User User
-		{
-			get => _user ?? (_user = new User());
-			set => _user = value;
-		}
-		public Request Request
-		{
-			get => _request ?? (_request = new Request());
-			set => _request = value;
-		}
-
-		public Response Response
-		{
-			get => _response ?? (_response = new Response());
-			set => _response = value;
-		}
+		public Lazy<Response> Response { get; set; }
 
 		public Dictionary<string, string> Tags => _tags.Value;
 	}

--- a/src/Elastic.Apm/Model/Payload/Context.cs
+++ b/src/Elastic.Apm/Model/Payload/Context.cs
@@ -6,10 +6,12 @@ namespace Elastic.Apm.Model.Payload
 	internal class Context
 	{
 		private readonly Lazy<Dictionary<string, string>> tags = new Lazy<Dictionary<string, string>>();
+		private readonly Lazy<Dictionary<string, object>> custom = new Lazy<Dictionary<string, object>>();
 		public Request Request { get; set; }
 
 		public Response Response { get; set; }
 
 		public Dictionary<string, string> Tags => tags.Value;
+		public Dictionary<string, object> Custom => custom.Value;
 	}
 }

--- a/src/Elastic.Apm/Model/Payload/Context.cs
+++ b/src/Elastic.Apm/Model/Payload/Context.cs
@@ -6,12 +6,10 @@ namespace Elastic.Apm.Model.Payload
 	internal class Context
 	{
 		private readonly Lazy<Dictionary<string, string>> tags = new Lazy<Dictionary<string, string>>();
-		private readonly Lazy<Dictionary<string, object>> custom = new Lazy<Dictionary<string, object>>();
 		public Request Request { get; set; }
 
 		public Response Response { get; set; }
 
 		public Dictionary<string, string> Tags => tags.Value;
-		public Dictionary<string, object> Custom => custom.Value;
 	}
 }

--- a/src/Elastic.Apm/Model/Payload/Context.cs
+++ b/src/Elastic.Apm/Model/Payload/Context.cs
@@ -5,11 +5,22 @@ namespace Elastic.Apm.Model.Payload
 {
 	internal class Context
 	{
-		private readonly Lazy<Dictionary<string, string>> tags = new Lazy<Dictionary<string, string>>();
-		public Request Request { get; set; }
+		private readonly Lazy<Dictionary<string, string>> _tags = new Lazy<Dictionary<string, string>>();
+		private Request _request;
+		private Response _response;
 
-		public Response Response { get; set; }
+		public Request Request
+		{
+			get => _request ?? (_request = new Request());
+			set => _request = value;
+		}
 
-		public Dictionary<string, string> Tags => tags.Value;
+		public Response Response
+		{
+			get => _response ?? (_response = new Response());
+			set => _response = value;
+		}
+
+		public Dictionary<string, string> Tags => _tags.Value;
 	}
 }

--- a/src/Elastic.Apm/Model/Payload/Context.cs
+++ b/src/Elastic.Apm/Model/Payload/Context.cs
@@ -6,10 +6,13 @@ namespace Elastic.Apm.Model.Payload
 	internal class Context
 	{
 		private readonly Lazy<Dictionary<string, string>> _tags = new Lazy<Dictionary<string, string>>();
-		public Lazy<User> User { get; set; }
-		public Lazy<Request> Request { get; set; }
+		private readonly Lazy<User> _user = new Lazy<User>();
+		private readonly Lazy<Response> _response = new Lazy<Response>();
+		private readonly Lazy<Request> _request = new Lazy<Request>();
 
-		public Lazy<Response> Response { get; set; }
+		public User User => _user.Value;
+		public Request Request => _request.Value;
+		public Response Response => _response.Value;
 
 		public Dictionary<string, string> Tags => _tags.Value;
 	}

--- a/src/Elastic.Apm/Model/Payload/Request.cs
+++ b/src/Elastic.Apm/Model/Payload/Request.cs
@@ -2,7 +2,7 @@
 
 namespace Elastic.Apm.Model.Payload
 {
-	internal class Request
+	internal class Request : IRequest
 	{
 		public string HttpVersion { get; set; }
 		public string Body { get; set; }

--- a/src/Elastic.Apm/Model/Payload/Request.cs
+++ b/src/Elastic.Apm/Model/Payload/Request.cs
@@ -1,11 +1,12 @@
-﻿using Newtonsoft.Json;
+﻿using Elastic.Apm.Api;
+using Newtonsoft.Json;
 
 namespace Elastic.Apm.Model.Payload
 {
 	internal class Request : IRequest
 	{
 		public string HttpVersion { get; set; }
-
+		public string Body { get; set; }
 		public string Method { get; set; }
 		public Socket Socket { get; set; }
 		public Url Url { get; set; }

--- a/src/Elastic.Apm/Model/Payload/Request.cs
+++ b/src/Elastic.Apm/Model/Payload/Request.cs
@@ -5,7 +5,7 @@ namespace Elastic.Apm.Model.Payload
 	internal class Request : IRequest
 	{
 		public string HttpVersion { get; set; }
-		public string Body { get; set; }
+
 		public string Method { get; set; }
 		public Socket Socket { get; set; }
 		public Url Url { get; set; }

--- a/src/Elastic.Apm/Model/Payload/Request.cs
+++ b/src/Elastic.Apm/Model/Payload/Request.cs
@@ -5,7 +5,7 @@ namespace Elastic.Apm.Model.Payload
 	internal class Request
 	{
 		public string HttpVersion { get; set; }
-
+		public string Body { get; set; }
 		public string Method { get; set; }
 		public Socket Socket { get; set; }
 		public Url Url { get; set; }

--- a/src/Elastic.Apm/Model/Payload/Request.cs
+++ b/src/Elastic.Apm/Model/Payload/Request.cs
@@ -15,7 +15,7 @@ namespace Elastic.Apm.Model.Payload
 			set => _httpVersion = value.TrimToMaxLength();
 		}
 
-		public string Body { get; set; }
+		public object Body { get; set; }
 
 		public string Method
 		{

--- a/src/Elastic.Apm/Model/Payload/Request.cs
+++ b/src/Elastic.Apm/Model/Payload/Request.cs
@@ -1,13 +1,28 @@
 ﻿using Elastic.Apm.Api;
+using Elastic.Apm.Helpers;
 using Newtonsoft.Json;
 
 namespace Elastic.Apm.Model.Payload
 {
 	internal class Request : IRequest
 	{
-		public string HttpVersion { get; set; }
+		private string _httpVersion;
+		private string _method;
+
+		public string HttpVersion
+		{
+			get => _httpVersion;
+			set => _httpVersion = value.TrimToMaxLength();
+		}
+
 		public string Body { get; set; }
-		public string Method { get; set; }
+
+		public string Method
+		{
+			get => _method;
+			set => _method = value.TrimToMaxLength();
+		}
+
 		public Socket Socket { get; set; }
 		public Url Url { get; set; }
 	}
@@ -22,9 +37,34 @@ namespace Elastic.Apm.Model.Payload
 
 	internal class Url
 	{
-		public string Full { get; set; }
-		public string HostName { get; set; }
-		public string Protocol { get; set; }
-		public string Raw { get; set; }
+		private string _full;
+		private string _raw;
+		private string _hostName;
+		private string _protocol;
+
+		public string Full
+		{
+			get => _full;
+			set => _full = value.TrimToMaxLength();
+		}
+
+		public string HostName
+		{
+			get => _hostName;
+			set => _hostName = value.TrimToMaxLength();
+		}
+
+		public string Protocol
+		{
+			get => _protocol;
+			set => _protocol = value.TrimToMaxLength();
+		}
+
+
+		public string Raw
+		{
+			get => _raw;
+			set => _raw = value.TrimToMaxLength();
+		}
 	}
 }

--- a/src/Elastic.Apm/Model/Payload/Request.cs
+++ b/src/Elastic.Apm/Model/Payload/Request.cs
@@ -11,7 +11,7 @@ namespace Elastic.Apm.Model.Payload
 
 		public string HttpVersion
 		{
-			get => _httpVersion;
+			get => _httpVersion ?? "";
 			set => _httpVersion = value.TrimToMaxLength();
 		}
 
@@ -19,7 +19,7 @@ namespace Elastic.Apm.Model.Payload
 
 		public string Method
 		{
-			get => _method;
+			get => _method ?? "";
 			set => _method = value.TrimToMaxLength();
 		}
 
@@ -44,26 +44,26 @@ namespace Elastic.Apm.Model.Payload
 
 		public string Full
 		{
-			get => _full;
+			get => _full ?? "";
 			set => _full = value.TrimToMaxLength();
 		}
 
 		public string HostName
 		{
-			get => _hostName;
+			get => _hostName ?? "";
 			set => _hostName = value.TrimToMaxLength();
 		}
 
 		public string Protocol
 		{
-			get => _protocol;
+			get => _protocol ?? "";
 			set => _protocol = value.TrimToMaxLength();
 		}
 
 
 		public string Raw
 		{
-			get => _raw;
+			get => _raw ?? "";
 			set => _raw = value.TrimToMaxLength();
 		}
 	}

--- a/src/Elastic.Apm/Model/Payload/Span.cs
+++ b/src/Elastic.Apm/Model/Payload/Span.cs
@@ -54,9 +54,6 @@ namespace Elastic.Apm.Model.Payload
 		[JsonIgnore]
 		public Dictionary<string, string> Tags => Context.Tags;
 
-		[JsonIgnore]
-		public Dictionary<string, object> Custom => Context.Custom;
-
 		internal Transaction Transaction;
 
 		public Guid TransactionId => Transaction.Id;
@@ -79,11 +76,9 @@ namespace Elastic.Apm.Model.Payload
 		private class ContextImpl : IContext
 		{
 			private readonly Lazy<Dictionary<string, string>> _tags = new Lazy<Dictionary<string, string>>();
-			private readonly Lazy<Dictionary<string, object>> _custom = new Lazy<Dictionary<string, object>>();
 			public IDb Db { get; set; }
 			public IHttp Http { get; set; }
 			public Dictionary<string, string> Tags => _tags.Value;
-			public Dictionary<string, object> Custom => _custom.Value;
 		}
 	}
 
@@ -96,7 +91,6 @@ namespace Elastic.Apm.Model.Payload
 		IDb Db { get; set; }
 		IHttp Http { get; set; }
 		Dictionary<string, string> Tags { get; }
-		Dictionary<string, object> Custom { get; }
 	}
 
 	internal interface IDb

--- a/src/Elastic.Apm/Model/Payload/Span.cs
+++ b/src/Elastic.Apm/Model/Payload/Span.cs
@@ -99,6 +99,7 @@ namespace Elastic.Apm.Model.Payload
 			public Dictionary<string, string> Tags => _tags.Value;
 		}
 	}
+
 	internal interface IContext
 	{
 		IDb Db { get; set; }

--- a/src/Elastic.Apm/Model/Payload/Span.cs
+++ b/src/Elastic.Apm/Model/Payload/Span.cs
@@ -29,7 +29,7 @@ namespace Elastic.Apm.Model.Payload
 
 		public string Action
 		{
-			get => _action;
+			get => _action ?? "";
 			set => _action = value.TrimToMaxLength();
 		}
 
@@ -52,7 +52,7 @@ namespace Elastic.Apm.Model.Payload
 		private string _name;
 		public string Name
 		{
-			get => _name;
+			get => _name ?? "";
 			set => _name = value.TrimToMaxLength();
 		}
 
@@ -65,7 +65,7 @@ namespace Elastic.Apm.Model.Payload
 
 		public string Subtype
 		{
-			get => _subtype;
+			get => _subtype ?? "";
 			set => _subtype = value.TrimToMaxLength();
 		}
 

--- a/src/Elastic.Apm/Model/Payload/Span.cs
+++ b/src/Elastic.Apm/Model/Payload/Span.cs
@@ -54,6 +54,9 @@ namespace Elastic.Apm.Model.Payload
 		[JsonIgnore]
 		public Dictionary<string, string> Tags => Context.Tags;
 
+		[JsonIgnore]
+		public Dictionary<string, object> Custom => Context.Custom;
+
 		internal Transaction Transaction;
 
 		public Guid TransactionId => Transaction.Id;
@@ -76,9 +79,11 @@ namespace Elastic.Apm.Model.Payload
 		private class ContextImpl : IContext
 		{
 			private readonly Lazy<Dictionary<string, string>> _tags = new Lazy<Dictionary<string, string>>();
+			private readonly Lazy<Dictionary<string, object>> _custom = new Lazy<Dictionary<string, object>>();
 			public IDb Db { get; set; }
 			public IHttp Http { get; set; }
 			public Dictionary<string, string> Tags => _tags.Value;
+			public Dictionary<string, object> Custom => _custom.Value;
 		}
 	}
 
@@ -87,6 +92,7 @@ namespace Elastic.Apm.Model.Payload
 		IDb Db { get; set; }
 		IHttp Http { get; set; }
 		Dictionary<string, string> Tags { get; }
+		Dictionary<string, object> Custom { get; }
 	}
 
 	internal interface IDb

--- a/src/Elastic.Apm/Model/Payload/Span.cs
+++ b/src/Elastic.Apm/Model/Payload/Span.cs
@@ -87,6 +87,10 @@ namespace Elastic.Apm.Model.Payload
 		}
 	}
 
+	public interface IRequest
+	{
+		string Body { get; set; }
+	}
 	internal interface IContext
 	{
 		IDb Db { get; set; }

--- a/src/Elastic.Apm/Model/Payload/Span.cs
+++ b/src/Elastic.Apm/Model/Payload/Span.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using Elastic.Apm.Api;
+using Elastic.Apm.Helpers;
 using Newtonsoft.Json;
 
 namespace Elastic.Apm.Model.Payload
@@ -24,7 +25,13 @@ namespace Elastic.Apm.Model.Payload
 			Id = rnd.Next();
 		}
 
-		public string Action { get; set; }
+		private string _action;
+
+		public string Action
+		{
+			get => _action;
+			set => _action = value.TrimToMaxLength();
+		}
 
 		/// <summary>
 		/// Any other arbitrary data captured by the agent, optionally provided by the user.
@@ -46,12 +53,7 @@ namespace Elastic.Apm.Model.Payload
 		public string Name
 		{
 			get => _name;
-			set
-			{
-				if (value.Length > Consts.PropertyMaxLength)
-					value = $"{value.Substring(0, Consts.PropertyMaxLength-3)}...";
-				_name = value;
-			}
+			set => _name = value.TrimToMaxLength();
 		}
 
 		[JsonProperty("Stacktrace")]
@@ -59,7 +61,13 @@ namespace Elastic.Apm.Model.Payload
 
 		public decimal Start { get; set; }
 
-		public string Subtype { get; set; }
+		private string _subtype;
+
+		public string Subtype
+		{
+			get => _subtype;
+			set => _subtype = value.TrimToMaxLength();
+		}
 
 		[JsonIgnore]
 		public Dictionary<string, string> Tags => Context.Tags;

--- a/src/Elastic.Apm/Model/Payload/Span.cs
+++ b/src/Elastic.Apm/Model/Payload/Span.cs
@@ -81,11 +81,6 @@ namespace Elastic.Apm.Model.Payload
 			public Dictionary<string, string> Tags => _tags.Value;
 		}
 	}
-
-	public interface IRequest
-	{
-		string Body { get; set; }
-	}
 	internal interface IContext
 	{
 		IDb Db { get; set; }

--- a/src/Elastic.Apm/Model/Payload/Transaction.cs
+++ b/src/Elastic.Apm/Model/Payload/Transaction.cs
@@ -51,7 +51,15 @@ namespace Elastic.Apm.Model.Payload
 
 		public Guid Id { get; }
 
-		public string Name { get; set; }
+		private string _name;
+
+		public string Name
+		{
+			get => _name;
+			set => _name = value.TrimToMaxLength();
+		}
+
+		private string _result;
 
 		/// <inheritdoc />
 		/// <summary>
@@ -59,7 +67,11 @@ namespace Elastic.Apm.Model.Payload
 		/// This is typically the HTTP status code, or e.g. "success" for a background task.
 		/// </summary>
 		/// <value>The result.</value>
-		public string Result { get; set; }
+		public string Result
+		{
+			get => _result;
+			set => _result = value.TrimToMaxLength();
+		}
 
 		internal Service Service;
 
@@ -74,7 +86,13 @@ namespace Elastic.Apm.Model.Payload
 
 		public string Timestamp => Start.ToString("yyyy-MM-ddTHH:mm:ss.FFFZ");
 
-		public string Type { get; set; }
+		private string _type;
+
+		public string Type
+		{
+			get => _type;
+			set => _type = value.TrimToMaxLength();
+		}
 
 		public void End()
 		{

--- a/src/Elastic.Apm/Model/Payload/Transaction.cs
+++ b/src/Elastic.Apm/Model/Payload/Transaction.cs
@@ -72,9 +72,6 @@ namespace Elastic.Apm.Model.Payload
 		[JsonIgnore]
 		public Dictionary<string, string> Tags => Context.Tags;
 
-		[JsonIgnore]
-		public Dictionary<string, object> Custom => Context.Custom;
-
 		public string Timestamp => Start.ToString("yyyy-MM-ddTHH:mm:ss.FFFZ");
 
 		public string Type { get; set; }

--- a/src/Elastic.Apm/Model/Payload/Transaction.cs
+++ b/src/Elastic.Apm/Model/Payload/Transaction.cs
@@ -55,7 +55,7 @@ namespace Elastic.Apm.Model.Payload
 
 		public string Name
 		{
-			get => _name;
+			get => _name ?? "";
 			set => _name = value.TrimToMaxLength();
 		}
 
@@ -69,7 +69,7 @@ namespace Elastic.Apm.Model.Payload
 		/// <value>The result.</value>
 		public string Result
 		{
-			get => _result;
+			get => _result ?? "";
 			set => _result = value.TrimToMaxLength();
 		}
 
@@ -93,7 +93,7 @@ namespace Elastic.Apm.Model.Payload
 
 		public string Type
 		{
-			get => _type;
+			get => _type ?? "";
 			set => _type = value.TrimToMaxLength();
 		}
 

--- a/src/Elastic.Apm/Model/Payload/Transaction.cs
+++ b/src/Elastic.Apm/Model/Payload/Transaction.cs
@@ -84,6 +84,9 @@ namespace Elastic.Apm.Model.Payload
 		[JsonIgnore]
 		public Dictionary<string, string> Tags => Context.Tags;
 
+		[JsonIgnore]
+		public IUser User => Context.User;
+
 		public string Timestamp => Start.ToString("yyyy-MM-ddTHH:mm:ss.FFFZ");
 
 		private string _type;

--- a/src/Elastic.Apm/Model/Payload/Transaction.cs
+++ b/src/Elastic.Apm/Model/Payload/Transaction.cs
@@ -70,6 +70,9 @@ namespace Elastic.Apm.Model.Payload
 		[JsonIgnore]
 		public Dictionary<string, string> Tags => Context.Tags;
 
+		[JsonIgnore]
+		public Dictionary<string, object> Custom => Context.Custom;
+
 		public string Timestamp => Start.ToString("yyyy-MM-ddTHH:mm:ss.FFFZ");
 
 		public string Type { get; set; }

--- a/src/Elastic.Apm/Model/Payload/Transaction.cs
+++ b/src/Elastic.Apm/Model/Payload/Transaction.cs
@@ -38,7 +38,7 @@ namespace Elastic.Apm.Model.Payload
 		/// </summary>
 		public Context Context => _context.Value;
 
-		public IRequest Request => _context.Value?.Request;
+		public IRequest Request => _context.Value?.Request?.Value;
 
 		/// <inheritdoc />
 		/// <summary>
@@ -85,7 +85,7 @@ namespace Elastic.Apm.Model.Payload
 		public Dictionary<string, string> Tags => Context.Tags;
 
 		[JsonIgnore]
-		public IUser User => Context.User;
+		public IUser User => Context.User?.Value;
 
 		public string Timestamp => Start.ToString("yyyy-MM-ddTHH:mm:ss.FFFZ");
 

--- a/src/Elastic.Apm/Model/Payload/Transaction.cs
+++ b/src/Elastic.Apm/Model/Payload/Transaction.cs
@@ -38,6 +38,8 @@ namespace Elastic.Apm.Model.Payload
 		/// </summary>
 		public Context Context => _context.Value;
 
+		public IRequest Request => _context.Value?.Request;
+
 		/// <inheritdoc />
 		/// <summary>
 		/// The duration of the transaction.

--- a/src/Elastic.Apm/Model/Payload/Transaction.cs
+++ b/src/Elastic.Apm/Model/Payload/Transaction.cs
@@ -38,7 +38,7 @@ namespace Elastic.Apm.Model.Payload
 		/// </summary>
 		public Context Context => _context.Value;
 
-		public IRequest Request => _context.Value?.Request?.Value;
+		public IRequest Request => _context.Value?.Request;
 
 		/// <inheritdoc />
 		/// <summary>
@@ -85,7 +85,7 @@ namespace Elastic.Apm.Model.Payload
 		public Dictionary<string, string> Tags => Context.Tags;
 
 		[JsonIgnore]
-		public IUser User => Context.User?.Value;
+		public IUser User => Context.User;
 
 		public string Timestamp => Start.ToString("yyyy-MM-ddTHH:mm:ss.FFFZ");
 

--- a/src/Elastic.Apm/Model/Payload/User.cs
+++ b/src/Elastic.Apm/Model/Payload/User.cs
@@ -1,0 +1,11 @@
+using Elastic.Apm.Api;
+
+namespace Elastic.Apm.Model.Payload
+{
+	internal class User : IUser
+	{
+		public string Id { get; set; }
+		public string Email { get; set; }
+		public string UserName { get; set; }
+	}
+}

--- a/src/Elastic.Apm/Model/Payload/User.cs
+++ b/src/Elastic.Apm/Model/Payload/User.cs
@@ -1,11 +1,32 @@
 using Elastic.Apm.Api;
+using Elastic.Apm.Helpers;
 
 namespace Elastic.Apm.Model.Payload
 {
 	internal class User : IUser
 	{
-		public string Id { get; set; }
-		public string Email { get; set; }
-		public string UserName { get; set; }
+		private string _id;
+		private string _userName;
+		private string _email;
+
+		public string Id
+		{
+			get => _id;
+			set => _id = value.TrimToMaxLength();
+		}
+
+
+		public string Email
+		{
+			get => _email;
+			set => _email = value.TrimToMaxLength();
+		}
+
+
+		public string UserName
+		{
+			get => _userName;
+			set => _userName = value.TrimToMaxLength();
+		}
 	}
 }

--- a/src/Elastic.Apm/Model/Payload/User.cs
+++ b/src/Elastic.Apm/Model/Payload/User.cs
@@ -11,21 +11,21 @@ namespace Elastic.Apm.Model.Payload
 
 		public string Id
 		{
-			get => _id;
+			get => _id ?? "";
 			set => _id = value.TrimToMaxLength();
 		}
 
 
 		public string Email
 		{
-			get => _email;
+			get => _email ?? "";
 			set => _email = value.TrimToMaxLength();
 		}
 
 
 		public string UserName
 		{
-			get => _userName;
+			get => _userName ?? "";
 			set => _userName = value.TrimToMaxLength();
 		}
 	}

--- a/test/Elastic.Apm.AspNetCore.Tests/AspNetCoreDiagnosticListenerTest.cs
+++ b/test/Elastic.Apm.AspNetCore.Tests/AspNetCoreDiagnosticListenerTest.cs
@@ -43,8 +43,8 @@ namespace Elastic.Apm.AspNetCore.Tests
 				Assert.Equal("This is a test exception!", capturedPayload.Errors[0].Errors[0].Exception.Message);
 				Assert.Equal(typeof(Exception).FullName, capturedPayload.Errors[0].Errors[0].Exception.Type);
 
-				Assert.Equal("/Home/TriggerError", capturedPayload.FirstErrorDetail.Context.Request.Value.Url.Full);
-				Assert.Equal(HttpMethod.Get.Method, capturedPayload.FirstErrorDetail.Context.Request.Value.Method);
+				Assert.Equal("/Home/TriggerError", capturedPayload.FirstErrorDetail.Context.Request.Url.Full);
+				Assert.Equal(HttpMethod.Get.Method, capturedPayload.FirstErrorDetail.Context.Request.Method);
 				Assert.False((capturedPayload.FirstErrorDetail.Exception as CapturedException)?.Handled);
 			}
 		}

--- a/test/Elastic.Apm.AspNetCore.Tests/AspNetCoreDiagnosticListenerTest.cs
+++ b/test/Elastic.Apm.AspNetCore.Tests/AspNetCoreDiagnosticListenerTest.cs
@@ -43,8 +43,8 @@ namespace Elastic.Apm.AspNetCore.Tests
 				Assert.Equal("This is a test exception!", capturedPayload.Errors[0].Errors[0].Exception.Message);
 				Assert.Equal(typeof(Exception).FullName, capturedPayload.Errors[0].Errors[0].Exception.Type);
 
-				Assert.Equal("/Home/TriggerError", capturedPayload.FirstErrorDetail.Context.Request.Url.Full);
-				Assert.Equal(HttpMethod.Get.Method, capturedPayload.FirstErrorDetail.Context.Request.Method);
+				Assert.Equal("/Home/TriggerError", capturedPayload.FirstErrorDetail.Context.Request.Value.Url.Full);
+				Assert.Equal(HttpMethod.Get.Method, capturedPayload.FirstErrorDetail.Context.Request.Value.Method);
 				Assert.False((capturedPayload.FirstErrorDetail.Exception as CapturedException)?.Handled);
 			}
 		}

--- a/test/Elastic.Apm.AspNetCore.Tests/AspNetCoreMiddlewareTests.cs
+++ b/test/Elastic.Apm.AspNetCore.Tests/AspNetCoreMiddlewareTests.cs
@@ -64,10 +64,10 @@ namespace Elastic.Apm.AspNetCore.Tests
 			Assert.Equal("request", transaction.Type);
 			Assert.True(transaction.Id != Guid.Empty);
 
-			var request = transaction.Context.Request.Value;
+			var request = transaction.Context.Request;
 
 			//test transaction.context.response
-			Assert.Equal(200, transaction.Context.Response.Value.StatusCode);
+			Assert.Equal(200, transaction.Context.Response.StatusCode);
 
 			//test transaction.context.request
 			Assert.Equal("2.0", request.HttpVersion);

--- a/test/Elastic.Apm.AspNetCore.Tests/AspNetCoreMiddlewareTests.cs
+++ b/test/Elastic.Apm.AspNetCore.Tests/AspNetCoreMiddlewareTests.cs
@@ -64,20 +64,22 @@ namespace Elastic.Apm.AspNetCore.Tests
 			Assert.Equal("request", transaction.Type);
 			Assert.True(transaction.Id != Guid.Empty);
 
+			var request = transaction.Context.Request.Value;
+
 			//test transaction.context.response
-			Assert.Equal(200, transaction.Context.Response.StatusCode);
+			Assert.Equal(200, transaction.Context.Response.Value.StatusCode);
 
 			//test transaction.context.request
-			Assert.Equal("2.0", transaction.Context.Request.HttpVersion);
-			Assert.Equal("GET", transaction.Context.Request.Method);
+			Assert.Equal("2.0", request.HttpVersion);
+			Assert.Equal("GET", request.Method);
 
 			//test transaction.context.request.url
-			Assert.Equal(response.RequestMessage.RequestUri.AbsolutePath, transaction.Context.Request.Url.Full);
-			Assert.Equal("localhost", transaction.Context.Request.Url.HostName);
-			Assert.Equal("HTTP", transaction.Context.Request.Url.Protocol);
+			Assert.Equal(response.RequestMessage.RequestUri.AbsolutePath, request.Url.Full);
+			Assert.Equal("localhost", request.Url.HostName);
+			Assert.Equal("HTTP", request.Url.Protocol);
 
 			//test transaction.context.request.encrypted
-			Assert.False(transaction.Context.Request.Socket.Encrypted);
+			Assert.False(request.Socket.Encrypted);
 		}
 
 		/// <summary>


### PR DESCRIPTION
Add Custom fields. Add the possibility to specify request_body

=============
p.s i need some help from you guys. There is a possible problem that Request and Response will be null on Context object when you create transaction manually. 
For now, i can see initialization for Request and Response only in internals libs such as Elastic.Apm.AspNetCore. The issue is that we need to have some mechanism of initialization for that objects outside of internal namespaces, for example for some custom rpc handlers or protocols. Any suggestions around that? We can pass some parameter to StartTransactionInternal, or pass some initial context object with request\response object or make that fields Lazy or smth like that. 

Thanks,
Stas