### PR TITLE
[Discussion #142] Logger optimization with `?.`- allocation free 

### DIFF
--- a/src/Elastic.Apm.AspNetCore/Config/MicrosoftExtensionsConfig.cs
+++ b/src/Elastic.Apm.AspNetCore/Config/MicrosoftExtensionsConfig.cs
@@ -72,7 +72,7 @@ namespace Elastic.Apm.AspNetCore.Config
 			if (_logLevel.HasValue && newLogLevel == _logLevel.Value) return;
 
 			_logLevel = newLogLevel;
-			Logger.LogInfo("Updated log level to {LogLevel}", newLogLevel);
+			Logger.Info()?.Log("Updated log level to {LogLevel}", newLogLevel);
 		}
 	}
 }

--- a/src/Elastic.Apm/Api/Tracer.cs
+++ b/src/Elastic.Apm/Api/Tracer.cs
@@ -36,7 +36,8 @@ namespace Elastic.Apm.Api
 				Service = _service
 			};
 
-			_logger.Debug()?.Log("Starting {TransactionValue}", Agent.TransactionContainer.Transactions.Value);
+			Agent.TransactionContainer.Transactions.Value = retVal;
+			_logger.Debug()?.Log("Starting {TransactionValue}", retVal);
 			return retVal;
 		}
 

--- a/src/Elastic.Apm/Api/Tracer.cs
+++ b/src/Elastic.Apm/Api/Tracer.cs
@@ -36,8 +36,7 @@ namespace Elastic.Apm.Api
 				Service = _service
 			};
 
-			Agent.TransactionContainer.Transactions.Value = retVal;
-			_logger.LogDebug($"Starting {retVal}");
+			_logger.Debug()?.Log("Starting {TransactionValue}", Agent.TransactionContainer.Transactions.Value);
 			return retVal;
 		}
 

--- a/src/Elastic.Apm/Config/AbstractConfigurationReader.cs
+++ b/src/Elastic.Apm/Config/AbstractConfigurationReader.cs
@@ -51,10 +51,10 @@ namespace Elastic.Apm.Config
 			if (TryParseLogLevel(kv?.Value, out var level)) return level.Value;
 
 			if (kv?.Value == null)
-				Logger?.LogDebug("No log level provided. Defaulting to log level '{DefaultLogLevel}'", ConsoleLogger.DefaultLogLevel);
+				Logger?.Debug()?.Log("No log level provided. Defaulting to log level '{DefaultLogLevel}'", ConsoleLogger.DefaultLogLevel);
 			else
 			{
-				Logger?.LogError("Failed parsing log level from {Origin}: {Key}, value: {Value}. Defaulting to log level '{DefaultLogLevel}'",
+				Logger?.Error()?.Log("Failed parsing log level from {Origin}: {Key}, value: {Value}. Defaulting to log level '{DefaultLogLevel}'",
 					kv.ReadFrom, kv.Key, kv.Value, ConsoleLogger.DefaultLogLevel);
 			}
 
@@ -75,7 +75,7 @@ namespace Elastic.Apm.Config
 					continue;
 				}
 
-				Logger?.LogError("Failed parsing server URL from {Origin}: {Key}, value: {Value}", kv.ReadFrom, kv.Key, u);
+				Logger?.Error()?.Log("Failed parsing server URL from {Origin}: {Key}, value: {Value}", kv.ReadFrom, kv.Key, u);
 			}
 
 			return list.Count == 0 ? LogAndReturnDefault().AsReadOnly() : list.AsReadOnly();
@@ -83,7 +83,7 @@ namespace Elastic.Apm.Config
 			List<Uri> LogAndReturnDefault()
 			{
 				list.Add(ConfigConsts.DefaultServerUri);
-				Logger?.LogDebug("Using default ServerUrl: {ServerUrl}", ConfigConsts.DefaultServerUri);
+				Logger?.Debug()?.Log("Using default ServerUrl: {ServerUrl}", ConfigConsts.DefaultServerUri);
 				return list;
 			}
 
@@ -103,9 +103,9 @@ namespace Elastic.Apm.Config
 			var retVal = kv.Value;
 			if (string.IsNullOrEmpty(retVal))
 			{
-				Logger?.LogInfo("The agent was started without a service name. The service name will be automatically calculated.");
+				Logger?.Info()?.Log("The agent was started without a service name. The service name will be automatically calculated.");
 				retVal = Assembly.GetEntryAssembly()?.GetName().Name;
-				Logger?.LogInfo("The agent was started without a service name. The Service name sis {ServiceName}", retVal);
+				Logger?.Info()?.Log("The agent was started without a service name. The Service name sis {ServiceName}", retVal);
 			}
 
 			if (string.IsNullOrEmpty(retVal))
