### PR TITLE
move assertions over to fluent assertions

### DIFF
--- a/test/Elastic.Apm.AspNetCore.Tests/AspNetCoreMiddlewareTests.cs
+++ b/test/Elastic.Apm.AspNetCore.Tests/AspNetCoreMiddlewareTests.cs
@@ -4,9 +4,11 @@ using System.Reflection;
 using System.Threading.Tasks;
 using Elastic.Apm.Model.Payload;
 using Elastic.Apm.Tests.Mocks;
+using FluentAssertions;
 using Microsoft.AspNetCore.Mvc.Testing;
 using SampleAspNetCoreApp;
 using Xunit;
+using Xunit.Sdk;
 
 namespace Elastic.Apm.AspNetCore.Tests
 {
@@ -43,41 +45,48 @@ namespace Elastic.Apm.AspNetCore.Tests
 		{
 			var response = await _client.GetAsync("/Home/SimplePage");
 
-			Assert.Single(_capturedPayload.Payloads);
-			Assert.Single(_capturedPayload.Payloads[0].Transactions);
+			_capturedPayload.Payloads.Should().ContainSingle();
+			_capturedPayload.Payloads[0].Transactions.Should().ContainSingle();
 
 			var payload = _capturedPayload.Payloads[0];
 
-			//test payload
-			Assert.Equal(Assembly.GetEntryAssembly()?.GetName()?.Name, payload.Service.Name);
-			Assert.Equal(Consts.AgentName, payload.Service.Agent.Name);
-			Assert.Equal(Assembly.Load("Elastic.Apm").GetName().Version.ToString(), payload.Service.Agent.Version);
-			Assembly.CreateQualifiedName("ASP.NET Core", payload.Service.Framework.Name);
-			Assembly.CreateQualifiedName(Assembly.Load("Microsoft.AspNetCore").GetName().Version.ToString(), payload.Service.Framework.Version);
+			payload.Service.Name.Should().NotBeNullOrWhiteSpace()
+				.And.Be(Assembly.GetEntryAssembly()?.GetName()?.Name);
+
+			payload.Service.Agent.Name.Should().Be(Consts.AgentName);
+			var apmVersion = Assembly.Load("Elastic.Apm").GetName().Version.ToString();
+			payload.Service.Agent.Version.Should().Be(apmVersion);
+
+			payload.Service.Framework.Name.Should().Be("ASP.NET Core");
+
+			var aspNetCoreVersion = Assembly.Load("Microsoft.AspNetCore").GetName().Version.ToString();
+			payload.Service.Framework.Version.Should().Be(aspNetCoreVersion);
 
 			var transaction = _capturedPayload.FirstTransaction;
 
 			//test transaction
-			Assert.Equal($"{response.RequestMessage.Method} {response.RequestMessage.RequestUri.AbsolutePath}", transaction.Name);
-			Assert.Equal("HTTP 2xx", transaction.Result);
-			Assert.True(transaction.Duration > 0);
-			Assert.Equal("request", transaction.Type);
-			Assert.True(transaction.Id != Guid.Empty);
+			var transactionName = $"{response.RequestMessage.Method} {response.RequestMessage.RequestUri.AbsolutePath}";
+			transaction.Name.Should().Be(transactionName);
+			transaction.Result.Should().Be("HTTP 2xx");
+			transaction.Duration.Should().BeGreaterThan(0);
+
+			transaction.Type.Should().Be("request");
+			transaction.Id.Should().NotBeEmpty();
 
 			//test transaction.context.response
-			Assert.Equal(200, transaction.Context.Response.StatusCode);
+			transaction.Context.Response.StatusCode.Should().Be(200);
 
 			//test transaction.context.request
-			Assert.Equal("2.0", transaction.Context.Request.HttpVersion);
-			Assert.Equal("GET", transaction.Context.Request.Method);
+			transaction.Context.Request.HttpVersion.Should().Be("2.0");
+			transaction.Context.Request.Method.Should().Be("GET");
 
 			//test transaction.context.request.url
-			Assert.Equal(response.RequestMessage.RequestUri.AbsolutePath, transaction.Context.Request.Url.Full);
-			Assert.Equal("localhost", transaction.Context.Request.Url.HostName);
-			Assert.Equal("HTTP", transaction.Context.Request.Url.Protocol);
+			transaction.Context.Request.Url.Full.Should().Be(response.RequestMessage.RequestUri.AbsolutePath);
+			transaction.Context.Request.Url.HostName.Should().Be("localhost");
+			transaction.Context.Request.Url.Protocol.Should().Be("HTTP");
 
 			//test transaction.context.request.encrypted
-			Assert.False(transaction.Context.Request.Socket.Encrypted);
+			transaction.Context.Request.Socket.Encrypted.Should().BeFalse();
 		}
 
 		/// <summary>
@@ -88,13 +97,9 @@ namespace Elastic.Apm.AspNetCore.Tests
 		public async Task HomeIndexSpanTest()
 		{
 			var response = await _client.GetAsync("/Home/Index");
-			Assert.True(response.IsSuccessStatusCode);
+			response.IsSuccessStatusCode.Should().BeTrue();
 
-			var transaction = _capturedPayload.Payloads[0].Transactions[0];
-			Assert.NotEmpty(_capturedPayload.SpansOnFirstTransaction);
-
-			//one of the spans is a DB call:
-			Assert.Contains(_capturedPayload.SpansOnFirstTransaction, n => n.Context.Db != null);
+			_capturedPayload.SpansOnFirstTransaction.Should().NotBeEmpty().And.Contain(n => n.Context.Db != null);
 		}
 
 		/// <summary>
@@ -106,16 +111,23 @@ namespace Elastic.Apm.AspNetCore.Tests
 		public async Task FailingRequestWithoutConfiguredExceptionPage()
 		{
 			_client = Helper.GetClientWithoutExceptionPage(_agent, _factory);
-			await Assert.ThrowsAsync<Exception>(async () => { await _client.GetAsync("Home/TriggerError"); });
 
-			Assert.Single(_capturedPayload.Payloads);
-			Assert.Single(_capturedPayload.Payloads[0].Transactions);
+			Func<Task> act = async () => await _client.GetAsync("Home/TriggerError");
+			await act.Should().ThrowAsync<Exception>();
 
-			Assert.NotEmpty(_capturedPayload.Errors);
-			Assert.Single(_capturedPayload.Errors[0].Errors);
+			_capturedPayload.Payloads.Should().ContainSingle();
+			_capturedPayload.Payloads[0].Transactions.Should().ContainSingle();
+
+			_capturedPayload.Errors.Should().NotBeEmpty();
+			_capturedPayload.Errors[0].Errors.Should().ContainSingle();
 
 			//also make sure the tag is captured
-			Assert.Equal(((_capturedPayload.Errors[0] as Error)?.Errors[0] as Error.ErrorDetail)?.Context.Tags["foo"], "bar");
+			var error = _capturedPayload.Errors[0] as Error;
+			error.Should().NotBeNull();
+			var errorDetail = error.Errors[0] as Error.ErrorDetail;
+			errorDetail.Should().NotBeNull();
+			var tags = errorDetail.Context.Tags;
+			tags.Should().NotBeEmpty().And.ContainKey("foo").And.Contain("foo", "bar");
 		}
 
 		public void Dispose()

--- a/test/Elastic.Apm.AspNetCore.Tests/DiagnosticListenerTests.cs
+++ b/test/Elastic.Apm.AspNetCore.Tests/DiagnosticListenerTests.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using Elastic.Apm.AspNetCore.DiagnosticListener;
 using Elastic.Apm.EntityFrameworkCore;
 using Elastic.Apm.Tests.Mocks;
+using FluentAssertions;
 using Microsoft.AspNetCore.Mvc.Testing;
 using SampleAspNetCoreApp;
 using Xunit;
@@ -47,12 +48,12 @@ namespace Elastic.Apm.AspNetCore.Tests
 //			{
 //				await _client.GetAsync("/Home/TriggerError");
 //
-//				Assert.Single(_capturedPayload.Payloads);
-//				Assert.Single(_capturedPayload.Payloads[0].Transactions);
+//				_capturedPayload.Payloads.Should().ContainSingle();
+//				_capturedPayload.Payloads[0].Transactions.Should().ContainSingle();
 //
-//				Assert.NotEmpty(_capturedPayload.Errors);
-//				Assert.Single(_capturedPayload.Errors[0].Errors);
-//				Assert.Equal(typeof(Exception).FullName, _capturedPayload.Errors[0].Errors[0].Exception.Type);
+//				_capturedPayload.Errors.Should().NotBeEmpty();
+//				_capturedPayload.Errors[0].Errors.Should().ContainSingle();
+//				 _capturedPayload.Errors[0].Errors[0].Exception.Type.Should().Be(typeof(Exception).FullName);
 //			} //here we unsubsribe, so no errors should be captured after this line.
 
 			_agent.Dispose();
@@ -62,9 +63,9 @@ namespace Elastic.Apm.AspNetCore.Tests
 
 			await _client.GetAsync("/Home/TriggerError");
 
-			Assert.Single(_capturedPayload.Payloads);
-			Assert.Single(_capturedPayload.Payloads[0].Transactions);
-			Assert.Empty(_capturedPayload.Errors);
+			_capturedPayload.Payloads.Should().ContainSingle();
+			_capturedPayload.Payloads[0].Transactions.Should().ContainSingle();
+			_capturedPayload.Errors.Should().BeEmpty();
 		}
 
 		/// <summary>
@@ -81,11 +82,11 @@ namespace Elastic.Apm.AspNetCore.Tests
 			{
 				await _client.GetAsync("/Home/Index");
 
-				Assert.Single(_capturedPayload.Payloads);
-				Assert.Single(_capturedPayload.Payloads[0].Transactions);
+				_capturedPayload.Payloads.Should().ContainSingle();
+				_capturedPayload.Payloads[0].Transactions.Should().ContainSingle();
 
-				Assert.NotEmpty(_capturedPayload.SpansOnFirstTransaction);
-				Assert.Contains(_capturedPayload.SpansOnFirstTransaction, n => n.Context.Db != null);
+				_capturedPayload.SpansOnFirstTransaction.Should().NotBeEmpty()
+					.And.Contain(n => n.Context.Db != null);
 			} //here we unsubsribe, so no errors should be captured after this line.
 
 			_capturedPayload.Payloads.Clear();
@@ -93,10 +94,10 @@ namespace Elastic.Apm.AspNetCore.Tests
 
 			await _client.GetAsync("/Home/Index");
 
-			Assert.Single(_capturedPayload.Payloads);
-			Assert.Single(_capturedPayload.Payloads[0].Transactions);
+			_capturedPayload.Payloads.Should().ContainSingle();
+			_capturedPayload.Payloads[0].Transactions.Should().ContainSingle();
 
-			Assert.Empty(_capturedPayload.SpansOnFirstTransaction);
+			_capturedPayload.SpansOnFirstTransaction.Should().BeEmpty();
 		}
 
 		public void Dispose()

--- a/test/Elastic.Apm.AspNetCore.Tests/Elastic.Apm.AspNetCore.Tests.csproj
+++ b/test/Elastic.Apm.AspNetCore.Tests/Elastic.Apm.AspNetCore.Tests.csproj
@@ -6,8 +6,12 @@
     <RootNamespace>Elastic.Apm.AspNetCore.Tests</RootNamespace>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\build\elasticapm.snk</AssemblyOriginatorKeyFile>
+    <!-- Always generate debug symbols this allows fluent symbols exception messages to include variable names -->
+    <DebugSymbols>True</DebugSymbols>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="FluentAssertions" Version="5.6.0" />
+    <PackageReference Include="FluentAssertions.Analyzers" Version="0.11.4" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
@@ -19,9 +23,6 @@
     <ProjectReference Include="..\..\src\Elastic.Apm\Elastic.Apm.csproj" />
     <ProjectReference Include="..\..\sample\SampleAspNetCoreApp\SampleAspNetCoreApp.csproj" />
     <ProjectReference Include="..\Elastic.Apm.Tests\Elastic.Apm.Tests.csproj" />
-  </ItemGroup>
-  <ItemGroup>
-    <Folder Include="TestConfigs\" />
   </ItemGroup>
   <ItemGroup>
     <Content Update="TestConfigs\appsettings_valid.json">

--- a/test/Elastic.Apm.AspNetCore.Tests/MicrosoftExtensionsConfigTests.cs
+++ b/test/Elastic.Apm.AspNetCore.Tests/MicrosoftExtensionsConfigTests.cs
@@ -7,6 +7,7 @@ using Elastic.Apm.AspNetCore.Config;
 using Elastic.Apm.Config;
 using Elastic.Apm.Logging;
 using Elastic.Apm.Tests.Mocks;
+using FluentAssertions;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.Extensions.Configuration;
 using SampleAspNetCoreApp;
@@ -27,10 +28,11 @@ namespace Elastic.Apm.AspNetCore.Tests
 		[Fact]
 		public void ReadValidConfigsFromAppSettingsJson()
 		{
-			var config = new MicrosoftExtensionsConfig(GetConfig($"TestConfigs{Path.DirectorySeparatorChar}appsettings_valid.json"), new TestLogger());
-			Assert.Equal(LogLevel.Debug, config.LogLevel);
-			Assert.Equal(new Uri("http://myServerFromTheConfigFile:8080"), config.ServerUrls[0]);
-			Assert.Equal("My_Test_Application", config.ServiceName);
+			var config = new MicrosoftExtensionsConfig(GetConfig($"TestConfigs{Path.DirectorySeparatorChar}appsettings_valid.json"),
+				new TestLogger());
+			config.LogLevel.Should().Be(LogLevel.Debug);
+			config.ServerUrls[0].Should().Be(new Uri("http://myServerFromTheConfigFile:8080"));
+			config.ServiceName.Should().Be("My_Test_Application");
 		}
 
 		/// <summary>
@@ -42,11 +44,17 @@ namespace Elastic.Apm.AspNetCore.Tests
 		{
 			var logger = new TestLogger();
 			var config = new MicrosoftExtensionsConfig(GetConfig($"TestConfigs{Path.DirectorySeparatorChar}appsettings_invalid.json"), logger);
-			Assert.Equal(LogLevel.Error, config.LogLevel);
+			config.LogLevel.Should().Be(LogLevel.Error);
 
-			Assert.Equal(
-				$"{{MicrosoftExtensionsConfig}} Failed parsing log level from {MicrosoftExtensionsConfig.Origin}: {MicrosoftExtensionsConfig.Keys.Level}, value: DbeugMisspelled. Defaulting to log level 'Error'",
-				logger.Lines[0]);
+			logger.Lines.Should().NotBeEmpty();
+			logger.Lines[0].Should()
+				.StartWith($"{{{nameof(MicrosoftExtensionsConfig)}}}")
+				.And.ContainAll(
+					"Failed parsing log level from",
+					MicrosoftExtensionsConfig.Origin,
+					MicrosoftExtensionsConfig.Keys.Level,
+					"Defaulting to "
+				);
 		}
 
 		/// <summary>
