### PR TITLE
[docs] Add release notes

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -8,14 +8,10 @@ endif::[]
 :server-branch: 6.5
 include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 
-ifdef::env-github[]
-NOTE: For the best reading experience,
-please view this documentation at https://www.elastic.co/guide/en/apm/agent/dotnet[elastic.co]
-endif::[]
-
 ifndef::env-github[]
 include::./intro.asciidoc[Introduction]
 include::./setup.asciidoc[Set Up]
 include::./configuration.asciidoc[Configuration]
 include::./public-api.asciidoc[API documentation]
+include::./release-notes.asciidoc[Release notes]
 endif::[]

--- a/docs/release-notes.asciidoc
+++ b/docs/release-notes.asciidoc
@@ -1,0 +1,4 @@
+[[release-notes]]
+== Release notes
+
+Release notes are published on the https://github.com/elastic/apm-agent-dotnet/releases[ GitHub releases page].


### PR DESCRIPTION
See elastic/apm#68.

Adds a link to release notes. Also removes a duplicate `ifdef` from index.asciidoc.