@@ -126,7 +126,7 @@ namespace Elastic.Apm.Config
 
 			if (string.IsNullOrEmpty(retVal))
 			{
-				Logger?.LogError("Failed calculating service name, the service name will be 'unknown'." +
+				Logger?.Error()?.Log("Failed calculating service name, the service name will be 'unknown'." +
 					" You can fix this by setting the service name to a specific value (e.g. by using the environment variable {ServiceNameVariable})", ConfigConsts.ConfigKeys.ServiceName);
 				retVal = "unknown";
 			}

--- a/src/Elastic.Apm/DiagnosticListeners/HttpDiagnosticListener.cs
+++ b/src/Elastic.Apm/DiagnosticListeners/HttpDiagnosticListener.cs
@@ -35,7 +35,7 @@ namespace Elastic.Apm.DiagnosticListeners
 
 		public void OnCompleted() { }
 
-		public void OnError(Exception error) => Logger.LogErrorException(error, nameof(OnError));
+		public void OnError(Exception error) { }  //TODO =>   //Logger.LogErrorException(error, nameof(OnError));
 
 		public void OnNext(KeyValuePair<string, object> kv)
 		{
@@ -93,7 +93,7 @@ namespace Elastic.Apm.DiagnosticListeners
 						const string message = "Failed capturing request '{HttpMethod} {Url}' in System.Net.Http.HttpRequestOut.Stop. This Span will be skipped in case it wasn't captured before.";
 						var url = request?.RequestUri?.AbsoluteUri;
 						var method = request?.Method?.Method;
-						Logger.LogWarning(message, method, url);
+						Logger?.Warning()?.Log(message, method, url);
 					}
 					break;
 			}

--- a/src/Elastic.Apm/DiagnosticListeners/HttpDiagnosticListener.cs
+++ b/src/Elastic.Apm/DiagnosticListeners/HttpDiagnosticListener.cs
@@ -35,7 +35,7 @@ namespace Elastic.Apm.DiagnosticListeners
 
 		public void OnCompleted() { }
 
-		public void OnError(Exception error) { }  //TODO =>   //Logger.LogErrorException(error, nameof(OnError));
+		public void OnError(Exception error) => Logger.Error()?.LogExceptionWithCaller(error, nameof(OnError));
 
 		public void OnNext(KeyValuePair<string, object> kv)
 		{
@@ -51,7 +51,7 @@ namespace Elastic.Apm.DiagnosticListeners
 					var exception = kv.Value.GetType().GetTypeInfo().GetDeclaredProperty("Exception").GetValue(kv.Value) as Exception;
 					var transaction = Agent.TransactionContainer.Transactions?.Value;
 
-					transaction.CaptureException(exception, "Failed outgoing HTTP request");
+					transaction?.CaptureException(exception, "Failed outgoing HTTP request");
 					//TODO: we don't know if exception is handled, currently reports handled = false
 					break;
 				case "System.Net.Http.HttpRequestOut.Start": //TODO: look for consts

--- a/src/Elastic.Apm/Helpers/StacktraceHelper.cs
+++ b/src/Elastic.Apm/Helpers/StacktraceHelper.cs
@@ -37,7 +37,6 @@ namespace Elastic.Apm.Helpers
 			catch (Exception e)
 			{
 				logger?.Warning()?.LogException(e, "Failed capturing stacktrace for {ApmContext}", capturingFor);
-				logger?.LogDebug(e, "Exception {ExceptionName}: {ExceptionMessage}", e.GetType().Name, e.Message);
 			}
 
 			return retVal;
@@ -59,7 +58,6 @@ namespace Elastic.Apm.Helpers
 			catch (Exception e)
 			{
 				logger?.Warning()?.LogException(e, "Failed extracting exception from stackTrace for {ApmContext}", capturingFor);
-				logger?.LogDebug(e, "Exception {ExceptionName}: {ExceptionMessage}", e.GetType().Name, e.Message);
 			}
 
 			return null;

--- a/src/Elastic.Apm/Helpers/StacktraceHelper.cs
+++ b/src/Elastic.Apm/Helpers/StacktraceHelper.cs
@@ -36,7 +36,7 @@ namespace Elastic.Apm.Helpers
 			}
 			catch (Exception e)
 			{
-				logger?.LogWarning(e, "Failed capturing stacktrace for {ApmContext}", capturingFor);
+				logger?.Warning()?.LogException(e, "Failed capturing stacktrace for {ApmContext}", capturingFor);
 				logger?.LogDebug(e, "Exception {ExceptionName}: {ExceptionMessage}", e.GetType().Name, e.Message);
 			}
 
@@ -58,7 +58,7 @@ namespace Elastic.Apm.Helpers
 			}
 			catch (Exception e)
 			{
-				logger?.LogWarning(e, "Failed extracting exception from stackTrace for {ApmContext}", capturingFor);
+				logger?.Warning()?.LogException(e, "Failed extracting exception from stackTrace for {ApmContext}", capturingFor);
 				logger?.LogDebug(e, "Exception {ExceptionName}: {ExceptionMessage}", e.GetType().Name, e.Message);
 			}
 

--- a/src/Elastic.Apm/Logging/ConsoleLogger.cs
+++ b/src/Elastic.Apm/Logging/ConsoleLogger.cs
@@ -12,7 +12,7 @@ namespace Elastic.Apm.Logging
 		{
 			Level = level;
 			_standardOut = standardOut ?? Console.Out;
-			_errorOut = standardOut ?? Console.Error;
+			_errorOut = errorOut ?? Console.Error;
 		}
 
 		protected internal static LogLevel DefaultLogLevel { get; } = LogLevel.Error;