@@ -58,11 +66,18 @@ namespace Elastic.Apm.AspNetCore.Tests
 		{
 			var logger = new TestLogger();
 			var config = new MicrosoftExtensionsConfig(GetConfig($"TestConfigs{Path.DirectorySeparatorChar}appsettings_invalid.json"), logger);
-			Assert.Equal(LogLevel.Error, config.LogLevel);
+			config.LogLevel.Should().Be(LogLevel.Error);
 
-			Assert.Equal(
-				$"{{MicrosoftExtensionsConfig}} Failed parsing log level from {MicrosoftExtensionsConfig.Origin}: {MicrosoftExtensionsConfig.Keys.Level}, value: DbeugMisspelled. Defaulting to log level 'Error'",
-				logger.Lines[0]);
+			logger.Lines.Should().NotBeEmpty();
+			logger.Lines[0].Should()
+				.StartWith($"{{{nameof(MicrosoftExtensionsConfig)}}}")
+				.And.ContainAll(
+					"Failed parsing log level from",
+					MicrosoftExtensionsConfig.Origin,
+					MicrosoftExtensionsConfig.Keys.Level,
+					"Defaulting to ",
+					"DbeugMisspelled"
+				);
 		}
 
 		/// <summary>
@@ -84,10 +99,10 @@ namespace Elastic.Apm.AspNetCore.Tests
 				.Build();
 
 			var config = new MicrosoftExtensionsConfig(configBuilder, new TestLogger());
-			Assert.Equal(LogLevel.Debug, config.LogLevel);
-			Assert.Equal(new Uri(serverUrl), config.ServerUrls[0]);
-			Assert.Equal(serviceName, config.ServiceName);
-			Assert.Equal(secretToken, config.SecretToken);
+			config.LogLevel.Should().Be(LogLevel.Debug);
+			config.ServerUrls[0].Should().Be(new Uri(serverUrl));
+			config.ServiceName.Should().Be(serviceName);
+			config.SecretToken.Should().Be(secretToken);
 		}
 
 		/// <summary>
@@ -100,8 +115,8 @@ namespace Elastic.Apm.AspNetCore.Tests
 			var testLogger = new TestLogger();
 			var config = new MicrosoftExtensionsConfig(GetConfig($"TestConfigs{Path.DirectorySeparatorChar}appsettings_invalid.json"), testLogger);
 			var serverUrl = config.ServerUrls.FirstOrDefault();
-			Assert.NotNull(serverUrl);
-			Assert.NotEmpty(testLogger.Lines);
+			serverUrl.Should().NotBeNull();
+			testLogger.Lines.Should().NotBeEmpty();
 		}
 
 		internal static IConfiguration GetConfig(string path)
@@ -149,10 +164,10 @@ namespace Elastic.Apm.AspNetCore.Tests
 		public async Task InvalidUrlTest()
 		{
 			var response = await _client.GetAsync("/Home/Index");
-			Assert.True(response.IsSuccessStatusCode);
+			response.IsSuccessStatusCode.Should().BeTrue();
 
-			Assert.NotEmpty(_logger.Lines);
-			Assert.Contains(_logger.Lines, n => n.Contains("Failed parsing server URL from"));
+			_logger.Lines.Should().NotBeEmpty()
+				.And.Contain(n => n.Contains("Failed parsing server URL from"));
 		}
 
 		public void Dispose()

--- a/test/Elastic.Apm.Tests/ApiTests/ApiTests.cs
+++ b/test/Elastic.Apm.Tests/ApiTests/ApiTests.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using Elastic.Apm.Api;
 using Elastic.Apm.Model.Payload;
 using Elastic.Apm.Tests.Mocks;
+using FluentAssertions;
 using Xunit;
 
 namespace Elastic.Apm.Tests.ApiTests
@@ -32,13 +33,14 @@ namespace Elastic.Apm.Tests.ApiTests
 			Thread.Sleep(5); //Make sure we have duration > 0
 
 			transaction.End();
-			Assert.Single(payloadSender.Payloads);
-			Assert.Equal(transactionName, payloadSender.Payloads[0].Transactions[0].Name);
-			Assert.Equal(transactionType, payloadSender.Payloads[0].Transactions[0].Type);
-			Assert.True(payloadSender.Payloads[0].Transactions[0].Duration >= 5);
-			Assert.True(payloadSender.Payloads[0].Transactions[0].Id != Guid.Empty);
+			payloadSender.Payloads.Should().ContainSingle();
+			var capturedTransaction = payloadSender.Payloads[0].Transactions[0];
+			capturedTransaction.Name.Should().Be(transactionName);
+			capturedTransaction.Type.Should().Be(transactionType);
+			capturedTransaction.Duration.Should().BeGreaterOrEqualTo(5);
+			capturedTransaction.Id.Should().NotBeEmpty();
 
-			Assert.NotNull(payloadSender.Payloads[0].Service);
+			payloadSender.Payloads[0].Service.Should().NotBeNull();
 		}
 
 		/// <summary>
@@ -54,7 +56,7 @@ namespace Elastic.Apm.Tests.ApiTests
 			var agent = new ApmAgent(new TestAgentComponents(payloadSender: payloadSender));
 
 			var unused = agent.Tracer.StartTransaction(transactionName, transactionType);
-			Assert.Empty(payloadSender.Payloads);
+			payloadSender.Payloads.Should().BeEmpty();
 		}
 
 		/// <summary>
@@ -74,7 +76,7 @@ namespace Elastic.Apm.Tests.ApiTests
 			transaction.Result = result;
 			transaction.End();
 
-			Assert.Equal(result, payloadSender.Payloads[0].Transactions[0].Result);
+			payloadSender.Payloads[0].Transactions[0].Result.Should().Be(result);
 		}
 
 		/// <summary>
@@ -86,7 +88,7 @@ namespace Elastic.Apm.Tests.ApiTests
 		{
 			var agent = new ApmAgent(new TestAgentComponents());
 			var currentTransaction = agent.Tracer.CurrentTransaction;
-			Assert.Null(currentTransaction);
+			currentTransaction.Should().BeNull();
 		}
 
 		/// <summary>
@@ -104,9 +106,9 @@ namespace Elastic.Apm.Tests.ApiTests
 
 			var currentTransaction = agent.Tracer.CurrentTransaction; //Get transaction in the current task
 
-			Assert.NotNull(currentTransaction);
-			Assert.Equal(transactionName, currentTransaction.Name);
-			Assert.Equal(ApiConstants.TypeRequest, currentTransaction.Type);
+			currentTransaction.Should().NotBeNull();
+			currentTransaction.Name.Should().Be(transactionName);
+			currentTransaction.Type.Should().Be(ApiConstants.TypeRequest);
 
 			void StartTransaction()
 			{
@@ -117,16 +119,16 @@ namespace Elastic.Apm.Tests.ApiTests
 			async Task DoAsyncWork()
 			{
 				//Make sure we have a transaction in the subtask before the async work
-				Assert.NotNull(agent.Tracer.CurrentTransaction);
-				Assert.Equal(transactionName, agent.Tracer.CurrentTransaction.Name);
-				Assert.Equal(ApiConstants.TypeRequest, agent.Tracer.CurrentTransaction.Type);
+				agent.Tracer.CurrentTransaction.Should().NotBeNull();
+				agent.Tracer.CurrentTransaction.Name.Should().Be(transactionName);
+				agent.Tracer.CurrentTransaction.Type.Should().Be(ApiConstants.TypeRequest);
 
 				await Task.Delay(50);
 
 				//and after the async work
-				Assert.NotNull(agent.Tracer.CurrentTransaction);
-				Assert.Equal(transactionName, agent.Tracer.CurrentTransaction.Name);
-				Assert.Equal(ApiConstants.TypeRequest, agent.Tracer.CurrentTransaction.Type);
+				agent.Tracer.CurrentTransaction.Should().NotBeNull();
+				agent.Tracer.CurrentTransaction.Name.Should().Be(transactionName);
+				agent.Tracer.CurrentTransaction.Type.Should().Be(ApiConstants.TypeRequest);
 			}
 		}
 
@@ -151,13 +153,12 @@ namespace Elastic.Apm.Tests.ApiTests
 
 			span.End();
 			transaction.End();
-			Assert.NotEmpty(payloadSender.Payloads);
-			Assert.NotEmpty(payloadSender.SpansOnFirstTransaction);
+			payloadSender.Payloads.Should().NotBeEmpty();
+			payloadSender.SpansOnFirstTransaction.Should().NotBeEmpty();
 
-			Assert.Equal(spanName, payloadSender.SpansOnFirstTransaction[0].Name);
-			Assert.True(payloadSender.SpansOnFirstTransaction[0].Duration >= 5);
-			Assert.True(payloadSender.SpansOnFirstTransaction[0].Id >= 5);
-			Assert.NotNull(payloadSender.Payloads[0].Service);
+			payloadSender.SpansOnFirstTransaction[0].Name.Should().Be(spanName);
+			payloadSender.SpansOnFirstTransaction[0].Duration.Should().BeGreaterOrEqualTo(5);
+			payloadSender.Payloads[0].Service.Should().NotBeNull();
 		}
 
 		/// <summary>
@@ -180,10 +181,10 @@ namespace Elastic.Apm.Tests.ApiTests
 			Thread.Sleep(5); //Make sure we have duration > 0
 
 			transaction.End(); //Ends transaction, but doesn't end span.
-			Assert.NotEmpty(payloadSender.Payloads);
-			Assert.Empty(payloadSender.SpansOnFirstTransaction);
+			payloadSender.Payloads.Should().NotBeEmpty();
+			payloadSender.SpansOnFirstTransaction.Should().BeEmpty();
 
-			Assert.NotNull(payloadSender.Payloads[0].Service);
+			payloadSender.Payloads[0].Service.Should().NotBeNull();
 		}
 
 		/// <summary>
@@ -204,14 +205,14 @@ namespace Elastic.Apm.Tests.ApiTests
 			span.End();
 			transaction.End();
 
-			Assert.NotEmpty(payloadSender.Payloads);
-			Assert.NotEmpty(payloadSender.SpansOnFirstTransaction);
+			payloadSender.Payloads.Should().NotBeEmpty();
+			payloadSender.SpansOnFirstTransaction.Should().NotBeEmpty();
 
-			Assert.Equal(ApiConstants.TypeDb, payloadSender.SpansOnFirstTransaction[0].Type);
-			Assert.Equal(ApiConstants.SubtypeMssql, payloadSender.SpansOnFirstTransaction[0].Subtype);
-			Assert.Equal(ApiConstants.ActionQuery, payloadSender.SpansOnFirstTransaction[0].Action);
+			payloadSender.SpansOnFirstTransaction[0].Type.Should().Be(ApiConstants.TypeDb);
+			payloadSender.SpansOnFirstTransaction[0].Subtype.Should().Be(ApiConstants.SubtypeMssql);
+			payloadSender.SpansOnFirstTransaction[0].Action.Should().Be(ApiConstants.ActionQuery);
 
-			Assert.NotNull(payloadSender.Payloads[0].Service);
+			payloadSender.Payloads[0].Service.Should().NotBeNull();
 		}
 
 		/// <summary>
@@ -256,12 +257,12 @@ namespace Elastic.Apm.Tests.ApiTests
 
 			transaction.End();
 
-			Assert.Single(payloadSender.Payloads);
-			Assert.Single(payloadSender.Errors);
-			Assert.Equal(exceptionMessage, payloadSender.Errors[0].Errors[0].Exception.Message);
-			Assert.Equal(exceptionMessage, payloadSender.Errors[0].Errors[0].Exception.Message);
+			payloadSender.Payloads.Should().ContainSingle();
+			payloadSender.Errors.Should().ContainSingle();
+			payloadSender.Errors[0].Errors[0].Exception.Message.Should().Be(exceptionMessage);
+			payloadSender.Errors[0].Errors[0].Exception.Message.Should().Be(exceptionMessage);
 
-			Assert.Equal(!string.IsNullOrEmpty(culprit) ? culprit : "PublicAPI-CaptureException", payloadSender.Errors[0].Errors[0].Culprit);
+			payloadSender.Errors[0].Errors[0].Culprit.Should().Be(!string.IsNullOrEmpty(culprit) ? culprit : "PublicAPI-CaptureException");
 		}
 
 		/// <summary>
@@ -296,10 +297,9 @@ namespace Elastic.Apm.Tests.ApiTests
 			span.End();
 			transaction.End();
 
-			Assert.Single(payloadSender.Payloads);
-			Assert.Single(payloadSender.Errors);
-			Assert.Equal(exceptionMessage, payloadSender.Errors[0].Errors[0].Exception.Message);
-			Assert.Equal(exceptionMessage, payloadSender.Errors[0].Errors[0].Exception.Message);
+			payloadSender.Payloads.Should().ContainSingle();
+			payloadSender.Errors.Should().ContainSingle();
+			payloadSender.Errors[0].Errors[0].Exception.Message.Should().Be(exceptionMessage);
 		}
 
 		/// <summary>
@@ -338,22 +338,21 @@ namespace Elastic.Apm.Tests.ApiTests
 			span.End();
 			transaction.End();
 
-			Assert.Single(payloadSender.Payloads);
-			Assert.Single(payloadSender.Errors);
-			Assert.Equal(exceptionMessage, payloadSender.Errors[0].Errors[0].Exception.Message);
-			Assert.Equal(exceptionMessage, payloadSender.Errors[0].Errors[0].Exception.Message);
+			payloadSender.Payloads.Should().ContainSingle();
+			payloadSender.Errors.Should().ContainSingle();
+			payloadSender.Errors[0].Errors[0].Exception.Message.Should().Be(exceptionMessage);
 
-			Assert.Equal("barTransaction1", payloadSender.Payloads[0].Transactions[0].Tags["fooTransaction1"]);
-			Assert.Equal("barTransaction1", payloadSender.FirstTransaction.Context.Tags["fooTransaction1"]);
+			payloadSender.Payloads[0].Transactions[0].Tags.Should().Contain("fooTransaction1", "barTransaction1");
+			payloadSender.FirstTransaction.Context.Tags.Should().Contain("fooTransaction1", "barTransaction1");
 
-			Assert.Equal("barTransaction2", payloadSender.Payloads[0].Transactions[0].Tags["fooTransaction2"]);
-			Assert.Equal("barTransaction2", payloadSender.FirstTransaction.Context.Tags["fooTransaction2"]);
+			payloadSender.Payloads[0].Transactions[0].Tags.Should().Contain("fooTransaction2", "barTransaction2");
+			payloadSender.FirstTransaction.Context.Tags.Should().Contain("fooTransaction2", "barTransaction2");
 
-			Assert.Equal("barSpan1", payloadSender.SpansOnFirstTransaction[0].Tags["fooSpan1"]);
-			Assert.Equal("barSpan1", payloadSender.SpansOnFirstTransaction[0].Context.Tags["fooSpan1"]);
+			payloadSender.SpansOnFirstTransaction[0].Tags.Should().Contain("fooSpan1", "barSpan1");
+			payloadSender.SpansOnFirstTransaction[0].Context.Tags.Should().Contain("fooSpan1", "barSpan1");
 
