### PR TITLE
Expose Db and Http on Span.Context via the Public Agent API

### DIFF
--- a/sample/ApiSamples/Program.cs
+++ b/sample/ApiSamples/Program.cs
@@ -1,16 +1,20 @@
 ﻿using System;
+using System.Diagnostics;
 using System.Threading;
 using Elastic.Apm;
 using Elastic.Apm.Api;
 
 namespace ApiSamples
 {
+	/// <summary>
+	/// This class exercices the Public Agent API.
+	/// </summary>
 	internal class Program
 	{
 		private static void Main(string[] args)
 		{
 			Console.WriteLine("Start");
-			SampleCustomTransactionWithConvenientApi();
+			SampleSpamWithCustomContextFillAll();
 
 			//WIP: if the process terminates the agent
 			//potentially does not have time to send the transaction to the server.
@@ -18,6 +22,47 @@ namespace ApiSamples
 
 			Console.WriteLine("Done");
 			Console.ReadKey();
+		}
+
+		public static void SampleSpamWithCustomContext()
+		{
+			Agent.Tracer.CaptureTransaction("SampleTransaction", "SampleTransactionType", transaction =>
+			{
+				transaction.CaptureSpan("SampleSpan", "SampleSpanType", span =>
+				{
+					span.Context.Db = new Database
+					{
+						Statement = "Select * from MyTable",
+						Type = "MSSQL"
+					};
+				});
+			});
+		}
+
+		public static void SampleSpamWithCustomContextFillAll()
+		{
+			Agent.Tracer.CaptureTransaction("SampleTransaction", "SampleTransactionType", transaction =>
+			{
+				transaction.CaptureSpan("SampleSpan1", "SampleSpanType", span =>
+				{
+					span.Context.Http = new Http
+					{
+						Url = "http://mysite.com",
+						Method = "GET",
+						StatusCode = 200,
+					};
+				});
+
+				transaction.CaptureSpan("SampleSpan2", "SampleSpanType", span =>
+				{
+					span.Context.Db = new Database
+					{
+						Statement = "Select * from MyTable",
+						Type = "MSSQL",
+						Instance = "MyInstance"
+					};
+				});
+			});
 		}
 
 		public static void SampleCustomTransaction()
@@ -75,7 +120,7 @@ namespace ApiSamples
 			t =>
 			{
 				t.Context.Response = new Response() { Finished = true, StatusCode = 200 };
-				t.Context.Request = new Request("GET", new Url{Protocol = "HTTP"});
+				t.Context.Request = new Request("GET", new Url { Protocol = "HTTP" });
 
 				t.Tags["fooTransaction1"] = "barTransaction1";
 				t.Tags["fooTransaction2"] = "barTransaction2";

--- a/sample/ApiSamples/Program.cs
+++ b/sample/ApiSamples/Program.cs
@@ -33,7 +33,7 @@ namespace ApiSamples
 					span.Context.Db = new Database
 					{
 						Statement = "Select * from MyTable",
-						Type = "MSSQL"
+						Type = ApiConstants.SubtypeMssql,
 					};
 				});
 			});
@@ -58,7 +58,7 @@ namespace ApiSamples
 					span.Context.Db = new Database
 					{
 						Statement = "Select * from MyTable",
-						Type = "MSSQL",
+						Type = ApiConstants.SubtypeMssql,
 						Instance = "MyInstance"
 					};
 				});

--- a/sample/ApiSamples/Program.cs
+++ b/sample/ApiSamples/Program.cs
@@ -32,8 +32,8 @@ namespace ApiSamples
 				{
 					span.Context.Db = new Database
 					{
-						Statement = "Select * from MyTable",
-						Type = ApiConstants.SubtypeMssql,
+						Statement = "GET /_all/_search?q=tag:wow",
+						Type = Database.TypeElasticsearch,
 					};
 				});
 			});
@@ -57,8 +57,8 @@ namespace ApiSamples
 				{
 					span.Context.Db = new Database
 					{
-						Statement = "Select * from MyTable",
-						Type = ApiConstants.SubtypeMssql,
+						Statement = "GET /_all/_search?q=tag:wow",
+						Type = Database.TypeElasticsearch,
 						Instance = "MyInstance"
 					};
 				});