@@ -31,7 +31,10 @@ namespace Elastic.Apm.Logging
 			var dateTime = DateTime.UtcNow;
 
 			var message = formatter(state, e);
-			var fullMessage = $"[{dateTime.ToString("yyyy-MM-dd hh:mm:ss")}][{LevelToString(level)}] - {message}";
+
+			var fullMessage = e == null ? $"[{dateTime.ToString("yyyy-MM-dd hh:mm:ss")}][{LevelToString(level)}] - {message}"
+				: $"[{dateTime.ToString("yyyy-MM-dd hh:mm:ss")}][{LevelToString(level)}] - {message}\nException: {e.GetType().FullName}, Message: {e.Message}";
+
 			switch (level)
 			{
 				case LogLevel.Critical when Level <= LogLevel.Critical:

--- a/src/Elastic.Apm/Logging/ConsoleLogger.cs
+++ b/src/Elastic.Apm/Logging/ConsoleLogger.cs
@@ -33,7 +33,7 @@ namespace Elastic.Apm.Logging
 			var message = formatter(state, e);
 
 			var fullMessage = e == null ? $"[{dateTime.ToString("yyyy-MM-dd hh:mm:ss")}][{LevelToString(level)}] - {message}"
-				: $"[{dateTime.ToString("yyyy-MM-dd hh:mm:ss")}][{LevelToString(level)}] - {message}\nException: {e.GetType().FullName}, Message: {e.Message}";
+				: $"[{dateTime.ToString("yyyy-MM-dd hh:mm:ss")}][{LevelToString(level)}] - {message}{Environment.NewLine}Exception: {e.GetType().FullName}, Message: {e.Message}";
 
 			switch (level)
 			{

--- a/src/Elastic.Apm/Logging/IApmLoggingExtensions.cs
+++ b/src/Elastic.Apm/Logging/IApmLoggingExtensions.cs
@@ -81,16 +81,15 @@ namespace Elastic.Apm.Logging
 			public void Log(string message, params object[] args) => _logger.DoLog(_level, message, null, args);
 
 			public void LogException(Exception exception, string message, params object[] args) =>
-				_logger.DoLog(_level, $"Exception: {{ExceptionType}}, Message: {{ExceptionMsg}} \n{message}", exception,
-					exception.GetType().FullName, exception.Message, args);
+				_logger.DoLog(_level, message, exception, args, exception.GetType().FullName, exception.Message);
 
 			public void LogExceptionWithCaller(Exception exception,
 				[CallerMemberName] string method = "",
-				[CallerFilePath] string filepath = "",
+				[CallerFilePath] string filePath = "",
 				[CallerLineNumber] int lineNumber = 0
 			)
 			{
-				var file = string.IsNullOrEmpty(filepath) ? string.Empty : new FileInfo(filepath).Name;
+				var file = string.IsNullOrEmpty(filePath) ? string.Empty : new FileInfo(filePath).Name;
 				_logger?.DoLog(_level, "{ExceptionName} in {Method} ({File}:{LineNumber}): {ExceptionMessage}", exception,
 					exception?.GetType().Name, method, file, lineNumber, exception?.Message);
 			}

--- a/src/Elastic.Apm/Logging/IApmLoggingExtensions.cs
+++ b/src/Elastic.Apm/Logging/IApmLoggingExtensions.cs
@@ -68,12 +68,16 @@ namespace Elastic.Apm.Logging
 		internal static MaybeLogger? IfLevel(this IApmLogger logger, LogLevel level) => logger.Level <= level ? new MaybeLogger(logger, level) : (MaybeLogger?)null;
 		internal readonly struct MaybeLogger
 		{
-			internal delegate void LogDelegate(string s, params object[] args);
+			private readonly IApmLogger _logger;
+			private readonly LogLevel _level;
 
-			internal readonly LogDelegate Log;
+			public MaybeLogger(IApmLogger logger, LogLevel level) => (_logger, _level) = (logger, level);
 
-			public MaybeLogger(IApmLogger logger, LogLevel level)
-				=> Log = (message, args) => logger.DoLog(level, message, null, args);
+			public void Log(string message, params object[] args) => _logger.DoLog(_level, message, null, args);
+
+			public void LogException(Exception exception, string message, params object[] args) =>
+ 				_logger.DoLog(_level, $"Exception: {{ExceptionType}}, Message: {{ExceptionMsg}} \n{message}", exception,
+					new object[]{ exception.GetType().FullName, exception.Message, args });
 		}
 	}
 }

--- a/src/Elastic.Apm/Logging/IApmLoggingExtensions.cs
+++ b/src/Elastic.Apm/Logging/IApmLoggingExtensions.cs
@@ -56,5 +56,33 @@ namespace Elastic.Apm.Logging
 			var logValues = formatter.GetState(args);
 			logger?.Log(level, logValues, e, (s, _) => formatter.Format(args));
 		}
