### PR TITLE
Change agent name `dotNet` -> `dotnet`

### DIFF
--- a/src/Elastic.Apm/Consts.cs
+++ b/src/Elastic.Apm/Consts.cs
@@ -9,6 +9,6 @@
 
 		public static string IntakeV2Events = "intake/v2/events";
 
-		public static string AgentName => "dotNet";
+		public static string AgentName => "dotnet";
 	}
 }


### PR DESCRIPTION
Reason behind the change:
All apm agents use only lower case agent names. Also `Net` isn't a common way to refer to .NET. 