--- a/src/Elastic.Apm.EntityFrameworkCore/EfCoreDiagnosticListener.cs
+++ b/src/Elastic.Apm.EntityFrameworkCore/EfCoreDiagnosticListener.cs
@@ -46,7 +46,7 @@ namespace Elastic.Apm.EntityFrameworkCore
 							{
 								Statement = commandExecutedEventData.Command.CommandText,
 								Instance = commandExecutedEventData.Command.Connection.Database,
-								Type = "sql"
+								Type = Database.TypeSql
 							};
 							span.Duration = commandExecutedEventData.Duration.TotalMilliseconds;
 

--- a/src/Elastic.Apm.EntityFrameworkCore/EfCoreDiagnosticListener.cs
+++ b/src/Elastic.Apm.EntityFrameworkCore/EfCoreDiagnosticListener.cs
@@ -42,7 +42,7 @@ namespace Elastic.Apm.EntityFrameworkCore
 					{
 						if (_spans.TryRemove(commandExecutedEventData.CommandId, out var span))
 						{
-							span.Context.Db = new Db
+							span.Context.Db = new Database
 							{
 								Statement = commandExecutedEventData.Command.CommandText,
 								Instance = commandExecutedEventData.Command.Connection.Database,

--- a/src/Elastic.Apm/Api/Database.cs
+++ b/src/Elastic.Apm/Api/Database.cs
@@ -9,5 +9,8 @@ namespace Elastic.Apm.Api
 		public string Instance { get; set; }
 		public string Statement { get; set; }
 		public string Type { get; set; }
+
+		public const string TypeSql = "sql";
+		public const string TypeElasticsearch = "elasticsearch";
 	}
 }

--- a/src/Elastic.Apm/Api/Database.cs
+++ b/src/Elastic.Apm/Api/Database.cs
@@ -1,0 +1,13 @@
+namespace Elastic.Apm.Api
+{
+	/// <summary>
+	/// An object containing contextual data for database spans.
+	/// It can be attached to an <see cref="ISpan"/> through <see cref="ISpan.Context"/>
+	/// </summary>
+	public class Database
+	{
+		public string Instance { get; set; }
+		public string Statement { get; set; }
+		public string Type { get; set; }
+	}
+}

--- a/src/Elastic.Apm/Api/Http.cs
+++ b/src/Elastic.Apm/Api/Http.cs
@@ -1,0 +1,13 @@
+namespace Elastic.Apm.Api
+{
+	/// <summary>
+	/// An object containing contextual data of the related http request.
+	/// It can be attached to an <see cref="ISpan"/> through <see cref="ISpan.Context"/>
+	/// </summary>
+	public class Http
+	{
+		public string Method { get; set; }
+		public int StatusCode { get; set; }
+		public string Url { get; set; }
+	}
+}

--- a/src/Elastic.Apm/Api/ISpan.cs
+++ b/src/Elastic.Apm/Api/ISpan.cs
@@ -13,6 +13,11 @@ namespace Elastic.Apm.Api
 		string Action { get; set; }
 
 		/// <summary>
+		/// Any other arbitrary data captured by the agent, optionally provided by the user.
+		/// </summary>
+		SpanContext Context { get; }
+
+		/// <summary>
 		/// The duration of the span.
 		/// If it's not set (its HasValue property is false) then the value
 		/// is automatically calculated when <see cref="End" /> is called.

--- a/src/Elastic.Apm/Api/SpanContext.cs
+++ b/src/Elastic.Apm/Api/SpanContext.cs
@@ -1,0 +1,17 @@
+using System;
+using System.Collections.Generic;
+using Elastic.Apm.Report.Serialization;
+using Newtonsoft.Json;
+
+namespace Elastic.Apm.Api
+{
+	public class SpanContext
+	{
+		private readonly Lazy<Dictionary<string, string>> _tags = new Lazy<Dictionary<string, string>>();
+		public Database Db { get; set; }
+		public Http Http { get; set; }
+
+		[JsonConverter(typeof(TagsJsonConverter))]
+		public Dictionary<string, string> Tags => _tags.Value;
+	}
+}

--- a/src/Elastic.Apm/Model/Payload/Span.cs
+++ b/src/Elastic.Apm/Model/Payload/Span.cs
@@ -12,7 +12,7 @@ namespace Elastic.Apm.Model.Payload
 {
 	internal class Span : ISpan
 	{
-		private readonly Lazy<ContextImpl> _context = new Lazy<ContextImpl>();
+		private readonly Lazy<SpanContext> _context = new Lazy<SpanContext>();
 		private readonly IApmLogger _logger;
 		private readonly IPayloadSender _payloadSender;
 
@@ -38,7 +38,7 @@ namespace Elastic.Apm.Model.Payload
 		/// <summary>
 		/// Any other arbitrary data captured by the agent, optionally provided by the user.
 		/// </summary>
-		public IContext Context => _context.Value;
+		public SpanContext Context => _context.Value;
 
 		/// <inheritdoc />
 		/// <summary>
@@ -126,50 +126,5 @@ namespace Elastic.Apm.Model.Payload
 			_payloadSender.QueueError(
 				new Error(capturedException, TraceId, Id, parentId ?? Id) { Culprit = capturedCulprit /*, Context = Context */ });
 		}
-
-		// ReSharper disable once ClassNeverInstantiated.Local - instantiated with Lazy<T>
-		private class ContextImpl : IContext
-		{
-			private readonly Lazy<Dictionary<string, string>> _tags = new Lazy<Dictionary<string, string>>();
-			public IDb Db { get; set; }
-			public IHttp Http { get; set; }
-			public Dictionary<string, string> Tags => _tags.Value;
-		}
-	}
-
-	internal interface IContext
-	{
-		IDb Db { get; set; }
-		IHttp Http { get; set; }
-
-		[JsonConverter(typeof(TagsJsonConverter))]
-		Dictionary<string, string> Tags { get; }
-	}
-
-	internal interface IDb
-	{
-		string Statement { get; set; }
-		string Type { get; set; }
-	}
-
-	internal interface IHttp
-	{
-		string Method { get; set; }
-		int StatusCode { get; set; }
-		string Url { get; set; }
-	}
-
-	internal class Db : IDb
-	{
-		public string Instance { get; set; }
-		public string Statement { get; set; }
-		public string Type { get; set; }
-	}
-
-	internal class Http : IHttp
-	{
-		public string Method { get; set; }
-		public int StatusCode { get; set; }
-		public string Url { get; set; }
 	}
 }