+
+		/// <summary>
+		/// Depending on the two parameters it either returns a MaybeLogger instance or null.
+		/// By using this class with `?.` you can avoid allocating delegates that are not necessary to allocate
+		/// in case the log won't be printed because the loglevel would not allow it.
+		/// </summary>
+		/// <param name="logger"></param>
+		/// <param name="level"></param>
+		/// <returns>If the return value is not null you can call <see cref="MaybeLogger.Log"/> to log</returns>
+		internal static MaybeLogger? IfLevel(this IApmLogger logger, LogLevel level) => logger.Level <= level ? new MaybeLogger(logger, level) : (MaybeLogger?)null;
+		internal readonly struct MaybeLogger
+		{
+			private readonly IApmLogger _logger;
+			private readonly LogLevel _level;
+
+			public MaybeLogger(IApmLogger source, LogLevel level)
+			{
+				_logger = source;
+				_level = level;
+			}
+
+			public void Log(Func<String> getLog)
+			{
+				var lineToPrint = getLog();
+				//Do the logging
+				//WIP: must be extended to handle args, but that should be doable
+			}
+		}
 	}
 }

--- a/src/Elastic.Apm/Logging/IApmLoggingExtensions.cs
+++ b/src/Elastic.Apm/Logging/IApmLoggingExtensions.cs
@@ -68,21 +68,15 @@ namespace Elastic.Apm.Logging
 		internal static MaybeLogger? IfLevel(this IApmLogger logger, LogLevel level) => logger.Level <= level ? new MaybeLogger(logger, level) : (MaybeLogger?)null;
 		internal readonly struct MaybeLogger
 		{
-			private readonly IApmLogger _logger;
-			private readonly LogLevel _level;
+			internal delegate void LogDelegate(string s, params object[] args);
 
-			public MaybeLogger(IApmLogger source, LogLevel level)
-			{
-				_logger = source;
-				_level = level;
-			}
+			internal readonly LogDelegate Log;
 
-			public void Log(Func<String> getLog)
-			{
-				var lineToPrint = getLog();
-				//Do the logging
-				//WIP: must be extended to handle args, but that should be doable
-			}
+			public MaybeLogger(IApmLogger logger, LogLevel level)
+				=> Log = (message, args) =>
+				{
+					logger.DoLog(level, message, null, args);
+				};
 		}
 	}
 }

--- a/src/Elastic.Apm/Logging/IApmLoggingExtensions.cs
+++ b/src/Elastic.Apm/Logging/IApmLoggingExtensions.cs
@@ -73,10 +73,7 @@ namespace Elastic.Apm.Logging
 			internal readonly LogDelegate Log;
 
 			public MaybeLogger(IApmLogger logger, LogLevel level)
-				=> Log = (message, args) =>
-				{
-					logger.DoLog(level, message, null, args);
-				};
+				=> Log = (message, args) => logger.DoLog(level, message, null, args);
 		}
 	}
 }