-			Assert.Equal("barSpan2", payloadSender.SpansOnFirstTransaction[0].Tags["fooSpan2"]);
-			Assert.Equal("barSpan2", payloadSender.SpansOnFirstTransaction[0].Context.Tags["fooSpan2"]);
+			payloadSender.SpansOnFirstTransaction[0].Tags.Should().Contain("fooSpan2", "barSpan2");
+			payloadSender.SpansOnFirstTransaction[0].Context.Tags.Should().Contain("fooSpan2", "barSpan2");
 		}
 	}
 }

--- a/test/Elastic.Apm.Tests/ApiTests/ConvenientApiSpanTests.cs
+++ b/test/Elastic.Apm.Tests/ApiTests/ConvenientApiSpanTests.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using Elastic.Apm.Api;
 using Elastic.Apm.Model.Payload;
 using Elastic.Apm.Tests.Mocks;
+using FluentAssertions;
 using Xunit;
 
 namespace Elastic.Apm.Tests.ApiTests
@@ -46,14 +47,15 @@ namespace Elastic.Apm.Tests.ApiTests
 		public void SimpleActionWithException()
 			=> AssertWith1TransactionAnd1SpanAnd1Error(t =>
 			{
-				Assert.Throws<InvalidOperationException>(() =>
+				Action act = () =>
 				{
 					t.CaptureSpan(SpanName, SpanType, new Action(() =>
 					{
 						WaitHelpers.Sleep2XMinimum();
 						throw new InvalidOperationException(ExceptionMessage);
 					}));
-				});
+				};
+				act.Should().Throw<InvalidOperationException>();
 			});
 
 		/// <summary>
@@ -68,7 +70,7 @@ namespace Elastic.Apm.Tests.ApiTests
 				t.CaptureSpan(SpanName, SpanType,
 					s =>
 					{
-						Assert.NotNull(s);
+						s.Should().NotBeNull();
 						WaitHelpers.Sleep2XMinimum();
 					});
 			});
@@ -85,15 +87,16 @@ namespace Elastic.Apm.Tests.ApiTests
 		public void SimpleActionWithExceptionAndParameter()
 			=> AssertWith1TransactionAnd1SpanAnd1Error(t =>
 			{
-				Assert.Throws<InvalidOperationException>(() =>
+				Action act = () =>
 				{
 					t.CaptureSpan(SpanName, SpanType, new Action<ISpan>(s =>
 					{
-						Assert.NotNull(s);
+						s.Should().NotBeNull();
 						WaitHelpers.Sleep2XMinimum();
 						throw new InvalidOperationException(ExceptionMessage);
 					}));
-				});
+				};
+				act.Should().Throw<InvalidOperationException>().WithMessage(ExceptionMessage);
 			});
 
 		/// <summary>
@@ -111,7 +114,7 @@ namespace Elastic.Apm.Tests.ApiTests
 					return 42;
 				});
 
-				Assert.Equal(42, res);
+				res.Should().Be(42);
 			});
 
 		/// <summary>
@@ -127,12 +130,12 @@ namespace Elastic.Apm.Tests.ApiTests
 			{
 				var res = t.CaptureSpan(SpanName, SpanType, s =>
 				{
-					Assert.NotNull(t);
+					t.Should().NotBeNull();
 					WaitHelpers.Sleep2XMinimum();
 					return 42;
 				});
 
-				Assert.Equal(42, res);
+				res.Should().Be(42);
 			});
 
 		/// <summary>
@@ -147,11 +150,11 @@ namespace Elastic.Apm.Tests.ApiTests
 		public void SimpleActionWithReturnTypeAndExceptionAndParameter()
 			=> AssertWith1TransactionAnd1SpanAnd1Error(t =>
 			{
-				Assert.Throws<InvalidOperationException>(() =>
+				Action act = () =>
 				{
 					var result = t.CaptureSpan(SpanName, SpanType, s =>
 					{
-						Assert.NotNull(s);
+						s.Should().NotBeNull();
 						WaitHelpers.Sleep2XMinimum();
 
 						if (new Random().Next(1) == 0) //avoid unreachable code warning.
@@ -159,10 +162,9 @@ namespace Elastic.Apm.Tests.ApiTests
 
 						return 42;
 					});
-
-					Assert.True(false); //Should not be executed because the agent isn't allowed to catch an exception.
-					Assert.Equal(42, result); //But if it'd not throw it'd be 42.
-				});
+					throw new Exception("CaptureSpan should not eat exception and continue");
+				};
+				act.Should().Throw<InvalidOperationException>().WithMessage(ExceptionMessage);
 			});
 
 		/// <summary>
@@ -177,21 +179,17 @@ namespace Elastic.Apm.Tests.ApiTests
 		public void SimpleActionWithReturnTypeAndException()
 			=> AssertWith1TransactionAnd1SpanAnd1Error(t =>
 			{
-				Assert.Throws<InvalidOperationException>(() =>
+				var alwaysThrow = new Random().Next(1) == 0;
+				Func<int> act = () => t.CaptureSpan(SpanName, SpanType, () =>
 				{
-					var result = t.CaptureSpan(SpanName, SpanType, () =>
-					{
-						WaitHelpers.Sleep2XMinimum();
+					WaitHelpers.Sleep2XMinimum();
 
-						if (new Random().Next(1) == 0) //avoid unreachable code warning.
-							throw new InvalidOperationException(ExceptionMessage);
+					if (alwaysThrow) //avoid unreachable code warning.
+						throw new InvalidOperationException(ExceptionMessage);
 
-						return 42;
-					});
-
-					Assert.True(false); //Should not be executed because the agent isn't allowed to catch an exception.
-					Assert.Equal(42, result); //But if it'd not throw it'd be 42.
+					return 42;
 				});
+				act.Should().Throw<InvalidOperationException>().WithMessage(ExceptionMessage);
 			});
 
 		/// <summary>
@@ -216,14 +214,16 @@ namespace Elastic.Apm.Tests.ApiTests
 		public async Task AsyncTaskWithException()
 			=> await AssertWith1TransactionAnd1ErrorAnd1SpanAsync(async t =>
 			{
-				await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+				Func<Task> act = async () =>
 				{
 					await t.CaptureSpan(SpanName, SpanType, async () =>
 					{
 						await WaitHelpers.Delay2XMinimum();
 						throw new InvalidOperationException(ExceptionMessage);
 					});
-				});
+				};
+				var should = await act.Should().ThrowAsync<InvalidOperationException>();
+				should.WithMessage(ExceptionMessage);
 			});
 
 		/// <summary>
@@ -238,7 +238,7 @@ namespace Elastic.Apm.Tests.ApiTests
 				await t.CaptureSpan(SpanName, SpanType,
 					async s =>
 					{
-						Assert.NotNull(s);
+						s.Should().NotBeNull();
 						await WaitHelpers.Delay2XMinimum();
 					});
 			});
@@ -254,15 +254,16 @@ namespace Elastic.Apm.Tests.ApiTests
 		public async Task AsyncTaskWithExceptionAndParameter()
 			=> await AssertWith1TransactionAnd1ErrorAnd1SpanAsync(async t =>
 			{
-				await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+				Func<Task> act = async () =>
 				{
 					await t.CaptureSpan(SpanName, SpanType, async s =>
 					{
-						Assert.NotNull(s);
+						s.Should().NotBeNull();
 						await WaitHelpers.Delay2XMinimum();
 						throw new InvalidOperationException(ExceptionMessage);
 					});
-				});
+				};
+				await act.Should().ThrowAsync<InvalidOperationException>();
 			});
 
 		/// <summary>
@@ -279,7 +280,7 @@ namespace Elastic.Apm.Tests.ApiTests
 					await WaitHelpers.Delay2XMinimum();
 					return 42;
 				});
-				Assert.Equal(42, res);
+				res.Should().Be(42);
 			});
 
 		/// <summary>
@@ -296,12 +297,12 @@ namespace Elastic.Apm.Tests.ApiTests
 				var res = await t.CaptureSpan(SpanName, SpanType,
 					async s =>
 					{
-						Assert.NotNull(s);
+						s.Should().NotBeNull();
 						await WaitHelpers.Delay2XMinimum();
 						return 42;
 					});
 
-				Assert.Equal(42, res);
+				res.Should().Be(42);
 			});
 
 		/// <summary>
@@ -316,11 +317,11 @@ namespace Elastic.Apm.Tests.ApiTests
 		public async Task AsyncTaskWithReturnTypeAndExceptionAndParameter()
 			=> await AssertWith1TransactionAnd1ErrorAnd1SpanAsync(async t =>
 			{
-				await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+				Func<Task> act = async () =>
 				{
 					var result = await t.CaptureSpan(SpanName, SpanType, async s =>
 					{
-						Assert.NotNull(s);
+						s.Should().NotBeNull();
 						await WaitHelpers.Delay2XMinimum();
 
 						if (new Random().Next(1) == 0) //avoid unreachable code warning.
@@ -328,10 +329,8 @@ namespace Elastic.Apm.Tests.ApiTests
 
 						return 42;
 					});
-
-					Assert.True(false); //Should not be executed because the agent isn't allowed to catch an exception.
-					Assert.Equal(42, result); //But if it'd not throw it'd be 42.
-				});
+				};
+				await act.Should().ThrowAsync<InvalidOperationException>();
 			});
 
 		/// <summary>
@@ -344,7 +343,7 @@ namespace Elastic.Apm.Tests.ApiTests
 		public async Task AsyncTaskWithReturnTypeAndException()
 			=> await AssertWith1TransactionAnd1ErrorAnd1SpanAsync(async t =>
 			{
-				await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+				Func<Task> act = async () =>
 				{
 					var result = await t.CaptureSpan(SpanName, SpanType, async () =>
 					{
@@ -355,10 +354,8 @@ namespace Elastic.Apm.Tests.ApiTests
 
 						return 42;
 					});
-
-					Assert.True(false); //Should not be executed because the agent isn't allowed to catch an exception.
-					Assert.Equal(42, result); //But if it'd not throw it'd be 42.
-				});
+				};
+				await act.Should().ThrowAsync<InvalidOperationException>();
 			});
 
 		/// <summary>
@@ -376,7 +373,7 @@ namespace Elastic.Apm.Tests.ApiTests
 
 			await agent.Tracer.CaptureTransaction(TransactionName, TransactionType, async t =>
 			{
-				await Assert.ThrowsAsync<OperationCanceledException>(async () =>
+				Func<Task> act = async () =>
 				{
 					await t.CaptureSpan(SpanName, SpanType, async () =>
 					{
@@ -384,7 +381,8 @@ namespace Elastic.Apm.Tests.ApiTests
 						await WaitHelpers.Delay2XMinimum();
 						token.ThrowIfCancellationRequested();
 					});
-				});
+				};
+				act.Should().Throw<OperationCanceledException>();
 			});
 		}
 
@@ -406,10 +404,10 @@ namespace Elastic.Apm.Tests.ApiTests
 				});
 
 			//According to the Intake API tags are stored on the Context (and not on Spans.Tags directly).
-			Assert.Equal("bar", payloadSender.SpansOnFirstTransaction[0].Context.Tags["foo"]);
+			payloadSender.SpansOnFirstTransaction[0].Context.Tags.Should().Contain("foo","bar");
 
 			//Also make sure the tag is visible directly on Span.Tags.
-			Assert.Equal("bar", payloadSender.SpansOnFirstTransaction[0].Tags["foo"]);
+			payloadSender.SpansOnFirstTransaction[0].Tags.Should().Contain("foo","bar");
 		}
 
 		/// <summary>
@@ -430,10 +428,10 @@ namespace Elastic.Apm.Tests.ApiTests
 				});
 
 			//According to the Intake API tags are stored on the Context (and not on Spans.Tags directly).
-			Assert.Equal("bar", payloadSender.SpansOnFirstTransaction[0].Context.Tags["foo"]);
+			payloadSender.SpansOnFirstTransaction[0].Context.Tags.Should().Contain("foo","bar");
 
 			//Also make sure the tag is visible directly on Span.Tags.
-			Assert.Equal("bar", payloadSender.SpansOnFirstTransaction[0].Tags["foo"]);
+			payloadSender.SpansOnFirstTransaction[0].Tags.Should().Contain("foo","bar");
 		}
 
 		/// <summary>
@@ -443,27 +441,27 @@ namespace Elastic.Apm.Tests.ApiTests
 		[Fact]
 		public async Task TagsOnSpanAsyncError()
 		{
-			var payloadSender = await AssertWith1TransactionAnd1ErrorAnd1SpanAsync(
-				async t =>
+			var payloadSender = await AssertWith1TransactionAnd1ErrorAnd1SpanAsync(async t =>
+			{
+				Func<Task> act = async () =>
 				{
-					await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+					await t.CaptureSpan(SpanName, SpanType, async span =>
 					{
-						await t.CaptureSpan(SpanName, SpanType, async span =>
-						{
-							await WaitHelpers.Delay2XMinimum();
-							span.Tags["foo"] = "bar";
+						await WaitHelpers.Delay2XMinimum();
+						span.Tags["foo"] = "bar";
 
-							if (new Random().Next(1) == 0) //avoid unreachable code warning.
-								throw new InvalidOperationException(ExceptionMessage);
-						});
+						if (new Random().Next(1) == 0) //avoid unreachable code warning.
+							throw new InvalidOperationException(ExceptionMessage);
 					});
-				});
+				};
+				act.Should().Throw<InvalidOperationException>();
+			});
 
 			//According to the Intake API tags are stored on the Context (and not on Spans.Tags directly).
-			Assert.Equal("bar", payloadSender.SpansOnFirstTransaction[0].Context.Tags["foo"]);
+			payloadSender.SpansOnFirstTransaction[0].Context.Tags.Should().Contain("foo","bar");
 
 			//Also make sure the tag is visible directly on Span.Tags.
-			Assert.Equal("bar", payloadSender.SpansOnFirstTransaction[0].Tags["foo"]);
+			payloadSender.SpansOnFirstTransaction[0].Tags.Should().Contain("foo","bar");
 		}
 
 		/// <summary>
@@ -480,26 +478,26 @@ namespace Elastic.Apm.Tests.ApiTests
 				await func(t);
 			});
 
-			Assert.NotEmpty(payloadSender.Payloads);
-			Assert.NotEmpty(payloadSender.Payloads[0].Transactions);
+			payloadSender.Payloads.Should().NotBeEmpty();
+			payloadSender.Payloads[0].Transactions.Should().NotBeEmpty();
 
