### PR TITLE
Expose Transaction.Context.Request through the public agent API

### DIFF
--- a/src/Elastic.Apm.AspNetCore/ApmMiddleware.cs
+++ b/src/Elastic.Apm.AspNetCore/ApmMiddleware.cs
@@ -6,6 +6,8 @@ using Elastic.Apm.Helpers;
 using Elastic.Apm.Model.Payload;
 using Microsoft.AspNetCore.Http;
 
+using Payload = Elastic.Apm.Model.Payload;
+
 [assembly:
 	InternalsVisibleTo(
 		"Elastic.Apm.Tests, PublicKey=002400000480000094000000060200000024000052534131000400000100010051df3e4d8341d66c6dfbf35b2fda3627d08073156ed98eef81122b94e86ef2e44e7980202d21826e367db9f494c265666ae30869fb4cd1a434d171f6b634aa67fa8ca5b9076d55dc3baa203d3a23b9c1296c9f45d06a45cf89520bef98325958b066d8c626db76dd60d0508af877580accdd0e9f88e46b6421bf09a33de53fe1")]
@@ -32,20 +34,19 @@ namespace Elastic.Apm.AspNetCore
 			var transaction = _tracer.StartTransactionInternal($"{context.Request.Method} {context.Request.Path}",
 				ApiConstants.TypeRequest);
 
-			transaction.Context.Request = new Request
+			var url = new Url
 			{
-				Method = context.Request.Method,
+				Full = context.Request?.Path.Value,
+				HostName = context.Request.Host.Host,
+				Protocol = GetProtocolName(context.Request.Protocol),
+				Raw = context.Request?.Path.Value //TODO
+			};
+			transaction.Context.Request = new Payload.Request(context.Request.Method, url)
+			{
 				Socket = new Socket
 				{
 					Encrypted = context.Request.IsHttps,
 					RemoteAddress = context.Connection?.RemoteIpAddress?.ToString()
-				},
-				Url = new Url
-				{
-					Full = context.Request?.Path.Value,
-					HostName = context.Request.Host.Host,
-					Protocol = GetProtocolName(context.Request.Protocol),
-					Raw = context.Request?.Path.Value //TODO
 				},
 				HttpVersion = GetHttpVersion(context.Request.Protocol)
 			};

--- a/src/Elastic.Apm/Api/ITransaction.cs
+++ b/src/Elastic.Apm/Api/ITransaction.cs
@@ -22,6 +22,15 @@ namespace Elastic.Apm.Api
 		/// </summary>
 		string Name { get; set; }
 
+
+		/// <summary>
+		/// If a log record was generated as a result of a http request, the http interface can be used to collect this
+		/// information.
+		/// This property is by default null! You have to assign a <see cref="Request" /> instance to this property in order to use
+		/// it.
+		/// </summary>
+		Request Request { get; set; }
+
 		/// <summary>
 		/// A string describing the result of the transaction.
 		/// This is typically the HTTP status code, or e.g. "success" for a background task.

--- a/src/Elastic.Apm/Api/Request.cs
+++ b/src/Elastic.Apm/Api/Request.cs
@@ -10,6 +10,7 @@ namespace Elastic.Apm.Api
 
 		public string HttpVersion { get; set; }
 		public string Method { get; }
+		public object Body { get; set; }
 
 		public bool SocketEncrypted { get; set; }
 		public string SocketRemoteAddress { get; set; }

--- a/src/Elastic.Apm/Api/Request.cs
+++ b/src/Elastic.Apm/Api/Request.cs
@@ -1,0 +1,22 @@
+namespace Elastic.Apm.Api
+{
+	/// <summary>
+	/// Encapsulates Request related information that can be attached to an <see cref="ITransaction" />.
+	/// See <see cref="ITransaction.Request" />
+	/// </summary>
+	public class Request
+	{
+		public Request(string method, string protocol) => (Method, UrlProtocol) = (method, protocol);
+
+		public string HttpVersion { get; set; }
+		public string Method { get; }
+
+		public bool SocketEncrypted { get; set; }
+		public string SocketRemoteAddress { get; set; }
+
+		public string UrlFull { get; set; }
+		public string UrlHostName { get; set; }
+		public string UrlProtocol { get; }
+		public string UrlRaw { get; set; }
+	}
+}

--- a/src/Elastic.Apm/Model/Payload/Request.cs
+++ b/src/Elastic.Apm/Model/Payload/Request.cs
@@ -7,7 +7,6 @@ namespace Elastic.Apm.Model.Payload
 		public Request(string method, Url url) => (Method, Url) = (method, url);
 
 		public string HttpVersion { get; set; }
-
 		public string Method { get; set; }
 		public Socket Socket { get; set; }
 		public Url Url { get; set; }