--- a/src/Elastic.Apm/Logging/IApmLoggingExtensions.cs
+++ b/src/Elastic.Apm/Logging/IApmLoggingExtensions.cs
@@ -8,22 +8,22 @@ namespace Elastic.Apm.Logging
 	{
 		private static ConcurrentDictionary<string, LogValuesFormatter> Formatters { get; } = new ConcurrentDictionary<string, LogValuesFormatter>();
 
-		public static void LogError(this IApmLogger logger, string message, params object[] args) => logger?.LogError(null, message, args);
-
-		public static void LogError(this IApmLogger logger, Exception exception, string message, params object[] args) =>
-			logger?.DoLog(LogLevel.Error, message, exception, args);
-
-		public static void LogWarning(this IApmLogger logger, string message, params object[] args) => logger?.LogWarning(null, message, args);
-
-		public static void LogWarning(this IApmLogger logger, Exception exception, string message, params object[] args) =>
-			logger?.DoLog(LogLevel.Warning, message, exception, args);
-
-		public static void LogInfo(this IApmLogger logger, string message, params object[] args) => logger?.LogInfo(null, message, args);
-
-		public static void LogInfo(this IApmLogger logger, Exception exception, string message, params object[] args) =>
-			logger?.DoLog(LogLevel.Information, message, exception, args);
-
-		public static void LogDebug(this IApmLogger logger, string message, params object[] args) => logger?.LogDebug(null, message, args);
+//		public static void LogError(this IApmLogger logger, string message, params object[] args) => logger?.LogError(null, message, args);
+//
+//		public static void LogError(this IApmLogger logger, Exception exception, string message, params object[] args) =>
+//			logger?.DoLog(LogLevel.Error, message, exception, args);
+//
+//		public static void LogWarning(this IApmLogger logger, string message, params object[] args) => logger?.LogWarning(null, message, args);
+//
+//		public static void LogWarning(this IApmLogger logger, Exception exception, string message, params object[] args) =>
+//			logger?.DoLog(LogLevel.Warning, message, exception, args);
+//
+//		public static void LogInfo(this IApmLogger logger, string message, params object[] args) => logger?.LogInfo(null, message, args);
+//
+//		public static void LogInfo(this IApmLogger logger, Exception exception, string message, params object[] args) =>
+//			logger?.DoLog(LogLevel.Information, message, exception, args);
+//
+//		public static void LogDebug(this IApmLogger logger, string message, params object[] args) => logger?.LogDebug(null, message, args);
 
 		public static void LogDebug(this IApmLogger logger, Exception exception, string message, params object[] args) =>
 			logger?.DoLog(LogLevel.Debug, message, exception, args);
@@ -31,18 +31,18 @@ namespace Elastic.Apm.Logging
 		public static void LogDebugException(this IApmLogger logger, Exception exception) =>
 			logger?.LogDebug(exception, "{ExceptionName}: {ExceptionMessage}", exception?.GetType().Name, exception?.Message);
 
-		public static void LogErrorException(this IApmLogger logger, Exception exception,
-			[System.Runtime.CompilerServices.CallerMemberName]
-			string method = "",
-			[System.Runtime.CompilerServices.CallerFilePath]
-			string filepath = "",
-			[System.Runtime.CompilerServices.CallerLineNumber]
-			int lineNumber = 0
-		)
-		{
-			var file = string.IsNullOrEmpty(filepath) ? string.Empty : new FileInfo(filepath).Name;
-			logger?.LogError(exception, "{ExceptionName} in {Method} ({File}:{LineNumber}): {ExceptionMessage}", exception?.GetType().Name, method, file, lineNumber, exception?.Message);
-		}
+//		public static void LogErrorException(this IApmLogger logger, Exception exception,
+//			[System.Runtime.CompilerServices.CallerMemberName]
+//			string method = "",
+//			[System.Runtime.CompilerServices.CallerFilePath]
+//			string filepath = "",
+//			[System.Runtime.CompilerServices.CallerLineNumber]
+//			int lineNumber = 0
+//		)
+//		{
+//			var file = string.IsNullOrEmpty(filepath) ? string.Empty : new FileInfo(filepath).Name;
+//			logger?.LogError(exception, "{ExceptionName} in {Method} ({File}:{LineNumber}): {ExceptionMessage}", exception?.GetType().Name, method, file, lineNumber, exception?.Message);
+//		}
 
 		public static ScopedLogger Scoped(this IApmLogger logger, string scope) =>
 			 new ScopedLogger((logger is ScopedLogger s ? s.Logger : logger), scope);
@@ -65,7 +65,17 @@ namespace Elastic.Apm.Logging
 		/// <param name="logger"></param>
 		/// <param name="level"></param>
 		/// <returns>If the return value is not null you can call <see cref="MaybeLogger.Log"/> to log</returns>
-		internal static MaybeLogger? IfLevel(this IApmLogger logger, LogLevel level) => logger.Level <= level ? new MaybeLogger(logger, level) : (MaybeLogger?)null;
+		//internal static MaybeLogger? IfLevel(this IApmLogger logger, LogLevel level) => logger.Level <= level ? new MaybeLogger(logger, level) : (MaybeLogger?)null;
+
+		internal static MaybeLogger? Debug(this IApmLogger logger) => logger.Level <= LogLevel.Debug ? new MaybeLogger(logger, LogLevel.Debug) : (MaybeLogger?)null;
+
+		internal static MaybeLogger? Error(this IApmLogger logger) => logger.Level <= LogLevel.Error ? new MaybeLogger(logger, LogLevel.Error) : (MaybeLogger?)null;
+
+		internal static MaybeLogger? Warning(this IApmLogger logger) => logger.Level <= LogLevel.Warning ? new MaybeLogger(logger, LogLevel.Warning) : (MaybeLogger?)null;
+
+		internal static MaybeLogger? Info(this IApmLogger logger) => logger.Level <= LogLevel.Information ? new MaybeLogger(logger, LogLevel.Information) : (MaybeLogger?)null;
+
+
 		internal readonly struct MaybeLogger
 		{
 			private readonly IApmLogger _logger;

--- a/src/Elastic.Apm/Model/Payload/Span.cs
+++ b/src/Elastic.Apm/Model/Payload/Span.cs
@@ -87,7 +87,7 @@ namespace Elastic.Apm.Model.Payload
 
 		public void End()
 		{
-			_logger.LogDebug($"Ending {ToString()}");
+			_logger.Debug()?.Log("Ending {SpanDetails}" , ToString());
 			if (!Duration.HasValue) Duration = (DateTimeOffset.UtcNow - _start).TotalMilliseconds;
 			_payloadSender.QueueSpan(this);
 		}

--- a/src/Elastic.Apm/Model/Payload/Transaction.cs
+++ b/src/Elastic.Apm/Model/Payload/Transaction.cs
@@ -107,7 +107,7 @@ namespace Elastic.Apm.Model.Payload
 
 			_sender.QueueTransaction(this);
 
-			_logger.LogDebug($"Ending {ToString()}");
+			_logger.Debug()?.Log("Ending {TransactionDetails}", ToString());
 			Agent.TransactionContainer.Transactions.Value = null;
 		}
 
@@ -123,7 +123,7 @@ namespace Elastic.Apm.Model.Payload
 			if (!string.IsNullOrEmpty(action)) retVal.Action = action;
 			SpanCount.Started++;
 
-			_logger.LogDebug($"Starting {retVal}");
+			_logger.Debug()?.Log("Starting {SpanDetails}", retVal.ToString());
 			return retVal;
 		}
 