-			Assert.Equal(TransactionName, payloadSender.Payloads[0].Transactions[0].Name);
-			Assert.Equal(TransactionType, payloadSender.Payloads[0].Transactions[0].Type);
+			payloadSender.Payloads[0].Transactions[0].Name.Should().Be(TransactionName);
+			payloadSender.Payloads[0].Transactions[0].Type.Should().Be(TransactionType);
 
 			var duration = payloadSender.Payloads[0].Transactions[0].Duration;
 			WaitHelpers.Assert3XMinimumSleepLength(duration);
 
-			Assert.NotEmpty(payloadSender.SpansOnFirstTransaction);
+			payloadSender.SpansOnFirstTransaction.Should().NotBeEmpty();
 
-			Assert.Equal(SpanName, payloadSender.SpansOnFirstTransaction[0].Name);
-			Assert.Equal(SpanType, payloadSender.SpansOnFirstTransaction[0].Type);
+			payloadSender.SpansOnFirstTransaction[0].Name.Should().Be(SpanName);
+			payloadSender.SpansOnFirstTransaction[0].Type.Should().Be(SpanType);
 
 
-			Assert.NotEmpty(payloadSender.Errors);
-			Assert.NotEmpty(payloadSender.Errors[0].Errors);
+			payloadSender.Errors.Should().NotBeEmpty();
+			payloadSender.Errors[0].Errors.Should().NotBeEmpty();
 
-			Assert.Equal(typeof(InvalidOperationException).FullName, payloadSender.Errors[0].Errors[0].Exception.Type);
-			Assert.Equal(ExceptionMessage, payloadSender.Errors[0].Errors[0].Exception.Message);
+			payloadSender.Errors[0].Errors[0].Exception.Type.Should().Be(typeof(InvalidOperationException).FullName);
+			payloadSender.Errors[0].Errors[0].Exception.Message.Should().Be(ExceptionMessage);
 
 			return payloadSender;
 		}
@@ -519,19 +517,19 @@ namespace Elastic.Apm.Tests.ApiTests
 				await func(t);
 			});
 
-			Assert.NotEmpty(payloadSender.Payloads);
-			Assert.NotEmpty(payloadSender.Payloads[0].Transactions);
+			payloadSender.Payloads.Should().NotBeEmpty();
+			payloadSender.Payloads[0].Transactions.Should().NotBeEmpty();
 
-			Assert.Equal(TransactionName, payloadSender.Payloads[0].Transactions[0].Name);
-			Assert.Equal(TransactionType, payloadSender.Payloads[0].Transactions[0].Type);
+			payloadSender.Payloads[0].Transactions[0].Name.Should().Be(TransactionName);
+			payloadSender.Payloads[0].Transactions[0].Type.Should().Be(TransactionType);
 
 			var duration = payloadSender.Payloads[0].Transactions[0].Duration;
 			WaitHelpers.Assert3XMinimumSleepLength(duration);
 
-			Assert.NotEmpty(payloadSender.SpansOnFirstTransaction);
+			payloadSender.SpansOnFirstTransaction.Should().NotBeEmpty();
 
-			Assert.Equal(SpanName, payloadSender.SpansOnFirstTransaction[0].Name);
-			Assert.Equal(SpanType, payloadSender.SpansOnFirstTransaction[0].Type);
+			payloadSender.SpansOnFirstTransaction[0].Name.Should().Be(SpanName);
+			payloadSender.SpansOnFirstTransaction[0].Type.Should().Be(SpanType);
 
 			return payloadSender;
 		}
@@ -550,16 +548,16 @@ namespace Elastic.Apm.Tests.ApiTests
 				action(t);
 			});
 
-			Assert.NotEmpty(payloadSender.Payloads);
-			Assert.NotEmpty(payloadSender.Payloads[0].Transactions);
+			payloadSender.Payloads.Should().NotBeEmpty();
+			payloadSender.Payloads[0].Transactions.Should().NotBeEmpty();
 
-			Assert.Equal(TransactionName, payloadSender.Payloads[0].Transactions[0].Name);
-			Assert.Equal(TransactionType, payloadSender.Payloads[0].Transactions[0].Type);
+			payloadSender.Payloads[0].Transactions[0].Name.Should().Be(TransactionName);
+			payloadSender.Payloads[0].Transactions[0].Type.Should().Be(TransactionType);
 
-			Assert.NotEmpty(payloadSender.SpansOnFirstTransaction);
+			payloadSender.SpansOnFirstTransaction.Should().NotBeEmpty();
 
-			Assert.Equal(SpanName, payloadSender.SpansOnFirstTransaction[0].Name);
-			Assert.Equal(SpanType, payloadSender.SpansOnFirstTransaction[0].Type);
+			payloadSender.SpansOnFirstTransaction[0].Name.Should().Be(SpanName);
+			payloadSender.SpansOnFirstTransaction[0].Type.Should().Be(SpanType);
 
 			var duration = payloadSender.Payloads[0].Transactions[0].Duration;
 			WaitHelpers.Assert3XMinimumSleepLength(duration);
@@ -581,25 +579,25 @@ namespace Elastic.Apm.Tests.ApiTests
 				action(t);
 			});
 
-			Assert.NotEmpty(payloadSender.Payloads);
-			Assert.NotEmpty(payloadSender.Payloads[0].Transactions);
+			payloadSender.Payloads.Should().NotBeEmpty();
+			payloadSender.Payloads[0].Transactions.Should().NotBeEmpty();
 
-			Assert.Equal(TransactionName, payloadSender.Payloads[0].Transactions[0].Name);
-			Assert.Equal(TransactionType, payloadSender.Payloads[0].Transactions[0].Type);
+			payloadSender.Payloads[0].Transactions[0].Name.Should().Be(TransactionName);
+			payloadSender.Payloads[0].Transactions[0].Type.Should().Be(TransactionType);
 
 			var duration = payloadSender.Payloads[0].Transactions[0].Duration;
 			WaitHelpers.Assert3XMinimumSleepLength(duration);
 
-			Assert.NotEmpty(payloadSender.SpansOnFirstTransaction);
+			payloadSender.SpansOnFirstTransaction.Should().NotBeEmpty();
 
-			Assert.Equal(SpanName, payloadSender.SpansOnFirstTransaction[0].Name);
-			Assert.Equal(SpanType, payloadSender.SpansOnFirstTransaction[0].Type);
+			payloadSender.SpansOnFirstTransaction[0].Name.Should().Be(SpanName);
+			payloadSender.SpansOnFirstTransaction[0].Type.Should().Be(SpanType);
 
-			Assert.NotEmpty(payloadSender.Errors);
-			Assert.NotEmpty(payloadSender.Errors[0].Errors);
+			payloadSender.Errors.Should().NotBeEmpty();
+			payloadSender.Errors[0].Errors.Should().NotBeEmpty();
 
-			Assert.Equal(typeof(InvalidOperationException).FullName, payloadSender.Errors[0].Errors[0].Exception.Type);
-			Assert.Equal(ExceptionMessage, payloadSender.Errors[0].Errors[0].Exception.Message);
+			payloadSender.Errors[0].Errors[0].Exception.Type.Should().Be(typeof(InvalidOperationException).FullName);
+			payloadSender.Errors[0].Errors[0].Exception.Message.Should().Be(ExceptionMessage);
 		}
 	}
 }

--- a/test/Elastic.Apm.Tests/ApiTests/ConvenientApiSpanTests.cs
+++ b/test/Elastic.Apm.Tests/ApiTests/ConvenientApiSpanTests.cs
@@ -3,6 +3,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Elastic.Apm.Api;
 using Elastic.Apm.Model.Payload;
+using Elastic.Apm.Tests.Extensions;
 using Elastic.Apm.Tests.Mocks;
 using FluentAssertions;
 using Xunit;
@@ -485,7 +486,7 @@ namespace Elastic.Apm.Tests.ApiTests
 			payloadSender.Payloads[0].Transactions[0].Type.Should().Be(TransactionType);
 
 			var duration = payloadSender.Payloads[0].Transactions[0].Duration;
-			WaitHelpers.Assert3XMinimumSleepLength(duration);
+			duration.Should().BeGreaterOrEqualToMinimumSleepLength(numberOfSleeps: 3);
 
 			payloadSender.SpansOnFirstTransaction.Should().NotBeEmpty();
 
@@ -524,7 +525,7 @@ namespace Elastic.Apm.Tests.ApiTests
 			payloadSender.Payloads[0].Transactions[0].Type.Should().Be(TransactionType);
 
 			var duration = payloadSender.Payloads[0].Transactions[0].Duration;
-			WaitHelpers.Assert3XMinimumSleepLength(duration);
+			duration.Should().BeGreaterOrEqualToMinimumSleepLength(numberOfSleeps: 3);
 
 			payloadSender.SpansOnFirstTransaction.Should().NotBeEmpty();
 
@@ -560,7 +561,7 @@ namespace Elastic.Apm.Tests.ApiTests
 			payloadSender.SpansOnFirstTransaction[0].Type.Should().Be(SpanType);
 
 			var duration = payloadSender.Payloads[0].Transactions[0].Duration;
-			WaitHelpers.Assert3XMinimumSleepLength(duration);
+			duration.Should().BeGreaterOrEqualToMinimumSleepLength(numberOfSleeps: 3);
 
 			return payloadSender;
 		}
@@ -586,7 +587,7 @@ namespace Elastic.Apm.Tests.ApiTests
 			payloadSender.Payloads[0].Transactions[0].Type.Should().Be(TransactionType);
 
 			var duration = payloadSender.Payloads[0].Transactions[0].Duration;
-			WaitHelpers.Assert3XMinimumSleepLength(duration);
+			duration.Should().BeGreaterOrEqualToMinimumSleepLength(numberOfSleeps: 3);
 
 			payloadSender.SpansOnFirstTransaction.Should().NotBeEmpty();
 

--- a/test/Elastic.Apm.Tests/ApiTests/ConvenientApiTransactionTests.cs
+++ b/test/Elastic.Apm.Tests/ApiTests/ConvenientApiTransactionTests.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using Elastic.Apm.Api;
 using Elastic.Apm.Model.Payload;
 using Elastic.Apm.Tests.Mocks;
+using FluentAssertions;
 using Xunit;
 
 namespace Elastic.Apm.Tests.ApiTests
@@ -45,14 +46,15 @@ namespace Elastic.Apm.Tests.ApiTests
 		[Fact]
 		public void SimpleActionWithException() => AssertWith1TransactionAnd1Error(agent =>
 		{
-			Assert.Throws<InvalidOperationException>(() =>
+			Action act = () =>
 			{
 				agent.Tracer.CaptureTransaction(TransactionName, TransactionType, new Action(() =>
 				{
 					WaitHelpers.SleepMinimum();
 					throw new InvalidOperationException(ExceptionMessage);
 				}));
-			});
+			};
+			act.Should().Throw<InvalidOperationException>();
 		});
 
 		/// <summary>
@@ -68,7 +70,7 @@ namespace Elastic.Apm.Tests.ApiTests
 			agent.Tracer.CaptureTransaction(TransactionName, TransactionType,
 				t =>
 				{
-					Assert.NotNull(t);
+					t.Should().NotBeNull();
 					WaitHelpers.SleepMinimum();
 				});
 		});
@@ -87,7 +89,7 @@ namespace Elastic.Apm.Tests.ApiTests
 			{
 				agent.Tracer.CaptureTransaction(TransactionName, TransactionType, new Action<ITransaction>(t =>
 				{
-					Assert.NotNull(t);
+					t.Should().NotBeNull();
 					WaitHelpers.SleepMinimum();
 					throw new InvalidOperationException(ExceptionMessage);
 				}));
@@ -108,7 +110,7 @@ namespace Elastic.Apm.Tests.ApiTests
 				return 42;
 			});
 
-			Assert.Equal(42, res);
+			res.Should().Be(42);
 		});
 
 		/// <summary>
@@ -124,12 +126,12 @@ namespace Elastic.Apm.Tests.ApiTests
 			var res = agent.Tracer.CaptureTransaction(TransactionName, TransactionType,
 				t =>
 				{
-					Assert.NotNull(t);
+					t.Should().NotBeNull();
 					WaitHelpers.SleepMinimum();
 					return 42;
 				});
 
-			Assert.Equal(42, res);
+			res.Should().Be(42);
 		});
 
 		/// <summary>
@@ -143,11 +145,11 @@ namespace Elastic.Apm.Tests.ApiTests
 		[Fact]
 		public void SimpleActionWithReturnTypeAndExceptionAndParameter() => AssertWith1TransactionAnd1Error(agent =>
 		{
-			Assert.Throws<InvalidOperationException>(() =>
+			Action act = () =>
 			{
 				var result = agent.Tracer.CaptureTransaction(TransactionName, TransactionType, t =>
 				{
-					Assert.NotNull(t);
+					t.Should().NotBeNull();
 					WaitHelpers.SleepMinimum();
 
 					if (new Random().Next(1) == 0) //avoid unreachable code warning.
@@ -155,10 +157,9 @@ namespace Elastic.Apm.Tests.ApiTests
 
 					return 42;
 				});
-
-				Assert.True(false); //Should not be executed because the agent isn't allowed to catch an exception.
-				Assert.Equal(42, result); //But if it'd not throw it'd be 42.
-			});
+				throw new Exception("CaptureTransaction should not eat exception and continue");
+			};
+			act.Should().Throw<InvalidOperationException>();
 		});
 
 		/// <summary>
@@ -170,7 +171,7 @@ namespace Elastic.Apm.Tests.ApiTests
 		[Fact]
 		public void SimpleActionWithReturnTypeAndException() => AssertWith1TransactionAnd1Error(agent =>
 		{
-			Assert.Throws<InvalidOperationException>(() =>
+			Action act = () =>
 			{
 				var result = agent.Tracer.CaptureTransaction(TransactionName, TransactionType, () =>
 				{
@@ -181,10 +182,9 @@ namespace Elastic.Apm.Tests.ApiTests
 
 					return 42;
 				});
-
-				Assert.True(false); //Should not be executed because the agent isn't allowed to catch an exception.
-				Assert.Equal(42, result); //But if it'd not throw it'd be 42.
-			});
+				throw new Exception("CaptureTransaction should not eat exception and continue");
+			};
+			act.Should().Throw<InvalidOperationException>();
 		});
 
 		/// <summary>
@@ -207,14 +207,15 @@ namespace Elastic.Apm.Tests.ApiTests
 		[Fact]
 		public async Task AsyncTaskWithException() => await AssertWith1TransactionAnd1ErrorAsync(async agent =>
 		{
-			await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+			Func<Task> act = async () =>
 			{
 				await agent.Tracer.CaptureTransaction(TransactionName, TransactionType, async () =>
 				{
 					await WaitHelpers.DelayMinimum();
 					throw new InvalidOperationException(ExceptionMessage);
 				});
-			});
+			};
+			await act.Should().ThrowAsync<InvalidOperationException>();
 		});
 
 		/// <summary>
@@ -229,7 +230,7 @@ namespace Elastic.Apm.Tests.ApiTests
 			await agent.Tracer.CaptureTransaction(TransactionName, TransactionType,
 				async t =>
 				{
-					Assert.NotNull(t);
+					t.Should().NotBeNull();
 					await WaitHelpers.DelayMinimum();
 				});
 		});
