### PR TITLE
[docs] Add CaptureHeaders and SecretToken settings docs and setup

### DIFF
--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -1,3 +1,8 @@
+ifdef::env-github[]
+NOTE: For the best reading experience,
+please view this documentation at https://www.elastic.co/guide/en/apm/agent/dotnet[elastic.co]
+endif::[]
+
 [[configuration]]
 == Configuration
 
@@ -76,6 +81,28 @@ NOTE: The service name must conform to this regular expression: ^[a-zA-Z0-9 _-]+
 
 [[config-reporter]]
 === Reporter configuration options
+
+[float]
+[[config-secret-token]]
+==== `SecretToken`
+
+[options="header"]
+|============
+| Environment variable name | IConfiguration key
+| `ELASTIC_APM_SECRET_TOKEN` | `ElasticApm:SecretToken`
+|============
+
+[options="header"]
+|============
+| Default                 | Type
+| `<none>`                | String
+|============
+
+This string is used to ensure that only your agents can send data to your APM server.
+
+Both the agents and the APM server have to be configured with the same secret token.
+Use this setting in case the APM Server requires a token (e.g. APM Server in Elastic Cloud).
+
 [float]
 [[config-server-urls]]
 ==== `ServerUrls`
@@ -93,7 +120,6 @@ NOTE: The service name must conform to this regular expression: ^[a-zA-Z0-9 _-]+
 |============
 
 The URLs for your APM Servers. The URLs must be fully qualified, including protocol (`http` or `https`) and port. To add multiple servers, separate them with a comma (`,`).
-
 
 NOTE: Providing multiple URLs only works with APM Server v6.5+.
 
@@ -116,3 +142,27 @@ NOTE: Providing multiple URLs only works with APM Server v6.5+.
 Sets the logging level for the agent.
 
 Valid options: `Error`, `Warning`, `Info`, `Debug`.
+
+[[config-http]]
+=== HTTP configuration options
+
+[float]
+[[config-capture-headers]]
+==== `CaptureHeaders` (performance)
+
+[options="header"]
+|============
+| Environment variable name     | IConfiguration key
+| `ELASTIC_APM_CAPTURE_HEADERS` | `ElasticApm:CaptureHeaders`
+|============
+
+[options="header"]
+|============
+| Default                 | Type
+| `true`                  | Boolean
+|============
+
+If set to `true`,
+the agent will capture request and response headers, including cookies.
+
+NOTE: Setting this to `false` reduces network bandwidth, disk space and object allocations.

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -1,3 +1,8 @@
+ifdef::env-github[]
+NOTE: For the best reading experience,
+please view this documentation at https://www.elastic.co/guide/en/apm/agent/dotnet[elastic.co]
+endif::[]
+
 = APM .NET Agent Reference (Prototype)
 :branch: current
 :server-branch: 6.5
@@ -10,6 +15,7 @@ endif::[]
 
 ifndef::env-github[]
 include::./intro.asciidoc[Introduction]
+include::./setup.asciidoc[Set Up]
 include::./configuration.asciidoc[Configuration]
 include::./public-api.asciidoc[API documentation]
 endif::[]

--- a/docs/setup.asciidoc
+++ b/docs/setup.asciidoc
@@ -1,0 +1,30 @@
+[[setup]]
+== Set up
+The agent ships as a set of NuGet packages via https://nuget.org[nuget.org].
+
+The following packages are available:
+
+* https://www.nuget.org/packages/Elastic.Apm.All[Elastic.Apm.All]: This is a meta package that references every other Elastic APM .NET agent package. If you plan to monitor a typical ASP.NET Core application that depends on the https://www.nuget.org/packages/Microsoft.AspNetCore.All[Microsoft.AspNetCore.All] package and uses Entity Framework Core then you should reference this package. 
+In order to avoid adding unnecessary dependencies in applications that aren’t depending on the https://www.nuget.org/packages/Microsoft.AspNetCore.All[Microsoft.AspNetCore.All] package we also shipped some other packages - those are all referenced by the `Elastic.Apm.All` package.
+* https://www.nuget.org/packages/Elastic.Apm[Elastic.Apm]: This is the core of the agent, which we didn’t name “Core”, because someone already took that name :) This package also contains the <<public-api>> and it is a .NET Standard 2.0 package. We also ship every tracing component that traces classes that are part of .NET Standard 2.0 in this package, which includes the monitoring part for HttpClient. Every other Elastic APM package references this package.
+* https://www.nuget.org/packages/Elastic.Apm.AspNetCore[Elastic.Apm.AspNetCore]: This package contains ASP.NET Core monitoring related code. The main difference between this package and the `Elastic.Apm.All` package is that this package does not reference the `Elastic.Apm.EntityFrameworkCore` package, so if you have an ASP.NET Core application that does not use EF Core and you want to avoid adding additional unused references, you should use this package.
+* https://www.nuget.org/packages/Elastic.Apm.EntityFrameworkCore[Elastic.Apm.EntityFrameworkCore]: This package contains EF Core monitoring related code.
+
+You simply add the agent to your .NET application by referencing one of these packages.
+
+For ASP.NET Core, once you referenced either the `Elastic.Apm.All` or the `Elastic.Apm.AspNetCore` package, you can enable auto instrumentation by calling the `UseElasticApm()` extension method:
+
+[source,csharp]
+----
+public class Startup
+{
+  public void Configure(IApplicationBuilder app, IHostingEnvironment env)
+  {
+    app.UseElasticApm(Configuration);
+    //…rest of the method
+  }
+  //…rest of the class
+}
+----
+
+In case you only want to use the <<public-api>>, you don't need to can any initalization, you can simply start using the API and the agent will send the data to the APM Server.


### PR DESCRIPTION
Catching up on documentation. 

- Documenting SecretToken and CaptureHeaders settings. Text is mainly from the Java agent docs.
- Added Setup instructions. The text is mainly from the [preview release blogpost](https://www.elastic.co/blog/elastic-apm-dot-net-agent-preview-released). We had [1 question on discuss](https://discuss.elastic.co/t/net-agent/168889) about this, I think this should be in the docs.