--- a/src/Elastic.Apm/Report/PayloadSenderV2.cs
+++ b/src/Elastic.Apm/Report/PayloadSenderV2.cs
@@ -177,9 +177,9 @@ namespace Elastic.Apm.Report
 			catch (Exception e)
 			{
 				_logger.IfLevel(LogLevel.Warning)
-					?.Log(
-						"Failed sending events. \nException: {ExceptionFullName}, Message: {ExceptionMessage} \nFollowing events were not transferred successfully to the server:\n{items}",
-						e.GetType().FullName, e.Message, string.Join(",\n", queueItems.ToArray()));
+					?.LogException(
+						e, "Failed sending events. Following events were not transferred successfully to the server:\n{items}",
+						string.Join(",\n", queueItems.ToArray()));
 			}
 		}
 

--- a/src/Elastic.Apm/Report/PayloadSenderV2.cs
+++ b/src/Elastic.Apm/Report/PayloadSenderV2.cs
@@ -98,7 +98,7 @@ namespace Elastic.Apm.Report
 		/// </summary>
 		internal async Task FlushAndFinishAsync()
 		{
-			_logger.LogDebug("FlushAndFinish called - PayloadSenderV2 will become invalid");
+			_logger.Debug()?.Log("FlushAndFinish called - PayloadSenderV2 will become invalid");
 			await _creation;
 			_eventQueue.TriggerBatch();
 
@@ -110,7 +110,7 @@ namespace Elastic.Apm.Report
 			}
 			catch (TaskCanceledException)
 			{
-				_logger.LogDebug("worker task cancelled");
+				_logger.Debug()?.Log("worker task cancelled");
 			}
 			finally
 			{
@@ -166,17 +166,17 @@ namespace Elastic.Apm.Report
 
 				if (result != null && !result.IsSuccessStatusCode)
 				{
-					_logger?.IfLevel(LogLevel.Error)?.Log("Failed sending event. {ApmServerResponse}", await result.Content.ReadAsStringAsync());
+					_logger?.Error()?.Log("Failed sending event. {ApmServerResponse}", await result.Content.ReadAsStringAsync());
 				}
 				else
 				{
-					_logger.IfLevel(LogLevel.Debug)
+					_logger?.Debug()
 						?.Log("Sent items to server: \n{items}", string.Join(",\n", queueItems.ToArray()));
 				}
 			}
 			catch (Exception e)
 			{
-				_logger.IfLevel(LogLevel.Warning)
+				_logger?.Warning()
 					?.LogException(
 						e, "Failed sending events. Following events were not transferred successfully to the server:\n{items}",
 						string.Join(",\n", queueItems.ToArray()));

--- a/src/Elastic.Apm/Report/PayloadSenderV2.cs
+++ b/src/Elastic.Apm/Report/PayloadSenderV2.cs
@@ -166,36 +166,20 @@ namespace Elastic.Apm.Report
 
 				if (result != null && !result.IsSuccessStatusCode)
 				{
-					var str = await result.Content.ReadAsStringAsync();
-					_logger.LogError("Failed sending event. {ApmServerResponse}", str);
+					_logger?.IfLevel(LogLevel.Error)?.Log("Failed sending event. {ApmServerResponse}", await result.Content.ReadAsStringAsync());
 				}
 				else
 				{
 					_logger.IfLevel(LogLevel.Debug)
-						?.Log(() =>
-						{
-							var sb = new StringBuilder();
-							sb.AppendLine("Sent items to server:");
-							foreach (var item in queueItems) sb.AppendLine(item.ToString());
-							return sb.ToString();
-						});
+						?.Log("Sent items to server: \n{items}", string.Join(",\n", queueItems.ToArray()));
 				}
 			}
 			catch (Exception e)
 			{
-				_logger.IfLevel(LogLevel.Warning)?.Log(() =>
-				{
-					var sb = new StringBuilder();
-					sb.AppendLine("Failed sending events. ");
-					sb.Append("Exception: ");
-					sb.Append(e.GetType().FullName);
-					sb.Append(", Message: ");
-					sb.AppendLine(e.Message);
-					sb.AppendLine("Following events were not transferred successfully to the server:");
-					foreach (var item in queueItems) sb.AppendLine(item.ToString());
-
-					return sb.ToString();
-				});
+				_logger.IfLevel(LogLevel.Warning)
+					?.Log(
+						"Failed sending events. \nException: {ExceptionFullName}, Message: {ExceptionMessage} \nFollowing events were not transferred successfully to the server:\n{items}",
+						e.GetType().FullName, e.Message, string.Join(",\n", queueItems.ToArray()));
 			}
 		}
 

--- a/src/Elastic.Apm/Report/PayloadSenderV2.cs
+++ b/src/Elastic.Apm/Report/PayloadSenderV2.cs
@@ -170,7 +170,7 @@ namespace Elastic.Apm.Report
 				else
 				{
 					_logger?.Debug()
-						?.Log("Sent items to server: \n{items}", string.Join(",\n", queueItems.ToArray()));
+						?.Log($"Sent items to server: {Environment.NewLine}{{items}}", string.Join($",{Environment.NewLine}", queueItems.ToArray()));
 				}
 			}
 			catch (Exception e)