@@ -245,15 +246,16 @@ namespace Elastic.Apm.Tests.ApiTests
 		[Fact]
 		public async Task AsyncTaskWithExceptionAndParameter() => await AssertWith1TransactionAnd1ErrorAsync(async agent =>
 		{
-			await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+			Func<Task> act = async () =>
 			{
 				await agent.Tracer.CaptureTransaction(TransactionName, TransactionType, async t =>
 				{
-					Assert.NotNull(t);
+					t.Should().NotBeNull();
 					await WaitHelpers.DelayMinimum();
 					throw new InvalidOperationException(ExceptionMessage);
 				});
-			});
+			};
+			await act.Should().ThrowAsync<InvalidOperationException>();
 		});
 
 		/// <summary>
@@ -269,7 +271,7 @@ namespace Elastic.Apm.Tests.ApiTests
 				await WaitHelpers.DelayMinimum();
 				return 42;
 			});
-			Assert.Equal(42, res);
+			res.Should().Be(42);
 		});
 
 		/// <summary>
@@ -285,12 +287,12 @@ namespace Elastic.Apm.Tests.ApiTests
 			var res = await agent.Tracer.CaptureTransaction(TransactionName, TransactionType,
 				async t =>
 				{
-					Assert.NotNull(t);
+					t.Should().NotBeNull();
 					await WaitHelpers.DelayMinimum();
 					return 42;
 				});
 
-			Assert.Equal(42, res);
+			res.Should().Be(42);
 		});
 
 		/// <summary>
@@ -304,11 +306,11 @@ namespace Elastic.Apm.Tests.ApiTests
 		[Fact]
 		public async Task AsyncTaskWithReturnTypeAndExceptionAndParameter() => await AssertWith1TransactionAnd1ErrorAsync(async agent =>
 		{
-			await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+			Func<Task> act = async () =>
 			{
 				var result = await agent.Tracer.CaptureTransaction(TransactionName, TransactionType, async t =>
 				{
-					Assert.NotNull(t);
+					t.Should().NotBeNull();
 					await WaitHelpers.DelayMinimum();
 
 					if (new Random().Next(1) == 0) //avoid unreachable code warning.
@@ -318,8 +320,9 @@ namespace Elastic.Apm.Tests.ApiTests
 				});
 
 				Assert.True(false); //Should not be executed because the agent isn't allowed to catch an exception.
-				Assert.Equal(42, result); //But if it'd not throw it'd be 42.
-			});
+				result.Should().Be(42); //But if it'd not throw it'd be 42.
+			};
+			await act.Should().ThrowAsync<InvalidOperationException>();
 		});
 
 		/// <summary>
@@ -331,7 +334,7 @@ namespace Elastic.Apm.Tests.ApiTests
 		[Fact]
 		public async Task AsyncTaskWithReturnTypeAndException() => await AssertWith1TransactionAnd1ErrorAsync(async agent =>
 		{
-			await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+			Func<Task> act = async () =>
 			{
 				var result = await agent.Tracer.CaptureTransaction(TransactionName, TransactionType, async () =>
 				{
@@ -344,8 +347,9 @@ namespace Elastic.Apm.Tests.ApiTests
 				});
 
 				Assert.True(false); //Should not be executed because the agent isn't allowed to catch an exception.
-				Assert.Equal(42, result); //But if it'd not throw it'd be 42.
-			});
+				result.Should().Be(42); //But if it'd not throw it'd be 42.
+			};
+			await act.Should().ThrowAsync<InvalidOperationException>();
 		});
 
 		/// <summary>
@@ -362,7 +366,7 @@ namespace Elastic.Apm.Tests.ApiTests
 			var token = cancellationTokenSource.Token;
 			cancellationTokenSource.Cancel();
 
-			await Assert.ThrowsAsync<OperationCanceledException>(async () =>
+			Func<Task> act = async () =>
 			{
 				await agent.Tracer.CaptureTransaction(TransactionName, TransactionType,
 					async () =>
@@ -371,22 +375,23 @@ namespace Elastic.Apm.Tests.ApiTests
 						await WaitHelpers.DelayMinimum();
 						token.ThrowIfCancellationRequested();
 					});
-			});
+			};
+			await act.Should().ThrowAsync<OperationCanceledException>();
 
-			Assert.NotEmpty(payloadSender.Payloads);
-			Assert.NotEmpty(payloadSender.Payloads[0].Transactions);
+			payloadSender.Payloads.Should().NotBeEmpty();
+			payloadSender.Payloads[0].Transactions.Should().NotBeEmpty();
 
-			Assert.Equal(TransactionName, payloadSender.Payloads[0].Transactions[0].Name);
-			Assert.Equal(TransactionType, payloadSender.Payloads[0].Transactions[0].Type);
+			payloadSender.Payloads[0].Transactions[0].Name.Should().Be(TransactionName);
+			payloadSender.Payloads[0].Transactions[0].Type.Should().Be(TransactionType);
 
 			var duration = payloadSender.Payloads[0].Transactions[0].Duration;
 			Assert.True(duration >= WaitHelpers.SleepLength, $"Expected {duration} to be greater or equal to: {WaitHelpers.SleepLength}");
 
-			Assert.NotEmpty(payloadSender.Errors);
-			Assert.NotEmpty(payloadSender.Errors[0].Errors);
+			payloadSender.Errors.Should().NotBeEmpty();
+			payloadSender.Errors[0].Errors.Should().NotBeEmpty();
 
-			Assert.Equal("A task was canceled", payloadSender.Errors[0].Errors[0].Culprit);
-			Assert.Equal("Task canceled", payloadSender.Errors[0].Errors[0].Exception.Message);
+			payloadSender.Errors[0].Errors[0].Culprit.Should().Be("A task was canceled");
+			payloadSender.Errors[0].Errors[0].Exception.Message.Should().Be("Task canceled");
 		}
 
 		/// <summary>
@@ -407,10 +412,10 @@ namespace Elastic.Apm.Tests.ApiTests
 				});
 
 			//According to the Intake API tags are stored on the Context (and not on Transaction.Tags directly).
-			Assert.Equal("bar", payloadSender.FirstTransaction.Context.Tags["foo"]);
+			payloadSender.FirstTransaction.Context.Tags.Should().Contain("foo", "bar");
 
 			//Also make sure the tag is visible directly on Transaction.Tags.
-			Assert.Equal("bar", payloadSender.Payloads[0].Transactions[0].Tags["foo"]);
+			payloadSender.Payloads[0].Transactions[0].Tags.Should().Contain("foo", "bar");
 		}
 
 		/// <summary>
@@ -431,10 +436,10 @@ namespace Elastic.Apm.Tests.ApiTests
 				});
 
 			//According to the Intake API tags are stored on the Context (and not on Transaction.Tags directly).
-			Assert.Equal("bar", payloadSender.FirstTransaction.Context.Tags["foo"]);
+			payloadSender.FirstTransaction.Context.Tags.Should().Contain("foo", "bar");
 
 			//Also make sure the tag is visible directly on Transaction.Tags.
-			Assert.Equal("bar", payloadSender.Payloads[0].Transactions[0].Tags["foo"]);
+			payloadSender.Payloads[0].Transactions[0].Tags.Should().Contain("foo", "bar");
 		}
 
 		/// <summary>
@@ -447,7 +452,7 @@ namespace Elastic.Apm.Tests.ApiTests
 			var payloadSender = await AssertWith1TransactionAnd1ErrorAsync(
 				async t =>
 				{
-					await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+					Func<Task> act = async () =>
 					{
 						await t.Tracer.CaptureTransaction(TransactionName, TransactionType, async transaction =>
 						{
@@ -457,14 +462,15 @@ namespace Elastic.Apm.Tests.ApiTests
 							if (new Random().Next(1) == 0) //avoid unreachable code warning.
 								throw new InvalidOperationException(ExceptionMessage);
 						});
-					});
+					};
+					await act.Should().ThrowAsync<InvalidOperationException>();
 				});
 
 			//According to the Intake API tags are stored on the Context (and not on Transaction.Tags directly).
-			Assert.Equal("bar", payloadSender.FirstTransaction.Context.Tags["foo"]);
+			payloadSender.FirstTransaction.Context.Tags.Should().Contain("foo", "bar");
 
 			//Also make sure the tag is visible directly on Transaction.Tags.
-			Assert.Equal("bar", payloadSender.Payloads[0].Transactions[0].Tags["foo"]);
+			payloadSender.Payloads[0].Transactions[0].Tags.Should().Contain("foo", "bar");
 		}
 
 		/// <summary>
@@ -477,11 +483,11 @@ namespace Elastic.Apm.Tests.ApiTests
 
 			await func(agent);
 
-			Assert.NotEmpty(payloadSender.Payloads);
-			Assert.NotEmpty(payloadSender.Payloads[0].Transactions);
+			payloadSender.Payloads.Should().NotBeEmpty();
+			payloadSender.Payloads[0].Transactions.Should().NotBeEmpty();
 
-			Assert.Equal(TransactionName, payloadSender.Payloads[0].Transactions[0].Name);
-			Assert.Equal(TransactionType, payloadSender.Payloads[0].Transactions[0].Type);
+			payloadSender.Payloads[0].Transactions[0].Name.Should().Be(TransactionName);
+			payloadSender.Payloads[0].Transactions[0].Type.Should().Be(TransactionType);
 
 			var duration = payloadSender.Payloads[0].Transactions[0].Duration;
 			WaitHelpers.AssertMinimumSleepLength(duration);
@@ -499,20 +505,20 @@ namespace Elastic.Apm.Tests.ApiTests
 
 			await func(agent);
 
-			Assert.NotEmpty(payloadSender.Payloads);
-			Assert.NotEmpty(payloadSender.Payloads[0].Transactions);
+			payloadSender.Payloads.Should().NotBeEmpty();
+			payloadSender.Payloads[0].Transactions.Should().NotBeEmpty();
 
-			Assert.Equal(TransactionName, payloadSender.Payloads[0].Transactions[0].Name);
-			Assert.Equal(TransactionType, payloadSender.Payloads[0].Transactions[0].Type);
+			payloadSender.Payloads[0].Transactions[0].Name.Should().Be(TransactionName);
+			payloadSender.Payloads[0].Transactions[0].Type.Should().Be(TransactionType);
 
 			var duration = payloadSender.Payloads[0].Transactions[0].Duration;
 			WaitHelpers.AssertMinimumSleepLength(duration);
 
-			Assert.NotEmpty(payloadSender.Errors);
-			Assert.NotEmpty(payloadSender.Errors[0].Errors);
+			payloadSender.Errors.Should().NotBeEmpty();
+			payloadSender.Errors[0].Errors.Should().NotBeEmpty();
 
-			Assert.Equal(typeof(InvalidOperationException).FullName, payloadSender.Errors[0].Errors[0].Exception.Type);
-			Assert.Equal(ExceptionMessage, payloadSender.Errors[0].Errors[0].Exception.Message);
+			payloadSender.Errors[0].Errors[0].Exception.Type.Should().Be(typeof(InvalidOperationException).FullName);
+			payloadSender.Errors[0].Errors[0].Exception.Message.Should().Be(ExceptionMessage);
 			return payloadSender;
 		}
 
@@ -526,11 +532,11 @@ namespace Elastic.Apm.Tests.ApiTests
 
 			action(agent);
 
-			Assert.NotEmpty(payloadSender.Payloads);
-			Assert.NotEmpty(payloadSender.Payloads[0].Transactions);
+			payloadSender.Payloads.Should().NotBeEmpty();
+			payloadSender.Payloads[0].Transactions.Should().NotBeEmpty();
 
-			Assert.Equal(TransactionName, payloadSender.Payloads[0].Transactions[0].Name);
-			Assert.Equal(TransactionType, payloadSender.Payloads[0].Transactions[0].Type);
+			payloadSender.Payloads[0].Transactions[0].Name.Should().Be(TransactionName);
+			payloadSender.Payloads[0].Transactions[0].Type.Should().Be(TransactionType);
 
 			var duration = payloadSender.Payloads[0].Transactions[0].Duration;
 			WaitHelpers.AssertMinimumSleepLength(duration);
@@ -548,20 +554,20 @@ namespace Elastic.Apm.Tests.ApiTests
 
 			action(agent);
 
-			Assert.NotEmpty(payloadSender.Payloads);
-			Assert.NotEmpty(payloadSender.Payloads[0].Transactions);
+			payloadSender.Payloads.Should().NotBeEmpty();
+			payloadSender.Payloads[0].Transactions.Should().NotBeEmpty();
 
-			Assert.Equal(TransactionName, payloadSender.Payloads[0].Transactions[0].Name);
-			Assert.Equal(TransactionType, payloadSender.Payloads[0].Transactions[0].Type);
+			payloadSender.Payloads[0].Transactions[0].Name.Should().Be(TransactionName);
+			payloadSender.Payloads[0].Transactions[0].Type.Should().Be(TransactionType);
 
 			var duration = payloadSender.Payloads[0].Transactions[0].Duration;
 			WaitHelpers.AssertMinimumSleepLength(duration);
 
-			Assert.NotEmpty(payloadSender.Errors);
-			Assert.NotEmpty(payloadSender.Errors[0].Errors);
+			payloadSender.Errors.Should().NotBeEmpty();
+			payloadSender.Errors[0].Errors.Should().NotBeEmpty();
 
-			Assert.Equal(typeof(InvalidOperationException).FullName, payloadSender.Errors[0].Errors[0].Exception.Type);
-			Assert.Equal(ExceptionMessage, payloadSender.Errors[0].Errors[0].Exception.Message);
+			payloadSender.Errors[0].Errors[0].Exception.Type.Should().Be(typeof(InvalidOperationException).FullName);
+			payloadSender.Errors[0].Errors[0].Exception.Message.Should().Be(ExceptionMessage);
 		}
 	}
 }

--- a/test/Elastic.Apm.Tests/ApiTests/ConvenientApiTransactionTests.cs
+++ b/test/Elastic.Apm.Tests/ApiTests/ConvenientApiTransactionTests.cs
@@ -3,6 +3,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Elastic.Apm.Api;
 using Elastic.Apm.Model.Payload;
+using Elastic.Apm.Tests.Extensions;
 using Elastic.Apm.Tests.Mocks;
 using FluentAssertions;
 using Xunit;
@@ -490,7 +491,7 @@ namespace Elastic.Apm.Tests.ApiTests
 			payloadSender.Payloads[0].Transactions[0].Type.Should().Be(TransactionType);
 
 			var duration = payloadSender.Payloads[0].Transactions[0].Duration;
-			WaitHelpers.AssertMinimumSleepLength(duration);
+			duration.Should().BeGreaterOrEqualToMinimumSleepLength();
 
 			return payloadSender;
 		}