--- a/test/Elastic.Apm.Tests/ApiTests/ConvenientApiSpanTests.cs
+++ b/test/Elastic.Apm.Tests/ApiTests/ConvenientApiSpanTests.cs
@@ -472,7 +472,6 @@ namespace Elastic.Apm.Tests.ApiTests
 		[Fact]
 		public void FillSpanContext()
 		{
-
 			var payloadSender = new MockPayloadSender();
 			var agent = new ApmAgent(new TestAgentComponents(payloadSender: payloadSender));
 

--- a/test/Elastic.Apm.Tests/ApiTests/ConvenientApiSpanTests.cs
+++ b/test/Elastic.Apm.Tests/ApiTests/ConvenientApiSpanTests.cs
@@ -153,7 +153,7 @@ namespace Elastic.Apm.Tests.ApiTests
 			{
 				Action act = () =>
 				{
-					var result = t.CaptureSpan(SpanName, SpanType, s =>
+					t.CaptureSpan(SpanName, SpanType, s =>
 					{
 						s.Should().NotBeNull();
 						WaitHelpers.Sleep2XMinimum();
@@ -320,7 +320,7 @@ namespace Elastic.Apm.Tests.ApiTests
 			{
 				Func<Task> act = async () =>
 				{
-					var result = await t.CaptureSpan(SpanName, SpanType, async s =>
+					await t.CaptureSpan(SpanName, SpanType, async s =>
 					{
 						s.Should().NotBeNull();
 						await WaitHelpers.Delay2XMinimum();
@@ -346,7 +346,7 @@ namespace Elastic.Apm.Tests.ApiTests
 			{
 				Func<Task> act = async () =>
 				{
-					var result = await t.CaptureSpan(SpanName, SpanType, async () =>
+					await t.CaptureSpan(SpanName, SpanType, async () =>
 					{
 						await WaitHelpers.Delay2XMinimum();
 
@@ -463,6 +463,52 @@ namespace Elastic.Apm.Tests.ApiTests
 
 			//Also make sure the tag is visible directly on Span.Tags.
 			payloadSender.SpansOnFirstTransaction[0].Tags.Should().Contain("foo","bar");
+		}
+
+		/// <summary>
+		/// Creates 1 span with db information on it and creates a 2. span with http information on it.
+		/// Makes sure the db and http info is captured on the span's context.
+		/// </summary>
+		[Fact]
+		public void FillSpanContext()
+		{
+
+			var payloadSender = new MockPayloadSender();
+			var agent = new ApmAgent(new TestAgentComponents(payloadSender: payloadSender));
+
+			agent.Tracer.CaptureTransaction(TransactionName, TransactionType, t =>
+			{
+				WaitHelpers.SleepMinimum();
+				t.CaptureSpan("SampleSpan1", "SampleSpanType", span =>
+				{
+					span.Context.Http = new Http
+					{
+						Url = "http://mysite.com",
+						Method = "GET",
+						StatusCode = 200,
+					};
+				});
+
+				t.CaptureSpan("SampleSpan2", "SampleSpanType", span =>
+				{
+					span.Context.Db = new Database
+					{
+						Statement = "Select * from MyTable",
+						Type = "MSSQL",
+						Instance = "MyInstance"
+					};
+				});
+			});
+
+			payloadSender.Spans[0].Name.Should().Be("SampleSpan1");
+			payloadSender.Spans[0].Context.Http.Url.Should().Be("http://mysite.com");
+			payloadSender.Spans[0].Context.Http.Method.Should().Be("GET");
+			payloadSender.Spans[0].Context.Http.StatusCode.Should().Be(200);
+
+			payloadSender.Spans[1].Name.Should().Be("SampleSpan2");
+			payloadSender.Spans[1].Context.Db.Statement.Should().Be("Select * from MyTable");
+			payloadSender.Spans[1].Context.Db.Type.Should().Be("MSSQL");
+			payloadSender.Spans[1].Context.Db.Instance.Should().Be("MyInstance");
 		}
 
 		/// <summary>

--- a/test/Elastic.Apm.Tests/ApiTests/ConvenientApiSpanTests.cs
+++ b/test/Elastic.Apm.Tests/ApiTests/ConvenientApiSpanTests.cs
@@ -493,7 +493,7 @@ namespace Elastic.Apm.Tests.ApiTests
 					span.Context.Db = new Database
 					{
 						Statement = "Select * from MyTable",
-						Type = "MSSQL",
+						Type = Database.TypeSql,
 						Instance = "MyInstance"
 					};
 				});
@@ -506,7 +506,7 @@ namespace Elastic.Apm.Tests.ApiTests
 
 			payloadSender.Spans[1].Name.Should().Be("SampleSpan2");
 			payloadSender.Spans[1].Context.Db.Statement.Should().Be("Select * from MyTable");
-			payloadSender.Spans[1].Context.Db.Type.Should().Be("MSSQL");
+			payloadSender.Spans[1].Context.Db.Type.Should().Be(Database.TypeSql);
 			payloadSender.Spans[1].Context.Db.Instance.Should().Be("MyInstance");
 		}
 

--- a/test/Elastic.Apm.Tests/SerializationTests.cs
+++ b/test/Elastic.Apm.Tests/SerializationTests.cs
@@ -127,11 +127,11 @@ namespace Elastic.Apm.Tests
 		{
 			var sb = new StringBuilder();
 			for (var i = 0; i < 1200; i++) sb.Append('a');
-			var db = new Db { Statement = sb.ToString() };
+			var db = new Database{ Statement = sb.ToString() };
 
 			var settings = new JsonSerializerSettings { ContractResolver = new CamelCasePropertyNamesContractResolver() };
 			var json = JsonConvert.SerializeObject(db, settings);
-			var deserializedDb = JsonConvert.DeserializeObject<Db>(json);
+			var deserializedDb = JsonConvert.DeserializeObject<Database>(json);
 
 			Assert.NotNull(deserializedDb);
 

--- a/test/Elastic.Apm.Tests/SerializationTests.cs
+++ b/test/Elastic.Apm.Tests/SerializationTests.cs
@@ -23,11 +23,9 @@ namespace Elastic.Apm.Tests
 		[Fact]
 		public void StringTruncationTest()
 		{
-			var sb = new StringBuilder();
+			var str = new string('a', 1200);
 
-			for (var i = 0; i < 1200; i++) sb.Append('a');
-
-			var transaction = new Transaction(new TestAgentComponents(), sb.ToString(), "test") { Duration = 1, Result = "fail" };
+			var transaction = new Transaction(new TestAgentComponents(), str, "test") { Duration = 1, Result = "fail" };
 
 			var settings = new JsonSerializerSettings { ContractResolver = new CamelCasePropertyNamesContractResolver() };
 			var json = JsonConvert.SerializeObject(transaction, settings);
@@ -50,11 +48,9 @@ namespace Elastic.Apm.Tests
 		[Fact]
 		public void StringNoTruncateAttributeTest()
 		{
-			var sb = new StringBuilder();
+			var str = new string('a', 1200);
 
-			for (var i = 0; i < 1200; i++) sb.Append('a');
-
-			var dummyInstance = new DummyType { IntProp = 42, StringProp = sb.ToString() };
+			var dummyInstance = new DummyType { IntProp = 42, StringProp = str };
 
 			var settings = new JsonSerializerSettings { ContractResolver = new CamelCasePropertyNamesContractResolver() };
 			var json = JsonConvert.SerializeObject(dummyInstance, settings);
@@ -62,8 +58,8 @@ namespace Elastic.Apm.Tests
 
 			Assert.NotNull(deserializedDummyInstance);
 
-			Assert.Equal(sb.Length, deserializedDummyInstance.StringProp.Length);
-			Assert.Equal(sb.ToString(), deserializedDummyInstance.StringProp);
+			Assert.Equal(str.Length, deserializedDummyInstance.StringProp.Length);
+			Assert.Equal(str, deserializedDummyInstance.StringProp);
 			Assert.Equal(42, deserializedDummyInstance.IntProp);
 		}
 
@@ -75,12 +71,10 @@ namespace Elastic.Apm.Tests
 		[Fact]
 		public void TagsTruncation()
 		{
-			var sb = new StringBuilder();
-
-			for (var i = 0; i < 1200; i++) sb.Append('a');
+			var str = new string('a', 1200);
 
 			var context = new Context();
-			context.Tags["foo"] = sb.ToString();
+			context.Tags["foo"] = str;
 
 			var settings = new JsonSerializerSettings { ContractResolver = new CamelCasePropertyNamesContractResolver() };
 			var json = JsonConvert.SerializeObject(context, settings);
@@ -101,12 +95,10 @@ namespace Elastic.Apm.Tests
 		[Fact]
 		public void DictionaryNoTruncateAttributeTest()
 		{
-			var sb = new StringBuilder();
-
-			for (var i = 0; i < 1200; i++) sb.Append('a');
+			var str = new string('a', 1200);
 
 			var dummyInstance = new DummyType();
-			dummyInstance.DictionaryProp["foo"] = sb.ToString();
+			dummyInstance.DictionaryProp["foo"] = str;
 
 			var settings = new JsonSerializerSettings { ContractResolver = new CamelCasePropertyNamesContractResolver() };
 			var json = JsonConvert.SerializeObject(dummyInstance, settings);
@@ -114,8 +106,8 @@ namespace Elastic.Apm.Tests
 
 			Assert.NotNull(deserializedDummyInstance);
 
-			Assert.Equal(sb.Length, deserializedDummyInstance["dictionaryProp"].Value<JObject>()["foo"]?.Value<string>()?.Length);
-			Assert.Equal(sb.ToString(), deserializedDummyInstance["dictionaryProp"].Value<JObject>()["foo"].Value<string>());
+			Assert.Equal(str.Length, deserializedDummyInstance["dictionaryProp"].Value<JObject>()["foo"]?.Value<string>()?.Length);
+			Assert.Equal(str, deserializedDummyInstance["dictionaryProp"].Value<JObject>()["foo"].Value<string>());
 		}
 
 		/// <summary>
@@ -125,9 +117,8 @@ namespace Elastic.Apm.Tests
 		[Fact]
 		public void DbStatementLengthTest()
 		{
-			var sb = new StringBuilder();
-			for (var i = 0; i < 1200; i++) sb.Append('a');
-			var db = new Database{ Statement = sb.ToString() };
+			var str = new string('a', 1200);
+			var db = new Database{ Statement = str };
 
 			var settings = new JsonSerializerSettings { ContractResolver = new CamelCasePropertyNamesContractResolver() };
 			var json = JsonConvert.SerializeObject(db, settings);
@@ -135,8 +126,8 @@ namespace Elastic.Apm.Tests
 
 			Assert.NotNull(deserializedDb);
 
-			Assert.Equal(sb.Length, deserializedDb.Statement.Length);
-			Assert.Equal(sb.ToString(), deserializedDb.Statement);
+			Assert.Equal(str.Length, deserializedDb.Statement.Length);
+			Assert.Equal(str, deserializedDb.Statement);
 		}
 
 		/// <summary>


### PR DESCRIPTION
Finishing #124.

We already expose `Transaction.Context` (and stuff on `Context`), that was done in #134. 

In this PR we expose `Span.Context` (and stuff on `Context). 

The approach is the same: as agreed in #124 we simply expose the API defined by the APM Server. No intermediate layer, just a 1-1 mapping of the server json schema to .NET. 