@@ -178,7 +178,7 @@ namespace Elastic.Apm.Report
 				_logger?.Warning()
 					?.LogException(
 						e, "Failed sending events. Following events were not transferred successfully to the server:\n{items}",
-						string.Join(",\n", queueItems.ToArray()));
+						string.Join($",{Environment.NewLine}", queueItems.ToArray()));
 			}
 		}
 

--- a/src/Elastic.Apm/Report/PayloadSenderV2.cs
+++ b/src/Elastic.Apm/Report/PayloadSenderV2.cs
@@ -18,7 +18,6 @@ using Newtonsoft.Json.Serialization;
 
 namespace Elastic.Apm.Report
 {
-	/// <inheritdoc />
 	/// <summary>
 	/// Responsible for sending the data to the server. Implements Intake V2.
 	/// Each instance creates its own thread to do the work. Therefore, instances should be reused if possible.
@@ -75,7 +74,7 @@ namespace Elastic.Apm.Report
 					}
 					catch (TaskCanceledException ex)
 					{
-						_logger.LogDebugException(ex);
+						_logger?.Debug()?.LogExceptionWithCaller(ex);
 					}
 				}, CancellationToken.None, TaskCreationOptions.LongRunning, _singleThreadTaskScheduler);
 		}

--- a/src/Elastic.Apm/Report/PayloadSenderV2.cs
+++ b/src/Elastic.Apm/Report/PayloadSenderV2.cs
@@ -171,24 +171,31 @@ namespace Elastic.Apm.Report
 				}
 				else
 				{
-					var sb = new StringBuilder();
-					sb.AppendLine("Sent items to server:");
-					foreach (var item in queueItems) sb.AppendLine(item.ToString());
-					_logger.LogDebug(sb.ToString());
+					_logger.IfLevel(LogLevel.Debug)
+						?.Log(() =>
+						{
+							var sb = new StringBuilder();
+							sb.AppendLine("Sent items to server:");
+							foreach (var item in queueItems) sb.AppendLine(item.ToString());
+							return sb.ToString();
+						});
 				}
 			}
 			catch (Exception e)
 			{
-				var sb = new StringBuilder();
-				sb.AppendLine("Failed sending events. ");
-				sb.Append("Exception: ");
-				sb.Append(e.GetType().FullName);
-				sb.Append(", Message: ");
-				sb.AppendLine(e.Message);
-				sb.AppendLine("Following events were not transferred successfully to the server:");
-				foreach (var item in queueItems) sb.AppendLine(item.ToString());
+				_logger.IfLevel(LogLevel.Warning)?.Log(() =>
+				{
+					var sb = new StringBuilder();
+					sb.AppendLine("Failed sending events. ");
+					sb.Append("Exception: ");
+					sb.Append(e.GetType().FullName);
+					sb.Append(", Message: ");
+					sb.AppendLine(e.Message);
+					sb.AppendLine("Following events were not transferred successfully to the server:");
+					foreach (var item in queueItems) sb.AppendLine(item.ToString());
 
-				_logger.LogWarning(sb.ToString());
+					return sb.ToString();
+				});
 			}
 		}
 

--- a/test/Elastic.Apm.Tests/LoggerTest.cs
+++ b/test/Elastic.Apm.Tests/LoggerTest.cs
@@ -53,10 +53,10 @@ namespace Elastic.Apm.Tests
 		{
 			var logger = new TestLogger(logLevel);
 
-			logger.LogError("Error log");
-			logger.LogWarning("Warning log");
-			logger.LogInfo("Info log");
-			logger.LogDebug("Debug log");
+			logger.Error()?.Log("Error log");
+			logger.Warning()?.Log("Warning log");
+			logger.Info()?.Log("Info log");
+			logger.Debug()?.Log("Debug log");
 			return logger;
 		}
 	}

--- a/test/Elastic.Apm.Tests/LoggerTest.cs
+++ b/test/Elastic.Apm.Tests/LoggerTest.cs
@@ -64,8 +64,8 @@ namespace Elastic.Apm.Tests
 
 			logger.Warning()
 				?.LogException(
-					new Exception("Something want wrong"), "Failed sending events. Following events were not transferred successfully to the server:\n{items}",
-					string.Join(",\n", new List<string>{"Item1", "Item2", "Item3"} ));
+					new Exception("Something went wrong"), "Failed sending events. Following events were not transferred successfully to the server:\n{items}",
+					string.Join($",{Environment.NewLine}", new List<string>{"Item1", "Item2", "Item3"} ));
 
 			logger.Lines[0]
 				.Should()
@@ -80,7 +80,7 @@ namespace Elastic.Apm.Tests
 				.ContainAll(new List<string>
 				{
 					"System.Exception",
-					"Something want wrong"
+					"Something went wrong"
 				});
 		}
 