@@ -512,7 +513,7 @@ namespace Elastic.Apm.Tests.ApiTests
 			payloadSender.Payloads[0].Transactions[0].Type.Should().Be(TransactionType);
 
 			var duration = payloadSender.Payloads[0].Transactions[0].Duration;
-			WaitHelpers.AssertMinimumSleepLength(duration);
+			duration.Should().BeGreaterOrEqualToMinimumSleepLength();
 
 			payloadSender.Errors.Should().NotBeEmpty();
 			payloadSender.Errors[0].Errors.Should().NotBeEmpty();
@@ -539,7 +540,7 @@ namespace Elastic.Apm.Tests.ApiTests
 			payloadSender.Payloads[0].Transactions[0].Type.Should().Be(TransactionType);
 
 			var duration = payloadSender.Payloads[0].Transactions[0].Duration;
-			WaitHelpers.AssertMinimumSleepLength(duration);
+			duration.Should().BeGreaterOrEqualToMinimumSleepLength();
 
 			return payloadSender;
 		}
@@ -561,7 +562,7 @@ namespace Elastic.Apm.Tests.ApiTests
 			payloadSender.Payloads[0].Transactions[0].Type.Should().Be(TransactionType);
 
 			var duration = payloadSender.Payloads[0].Transactions[0].Duration;
-			WaitHelpers.AssertMinimumSleepLength(duration);
+			duration.Should().BeGreaterOrEqualToMinimumSleepLength();
 
 			payloadSender.Errors.Should().NotBeEmpty();
 			payloadSender.Errors[0].Errors.Should().NotBeEmpty();

--- a/test/Elastic.Apm.Tests/ApiTests/ConvenientApiTransactionTests.cs
+++ b/test/Elastic.Apm.Tests/ApiTests/ConvenientApiTransactionTests.cs
@@ -86,7 +86,7 @@ namespace Elastic.Apm.Tests.ApiTests
 		[Fact]
 		public void SimpleActionWithExceptionAndParameter() => AssertWith1TransactionAnd1Error(agent =>
 		{
-			Assert.Throws<InvalidOperationException>(() =>
+			Action act = () =>
 			{
 				agent.Tracer.CaptureTransaction(TransactionName, TransactionType, new Action<ITransaction>(t =>
 				{
@@ -94,7 +94,8 @@ namespace Elastic.Apm.Tests.ApiTests
 					WaitHelpers.SleepMinimum();
 					throw new InvalidOperationException(ExceptionMessage);
 				}));
-			});
+			};
+			act.Should().Throw<InvalidOperationException>();
 		});
 
 		/// <summary>
@@ -319,9 +320,6 @@ namespace Elastic.Apm.Tests.ApiTests
 
 					return 42;
 				});
-
-				Assert.True(false); //Should not be executed because the agent isn't allowed to catch an exception.
-				result.Should().Be(42); //But if it'd not throw it'd be 42.
 			};
 			await act.Should().ThrowAsync<InvalidOperationException>();
 		});
@@ -346,9 +344,6 @@ namespace Elastic.Apm.Tests.ApiTests
 
 					return 42;
 				});
-
-				Assert.True(false); //Should not be executed because the agent isn't allowed to catch an exception.
-				result.Should().Be(42); //But if it'd not throw it'd be 42.
 			};
 			await act.Should().ThrowAsync<InvalidOperationException>();
 		});
@@ -386,7 +381,7 @@ namespace Elastic.Apm.Tests.ApiTests
 			payloadSender.Payloads[0].Transactions[0].Type.Should().Be(TransactionType);
 
 			var duration = payloadSender.Payloads[0].Transactions[0].Duration;
-			Assert.True(duration >= WaitHelpers.SleepLength, $"Expected {duration} to be greater or equal to: {WaitHelpers.SleepLength}");
+			duration.Should().BeGreaterOrEqualToMinimumSleepLength();
 
 			payloadSender.Errors.Should().NotBeEmpty();
 			payloadSender.Errors[0].Errors.Should().NotBeEmpty();

--- a/test/Elastic.Apm.Tests/BasicAgentTests.cs
+++ b/test/Elastic.Apm.Tests/BasicAgentTests.cs
@@ -11,6 +11,7 @@ using Elastic.Apm.Logging;
 using Elastic.Apm.Model.Payload;
 using Elastic.Apm.Report;
 using Elastic.Apm.Tests.Mocks;
+using FluentAssertions;
 using Xunit;
 
 [assembly:
@@ -37,7 +38,7 @@ namespace Elastic.Apm.Tests
 			using (var agent = new ApmAgent(new TestAgentComponents(payloadSender: payloadSender)))
 				agent.Tracer.CaptureTransaction("TestName", "TestType", () => { Thread.Sleep(5); });
 
-			Assert.Equal(Assembly.Load("Elastic.Apm").GetName().Version.ToString(), payloadSender.Payloads[0].Service.Agent.Version);
+			payloadSender.Payloads[0].Service.Agent.Version.Should().Be(Assembly.Load("Elastic.Apm").GetName().Version.ToString());
 		}
 
 		/// <summary>
@@ -57,12 +58,12 @@ namespace Elastic.Apm.Tests
 
 			agent.Tracer.CaptureTransaction("TestTransaction", "Test", (t) => { t.CaptureSpan(spanName.ToString(), "test", () => { }); });
 
-			Assert.NotNull(payloadSender.FirstSpan);
-			Assert.Equal(1024, payloadSender.FirstSpan.Name.Length);
-			Assert.Equal(spanName.ToString(0, 1021), payloadSender.FirstSpan.Name.Substring(0, 1021));
-			Assert.Equal("...", payloadSender.FirstSpan.Name.Substring(1021, 3));
+			payloadSender.FirstSpan.Should().NotBeNull();
+			payloadSender.FirstSpan.Name.Length.Should().Be(1024);
+			spanName.ToString(0, 1021).Should().Be(payloadSender.FirstSpan.Name.Substring(0, 1021));
+			payloadSender.FirstSpan.Name.Substring(1021, 3).Should().Be("...");
 		}
-    
+
 		[Fact]
 		public void PayloadSentWithBearerToken()
 		{
@@ -83,9 +84,9 @@ namespace Elastic.Apm.Tests
 			// ideally, introduce a mechanism to flush payloads
 			Thread.Sleep(TimeSpan.FromSeconds(2));
 
-			Assert.NotNull(authHeader);
-			Assert.Equal("Bearer", authHeader.Scheme);
-			Assert.Equal(secretToken, authHeader.Parameter);
+			authHeader.Should().NotBeNull();
+			authHeader.Scheme.Should().Be("Bearer");
+			authHeader.Parameter.Should().Be(secretToken);
 		}
 	}
 }

--- a/test/Elastic.Apm.Tests/ConfigTest.cs
+++ b/test/Elastic.Apm.Tests/ConfigTest.cs
@@ -4,6 +4,7 @@ using System.Threading;
 using Elastic.Apm.Config;
 using Elastic.Apm.Logging;
 using Elastic.Apm.Tests.Mocks;
+using FluentAssertions;
 using Xunit;
 
 namespace Elastic.Apm.Tests
@@ -18,8 +19,9 @@ namespace Elastic.Apm.Tests
 		{
 			var serverUrl = "http://myServer.com:1234";
 			var agent = new ApmAgent(new TestAgentComponents(serverUrls: serverUrl));
-			Assert.Equal(serverUrl, agent.ConfigurationReader.ServerUrls[0].OriginalString);
-			Assert.Equal(serverUrl.ToLower() + "/", agent.ConfigurationReader.ServerUrls[0].ToString().ToLower());
+			agent.ConfigurationReader.ServerUrls[0].OriginalString.Should().Be(serverUrl);
+			var rootedUrl = serverUrl + "/";
+			rootedUrl.Should().BeEquivalentTo(agent.ConfigurationReader.ServerUrls[0].AbsoluteUri);
 		}
 
 		[Fact]
@@ -27,7 +29,7 @@ namespace Elastic.Apm.Tests
 		{
 			var serverUrl = "InvalidUrl";
 			var agent = new ApmAgent(new TestAgentComponents(serverUrls: serverUrl));
-			Assert.Equal(ConfigConsts.DefaultServerUri.ToString(), agent.ConfigurationReader.ServerUrls[0].ToString());
+			agent.ConfigurationReader.ServerUrls[0].Should().Be(ConfigConsts.DefaultServerUri);
 		}
 
 		[Fact]
@@ -36,11 +38,17 @@ namespace Elastic.Apm.Tests
 			var serverUrl = "InvalidUrl";
 			var logger = new TestLogger();
 			var agent = new ApmAgent(new TestAgentComponents(logger, serverUrl));
-			Assert.Equal(ConfigConsts.DefaultServerUri.ToString(), agent.ConfigurationReader.ServerUrls[0].ToString());
+			agent.ConfigurationReader.ServerUrls[0].Should().Be(ConfigConsts.DefaultServerUri);
 
-			Assert.Equal(
-				$"{{{nameof(TestAgentConfigurationReader)}}} Failed parsing server URL from {TestAgentConfigurationReader.Origin}: {ConfigConsts.ConfigKeys.Urls}, value: {serverUrl}",
-				logger.Lines[0]);
+			logger.Lines.Should().NotBeEmpty();
+			logger.Lines[0].Should()
+				.StartWith($"{{{nameof(TestAgentConfigurationReader)}}}")
+				.And.ContainAll(
+					"Failed parsing server URL from",
+					TestAgentConfigurationReader.Origin,
+					ConfigConsts.ConfigKeys.Urls,
+					serverUrl
+				);
 		}
 
 		/// <summary>
@@ -56,11 +64,12 @@ namespace Elastic.Apm.Tests
 			var logger = new TestLogger();
 			var agent = new ApmAgent(new TestAgentComponents(logger, serverUrls));
 
-			Assert.Equal(serverUrl1, agent.ConfigurationReader.ServerUrls[0].OriginalString);
-			Assert.Equal(serverUrl1.ToLower() + "/", agent.ConfigurationReader.ServerUrls[0].ToString().ToLower());
+			var parsedUrls = agent.ConfigurationReader.ServerUrls;
+			parsedUrls[0].OriginalString.Should().Be(serverUrl1);
+			parsedUrls[0].AbsoluteUri.Should().BeEquivalentTo($"{serverUrl1}/");
 
-			Assert.Equal(serverUrl2, agent.ConfigurationReader.ServerUrls[1].OriginalString);
-			Assert.Equal(serverUrl2.ToLower() + "/", agent.ConfigurationReader.ServerUrls[1].ToString().ToLower());
+			parsedUrls[1].OriginalString.Should().Be(serverUrl2);
+			parsedUrls[1].AbsoluteUri.Should().BeEquivalentTo($"{serverUrl2}/");
 		}
 
 		/// <summary>
@@ -77,15 +86,23 @@ namespace Elastic.Apm.Tests
 			var logger = new TestLogger();
 			var agent = new ApmAgent(new TestAgentComponents(logger, serverUrls));
 
-			Assert.Equal(serverUrl1, agent.ConfigurationReader.ServerUrls[0].OriginalString);
-			Assert.Equal(serverUrl1.ToLower() + "/", agent.ConfigurationReader.ServerUrls[0].ToString().ToLower());
+			var parsedUrls = agent.ConfigurationReader.ServerUrls;
+			parsedUrls.Should().NotBeEmpty().And.HaveCount(2, "seeded 3 but one was invalid");
+			parsedUrls[0].OriginalString.Should().Be(serverUrl1);
+			parsedUrls[0].AbsoluteUri.Should().BeEquivalentTo($"{serverUrl1}/");
 
-			Assert.Equal(serverUrl3, agent.ConfigurationReader.ServerUrls[1].OriginalString);
-			Assert.Equal(serverUrl3.ToLower() + "/", agent.ConfigurationReader.ServerUrls[1].ToString().ToLower());
+			parsedUrls[1].OriginalString.Should().Be(serverUrl3);
+			parsedUrls[1].AbsoluteUri.Should().BeEquivalentTo($"{serverUrl3}/");
 
-			Assert.Equal(
-				$"{{{nameof(TestAgentConfigurationReader)}}} Failed parsing server URL from {TestAgentConfigurationReader.Origin}: {ConfigConsts.ConfigKeys.Urls}, value: {serverUrl2}",
-				logger.Lines[0]);
+			logger.Lines.Should().NotBeEmpty();
+			logger.Lines[0].Should()
+				.StartWith($"{{{nameof(TestAgentConfigurationReader)}}}")
+				.And.ContainAll(
+					"Failed parsing server URL from",
+					TestAgentConfigurationReader.Origin,
+					ConfigConsts.ConfigKeys.Urls,
+					serverUrl2
+				);
 		}
 
 		[Fact]
@@ -93,38 +110,38 @@ namespace Elastic.Apm.Tests
 		{
 			var secretToken = "secretToken";
 			var agent = new ApmAgent(new TestAgentComponents(secretToken: secretToken));
-			Assert.Equal(secretToken, agent.ConfigurationReader.SecretToken);
+			agent.ConfigurationReader.SecretToken.Should().Be(secretToken);
 		}
 
 		[Fact]
-		public void DefaultLogLevelTest() => Assert.Equal(LogLevel.Error, Agent.Config.LogLevel);
+		public void DefaultLogLevelTest() => Agent.Config.LogLevel.Should().Be(LogLevel.Error);
 
 		[Fact]
 		public void SetDebugLogLevelTest()
 		{
 			var agent = new ApmAgent(new TestAgentComponents("Debug"));
-			Assert.Equal(LogLevel.Debug, agent.ConfigurationReader.LogLevel);
+			agent.ConfigurationReader.LogLevel.Should().Be(LogLevel.Debug);
 		}
 
 		[Fact]
 		public void SetErrorLogLevelTest()
 		{
 			var agent = new ApmAgent(new TestAgentComponents("Error"));
-			Assert.Equal(LogLevel.Error, agent.ConfigurationReader.LogLevel);
+			agent.ConfigurationReader.LogLevel.Should().Be(LogLevel.Error);
 		}
 
 		[Fact]
 		public void SetInfoLogLevelTest()
 		{
 			var agent = new ApmAgent(new TestAgentComponents("Information"));
-			Assert.Equal(LogLevel.Information, agent.ConfigurationReader.LogLevel);
+			agent.ConfigurationReader.LogLevel.Should().Be(LogLevel.Information);
 		}
 
 		[Fact]
 		public void SetWarningLogLevelTest()
 		{
 			var agent = new ApmAgent(new TestAgentComponents("Warning"));
-			Assert.Equal(LogLevel.Warning, agent.ConfigurationReader.LogLevel);
+			agent.ConfigurationReader.LogLevel.Should().Be(LogLevel.Warning);
 		}
 
 		[Fact]
@@ -134,10 +151,16 @@ namespace Elastic.Apm.Tests
 			var agent = new ApmAgent(new TestAgentComponents(logLevelValue));
 			var logger = agent.Logger as TestLogger;
 