--- a/src/Elastic.Apm/Model/Payload/Request.cs
+++ b/src/Elastic.Apm/Model/Payload/Request.cs
@@ -4,6 +4,8 @@ namespace Elastic.Apm.Model.Payload
 {
 	internal class Request
 	{
+		public Request(string method, Url url) => (Method, Url) = (method, url);
+
 		public string HttpVersion { get; set; }
 
 		public string Method { get; set; }

--- a/src/Elastic.Apm/Model/Payload/Request.cs
+++ b/src/Elastic.Apm/Model/Payload/Request.cs
@@ -10,6 +10,7 @@ namespace Elastic.Apm.Model.Payload
 		public string Method { get; set; }
 		public Socket Socket { get; set; }
 		public Url Url { get; set; }
+		public object Body { get; set; }
 	}
 
 	internal class Socket

--- a/src/Elastic.Apm/Model/Payload/Transaction.cs
+++ b/src/Elastic.Apm/Model/Payload/Transaction.cs
@@ -33,6 +33,8 @@ namespace Elastic.Apm.Model.Payload
 			Id = Guid.NewGuid();
 		}
 
+		private Api.Request _request;
+
 		/// <summary>
 		/// Any arbitrary contextual information regarding the event, captured by the agent, optionally provided by the user.
 		/// </summary>
@@ -50,6 +52,21 @@ namespace Elastic.Apm.Model.Payload
 		public Guid Id { get; }
 
 		public string Name { get; set; }
+
+		public Api.Request Request
+		{
+			get => _request;
+			set
+			{
+				_request = value;
+				_context.Value.Request = new Request(value.Method,
+					new Url { Full = value.UrlFull, Protocol = value.UrlProtocol, Raw = value.UrlRaw, HostName = value.UrlHostName })
+				{
+					HttpVersion = value.HttpVersion,
+					Socket = new Socket { Encrypted = value.SocketEncrypted, RemoteAddress = value.SocketRemoteAddress }
+				};
+			}
+		}
 
 		/// <inheritdoc />
 		/// <summary>

--- a/src/Elastic.Apm/Model/Payload/Transaction.cs
+++ b/src/Elastic.Apm/Model/Payload/Transaction.cs
@@ -86,6 +86,7 @@ namespace Elastic.Apm.Model.Payload
 					new Url { Full = Request.UrlFull, Protocol = Request.UrlProtocol, Raw = Request.UrlRaw, HostName = Request.UrlHostName })
 				{
 					HttpVersion = Request.HttpVersion,
+					Body =  Request.Body,
 					Socket = new Socket { Encrypted = Request.SocketEncrypted, RemoteAddress = Request.SocketRemoteAddress }
 				};
 			}

--- a/test/Elastic.Apm.AspNetCore.Tests/AspNetCoreMiddlewareTests.cs
+++ b/test/Elastic.Apm.AspNetCore.Tests/AspNetCoreMiddlewareTests.cs
@@ -115,7 +115,7 @@ namespace Elastic.Apm.AspNetCore.Tests
 			Assert.Single(_capturedPayload.Errors[0].Errors);
 
 			//also make sure the tag is captured
-			Assert.Equal(((_capturedPayload.Errors[0] as Error)?.Errors[0] as Error.ErrorDetail)?.Context.Tags["foo"], "bar");
+			Assert.Equal("bar", ((_capturedPayload.Errors[0] as Error)?.Errors[0] as Error.ErrorDetail)?.Context.Tags["foo"]);
 		}
 
 		public void Dispose()

--- a/test/Elastic.Apm.Tests/ApiTests/ConvenientApiTransactionTests.cs
+++ b/test/Elastic.Apm.Tests/ApiTests/ConvenientApiTransactionTests.cs
@@ -511,6 +511,7 @@ namespace Elastic.Apm.Tests.ApiTests
 						transaction.Request.UrlRaw = "https://elastic.co";
 						transaction.Request.SocketRemoteAddress = "127.0.0.1";
 						transaction.Request.UrlHostName = "elastic";
+						transaction.Request.Body = "123";
 					});
 				});
 
@@ -523,6 +524,7 @@ namespace Elastic.Apm.Tests.ApiTests
 			Assert.Equal("https://elastic.co", payloadSender.FirstTransaction.Context.Request.Url.Raw);
 			Assert.Equal("127.0.0.1", payloadSender.FirstTransaction.Context.Request.Socket.RemoteAddress);
 			Assert.Equal("elastic", payloadSender.FirstTransaction.Context.Request.Url.HostName);
+			Assert.Equal("123", payloadSender.FirstTransaction.Context.Request.Body);
 		}
 
 		/// <summary>


### PR DESCRIPTION
This is a potential solution for https://github.com/elastic/apm-agent-dotnet/issues/124 

Some general thinking:
- We force users to provide required fields - aka: added constructors. It's very hard to have data that'd make the APM server unhappy.
- I added a POCO class `Api.Request`. The idea behind this is that I'd like to avoid exposing the model classes. Those can be changes (yes, breaking changes happen only on major versions), still I think it's not a good idea to expose those - most agents don't do it either.
- The `Request` class flattens the object hierarchy, it does not have properties that are other classes (like `Socket` and `Url`). Idea behind this: I think it's simply confusing... With that we would have an API where we constantly force users to new up objects and nullcheck things.
- Some agents call this `Context`. Since `Context` will probably disappear I'd simply not use that word - I'd not expose the concept of `Context` in generqal. To me this is just an additional information on the `ITransaction` called `Request`. 

- I'd use a similar solution with other things that we'd like to expose on `Context`. 