--- a/test/Elastic.Apm.Tests/LoggerTest.cs
+++ b/test/Elastic.Apm.Tests/LoggerTest.cs
@@ -64,7 +64,7 @@ namespace Elastic.Apm.Tests
 
 			logger.Warning()
 				?.LogException(
-					new Exception("Something went wrong"), "Failed sending events. Following events were not transferred successfully to the server:\n{items}",
+					new Exception("Something went wrong"), $"Failed sending events. Following events were not transferred successfully to the server:{Environment.NewLine}{{items}}",
 					string.Join($",{Environment.NewLine}", new List<string>{"Item1", "Item2", "Item3"} ));
 
 			logger.Lines[0]


### PR DESCRIPTION
In #142 we had the idea to add overloads to our logger to log through lambdas. 

This is useful when we have to build the message and then log it. This way in case due to the log level we don't want to log the message we could avoid all the work needed. 

Example:
```	
catch (Exception e)
{
   _logger.LogWarning("Failed sending events. \nException: {ExceptionFullName}, Message: {ExceptionMessage} \nFollowing events were not transferred successfully to the server:\n{items}", e.GetType().FullName, e.Message, string.Join(",\n", queueItems.ToArray()));
}
```

If the `LogLevel` is higher than `Warning`, we do all the work, so all these code will be executed:
```
e.GetType().FullName, e.Message, string.Join(",\n", queueItems.ToArray()
```

But none of that will be used, because due to the loglevel, we don't print anything.

One approach would be to have `if` blocks in the code and check if the current loglevel would enable to log, and if not, then simply skip the work. This is not very nice, and we would always repeat this code. (Although I personally don't think it's very bad). 

By adding an overload to a logger that takes a `Func<sting>` or something similar we could only execute the `Func<string>` if the level enables that. This would save all the work. Problem is, that in this case we would allocate a delegate each time, regardless of the loglevel, so from overhead point of view still not as good as the if block.

This PR goes further and adds a nullable struct combined with `?.` to do the checking. Also by thinking about this I'd say we don't even need overloads that take lambdas. The `?.` already gives us what we want: with that we can prevent the execution of the expensive code when the loglevel would prevent us from printing the stuff we calculate expensively.

So lines like this (this is btw. the proposed syntax):
```
_logger.IfLevel(LogLevel.Debug)
	?.Log("Sent items to server: \n{items}", string.Join(",\n", queueItems.ToArray()));
```

Compile into this:

```
IL_03f2: nop
IL_03f3: ldarg.0
IL_03f4: ldfld class Elastic.Apm.Report.PayloadSenderV2 Elastic.Apm.Report.PayloadSenderV2/'<ProcessQueueItems>d__16'::'<>4__this'
IL_03f9: ldfld class Elastic.Apm.Logging.IApmLogger Elastic.Apm.Report.PayloadSenderV2::_logger
IL_03fe: ldc.i4.1
IL_03ff: call valuetype [netstandard]System.Nullable`1<valuetype Elastic.Apm.Logging.LoggingExtensions/MaybeLogger> Elastic.Apm.Logging.LoggingExtensions::IfLevel(class Elastic.Apm.Logging.IApmLogger, valuetype Elastic.Apm.Logging.LogLevel)
IL_0404: stloc.s 9
IL_0406: ldloca.s 9
IL_0408: dup
IL_0409: call instance bool valuetype [netstandard]System.Nullable`1<valuetype Elastic.Apm.Logging.LoggingExtensions/MaybeLogger>::get_HasValue()
IL_040e: brtrue.s IL_0413

IL_0410: pop
IL_0411: br.s IL_0446

IL_0413: call instance !0 valuetype [netstandard]System.Nullable`1<valuetype Elastic.Apm.Logging.LoggingExtensions/MaybeLogger>::GetValueOrDefault()
IL_0418: ldfld class Elastic.Apm.Logging.LoggingExtensions/MaybeLogger/LogDelegate Elastic.Apm.Logging.LoggingExtensions/MaybeLogger::Log
IL_041d: ldstr "Sent items to server: \n{items}"
IL_0422: ldc.i4.1
IL_0423: newarr [netstandard]System.Object
IL_0428: dup
IL_0429: ldc.i4.0
IL_042a: ldstr ",\n"
IL_042f: ldarg.0
IL_0430: ldfld object[] Elastic.Apm.Report.PayloadSenderV2/'<ProcessQueueItems>d__16'::queueItems
IL_0435: call !!0[] [netstandard]System.Linq.Enumerable::ToArray<object>(class [netstandard]System.Collections.Generic.IEnumerable`1<!!0>)
IL_043a: call string [netstandard]System.String::Join(string, object[])
IL_043f: stelem.ref
IL_0440: callvirt instance void Elastic.Apm.Logging.LoggingExtensions/MaybeLogger/LogDelegate::Invoke(string, object[])
IL_0445: nop

IL_0446: nop
```

And as you can spot in the IL code in case the `loglevel` is higher than `Debug` we don't allocate anything and we also don't run the expensive code, this part skips those instructions: 

```
IL_0409: call instance bool valuetype [netstandard]System.Nullable`1<valuetype Elastic.Apm.Logging.LoggingExtensions/MaybeLogger>::get_HasValue()
IL_040e: brtrue.s IL_0413
```


Ps: heavily inspired by @markrendle from [this presentation](https://youtu.be/QgL6vVyjQzw?t=2883).