-			Assert.Equal(LogLevel.Error, agent.ConfigurationReader.LogLevel);
-			Assert.Equal(
-				$"{{{nameof(TestAgentConfigurationReader)}}} Failed parsing log level from {TestAgentConfigurationReader.Origin}: {ConfigConsts.ConfigKeys.Level}, value: {logLevelValue}. Defaulting to log level 'Error'",
-				logger.Lines[0]);
+			agent.ConfigurationReader.LogLevel.Should().Be(LogLevel.Error);
+			logger.Lines.Should().NotBeEmpty();
+			logger.Lines[0].Should()
+				.StartWith($"{{{nameof(TestAgentConfigurationReader)}}}")
+				.And.ContainAll(
+					"Failed parsing log level from",
+					TestAgentConfigurationReader.Origin,
+					ConfigConsts.ConfigKeys.Level,
+					"Defaulting to "
+				);
 		}
 
 		/// <summary>
@@ -153,8 +176,9 @@ namespace Elastic.Apm.Tests
 
 			//By default XUnit uses 'testhost' as the entry assembly, and that is what the
 			//agent reports if we don't set it to anything:
-			Assert.False(string.IsNullOrEmpty(payloadSender.Payloads[0].Service.Name));
-			Assert.False(payloadSender.Payloads[0].Service.Name.Contains('.'));
+			var serviceName = payloadSender.Payloads[0].Service.Name;
+			serviceName.Should().NotBeNullOrWhiteSpace();
+			serviceName.Should().NotContain(".");
 		}
 
 		/// <summary>
@@ -171,7 +195,7 @@ namespace Elastic.Apm.Tests
 			var agent = new ApmAgent(new AgentComponents(payloadSender: payloadSender));
 			agent.Tracer.CaptureTransaction("TestTransactionName", "TestTransactionType", t => { Thread.Sleep(2); });
 
-			Assert.Equal(serviceName, payloadSender.Payloads[0].Service.Name);
+			payloadSender.Payloads[0].Service.Name.Should().Be(serviceName);
 		}
 
 		/// <summary>
@@ -189,8 +213,9 @@ namespace Elastic.Apm.Tests
 			var agent = new ApmAgent(new AgentComponents(payloadSender: payloadSender));
 			agent.Tracer.CaptureTransaction("TestTransactionName", "TestTransactionType", t => { Thread.Sleep(2); });
 
-			Assert.Equal(serviceName.Replace('.', '_'), payloadSender.Payloads[0].Service.Name);
-			Assert.False(payloadSender.Payloads[0].Service.Name.Contains('.'));
+
+			payloadSender.Payloads[0].Service.Name.Should().Be(serviceName.Replace('.', '_'));
+			payloadSender.Payloads[0].Service.Name.Should().NotContain(".");
 		}
 
 		/// <summary>
@@ -204,18 +229,17 @@ namespace Elastic.Apm.Tests
 			var elasticToken = new byte[] { 174, 116, 0, 210, 193, 137, 207, 34 };
 			var mscorlibToken = new byte[] { 183, 122, 92, 86, 25, 52, 224, 137 };
 
-			Assert.True(AbstractConfigurationReader.IsMsOrElastic(elasticToken));
-			Assert.True(AbstractConfigurationReader.IsMsOrElastic(elasticToken));
+			AbstractConfigurationReader.IsMsOrElastic(elasticToken).Should().BeTrue();
 
-			Assert.False(AbstractConfigurationReader.IsMsOrElastic(new byte[] { 0 }));
-			Assert.False(AbstractConfigurationReader.IsMsOrElastic(new byte[] { }));
+			AbstractConfigurationReader.IsMsOrElastic(new byte[] { 0 }).Should().BeFalse();
+			AbstractConfigurationReader.IsMsOrElastic(new byte[] { }).Should().BeFalse();
 
-			Assert.False(AbstractConfigurationReader
+			AbstractConfigurationReader
 				.IsMsOrElastic(new[]
 				{
 					elasticToken[0], mscorlibToken[1], elasticToken[2],
 					mscorlibToken[3], elasticToken[4], mscorlibToken[5], elasticToken[6], mscorlibToken[7]
-				}));
+				}).Should().BeFalse();
 		}
 
 		/// <summary>
@@ -230,8 +254,8 @@ namespace Elastic.Apm.Tests
 			var config = new EnvironmentConfigurationReader(testLogger);
 			var serverUrl = config.ServerUrls.FirstOrDefault();
 
-			Assert.NotNull(serverUrl);
-			Assert.NotEmpty(testLogger.Lines);
+			serverUrl.Should().NotBeNull();
+			testLogger.Lines.Should().NotBeEmpty();
 		}
 
 		public void Dispose() => Environment.SetEnvironmentVariable(ConfigConsts.ConfigKeys.Urls, null);

--- a/test/Elastic.Apm.Tests/Elastic.Apm.Tests.csproj
+++ b/test/Elastic.Apm.Tests/Elastic.Apm.Tests.csproj
@@ -8,9 +8,12 @@
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\build\elasticapm.snk</AssemblyOriginatorKeyFile>
     <DelaySign>false</DelaySign>
+    <!-- Always generate debug symbols this allows fluent symbols exception messages to include variable names -->
+    <DebugSymbols>True</DebugSymbols>
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="FluentAssertions" Version="5.6.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />

--- a/test/Elastic.Apm.Tests/Extensions/ShouldWaitDurationExtensions.cs
+++ b/test/Elastic.Apm.Tests/Extensions/ShouldWaitDurationExtensions.cs
@@ -1,0 +1,19 @@
+using System.Threading;
+using Elastic.Apm.Tests.Extensions;
+using FluentAssertions;
+using FluentAssertions.Numeric;
+
+namespace Elastic.Apm.Tests
+{
+	public static class ShouldWaitDurationExtensions
+	{
+		public static AndConstraint<NumericAssertions<double>> BeGreaterOrEqualToMinimumSleepLength(this NullableNumericAssertions<double> duration) =>
+			duration.NotBeNull().And.BeGreaterOrEqualTo(WaitHelpers.SleepLength);
+
+		public static AndConstraint<NumericAssertions<double>> BeGreaterOrEqualToMinimumSleepLength(this NullableNumericAssertions<double> duration, int numberOfSleeps)
+		{
+			var expectedTransactionLength = numberOfSleeps * WaitHelpers.SleepLength;
+			return duration.NotBeNull().And.BeGreaterOrEqualTo(expectedTransactionLength, $"we expected {numberOfSleeps} to influence the total duration");
+		}
+	}
+}

--- a/test/Elastic.Apm.Tests/Extensions/WaitExtensions.cs
+++ b/test/Elastic.Apm.Tests/Extensions/WaitExtensions.cs
@@ -1,9 +1,10 @@
 using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
+using FluentAssertions;
 using Xunit;
 
-namespace Elastic.Apm.Tests
+namespace Elastic.Apm.Tests.Extensions
 {
 	/// <summary>
 	/// Helper class that runs Task.Delay and Thread.Sleep
@@ -32,15 +33,7 @@ namespace Elastic.Apm.Tests
 
 		public static void SleepMinimum() => Thread.Sleep(SleepLength);
 
-		public static int A(this string str) => 24;
-
-		public static void AssertMinimumSleepLength(double? duration)
-			=> Assert.True(duration >= SleepLength, $"Expected {duration} to be greater or equal to: {SleepLength}");
-
-		public static void Assert3XMinimumSleepLength(double? duration)
-		{
-			var expectedTransactionLength = SleepLength + 2 *  SleepLength;
-			Assert.True(duration >= expectedTransactionLength, $"Expected {duration} to be greater or equal to: {expectedTransactionLength}");
-		}
+		public static void Assert3XMinimumSleepLength(double? duration) => duration.Should().BeGreaterOrEqualToMinimumSleepLength(numberOfSleeps: 3);
 	}
+
 }

--- a/test/Elastic.Apm.Tests/HttpDiagnosticListenerTest.cs
+++ b/test/Elastic.Apm.Tests/HttpDiagnosticListenerTest.cs
@@ -12,6 +12,7 @@ using Elastic.Apm.DiagnosticSource;
 using Elastic.Apm.Logging;
 using Elastic.Apm.Model.Payload;
 using Elastic.Apm.Tests.Mocks;
+using FluentAssertions;
 using Xunit;
 
 namespace Elastic.Apm.Tests
@@ -32,8 +33,15 @@ namespace Elastic.Apm.Tests
 			var fakeException = new Exception(exceptionMessage);
 			listener.OnError(fakeException);
 
-			Assert.Equal($"{{{nameof(HttpDiagnosticListener)}}} {nameof(Exception)} in OnError ({nameof(HttpDiagnosticListener)}.cs:38): {exceptionMessage}",
-				logger.Lines?.FirstOrDefault());
+			logger.Lines.Should().NotBeEmpty();
+			logger.Lines[0]
+				.Should()
+				.StartWith($"{{{nameof(HttpDiagnosticListener)}}}")
+				.And.ContainAll(
+					"in OnError",
+					".cs:",
+					exceptionMessage
+				);
 		}
 
 		/// <summary>
@@ -52,9 +60,9 @@ namespace Elastic.Apm.Tests
 
 			//Simulate Start
 			listener.OnNext(new KeyValuePair<string, object>("System.Net.Http.HttpRequestOut.Start", new { Request = request }));
-			Assert.Single(listener.ProcessingRequests);
-			Assert.Equal(request.RequestUri.ToString(), listener.ProcessingRequests[request].Context.Http.Url);
-			Assert.Equal(HttpMethod.Get.ToString(), listener.ProcessingRequests[request].Context.Http.Method);
+			listener.ProcessingRequests.Should().NotBeEmpty().And.HaveCount(1);
+			listener.ProcessingRequests[request].Context.Http.Url.Should().Be(request.RequestUri.ToString());
+			listener.ProcessingRequests[request].Context.Http.Method.Should().Be(HttpMethod.Get.ToString());
 		}
 
 		/// <summary>
@@ -79,10 +87,12 @@ namespace Elastic.Apm.Tests
 			listener.OnNext(new KeyValuePair<string, object>("System.Net.Http.HttpRequestOut.Start", new { Request = request }));
 			//Simulate Stop
 			listener.OnNext(new KeyValuePair<string, object>("System.Net.Http.HttpRequestOut.Stop", new { Request = request, Response = response }));
-			Assert.Empty(listener.ProcessingRequests);
+			listener.ProcessingRequests.Should().BeEmpty();
 
-			Assert.Equal(request.RequestUri.ToString(), (Agent.TransactionContainer.Transactions.Value.Spans[0] as Span)?.Context.Http.Url);
-			Assert.Equal(HttpMethod.Get.ToString(), (Agent.TransactionContainer.Transactions.Value.Spans[0] as Span)?.Context.Http.Method);
+			var firstSpan = Agent.TransactionContainer.Transactions.Value.Spans[0] as Span;
+			firstSpan.Should().NotBeNull();
+			firstSpan.Context.Http.Url.Should().BeEquivalentTo(request.RequestUri.AbsoluteUri);
+			firstSpan.Context.Http.Method.Should().Be(HttpMethod.Get.Method);
 		}
 
 		/// <summary>
@@ -108,11 +118,17 @@ namespace Elastic.Apm.Tests
 			//Simulate Stop again. This should not happen, still we test for this.
 			listener.OnNext(new KeyValuePair<string, object>("System.Net.Http.HttpRequestOut.Stop", new { Request = request, Response = response }));
 
-			Assert.Equal(
-				$"{{{nameof(HttpDiagnosticListener)}}} Failed capturing request '{HttpMethod.Get} {request.RequestUri}' in System.Net.Http.HttpRequestOut.Stop. This Span will be skipped in case it wasn't captured before.",
-				logger.Lines[0]);
-			Assert.NotNull(Agent.TransactionContainer.Transactions.Value);
-			Assert.Single(Agent.TransactionContainer.Transactions.Value.Spans);
+			logger.Lines.Should().NotBeEmpty();
+			logger.Lines[0]
+				.Should()
+				.StartWith($"{{{nameof(HttpDiagnosticListener)}}}")
+				.And.ContainAll(
+					"Failed capturing request",
+					HttpMethod.Get.Method,
+					request.RequestUri.AbsoluteUri
+				);
+			Agent.TransactionContainer.Transactions.Value.Should().NotBeNull();
+			Agent.TransactionContainer.Transactions.Value.Spans.Should().ContainSingle();
 		}
 
 		/// <summary>
@@ -130,7 +146,7 @@ namespace Elastic.Apm.Tests
 			var exception =
 				Record.Exception(() => { listener.OnNext(new KeyValuePair<string, object>("System.Net.Http.HttpRequestOut.Start", myFake)); });
 
-			Assert.Null(exception);
+			exception.Should().BeNull();
 		}
 
 		/// <summary>
@@ -147,7 +163,7 @@ namespace Elastic.Apm.Tests
 			var exception =
 				Record.Exception(() => { listener.OnNext(new KeyValuePair<string, object>("System.Net.Http.HttpRequestOut.Start", null)); });
 
-			Assert.Null(exception);
+			exception.Should().BeNull();
 		}
 
 		/// <summary>
@@ -164,7 +180,7 @@ namespace Elastic.Apm.Tests
 			var exception =
 				Record.Exception(() => { listener.OnNext(new KeyValuePair<string, object>(null, null)); });
 
-			Assert.Null(exception);
+			exception.Should().BeNull();
 		}
 
 		/// <summary>
@@ -182,12 +198,13 @@ namespace Elastic.Apm.Tests
 				var httpClient = new HttpClient();
 				var res = await httpClient.GetAsync(localServer.Uri);
 
-				Assert.True(res.IsSuccessStatusCode);
-				Assert.Equal(localServer.Uri, (Agent.TransactionContainer.Transactions.Value.Spans[0] as Span)?.Context.Http.Url);
+				res.IsSuccessStatusCode.Should().BeTrue();
+				var firstSpan = Agent.TransactionContainer.Transactions.Value.Spans[0] as Span;
+				firstSpan.Should().NotBeNull();
+				firstSpan.Context.Http.Url.Should().Be(localServer.Uri);
+				firstSpan.Context.Http.StatusCode.Should().Be(200);
+				firstSpan.Context.Http.Method.Should().Be(HttpMethod.Get.Method);
 			}
-
-			Assert.Equal(200, (Agent.TransactionContainer.Transactions.Value.Spans[0] as Span)?.Context.Http.StatusCode);
-			Assert.Equal(HttpMethod.Get.ToString(), (Agent.TransactionContainer.Transactions.Value.Spans[0] as Span)?.Context.Http.Method);
 		}
 
 		/// <summary>
@@ -206,12 +223,13 @@ namespace Elastic.Apm.Tests
 				var httpClient = new HttpClient();
 				var res = await httpClient.PostAsync(localServer.Uri, new StringContent("foo"));
 
-				Assert.False(res.IsSuccessStatusCode);
-				Assert.Equal(localServer.Uri, (Agent.TransactionContainer.Transactions.Value.Spans[0] as Span)?.Context.Http.Url);
+				res.IsSuccessStatusCode.Should().BeFalse();
+				var firstSpan = Agent.TransactionContainer.Transactions.Value.Spans[0] as Span;
+				firstSpan.Should().NotBeNull();
+				firstSpan.Context.Http.Url.Should().Be(localServer.Uri);
+				firstSpan.Context.Http.StatusCode.Should().Be(500);
+				firstSpan.Context.Http.Method.Should().Be(HttpMethod.Post.Method);
 			}
-
-			Assert.Equal(500, (Agent.TransactionContainer.Transactions.Value.Spans[0] as Span)?.Context.Http.StatusCode);
-			Assert.Equal(HttpMethod.Post.ToString(), (Agent.TransactionContainer.Transactions.Value.Spans[0] as Span)?.Context.Http.Method);
 		}
 
 		/// <summary>
@@ -226,22 +244,12 @@ namespace Elastic.Apm.Tests
 			using (listener)
 			{
 				var httpClient = new HttpClient();
-				try
-				{
-					await httpClient.GetAsync("http://nonexistenturl_dsfdsf.ghkdehfn");
-					Assert.True(false); //Make it fail if no exception is thrown
-				}
-				catch (Exception e)
-				{
-					Assert.NotNull(e);
-				}
-				finally
-				{
-					listener.Dispose();
-				}
+
+				Func<Task> act = async () => await httpClient.GetAsync("http://nonexistenturl_dsfdsf.ghkdehfn");
+				act.Should().Throw<Exception>();
 			}
 
-			Assert.NotEmpty(payloadSender.Errors);
+			payloadSender.Errors.Should().NotBeEmpty();
 		}
 
 		/// <summary>
@@ -268,9 +276,9 @@ namespace Elastic.Apm.Tests
 				//Simulate Exception
 				listener.OnNext(new KeyValuePair<string, object>("System.Net.Http.Exception", new { Request = request, Exception = exception }));
 
-				Assert.NotEmpty(payloadSender.Errors);
-				Assert.Equal(exceptionMsg, payloadSender.Errors[0].Errors[0].Exception.Message);
-				Assert.Equal(typeof(Exception).FullName, payloadSender.Errors[0].Errors[0].Exception.Type);
+				payloadSender.Errors.Should().NotBeEmpty();
+				payloadSender.Errors[0].Errors[0].Exception.Message.Should().Be(exceptionMsg);
+				payloadSender.Errors[0].Errors[0].Exception.Type.Should().Be(typeof(Exception).FullName);
 			}
 		}
 
@@ -288,12 +296,12 @@ namespace Elastic.Apm.Tests
 				var httpClient = new HttpClient();
 				var res = await httpClient.GetAsync(localServer.Uri);
 
-				Assert.True(res.IsSuccessStatusCode);
+				res.IsSuccessStatusCode.Should().BeTrue();
 			}
 
-			Assert.Equal(ApiConstants.TypeExternal, Agent.TransactionContainer.Transactions.Value.Spans[0].Type);
-			Assert.Equal(ApiConstants.SubtypeHttp, Agent.TransactionContainer.Transactions.Value.Spans[0].Subtype);
-			Assert.Null(Agent.TransactionContainer.Transactions.Value.Spans[0].Action); //we don't set Action for HTTP calls
+			Agent.TransactionContainer.Transactions.Value.Spans[0].Type.Should().Be(ApiConstants.TypeExternal);
+			Agent.TransactionContainer.Transactions.Value.Spans[0].Subtype.Should().Be(ApiConstants.SubtypeHttp);
+			Agent.TransactionContainer.Transactions.Value.Spans[0].Action.Should().BeNull(); //we don't set Action for HTTP calls
 		}
 
 		/// <summary>
@@ -310,10 +318,10 @@ namespace Elastic.Apm.Tests
 				var httpClient = new HttpClient();
 				var res = await httpClient.GetAsync(localServer.Uri);
 
-				Assert.True(res.IsSuccessStatusCode);
+				res.IsSuccessStatusCode.Should().BeTrue();
 			}
 
-			Assert.Equal("GET localhost", Agent.TransactionContainer.Transactions.Value.Spans[0].Name);
+			Agent.TransactionContainer.Transactions.Value.Spans[0].Name.Should().Be("GET localhost");
 		}
 
 		/// <summary>
@@ -335,11 +343,14 @@ namespace Elastic.Apm.Tests
 				var httpClient = new HttpClient();
 				var res = await httpClient.GetAsync(localServer.Uri);
 
-				Assert.True(res.IsSuccessStatusCode);
-				Assert.Equal(localServer.Uri, (Agent.TransactionContainer.Transactions.Value.Spans[0] as Span)?.Context.Http.Url);
+				res.IsSuccessStatusCode.Should().BeTrue();
+				var firstSpan = Agent.TransactionContainer.Transactions.Value.Spans[0] as Span;
+				firstSpan.Should().NotBeNull();
+				firstSpan.Context.Http.Url.Should().Be(localServer.Uri);
+				firstSpan.Context.Http.StatusCode.Should().Be(200);
+				firstSpan.Context.Http.Method.Should().Be(HttpMethod.Get.Method);
+				firstSpan.Duration.Should().BeGreaterThan(0);
 			}
-
-			Assert.True(Agent.TransactionContainer.Transactions.Value.Spans[0].Duration > 0);
 		}
 
 		/// <summary>
@@ -356,11 +367,14 @@ namespace Elastic.Apm.Tests
 				var httpClient = new HttpClient();
 				var res = await httpClient.GetAsync(localServer.Uri);
 
-				Assert.True(res.IsSuccessStatusCode);
-				Assert.Equal(localServer.Uri, (Agent.TransactionContainer.Transactions.Value.Spans[0] as Span)?.Context.Http.Url);
+				res.IsSuccessStatusCode.Should().BeTrue();
+				var firstSpan = Agent.TransactionContainer.Transactions.Value.Spans[0] as Span;
+				firstSpan.Should().NotBeNull();
+				firstSpan.Context.Http.Url.Should().Be(localServer.Uri);
+				firstSpan.Context.Http.StatusCode.Should().Be(200);
+				firstSpan.Context.Http.Method.Should().Be(HttpMethod.Get.Method);
+				firstSpan.Duration.Should().BeGreaterThan(0);
 			}
-
-			Assert.True(Agent.TransactionContainer.Transactions.Value.Spans[0].Id > 0);
 		}
 
 		/// <summary>
@@ -392,9 +406,8 @@ namespace Elastic.Apm.Tests
 					}
 				});
 
-				Assert.NotEmpty(mockPayloadSender.Payloads[0].Transactions);
-				Assert.Empty(mockPayloadSender.SpansOnFirstTransaction);
-
+				mockPayloadSender.Payloads[0].Transactions.Should().NotBeEmpty();
+				mockPayloadSender.SpansOnFirstTransaction.Should().BeEmpty();
 			}
 		}
 
@@ -412,22 +425,24 @@ namespace Elastic.Apm.Tests
 			using (var localServer = new LocalServer())
 			using (var httpClient = new HttpClient())
 			{
-				Assert.True(spans.Length == 0, $"Expected 0 spans has count: {spans.Length}");
+				spans.Should().BeEmpty();
 				using (agent.Subscribe(new HttpDiagnosticsSubscriber()))
 				{
 					var res = await httpClient.GetAsync(localServer.Uri);
-					Assert.True(res.IsSuccessStatusCode);
+					res.IsSuccessStatusCode.Should().BeTrue();
 					res = await httpClient.GetAsync(localServer.Uri);
-					Assert.True(res.IsSuccessStatusCode);
+					res.IsSuccessStatusCode.Should().BeTrue();
 				}
 				spans = Agent.TransactionContainer.Transactions.Value.Spans;
-				Assert.True(spans.Length == 2, $"Expected 2 but spans has count: {spans.Length}");
+				spans.Should().NotBeEmpty().And.HaveCount(2);
 				foreach (var _ in Enumerable.Range(0, 10))
 					await httpClient.GetAsync(localServer.Uri);
 
-				Assert.True(localServer.SeenRequests > 10, "Make sure we actually performed more than 1 request to our local server");
+				localServer.SeenRequests.Should()
+					.BeGreaterOrEqualTo(10,
+						"Make sure we actually performed more than 1 request to our local server");
 			}
-			Assert.True(spans.Length == 2, $"Expected 1 span because the listener is disposed but spans has count: {spans.Length}");
+			spans.Should().HaveCount(2);
 		}
 
 		/// <summary>
@@ -461,11 +476,11 @@ namespace Elastic.Apm.Tests
 					}
 				});
 
-				Assert.NotEmpty(mockPayloadSender.Payloads[0].Transactions);
-				Assert.NotEmpty(mockPayloadSender.SpansOnFirstTransaction);
+				mockPayloadSender.Payloads[0].Transactions.Should().NotBeEmpty();
+				mockPayloadSender.SpansOnFirstTransaction.Should().NotBeEmpty();
 
-				Assert.NotNull(mockPayloadSender.SpansOnFirstTransaction[0].Context.Http);
-				Assert.Equal(url, mockPayloadSender.SpansOnFirstTransaction[0].Context.Http.Url);
+				mockPayloadSender.SpansOnFirstTransaction[0].Context.Http.Should().NotBeNull();
+				mockPayloadSender.SpansOnFirstTransaction[0].Context.Http.Url.Should().Be(url);
 			}
 		}
 
@@ -518,8 +533,8 @@ namespace Elastic.Apm.Tests
 					}
 				});
 
-				Assert.NotNull(mockPayloadSender.Payloads[0].Transactions[0]);
-				Assert.Empty(mockPayloadSender.SpansOnFirstTransaction);
+				mockPayloadSender.Payloads[0].Transactions[0].Should().NotBeNull();
+				mockPayloadSender.SpansOnFirstTransaction.Should().BeEmpty();
 			}
 		}
 

--- a/test/Elastic.Apm.Tests/LoggerTest.cs
+++ b/test/Elastic.Apm.Tests/LoggerTest.cs
@@ -1,5 +1,6 @@
 ﻿using Elastic.Apm.Logging;
 using Elastic.Apm.Tests.Mocks;
+using FluentAssertions;
 using Xunit;
 
 namespace Elastic.Apm.Tests
@@ -11,8 +12,8 @@ namespace Elastic.Apm.Tests
 		{
 			var logger = LogWithLevel(LogLevel.Error);
 
-			Assert.Single(logger.Lines);
-			Assert.Equal("Error log", logger.Lines[0]);
+			logger.Lines.Should().ContainSingle();
+			logger.Lines[0].Should().Be("Error log");
 		}
 
 		[Fact]
@@ -20,9 +21,9 @@ namespace Elastic.Apm.Tests
 		{
 			var logger = LogWithLevel(LogLevel.Warning);
 
-			Assert.Equal(2, logger.Lines.Count);
-			Assert.Equal("Error log", logger.Lines[0]);
-			Assert.Equal("Warning log", logger.Lines[1]);
+			logger.Lines.Count.Should().Be(2);
+			logger.Lines[0].Should().Be("Error log");
+			logger.Lines[1].Should().Be("Warning log");
 		}
 
 		[Fact]
@@ -30,10 +31,10 @@ namespace Elastic.Apm.Tests
 		{
 			var logger = LogWithLevel(LogLevel.Information);
 
-			Assert.Equal(3, logger.Lines.Count);
-			Assert.Equal("Error log", logger.Lines[0]);
-			Assert.Equal("Warning log", logger.Lines[1]);
-			Assert.Equal("Info log", logger.Lines[2]);
+			logger.Lines.Count.Should().Be(3);
+			logger.Lines[0].Should().Be("Error log");
+			logger.Lines[1].Should().Be("Warning log");
+			logger.Lines[2].Should().Be("Info log");
 		}
 
 		[Fact]
@@ -41,11 +42,11 @@ namespace Elastic.Apm.Tests
 		{
 			var logger = LogWithLevel(LogLevel.Debug);
 
-			Assert.Equal(4, logger.Lines.Count);
-			Assert.Equal("Error log", logger.Lines[0]);
-			Assert.Equal("Warning log", logger.Lines[1]);
-			Assert.Equal("Info log", logger.Lines[2]);
-			Assert.Equal("Debug log", logger.Lines[3]);
+			logger.Lines.Count.Should().Be(4);
+			logger.Lines[0].Should().Be("Error log");
+			logger.Lines[1].Should().Be("Warning log");
+			logger.Lines[2].Should().Be("Info log");
+			logger.Lines[3].Should().Be("Debug log");
 		}
 
 		private TestLogger LogWithLevel(LogLevel logLevel)

--- a/test/Elastic.Apm.Tests/StackTraceTests.cs
+++ b/test/Elastic.Apm.Tests/StackTraceTests.cs
@@ -3,6 +3,7 @@ using System.Runtime.InteropServices.ComTypes;
 using System.Threading.Tasks;
 using Elastic.Apm.Model.Payload;
 using Elastic.Apm.Tests.Mocks;
+using FluentAssertions;
 using Xunit;
 
 namespace Elastic.Apm.Tests
@@ -28,13 +29,12 @@ namespace Elastic.Apm.Tests
 				var httpClient = new HttpClient();
 				var res = await httpClient.GetAsync(localServer.Uri);
 
-				Assert.True(res.IsSuccessStatusCode);
+				res.IsSuccessStatusCode.Should().BeTrue();
 			}
 
 			var stackFrames = (Agent.TransactionContainer.Transactions.Value.Spans[0] as Span)?.StackTrace;
 
-			Assert.NotNull(stackFrames);
-			Assert.Contains(stackFrames, frame => frame.LineNo!=0);
+			stackFrames.Should().NotBeEmpty().And.Contain(frame => frame.LineNo != 0);
 		}
 	}
 }


### PR DESCRIPTION
https://fluentassertions.com makes it easy to write assertions that have good exception messages and ships with a lot of useful asserts.

`Assert.IsTrue` `Assert.IsFalse` `Assert.Equal` all kind of hide the intend of the assertion. 

https://fluentassertions.com/tips/#improved-assertions lists quite an extensive list on how it can be utilized to write sane assertions 👍 

One particular thing I like is that it captures the variable under test (hence why `<DebugSymbols>` is now always true). 

Consider this xUnit assert:

```csharp
Assert.Equal("bar", payloadSender.SpansOnFirstTransaction[0].Context.Tags["foo"]);
```

```
Assert.Equal() Failure
             ↓ (pos 3)
Expected: bar
Actual:   bar2
             ↑ (pos 3)
```

vs FluentAssertions

```csharp
payloadSender.SpansOnFirstTransaction[0].Context.Tags.Should().Contain("foo","bar");
````

```
Expected payloadSender.SpansOnFirstTransaction[0].Context.Tags to contain value "bar" at key "foo", but found "bar2".
```

The nice thing here that it captures the `SUT` and will assert tags actually not being null or empty and having a key foo in one go 👍 

String assertions also include positional information:

```

Expected string to be "xya", but "xyz" differs near "z" (index 2).
```

Albeit it less nice then xUnit assertions.




