### PR TITLE
Distributed tracing - implement traceparent from w3c Trace Context

### DIFF
--- a/ElasticApmAgent.sln
+++ b/ElasticApmAgent.sln
@@ -1,4 +1,4 @@
-
+﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
 VisualStudioVersion = 15.0.28010.2050
@@ -41,6 +41,8 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Elastic.Apm.PerfTests", "test\Elastic.Apm.PerfTests\Elastic.Apm.PerfTests.csproj", "{F069CE99-F418-4BC2-9E44-8F03497D8DA8}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AspNetFullFrameworkSampleApp", "sample\AspNetFullFrameworkSampleApp\AspNetFullFrameworkSampleApp.csproj", "{C45DCD78-7E8A-437C-ABBB-01D154ABCFC4}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WebApiSample", "sample\WebApiSample\WebApiSample.csproj", "{319E2094-D2E1-46C5-8985-9693CD8DDCBD}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -91,6 +93,10 @@ Global
 		{C45DCD78-7E8A-437C-ABBB-01D154ABCFC4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{C45DCD78-7E8A-437C-ABBB-01D154ABCFC4}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{C45DCD78-7E8A-437C-ABBB-01D154ABCFC4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{319E2094-D2E1-46C5-8985-9693CD8DDCBD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{319E2094-D2E1-46C5-8985-9693CD8DDCBD}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{319E2094-D2E1-46C5-8985-9693CD8DDCBD}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{319E2094-D2E1-46C5-8985-9693CD8DDCBD}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -108,6 +114,7 @@ Global
 		{1AAB1A30-42C0-4C76-AE2E-9D7293945D80} = {3C791D9C-6F19-4F46-B367-2EC0F818762D}
 		{F069CE99-F418-4BC2-9E44-8F03497D8DA8} = {267A241E-571F-458F-B04C-B6C4DE79E735}
 		{C45DCD78-7E8A-437C-ABBB-01D154ABCFC4} = {3C791D9C-6F19-4F46-B367-2EC0F818762D}
+		{319E2094-D2E1-46C5-8985-9693CD8DDCBD} = {3C791D9C-6F19-4F46-B367-2EC0F818762D}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {69E02FD9-C9DE-412C-AB6B-5B8BECC6BFA5}

--- a/ElasticApmAgent.sln
+++ b/ElasticApmAgent.sln
@@ -94,6 +94,7 @@ Global
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{0ADF687D-4DB7-417E-80B4-27B3FD86875E} = {3C791D9C-6F19-4F46-B367-2EC0F818762D}

--- a/sample/SampleAspNetCoreApp/Controllers/HomeController.cs
+++ b/sample/SampleAspNetCoreApp/Controllers/HomeController.cs
@@ -56,9 +56,13 @@ namespace SampleAspNetCoreApp.Controllers
 			return Redirect("/Home/Index");
 		}
 
-		public IActionResult SimplePage()
+		public async Task<IActionResult> SimplePage()
 		{
 			Response.Headers.Add("X-Additional-Header", "For-Elastic-Apm-Agent");
+
+			var httpClient = new HttpClient();
+			var retVal = await httpClient.GetAsync("http://localhost:5005/api/Values");
+			Console.WriteLine(await retVal.Content.ReadAsStringAsync());
 			return View();
 		}
 

--- a/sample/SampleAspNetCoreApp/Controllers/HomeController.cs
+++ b/sample/SampleAspNetCoreApp/Controllers/HomeController.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Net.Http;
@@ -6,6 +7,7 @@ using System.Threading.Tasks;
 using Elastic.Apm;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
+using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using SampleAspNetCoreApp.Data;
 using SampleAspNetCoreApp.Models;
@@ -71,8 +73,8 @@ namespace SampleAspNetCoreApp.Controllers
 				var retVal = await httpClient.GetAsync("http://localhost:5050/api/values");
 
 				var resultInStr = await retVal.Content.ReadAsStringAsync();
-				var list = resultInStr.Split(',');
-				return View(list.ToList());
+				var list = JsonConvert.DeserializeObject<List<string>>(resultInStr);
+				return View(list);
 			}
 			catch (Exception e)
 			{

--- a/sample/SampleAspNetCoreApp/Controllers/HomeController.cs
+++ b/sample/SampleAspNetCoreApp/Controllers/HomeController.cs
@@ -56,14 +56,30 @@ namespace SampleAspNetCoreApp.Controllers
 			return Redirect("/Home/Index");
 		}
 
-		public async Task<IActionResult> SimplePage()
+		public IActionResult SimplePage()
 		{
 			Response.Headers.Add("X-Additional-Header", "For-Elastic-Apm-Agent");
-
-			var httpClient = new HttpClient();
-			var retVal = await httpClient.GetAsync("http://localhost:5005/api/Values");
-			Console.WriteLine(await retVal.Content.ReadAsStringAsync());
 			return View();
+		}
+
+		public async Task<IActionResult> DistributedTracingMiniSample()
+		{
+			var httpClient = new HttpClient();
+
+			try
+			{
+				var retVal = await httpClient.GetAsync("http://localhost:5050/api/values");
+
+				var resultInStr = await retVal.Content.ReadAsStringAsync();
+				var list = resultInStr.Split(',');
+				return View(list.ToList());
+			}
+			catch (Exception e)
+			{
+				ViewData["Fail"] =
+					$"Failed calling http://localhost:5050/api/values, make sure the WebApiSample listens on localhost:5050, {e.Message}";
+				return View();
+			}
 		}
 
 		public async Task<IActionResult> ChartPage()

--- a/sample/SampleAspNetCoreApp/README.md
+++ b/sample/SampleAspNetCoreApp/README.md
@@ -1,4 +1,4 @@
-## SampleAspNetCoreApp with Elastic .NET Agent. 
+# SampleAspNetCoreApp with Elastic .NET Agent. 
 
 The goal of this sample is to show you how you can use the Elastic APM .NET Agent with an ASP.NET Core application.
 

--- a/sample/SampleAspNetCoreApp/SampleAspNetCoreApp.csproj
+++ b/sample/SampleAspNetCoreApp/SampleAspNetCoreApp.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.1</TargetFramework>

--- a/sample/SampleAspNetCoreApp/Startup.cs
+++ b/sample/SampleAspNetCoreApp/Startup.cs
@@ -37,14 +37,12 @@ namespace SampleAspNetCoreApp
 		public void Configure(IApplicationBuilder app, IHostingEnvironment env)
 		{
 			app.UseElasticApm(Configuration);
+			ConfigureAllExceptAgent(app);
+		}
 
-			if (env.IsDevelopment())
-				app.UseDeveloperExceptionPage();
-			else
-			{
-				app.UseExceptionHandler("/Home/Error");
-				app.UseHsts();
-			}
+		public static void ConfigureAllExceptAgent(IApplicationBuilder app)
+		{
+			app.UseDeveloperExceptionPage();
 
 			app.UseHttpsRedirection();
 			app.UseStaticFiles();

--- a/sample/SampleAspNetCoreApp/Views/Home/DistributedTracingMiniSample.cshtml
+++ b/sample/SampleAspNetCoreApp/Views/Home/DistributedTracingMiniSample.cshtml
@@ -1,0 +1,27 @@
+@model List<string>
+
+<div class="alert alert-info" role="alert">
+	This sample demonstrates distributed tracing support. The app creates an HTTP GET request to "TODO URL". In case the WebApiSample listen on that URL
+	you see some values from the Web API sample below. In this case the agent will create a trace and in Kibana you will be able to see that the two apps are connected.
+</div>
+
+
+<div>
+	Data from the WebApiSample service:
+	
+	@if(ViewData["Fail"] == null)
+	{
+		<ul>
+			@{
+				foreach (var item in @Model)
+				{
+					<li>@item</li>
+				}
+			}
+		</ul>
+	}
+	else
+	{
+		@ViewData["Fail"];
+	}
+</div>

--- a/sample/SampleAspNetCoreApp/Views/Home/DistributedTracingMiniSample.cshtml
+++ b/sample/SampleAspNetCoreApp/Views/Home/DistributedTracingMiniSample.cshtml
@@ -1,15 +1,16 @@
 @model List<string>
 
+<br/>
 <div class="alert alert-info" role="alert">
-	This sample demonstrates distributed tracing support. The app creates an HTTP GET request to "TODO URL". In case the WebApiSample listen on that URL
-	you see some values from the Web API sample below. In this case the agent will create a trace and in Kibana you will be able to see that the two apps are connected.
+	This sample demonstrates distributed tracing support. The app creates an HTTP GET request to localhost:5050. In case the WebApiSample
+	listen on that URL you see some values from the Web API sample below. In this case the agent will create a trace and in Kibana you
+	will be able to see that the two apps are connected.
 </div>
-
 
 <div>
 	Data from the WebApiSample service:
-	
-	@if(ViewData["Fail"] == null)
+
+	@if (ViewData["Fail"] == null)
 	{
 		<ul>
 			@{
@@ -22,6 +23,7 @@
 	}
 	else
 	{
-		@ViewData["Fail"];
+		@ViewData["Fail"]
+		;
 	}
 </div>

--- a/sample/SampleAspNetCoreApp/Views/Home/SimplePage.cshtml
+++ b/sample/SampleAspNetCoreApp/Views/Home/SimplePage.cshtml
@@ -1,4 +1,5 @@
 <br/>
 <div class="alert alert-info" role="alert">
-	This is a very simple page without any code inside the controller. <br/> If the APM .NET Agent is activated then the request is captured by the agent and you can see it in Kibana.
+	This is a very simple page with very minimal code inside the controller: all it does is that it sets the header 'X-Additional-Header' to 'For-Elastic-Apm-Agent'. <br/> 
+	If the APM .NET Agent is activated then the request is captured by the agent and you can see it in Kibana including the captured header.
 </div>

--- a/sample/SampleAspNetCoreApp/Views/Shared/_Layout.cshtml
+++ b/sample/SampleAspNetCoreApp/Views/Shared/_Layout.cshtml
@@ -48,6 +48,9 @@
 				<li>
 					<a asp-area="" asp-controller="Home" asp-action="FailingOutGoingHttpCall">FailingOutgoingHttpCall</a>
 				</li>
+				<li>
+					<a asp-area="" asp-controller="Home" asp-action="DistributedTracingMiniSample">DistributedTracingMiniSample</a>
+				</li>
 			</ul>
 		</div>
 	</div>

--- a/sample/SampleAspNetCoreApp/appsettings.json
+++ b/sample/SampleAspNetCoreApp/appsettings.json
@@ -4,11 +4,11 @@
       "Default": "Warning"
     }
   },
-  "AllowedHosts": "*"//,
-  //Settings for the elastic APM Agent
-//  "ElasticApm":
-//    {
-//      "LogLevel":  "Debug",
-//      "ServerUrls":  "http://localhost:8200"
-//    }
+  "AllowedHosts": "*",
+ // Settings for the elastic APM Agent
+  "ElasticApm":
+    {
+      "LogLevel":  "Debug",
+      "ServerUrls":  "http://localhost:8200"
+    }
 }

--- a/sample/SampleAspNetCoreApp/appsettings.json
+++ b/sample/SampleAspNetCoreApp/appsettings.json
@@ -4,12 +4,9 @@
       "Default": "Warning"
     }
   },
-  "AllowedHosts": "*"
-  //,
-  // Settings for the elastic APM Agent
-  //  "ElasticApm":
-  //    {
-  //      "LogLevel":  "Debug",
-  //      "ServerUrls":  "http://localhost:8200"
-  //    }
+  "AllowedHosts": "*",
+  "ElasticApm": {
+    "LogLevel": "Error",
+    "ServerUrls": "http://localhost:8200"
+  }
 }

--- a/sample/SampleAspNetCoreApp/appsettings.json
+++ b/sample/SampleAspNetCoreApp/appsettings.json
@@ -4,11 +4,12 @@
       "Default": "Warning"
     }
   },
-  "AllowedHosts": "*",
- // Settings for the elastic APM Agent
-  "ElasticApm":
-    {
-      "LogLevel":  "Debug",
-      "ServerUrls":  "http://localhost:8200"
-    }
+  "AllowedHosts": "*"
+  //,
+  // Settings for the elastic APM Agent
+  //  "ElasticApm":
+  //    {
+  //      "LogLevel":  "Debug",
+  //      "ServerUrls":  "http://localhost:8200"
+  //    }
 }

--- a/sample/WebApiSample/Controllers/ValuesController.cs
+++ b/sample/WebApiSample/Controllers/ValuesController.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
+﻿using System.Collections.Generic;
 using System.Net.Http;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
@@ -22,7 +20,7 @@ namespace WebApiSample.Controllers
 				var elasticRes = await httpClient.GetAsync("https://elastic.co");
 				lastValue += elasticRes.StatusCode;
 			}
-			catch (Exception e)
+			catch
 			{
 				lastValue += "failed";
 			}

--- a/sample/WebApiSample/Controllers/ValuesController.cs
+++ b/sample/WebApiSample/Controllers/ValuesController.cs
@@ -27,24 +27,5 @@ namespace WebApiSample.Controllers
 
 			return new[] { "value1", "value2", lastValue };
 		}
-
-		// GET api/values/5
-		[HttpGet("{id}")]
-		public ActionResult<string> Get(int id)
-		{
-			return "value";
-		}
-
-		// POST api/values
-		[HttpPost]
-		public void Post([FromBody] string value) { }
-
-		// PUT api/values/5
-		[HttpPut("{id}")]
-		public void Put(int id, [FromBody] string value) { }
-
-		// DELETE api/values/5
-		[HttpDelete("{id}")]
-		public void Delete(int id) { }
 	}
 }

--- a/sample/WebApiSample/Controllers/ValuesController.cs
+++ b/sample/WebApiSample/Controllers/ValuesController.cs
@@ -15,9 +15,19 @@ namespace WebApiSample.Controllers
 		[HttpGet]
 		public async Task<ActionResult<IEnumerable<string>>> Get()
 		{
-			var httpClient = new HttpClient();
-			var elasticRes = await httpClient.GetAsync("https://elastic.co");
-			return new string[] { "value1", "value2", elasticRes.IsSuccessStatusCode.ToString() };
+			var lastValue = "call to elastic.co: ";
+			try
+			{
+				var httpClient = new HttpClient();
+				var elasticRes = await httpClient.GetAsync("https://elastic.co");
+				lastValue += elasticRes.StatusCode;
+			}
+			catch (Exception e)
+			{
+				lastValue += "failed";
+			}
+
+			return new[] { "value1", "value2", lastValue };
 		}
 
 		// GET api/values/5

--- a/sample/WebApiSample/Controllers/ValuesController.cs
+++ b/sample/WebApiSample/Controllers/ValuesController.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+
+namespace WebApiSample.Controllers
+{
+	[Route("api/[controller]")]
+	[ApiController]
+	public class ValuesController : ControllerBase
+	{
+		// GET api/values
+		[HttpGet]
+		public async Task<ActionResult<IEnumerable<string>>> Get()
+		{
+			var httpClient = new HttpClient();
+			var elasticRes = await httpClient.GetAsync("https://elastic.co");
+			return new string[] { "value1", "value2", elasticRes.IsSuccessStatusCode.ToString() };
+		}
+
+		// GET api/values/5
+		[HttpGet("{id}")]
+		public ActionResult<string> Get(int id)
+		{
+			return "value";
+		}
+
+		// POST api/values
+		[HttpPost]
+		public void Post([FromBody] string value) { }
+
+		// PUT api/values/5
+		[HttpPut("{id}")]
+		public void Put(int id, [FromBody] string value) { }
+
+		// DELETE api/values/5
+		[HttpDelete("{id}")]
+		public void Delete(int id) { }
+	}
+}

--- a/sample/WebApiSample/Program.cs
+++ b/sample/WebApiSample/Program.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+
+namespace WebApiSample
+{
+	public class Program
+	{
+		public static void Main(string[] args)
+		{
+			CreateWebHostBuilder(args).Build().Run();
+		}
+
+		public static IWebHostBuilder CreateWebHostBuilder(string[] args) =>
+			WebHost.CreateDefaultBuilder(args)
+				.UseStartup<Startup>();
+	}
+}

--- a/sample/WebApiSample/Program.cs
+++ b/sample/WebApiSample/Program.cs
@@ -19,6 +19,6 @@ namespace WebApiSample
 
 		public static IWebHostBuilder CreateWebHostBuilder(string[] args) =>
 			WebHost.CreateDefaultBuilder(args)
-				.UseStartup<Startup>();
+				.UseStartup<Startup>().UseUrls("http://localhost:5050");
 	}
 }

--- a/sample/WebApiSample/README.md
+++ b/sample/WebApiSample/README.md
@@ -1,0 +1,11 @@
+# WebApiSample with Elastic .NET Agent. 
+
+This is a very small ASP.NET Core WebApi application with the Elastic APM .NET Agent. This sample is intended to showcase the distributed tracing capabilities of the agent.
+
+When you start the application it starts listening on `http://localhost:5050`, and under `http://localhost:5050/api/values` there is a controller that does the following: 
+- returns a list of strings as JSON 
+- all strings are static except the last one
+- it creates an HTTP GET request to `https://elastic.co`
+- the last string is the result of the http request.
+
+The `SampleAspNetCoreApp` sample under `/Home/DistributedTracingMiniSample` creates an HTTP call to `http://localhost:5050/api/values`. As the result the Elastic APM will capture a trace including the 2 ASP.NET Core applications. You can look at this trace in Kibana, where you will see that the 2 services were correlated into a single trace.

--- a/sample/WebApiSample/Startup.cs
+++ b/sample/WebApiSample/Startup.cs
@@ -26,22 +26,19 @@ namespace WebApiSample
 		// This method gets called by the runtime. Use this method to add services to the container.
 		public void ConfigureServices(IServiceCollection services)
 		{
-			services.AddMvc().SetCompatibilityVersion(CompatibilityVersion.Version_2_2);
+			services.AddMvc().SetCompatibilityVersion(CompatibilityVersion.Version_2_1);
 		}
 
 		// This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
 		public void Configure(IApplicationBuilder app, IHostingEnvironment env)
 		{
 			app.UseElasticApm();
-			if (env.IsDevelopment())
-			{
-				app.UseDeveloperExceptionPage();
-			}
-			else
-			{
-				// The default HSTS value is 30 days. You may want to change this for production scenarios, see https://aka.ms/aspnetcore-hsts.
-				app.UseHsts();
-			}
+			ConfigureAllExceptAgent(app);
+		}
+
+		public static void ConfigureAllExceptAgent(IApplicationBuilder app)
+		{
+			app.UseDeveloperExceptionPage();
 
 			app.UseHttpsRedirection();
 			app.UseMvc();

--- a/sample/WebApiSample/Startup.cs
+++ b/sample/WebApiSample/Startup.cs
@@ -16,8 +16,11 @@ namespace WebApiSample
 {
 	public class Startup
 	{
+		private readonly IConfiguration _configuration;
+
 		public Startup(IConfiguration configuration)
 		{
+			_configuration = configuration;
 		}
 
 		// This method gets called by the runtime. Use this method to add services to the container.
@@ -29,7 +32,7 @@ namespace WebApiSample
 		// This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
 		public void Configure(IApplicationBuilder app, IHostingEnvironment env)
 		{
-			app.UseElasticApm();
+			app.UseElasticApm(_configuration);
 			ConfigureAllExceptAgent(app);
 		}
 

--- a/sample/WebApiSample/Startup.cs
+++ b/sample/WebApiSample/Startup.cs
@@ -18,10 +18,7 @@ namespace WebApiSample
 	{
 		public Startup(IConfiguration configuration)
 		{
-			Configuration = configuration;
 		}
-
-		public IConfiguration Configuration { get; }
 
 		// This method gets called by the runtime. Use this method to add services to the container.
 		public void ConfigureServices(IServiceCollection services)

--- a/sample/WebApiSample/Startup.cs
+++ b/sample/WebApiSample/Startup.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Elastic.Apm.All;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.HttpsPolicy;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace WebApiSample
+{
+	public class Startup
+	{
+		public Startup(IConfiguration configuration)
+		{
+			Configuration = configuration;
+		}
+
+		public IConfiguration Configuration { get; }
+
+		// This method gets called by the runtime. Use this method to add services to the container.
+		public void ConfigureServices(IServiceCollection services)
+		{
+			services.AddMvc().SetCompatibilityVersion(CompatibilityVersion.Version_2_2);
+		}
+
+		// This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
+		public void Configure(IApplicationBuilder app, IHostingEnvironment env)
+		{
+			app.UseElasticApm();
+			if (env.IsDevelopment())
+			{
+				app.UseDeveloperExceptionPage();
+			}
+			else
+			{
+				// The default HSTS value is 30 days. You may want to change this for production scenarios, see https://aka.ms/aspnetcore-hsts.
+				app.UseHsts();
+			}
+
+			app.UseHttpsRedirection();
+			app.UseMvc();
+		}
+	}
+}

--- a/sample/WebApiSample/WebApiSample.csproj
+++ b/sample/WebApiSample/WebApiSample.csproj
@@ -1,13 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
-        <TargetFramework>netcoreapp2.2</TargetFramework>
+        <TargetFramework>netcoreapp2.1</TargetFramework>
         <AspNetCoreHostingModel>InProcess</AspNetCoreHostingModel>
     </PropertyGroup>
 
     <ItemGroup>
         <PackageReference Include="Microsoft.AspNetCore.App" />
-        <PackageReference Include="Microsoft.AspNetCore.Razor.Design" Version="2.2.0" PrivateAssets="All" />
+        <PackageReference Include="Microsoft.AspNetCore.Razor.Design" Version="2.1.4" PrivateAssets="All" />
     </ItemGroup>
 
     <ItemGroup>

--- a/sample/WebApiSample/WebApiSample.csproj
+++ b/sample/WebApiSample/WebApiSample.csproj
@@ -1,0 +1,17 @@
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+
+    <PropertyGroup>
+        <TargetFramework>netcoreapp2.2</TargetFramework>
+        <AspNetCoreHostingModel>InProcess</AspNetCoreHostingModel>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.AspNetCore.App" />
+        <PackageReference Include="Microsoft.AspNetCore.Razor.Design" Version="2.2.0" PrivateAssets="All" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\..\src\Elastic.Apm.All\Elastic.Apm.All.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/sample/WebApiSample/WebApiSample.csproj
+++ b/sample/WebApiSample/WebApiSample.csproj
@@ -1,17 +1,18 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
-    <PropertyGroup>
-        <TargetFramework>netcoreapp2.1</TargetFramework>
-        <AspNetCoreHostingModel>InProcess</AspNetCoreHostingModel>
-    </PropertyGroup>
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <AssemblyOriginatorKeyFile>..\..\build\elasticapm.snk</AssemblyOriginatorKeyFile>
+    <DelaySign>false</DelaySign>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
 
-    <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.App" />
-        <PackageReference Include="Microsoft.AspNetCore.Razor.Design" Version="2.1.4" PrivateAssets="All" />
-    </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.App"/>
+  </ItemGroup>
 
-    <ItemGroup>
-      <ProjectReference Include="..\..\src\Elastic.Apm.All\Elastic.Apm.All.csproj" />
-    </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Elastic.Apm.All\Elastic.Apm.All.csproj" />
+  </ItemGroup>
 
 </Project>

--- a/sample/WebApiSample/appsettings.Development.json
+++ b/sample/WebApiSample/appsettings.Development.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Debug",
+      "System": "Information",
+      "Microsoft": "Information"
+    }
+  }
+}

--- a/sample/WebApiSample/appsettings.json
+++ b/sample/WebApiSample/appsettings.json
@@ -4,12 +4,9 @@
       "Default": "Warning"
     }
   },
-  "AllowedHosts": "*"
-  //,
-  // Settings for the elastic APM Agent
-  //  "ElasticApm":
-  //  {
-  //    "LogLevel":  "Debug",
-  //    "ServerUrls":  "http://localhost:8200"
-  //  }
+  "AllowedHosts": "*",
+  "ElasticApm": {
+    "LogLevel": "Error",
+    "ServerUrls": "http://localhost:8200"
+  }
 }

--- a/sample/WebApiSample/appsettings.json
+++ b/sample/WebApiSample/appsettings.json
@@ -1,0 +1,14 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Warning"
+    }
+  },
+  "AllowedHosts": "*",
+  // Settings for the elastic APM Agent
+  "ElasticApm":
+  {
+    "LogLevel":  "Debug",
+    "ServerUrls":  "http://localhost:8200"
+  }
+}

--- a/sample/WebApiSample/appsettings.json
+++ b/sample/WebApiSample/appsettings.json
@@ -4,11 +4,12 @@
       "Default": "Warning"
     }
   },
-  "AllowedHosts": "*",
+  "AllowedHosts": "*"
+  //,
   // Settings for the elastic APM Agent
-  "ElasticApm":
-  {
-    "LogLevel":  "Debug",
-    "ServerUrls":  "http://localhost:8200"
-  }
+  //  "ElasticApm":
+  //  {
+  //    "LogLevel":  "Debug",
+  //    "ServerUrls":  "http://localhost:8200"
+  //  }
 }

--- a/src/Elastic.Apm.AspNetCore/ApmMiddleware.cs
+++ b/src/Elastic.Apm.AspNetCore/ApmMiddleware.cs
@@ -4,6 +4,7 @@ using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using Elastic.Apm.Api;
 using Elastic.Apm.Config;
+using Elastic.Apm.DistributedTracing;
 using Elastic.Apm.Helpers;
 using Microsoft.AspNetCore.Http;
 
@@ -32,10 +33,23 @@ namespace Elastic.Apm.AspNetCore
 
 		public async Task InvokeAsync(HttpContext context)
 		{
-			var transaction = _tracer.StartTransactionInternal($"{context.Request.Method} {context.Request.Path}",
-				ApiConstants.TypeRequest);
+			Elastic.Apm.Model.Payload.Transaction transaction = null;
 
 			//Get traceparent and parse
+
+			if (context.Request.Headers.ContainsKey(TraceParent.TraceParentHeaderName))
+			{
+				var headerValue = context.Request.Headers[TraceParent.TraceParentHeaderName].ToString();
+				var (traceId, parentId) = TraceParent.ParseTraceParentString(headerValue);
+
+				//_tracer.StartTransactionInternal()
+			}
+			else
+			{
+				transaction = _tracer.StartTransactionInternal($"{context.Request.Method} {context.Request.Path}",
+					ApiConstants.TypeRequest);
+			}
+			//TraceParent.
 
 			var url = new Url
 			{

--- a/src/Elastic.Apm.AspNetCore/ApmMiddleware.cs
+++ b/src/Elastic.Apm.AspNetCore/ApmMiddleware.cs
@@ -26,12 +26,12 @@ namespace Elastic.Apm.AspNetCore
 		private readonly IConfigurationReader _configurationReader;
 		private readonly IApmLogger _logger;
 
-		public ApmMiddleware(RequestDelegate next, Tracer tracer, IConfigurationReader configurationReader, IApmLogger logger)
+		public ApmMiddleware(RequestDelegate next, Tracer tracer, IApmAgent agent)
 		{
 			_next = next;
 			_tracer = tracer;
-			_configurationReader = configurationReader;
-			_logger = logger.Scoped(nameof(ApmMiddleware));
+			_configurationReader = agent.ConfigurationReader;
+			_logger = agent.Logger.Scoped(nameof(ApmMiddleware));
 		}
 
 		public async Task InvokeAsync(HttpContext context)

--- a/src/Elastic.Apm.AspNetCore/ApmMiddleware.cs
+++ b/src/Elastic.Apm.AspNetCore/ApmMiddleware.cs
@@ -35,6 +35,8 @@ namespace Elastic.Apm.AspNetCore
 			var transaction = _tracer.StartTransactionInternal($"{context.Request.Method} {context.Request.Path}",
 				ApiConstants.TypeRequest);
 
+			//Get traceparent and parse
+
 			var url = new Url
 			{
 				Full = context.Request?.Path.Value,

--- a/src/Elastic.Apm.AspNetCore/ApmMiddleware.cs
+++ b/src/Elastic.Apm.AspNetCore/ApmMiddleware.cs
@@ -46,9 +46,10 @@ namespace Elastic.Apm.AspNetCore
 				{
 					var traceId = string.Empty;
 					var parentId = string.Empty;
+					var isRecorded = false; //Currently only used for logging. Later it can be useful to make sampling decisions.
 					try
 					{
-						(traceId, parentId) = TraceParent.ParseTraceParentString(headerValue);
+						(traceId, parentId, isRecorded) = TraceParent.ParseTraceParentString(headerValue);
 					}
 					catch (Exception e)
 					{
@@ -60,8 +61,8 @@ namespace Elastic.Apm.AspNetCore
 							ApiConstants.TypeRequest, traceId, parentId);
 
 						_logger.Debug()
-							?.Log("Incoming request with {TraceParentHeaderName} header. TraceId: {TraceId}, ParentId: {ParentId}. Starting Trace.",
-								TraceParent.TraceParentHeaderName, traceId, parentId);
+							?.Log("Incoming request with {TraceParentHeaderName} header. TraceId: {TraceId}, ParentId: {ParentId}, Recorded: {IsRecorded}. Starting Trace.",
+								TraceParent.TraceParentHeaderName, traceId, parentId, isRecorded);
 					}
 				}
 				else

--- a/src/Elastic.Apm.AspNetCore/ApmMiddlewareExtension.cs
+++ b/src/Elastic.Apm.AspNetCore/ApmMiddlewareExtension.cs
@@ -8,7 +8,6 @@ using Elastic.Apm.AspNetCore.DiagnosticListener;
 using Elastic.Apm.Config;
 using Elastic.Apm.DiagnosticSource;
 using Elastic.Apm.Logging;
-using Elastic.Apm.Model.Payload;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.Configuration;
 

--- a/src/Elastic.Apm.AspNetCore/ApmMiddlewareExtension.cs
+++ b/src/Elastic.Apm.AspNetCore/ApmMiddlewareExtension.cs
@@ -45,12 +45,13 @@ namespace Elastic.Apm.AspNetCore
 			UpdateServiceInformation(config.Service);
 
 			Agent.Setup(config);
-			return UseElasticApm(builder, Agent.Instance, subscribers);
+			return UseElasticApm(builder, Agent.Instance, logger, subscribers);
 		}
 
 		internal static IApplicationBuilder UseElasticApm(
 			this IApplicationBuilder builder,
 			ApmAgent agent,
+			IApmLogger logger,
 			params IDiagnosticsSubscriber[] subscribers
 		)
 		{
@@ -59,7 +60,7 @@ namespace Elastic.Apm.AspNetCore
 				new AspNetCoreDiagnosticsSubscriber()
 			};
 			agent.Subscribe(subs.ToArray());
-			return builder.UseMiddleware<ApmMiddleware>(agent.Tracer, agent.ConfigurationReader);
+			return builder.UseMiddleware<ApmMiddleware>(agent.Tracer, agent.ConfigurationReader, logger);
 		}
 
 		internal static void UpdateServiceInformation(Service service)

--- a/src/Elastic.Apm.AspNetCore/ApmMiddlewareExtension.cs
+++ b/src/Elastic.Apm.AspNetCore/ApmMiddlewareExtension.cs
@@ -59,7 +59,7 @@ namespace Elastic.Apm.AspNetCore
 				new AspNetCoreDiagnosticsSubscriber()
 			};
 			agent.Subscribe(subs.ToArray());
-			return builder.UseMiddleware<ApmMiddleware>(agent.Tracer, agent.ConfigurationReader, logger);
+			return builder.UseMiddleware<ApmMiddleware>(agent.Tracer, agent);
 		}
 
 		internal static void UpdateServiceInformation(Service service)

--- a/src/Elastic.Apm/Api/Tracer.cs
+++ b/src/Elastic.Apm/Api/Tracer.cs
@@ -27,9 +27,9 @@ namespace Elastic.Apm.Api
 		public ITransaction StartTransaction(string name, string type)
 			=> StartTransactionInternal(name, type);
 
-		internal Transaction StartTransactionInternal(string name, string type)
+		internal Transaction StartTransactionInternal(string name, string type, string traceId = null, string parentId = null)
 		{
-			var retVal = new Transaction(_logger, name, type, _sender)
+			var retVal = new Transaction(_logger, name, type, _sender, traceId, parentId)
 			{
 				Name = name,
 				Type = type,

--- a/src/Elastic.Apm/Consts.cs
+++ b/src/Elastic.Apm/Consts.cs
@@ -2,9 +2,6 @@
 {
 	internal static class Consts
 	{
-		public const string IntakeV1Errors = "v1/errors";
-		public const string IntakeV1Transactions = "v1/transactions";
-
 		public const int PropertyMaxLength = 1024;
 
 		public static string IntakeV2Events = "intake/v2/events";

--- a/src/Elastic.Apm/DiagnosticListeners/HttpDiagnosticListener.cs
+++ b/src/Elastic.Apm/DiagnosticListeners/HttpDiagnosticListener.cs
@@ -73,7 +73,9 @@ namespace Elastic.Apm.DiagnosticListeners
 
 					if (ProcessingRequests.TryAdd(request, span))
 					{
-						request.Headers.Add(TraceParent.TraceParentHeaderName, TraceParent.GetTraceParentVal(span.TraceId, span.Id));
+						if(!request.Headers.Contains(TraceParent.TraceParentHeaderName))
+							request.Headers.Add(TraceParent.TraceParentHeaderName, TraceParent.GetTraceParentVal(span.TraceId, span.Id));
+
 						span.Context.Http = new Http
 						{
 							Url = request?.RequestUri?.ToString(),

--- a/src/Elastic.Apm/DiagnosticListeners/HttpDiagnosticListener.cs
+++ b/src/Elastic.Apm/DiagnosticListeners/HttpDiagnosticListener.cs
@@ -8,6 +8,7 @@ using System.Reflection;
 using Elastic.Apm.Api;
 using Elastic.Apm.Config;
 using Elastic.Apm.DiagnosticSource;
+using Elastic.Apm.DistributedTracing;
 using Elastic.Apm.Helpers;
 using Elastic.Apm.Logging;
 using Elastic.Apm.Model.Payload;
@@ -64,6 +65,7 @@ namespace Elastic.Apm.DiagnosticListeners
 
 					if (ProcessingRequests.TryAdd(request, span))
 					{
+						request.Headers.Add(TraceParent.TraceParentHeaderName, TraceParent.GetTraceParentVal(span.TraceId, span.Id));
 						span.Context.Http = new Http
 						{
 							Url = request?.RequestUri?.ToString(),

--- a/src/Elastic.Apm/DiagnosticListeners/HttpDiagnosticListener.cs
+++ b/src/Elastic.Apm/DiagnosticListeners/HttpDiagnosticListener.cs
@@ -72,7 +72,7 @@ namespace Elastic.Apm.DiagnosticListeners
 					if (ProcessingRequests.TryAdd(request, span))
 					{
 						if(!request.Headers.Contains(TraceParent.TraceParentHeaderName))
-							request.Headers.Add(TraceParent.TraceParentHeaderName, TraceParent.GetTraceParentVal(span.TraceId, span.Id));
+							request.Headers.Add(TraceParent.TraceParentHeaderName, TraceParent.BuildTraceparent(span.TraceId, span.Id));
 
 						span.Context.Http = new Http
 						{

--- a/src/Elastic.Apm/DiagnosticListeners/HttpDiagnosticListener.cs
+++ b/src/Elastic.Apm/DiagnosticListeners/HttpDiagnosticListener.cs
@@ -55,7 +55,6 @@ namespace Elastic.Apm.DiagnosticListeners
 					var transaction = Agent.TransactionContainer.Transactions?.Value;
 
 					transaction?.CaptureException(exception, "Failed outgoing HTTP request");
-					//!!TODO: We should set the status code here! the span must be updated!
 					//TODO: we don't know if exception is handled, currently reports handled = false
 					break;
 				case "System.Net.Http.HttpRequestOut.Start": //TODO: look for consts

--- a/src/Elastic.Apm/DiagnosticListeners/HttpDiagnosticListener.cs
+++ b/src/Elastic.Apm/DiagnosticListeners/HttpDiagnosticListener.cs
@@ -27,16 +27,16 @@ namespace Elastic.Apm.DiagnosticListeners
 		internal readonly ConcurrentDictionary<HttpRequestMessage, Span> ProcessingRequests = new ConcurrentDictionary<HttpRequestMessage, Span>();
 
 		public HttpDiagnosticListener(IApmAgent components) =>
-			(Logger, ConfigurationReader) = (components.Logger?.Scoped(nameof(HttpDiagnosticListener)), components.ConfigurationReader);
+			(_logger, _configurationReader) = (components.Logger?.Scoped(nameof(HttpDiagnosticListener)), components.ConfigurationReader);
 
-		private ScopedLogger Logger { get; }
-		private IConfigurationReader ConfigurationReader { get; }
+		private readonly ScopedLogger _logger;
+		private readonly IConfigurationReader _configurationReader;
 
 		public string Name => "HttpHandlerDiagnosticListener"; // "HttpHandlerDiagnosticListener" for .NET Core, "System.Net.Http.Desktop" for Full .NET Framework
 
 		public void OnCompleted() { }
 
-		public void OnError(Exception error) => Logger.Error()?.LogExceptionWithCaller(error, nameof(OnError));
+		public void OnError(Exception error) => _logger.Error()?.LogExceptionWithCaller(error, nameof(OnError));
 
 		public void OnNext(KeyValuePair<string, object> kv)
 		{
@@ -49,14 +49,22 @@ namespace Elastic.Apm.DiagnosticListeners
 			switch (kv.Key)
 			{
 				case "System.Net.Http.Exception":
+
+					_logger.Debug()?.Log("System.Net.Http.Exception - {url}", request.RequestUri);
 					var exception = kv.Value.GetType().GetTypeInfo().GetDeclaredProperty("Exception").GetValue(kv.Value) as Exception;
 					var transaction = Agent.TransactionContainer.Transactions?.Value;
 
 					transaction?.CaptureException(exception, "Failed outgoing HTTP request");
+					//!!TODO: We should set the status code here! the span must be updated!
 					//TODO: we don't know if exception is handled, currently reports handled = false
 					break;
 				case "System.Net.Http.HttpRequestOut.Start": //TODO: look for consts
-					if (Agent.TransactionContainer.Transactions == null || Agent.TransactionContainer.Transactions.Value == null) return;
+					_logger.Debug()?.Log("System.Net.Http.Start - {url}", request.RequestUri);
+					if (Agent.TransactionContainer.Transactions == null || Agent.TransactionContainer.Transactions.Value == null)
+					{
+						_logger.Debug()?.Log("No active transaction, skip creating span for outgoing HTTP request");
+						return;
+					}
 
 					transaction = Agent.TransactionContainer.Transactions.Value;
 
@@ -73,12 +81,13 @@ namespace Elastic.Apm.DiagnosticListeners
 						};
 
 						var frames = new StackTrace(true).GetFrames();
-						var stackFrames = StacktraceHelper.GenerateApmStackTrace(frames, Logger, span.Name);
+						var stackFrames = StacktraceHelper.GenerateApmStackTrace(frames, _logger, span.Name);
 						span.StackTrace = stackFrames;
 					}
 					break;
 
 				case "System.Net.Http.HttpRequestOut.Stop":
+					_logger.Debug()?.Log("System.Net.Http.Stop - {url}", request.RequestUri);
 					var response = kv.Value.GetType().GetTypeInfo().GetDeclaredProperty("Response").GetValue(kv.Value) as HttpResponseMessage;
 
 					if (ProcessingRequests.TryRemove(request, out var mspan))
@@ -95,7 +104,7 @@ namespace Elastic.Apm.DiagnosticListeners
 						const string message = "Failed capturing request '{HttpMethod} {Url}' in System.Net.Http.HttpRequestOut.Stop. This Span will be skipped in case it wasn't captured before.";
 						var url = request?.RequestUri?.AbsoluteUri;
 						var method = request?.Method?.Method;
-						Logger?.Warning()?.Log(message, method, url);
+						_logger?.Warning()?.Log(message, method, url);
 					}
 					break;
 			}
@@ -111,7 +120,7 @@ namespace Elastic.Apm.DiagnosticListeners
 			switch (requestUri)
 			{
 				case Uri uri when uri == null: return true;
-				case Uri uri when ConfigurationReader.ServerUrls.Any(n => n.IsBaseOf(uri)): //TODO: measure the perf of this!
+				case Uri uri when _configurationReader.ServerUrls.Any(n => n.IsBaseOf(uri)): //TODO: measure the perf of this!
 					return true;
 				default:
 					return false;

--- a/src/Elastic.Apm/DiagnosticListeners/HttpDiagnosticListener.cs
+++ b/src/Elastic.Apm/DiagnosticListeners/HttpDiagnosticListener.cs
@@ -49,7 +49,6 @@ namespace Elastic.Apm.DiagnosticListeners
 			switch (kv.Key)
 			{
 				case "System.Net.Http.Exception":
-
 					_logger.Debug()?.Log("System.Net.Http.Exception - {url}", request.RequestUri);
 					var exception = kv.Value.GetType().GetTypeInfo().GetDeclaredProperty("Exception").GetValue(kv.Value) as Exception;
 					var transaction = Agent.TransactionContainer.Transactions?.Value;

--- a/src/Elastic.Apm/DistributedTracing/TraceParent.cs
+++ b/src/Elastic.Apm/DistributedTracing/TraceParent.cs
@@ -53,7 +53,7 @@ namespace Elastic.Apm.DistributedTracing
 
 			try
 			{
-				var versionArray = StringTwoCharToByte(traceParentValue);
+				var versionArray = HexStringTwoCharToByte(traceParentValue);
 				if (versionArray == 255)
 					return false;
 
@@ -105,7 +105,7 @@ namespace Elastic.Apm.DistributedTracing
 
 			try
 			{
-				traceFields = StringTwoCharToByte(traceParentValue, VersionAndTraceIdAndSpanIdLength);
+				traceFields = HexStringTwoCharToByte(traceParentValue, VersionAndTraceIdAndSpanIdLength);
 			}
 			catch (ArgumentOutOfRangeException)
 			{
@@ -149,7 +149,7 @@ namespace Elastic.Apm.DistributedTracing
 		/// <param name="src">The string to convert - must be at least 2 char long</param>
 		/// <param name="start">The position of the first character to convert.</param>
 		/// <returns>The byte representation of the string</returns>
-		private static byte StringTwoCharToByte(string src, int start = 0)
+		private static byte HexStringTwoCharToByte(string src, int start = 0)
 		{
 			if (string.IsNullOrWhiteSpace(src) || src.Length <= start + 1)
 				throw new Exception("String is expected to be at least 2 char long");

--- a/src/Elastic.Apm/DistributedTracing/TraceParent.cs
+++ b/src/Elastic.Apm/DistributedTracing/TraceParent.cs
@@ -1,5 +1,6 @@
 using System;
-using Elastic.Apm.Logging;
+using System.Collections.Generic;
+using System.Text;
 
 namespace Elastic.Apm.DistributedTracing
 {
@@ -15,48 +16,184 @@ namespace Elastic.Apm.DistributedTracing
 	/// </summary>
 	internal struct TraceParent
 	{
-		private const int TraceParentLength = 55;
-		private const byte FlagRecorded = 1; // 00000001
+		private const int VersionPrefixIdLength = 3;
+		private const int VersionLength = 2;
+		private const int VersionAndTraceIdLength = 36;
 
+		private const int TraceIdLength = 32;
+		private const int VersionAndTraceIdAndSpanIdLength = 53;
+		private const int SpanIdLength = 16;
+		private const int OptionsLength = 2;
+
+		private const byte FlagRecorded = 1; // 00000001
 		internal const string TraceParentHeaderName = "elastic-apm-traceparent";
 
-		public static bool ValidateTraceParentValue(string traceParentValue, IApmLogger logger)
+		/// <summary>
+		/// Checks if the <paramref name="traceOptions" /> flag contains the <see cref="FlagRecorded" /> flag.
+		/// </summary>
+		/// <param name="traceOptions">The traceOptions flags return from <see cref="TryExtractTraceparent" />.</param>
+		/// <returns>true if <paramref name="traceOptions" /> contains <see cref="FlagRecorded" />, false otherwise.</returns>
+		public static bool IsFlagRecordedActive(byte[] traceOptions) => (traceOptions[0] & FlagRecorded) == FlagRecorded;
+
+		/// <summary>
+		/// Parses the traceparent header
+		/// </summary>
+		/// <param name="traceParentValue">The value of the traceparent header</param>
+		/// <param name="traceId">The parsed traceId</param>
+		/// <param name="prentId">The parsed parentId</param>
+		/// <param name="traceOptions">The parsed traceOptions flags</param>
+		/// <returns>True if parsing was successful, false otherwise.</returns>
+		internal static bool TryExtractTraceparent(string traceParentValue, out string traceId, out string prentId, out byte[] traceOptions)
 		{
-			if (traceParentValue.Length != 55)
+			traceId = string.Empty;
+			prentId = string.Empty;
+			traceOptions = null;
+
+			var bestAttempt = false;
+
+			if (string.IsNullOrWhiteSpace(traceParentValue)) return false;
+
+			if (traceParentValue.Length < VersionPrefixIdLength || traceParentValue[VersionPrefixIdLength - 1] != '-') return false;
+
+			try
 			{
-				logger.Warning()
-					?.Log("Traceparent contains invalid length, expected: {ExpectedTraceParentLength}, got: {GotLength}", TraceParentLength,
-						traceParentValue.Length);
+				var versionArray = StringToByteArray(traceParentValue, 0, VersionLength);
+				if (versionArray[0] == 255)
+					return false;
+
+				if (versionArray[0] > 0)
+					// expected version is 00
+					// for higher versions - best attempt parsing of trace id, span id, etc.
+					bestAttempt = true;
+			}
+			catch
+			{
 				return false;
 			}
 
-			if (!traceParentValue.StartsWith("00-"))
+			if (traceParentValue.Length < VersionAndTraceIdLength || traceParentValue[VersionAndTraceIdLength - 1] != '-') return false;
+
+			try
 			{
-				logger.Warning()
-					?.Log("Only version 00 of the traceparent header is supported, but was {GotVersion}", traceParentValue.Substring(0, 3));
+				//parse value to byte array and back to string:
+				//TODO: probably we should just validate the chars
+				var traceIdVal = ByteArrayToString(StringToByteArray(traceParentValue, VersionPrefixIdLength, TraceIdLength));
+
+				if (traceIdVal == "00000000000000000000000000000000")
+					return false;
+
+				traceId = traceIdVal;
+			}
+			catch (ArgumentOutOfRangeException)
+			{
 				return false;
 			}
 
-			// ReSharper disable once InvertIf
-			if (traceParentValue[35] != '-' || traceParentValue[52] != '-')
+			if (traceParentValue.Length < VersionAndTraceIdAndSpanIdLength
+				|| traceParentValue[VersionAndTraceIdAndSpanIdLength - 1] != '-') return false;
+
+			try
 			{
-				logger.Warning()?.Log("Invalid traceparent format, got: {TraceParentValue}", traceParentValue);
+				//parse value to byte array and back to string:
+				//TODO: probably we should just validate the chars
+				var prentIdVal = ByteArrayToString(StringToByteArray(traceParentValue, VersionAndTraceIdLength, SpanIdLength));
+
+				if (prentIdVal == "0000000000000000")
+					return false;
+
+				prentId = prentIdVal;
+			}
+			catch (ArgumentOutOfRangeException)
+			{
 				return false;
+			}
+
+			if (traceParentValue.Length < VersionAndTraceIdAndSpanIdLength + OptionsLength) return false;
+
+			try
+			{
+				traceOptions = StringToByteArray(traceParentValue, VersionAndTraceIdAndSpanIdLength, OptionsLength);
+			}
+			catch (ArgumentOutOfRangeException)
+			{
+				return false;
+			}
+
+			if (!bestAttempt && traceParentValue.Length != VersionAndTraceIdAndSpanIdLength + OptionsLength) return false;
+
+			// ReSharper disable once InvertIf - imo that would make it hard to read.
+			if (bestAttempt)
+			{
+				if (traceParentValue.Length > VersionAndTraceIdAndSpanIdLength + OptionsLength &&
+					traceParentValue[VersionAndTraceIdAndSpanIdLength + OptionsLength] != '-')
+					return false;
 			}
 
 			return true;
 		}
 
+		private static string ByteArrayToString(IEnumerable<byte> bytes)
+		{
+			var sb = new StringBuilder();
+			foreach (var t in bytes) sb.Append(ByteToHexCharArray(t));
+
+			return sb.ToString();
+
+			char[] ByteToHexCharArray(byte b)
+			{
+				var result = new char[2];
+
+				result[0] = (char)ByteToHexLookupTable[b];
+				result[1] = (char)(ByteToHexLookupTable[b] >> 16);
+
+				return result;
+			}
+		}
+
+		private static readonly uint[] ByteToHexLookupTable = CreateLookupTable();
+
+		// https://stackoverflow.com/a/24343727
+		private static uint[] CreateLookupTable()
+		{
+			var table = new uint[256];
+			for (var i = 0; i < 256; i++)
+			{
+				var s = i.ToString("x2");
+				table[i] = s[0];
+				table[i] += (uint)s[1] << 16;
+			}
+
+			return table;
+		}
+
 		public static string GetTraceParentVal(string traceId, string spanId)
 			=> $"00-{traceId}-{spanId}-01";
 
-		public static (string parent, string traceId, bool isRecordedFalgActive) ParseTraceParentString(string traceParent)
+		private static byte[] StringToByteArray(string src, int start = 0, int len = -1)
 		{
-			var traceParentByte = traceParent.Substring(3, 32);
-			var parentId = traceParent.Substring(36, 16);
-			var isRecordedFlagActive = (Convert.ToByte(traceParent.Substring(53, 2)) & FlagRecorded) == FlagRecorded;
+			if (len == -1) len = src.Length;
 
-			return (traceParentByte, parentId, isRecordedFlagActive);
+			var size = len / 2;
+			var bytes = new byte[size];
+			for (int i = 0, j = start; i < size; i++)
+			{
+				var high = HexCharToInt(src[j++]);
+				var low = HexCharToInt(src[j++]);
+				bytes[i] = (byte)((high << 4) | low);
+			}
+
+			return bytes;
+
+			int HexCharToInt(char c)
+			{
+				if (c >= '0' && c <= '9') return c - '0';
+
+				if (c >= 'a' && c <= 'f') return c - 'a' + 10;
+
+				if (c >= 'A' && c <= 'F') return c - 'A' + 10;
+
+				throw new ArgumentOutOfRangeException("Invalid character: " + c);
+			}
 		}
 	}
 }

--- a/src/Elastic.Apm/DistributedTracing/TraceParent.cs
+++ b/src/Elastic.Apm/DistributedTracing/TraceParent.cs
@@ -74,7 +74,7 @@ namespace Elastic.Apm.DistributedTracing
 			{
 				var traceIdVal =
 					traceParentValue.Substring(VersionPrefixIdLength,
-						TraceIdLength); // ByteArrayToString(StringToByteArray(traceParentValue, VersionPrefixIdLength, TraceIdLength));
+						TraceIdLength);
 
 				if (!IsHex(traceIdVal) || traceIdVal == "00000000000000000000000000000000")
 					return false;

--- a/src/Elastic.Apm/DistributedTracing/TraceParent.cs
+++ b/src/Elastic.Apm/DistributedTracing/TraceParent.cs
@@ -2,15 +2,42 @@ using System;
 
 namespace Elastic.Apm.DistributedTracing
 {
+	//00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01
+
+
+	/// <summary>
+	/// This is an implementation of the "https://w3c.github.io/distributed-tracing/report-trace-context.html#traceparent-field" w3c traceparent header draft.
+	/// traceparent: 00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01
+	/// (_________)  () (______________________________) (______________) ()
+	///      v       v                 v                        v         v
+	/// Header name  Version        Trace-Id                Span-Id     Flags
+	/// </summary>
 	internal struct TraceParent
 	{
 		public byte[] TraceFlag { get; set; }
 
 		public static string GetTraceParentVal(string traceId, string spanId)
-		=> $"00-{traceId}-{spanId}-01";
+			=> $"00-{traceId}-{spanId}-01";
+
+		public static (string parent, string traceId) ParseTraceParentString(string traceParent)
+		{
+			var traceParentByte = traceParent.Substring(3, 32);
+			var parentId = traceParent.Substring(36, 16);
+
+			return (traceParentByte, parentId);
+		}
 
 
 		internal const string TraceParentHeaderName = "traceparent";
+
+		private static byte[] StringToByteArray(string hex)
+		{
+			var NumberChars = hex.Length;
+			var bytes = new byte[NumberChars / 2];
+			for (var i = 0; i < NumberChars; i += 2)
+				bytes[i / 2] = Convert.ToByte(hex.Substring(i, 2), 16);
+			return bytes;
+		}
 	}
 
 	internal static class Consts

--- a/src/Elastic.Apm/DistributedTracing/TraceParent.cs
+++ b/src/Elastic.Apm/DistributedTracing/TraceParent.cs
@@ -1,0 +1,20 @@
+using System;
+
+namespace Elastic.Apm.DistributedTracing
+{
+	internal struct TraceParent
+	{
+		public byte[] TraceFlag { get; set; }
+
+		public static string GetTraceParentVal(string traceId, string spanId)
+		=> $"00-{traceId}-{spanId}-01";
+
+
+		internal const string TraceParentHeaderName = "traceparent";
+	}
+
+	internal static class Consts
+	{
+		private static byte Version0 = 00000000;
+	}
+}

--- a/src/Elastic.Apm/DistributedTracing/TraceParent.cs
+++ b/src/Elastic.Apm/DistributedTracing/TraceParent.cs
@@ -14,7 +14,7 @@ namespace Elastic.Apm.DistributedTracing
 	/// Since the w3c document is just a draft at the moment,
 	/// we don't use the official header name but prepend the custom prefix "Elastic-Apm-".
 	/// </summary>
-	internal struct TraceParent
+	internal static class TraceParent
 	{
 		private const int VersionPrefixIdLength = 3;
 		private const int VersionLength = 2;

--- a/src/Elastic.Apm/Helpers/RandomGenerator.cs
+++ b/src/Elastic.Apm/Helpers/RandomGenerator.cs
@@ -29,7 +29,7 @@ namespace Elastic.Apm.Helpers
 		public static string GetRandomBytesAsString(byte[] bytes)
 		{
 			GetRandomBytes(bytes);
-			return BitConverter.ToString(bytes).Replace("-", "");
+			return BitConverter.ToString(bytes).Replace("-", "").ToLower();
 		}
 	}
 }

--- a/src/Elastic.Apm/Model/Payload/Transaction.cs
+++ b/src/Elastic.Apm/Model/Payload/Transaction.cs
@@ -34,7 +34,7 @@ namespace Elastic.Apm.Model.Payload
 			var idBytes = new byte[8];
 			Id = RandomGenerator.GetRandomBytesAsString(idBytes);
 
-			if (traceId == null)
+			if (string.IsNullOrEmpty(traceId))
 			{
 				idBytes = new byte[16];
 				TraceId = RandomGenerator.GetRandomBytesAsString(idBytes);

--- a/test/Elastic.Apm.AspNetCore.Tests/DistributedTracingAspNetCoreTests.cs
+++ b/test/Elastic.Apm.AspNetCore.Tests/DistributedTracingAspNetCoreTests.cs
@@ -1,10 +1,8 @@
-using System;
 using System.Net.Http;
 using System.Reflection;
 using System.Threading.Tasks;
 using Elastic.Apm.DiagnosticSource;
 using Elastic.Apm.EntityFrameworkCore;
-using Elastic.Apm.Logging;
 using Elastic.Apm.Tests.Mocks;
 using FluentAssertions;
 using Microsoft.AspNetCore.Hosting;
@@ -28,12 +26,10 @@ namespace Elastic.Apm.AspNetCore.Tests
 	{
 		private readonly MockPayloadSender _payloadSender1 = new MockPayloadSender();
 		private readonly MockPayloadSender _payloadSender2 = new MockPayloadSender();
-		private readonly Task _task1;
-		private readonly Task _task2;
 
 		public DistributedTracingAspNetCoreTests()
 		{
-			_task1 = SampleAspNetCoreApp.Program.CreateWebHostBuilder(null)
+			var unused = SampleAspNetCoreApp.Program.CreateWebHostBuilder(null)
 				.ConfigureServices(services =>
 					{
 						var connection = @"Data Source=blogging.db";
@@ -53,7 +49,7 @@ namespace Elastic.Apm.AspNetCore.Tests
 				.Build()
 				.RunAsync();
 
-			_task2 = WebApiSample.Program.CreateWebHostBuilder(null)
+			var unused1 = WebApiSample.Program.CreateWebHostBuilder(null)
 				.ConfigureServices(services =>
 				{
 					services.AddMvc()

--- a/test/Elastic.Apm.AspNetCore.Tests/DistributedTracingAspNetCoreTests.cs
+++ b/test/Elastic.Apm.AspNetCore.Tests/DistributedTracingAspNetCoreTests.cs
@@ -60,8 +60,10 @@ namespace Elastic.Apm.AspNetCore.Tests
 				})
 				.Configure(app =>
 				{
-					app.UseElasticApm(new ApmAgent(new TestAgentComponents(payloadSender: _payloadSender2)), new TestLogger(),
-						new HttpDiagnosticsSubscriber(), new EfCoreDiagnosticsSubscriber());
+					//normally we would also subscribe to HttpDiagnosticsSubscriber and EfCoreDiagnosticsSubscriber,
+					//but in this test 2 web apps run in a single process, so subscribing once is enough, and we
+					//already do it above when we configure the SampleAspNetCoreApp.
+					app.UseElasticApm(new ApmAgent(new TestAgentComponents(payloadSender: _payloadSender2)), new TestLogger());
 					WebApiSample.Startup.ConfigureAllExceptAgent(app);
 				})
 				.UseUrls("http://localhost:5050")

--- a/test/Elastic.Apm.AspNetCore.Tests/DistributedTracingAspNetCoreTests.cs
+++ b/test/Elastic.Apm.AspNetCore.Tests/DistributedTracingAspNetCoreTests.cs
@@ -1,0 +1,88 @@
+using System;
+using System.Net.Http;
+using System.Reflection;
+using System.Threading.Tasks;
+using Elastic.Apm.DiagnosticSource;
+using Elastic.Apm.EntityFrameworkCore;
+using Elastic.Apm.Logging;
+using Elastic.Apm.Tests.Mocks;
+using FluentAssertions;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using SampleAspNetCoreApp.Data;
+using Xunit;
+
+namespace Elastic.Apm.AspNetCore.Tests
+{
+	/// <summary>
+	/// Distributed tracing integration test.
+	/// It starts <see cref="SampleAspNetCoreApp"/> with 1 agent and <see cref="WebApiSample"/> with another agent.
+	/// It calls the 'DistributedTracingMiniSample' in <see cref="SampleAspNetCoreApp"/>, which generates a simple HTTP response
+	/// by calling <see cref="WebApiSample"/> via HTTP.
+	/// Makes sure that all spans and transactions across the 2 services have the same trace id.
+	/// </summary>
+	[Collection("DiagnosticListenerTest")]
+	public class DistributedTracingAspNetCoreTests
+	{
+		private readonly MockPayloadSender _payloadSender1 = new MockPayloadSender();
+		private readonly MockPayloadSender _payloadSender2 = new MockPayloadSender();
+		private readonly Task _task1;
+		private readonly Task _task2;
+
+		public DistributedTracingAspNetCoreTests()
+		{
+			_task1 = SampleAspNetCoreApp.Program.CreateWebHostBuilder(null)
+				.ConfigureServices(services =>
+					{
+						var connection = @"Data Source=blogging.db";
+						services.AddDbContext<SampleDataContext>
+							(options => options.UseSqlite(connection));
+						services.AddMvc()
+							.AddApplicationPart(Assembly.Load(new AssemblyName(nameof(SampleAspNetCoreApp))))
+							.SetCompatibilityVersion(CompatibilityVersion.Version_2_1);
+					}
+				)
+				.Configure(app =>
+				{
+					app.UseElasticApm(new ApmAgent(new TestAgentComponents(payloadSender: _payloadSender1)), new TestLogger(), new HttpDiagnosticsSubscriber(), new EfCoreDiagnosticsSubscriber());
+					SampleAspNetCoreApp.Startup.ConfigureAllExceptAgent(app);
+				})
+				.UseUrls("http://localhost:5900")
+				.Build()
+				.RunAsync();
+
+			_task2 = WebApiSample.Program.CreateWebHostBuilder(null)
+				.ConfigureServices(services =>
+				{
+					services.AddMvc()
+						.AddApplicationPart(Assembly.Load(new AssemblyName(nameof(WebApiSample))))
+						.SetCompatibilityVersion(CompatibilityVersion.Version_2_1);
+				})
+				.Configure(app =>
+				{
+					app.UseElasticApm(new ApmAgent(new TestAgentComponents(payloadSender: _payloadSender2)), new TestLogger(), new HttpDiagnosticsSubscriber(), new EfCoreDiagnosticsSubscriber());
+					WebApiSample.Startup.ConfigureAllExceptAgent(app);
+				})
+				.UseUrls("http://localhost:5050")
+				.Build()
+				.RunAsync();
+		}
+
+		[Fact]
+		public async Task DistributedTraceAcross2Service()
+		{
+			var client = new HttpClient();
+			var res = await client.GetAsync("http://localhost:5900/Home/DistributedTracingMiniSample");
+			res.IsSuccessStatusCode.Should().BeTrue();
+
+			//make sure the 2 transactions have the same traceid:
+			_payloadSender2.FirstTransaction.TraceId.Should().Be(_payloadSender1.FirstTransaction.TraceId);
+
+			//make sure all spans have the same traceid:
+			_payloadSender1.Spans.Should().NotContain(n => n.TraceId != _payloadSender1.FirstTransaction.TraceId);
+			_payloadSender2.Spans.Should().NotContain(n => n.TraceId != _payloadSender1.FirstTransaction.TraceId);
+		}
+	}
+}

--- a/test/Elastic.Apm.AspNetCore.Tests/Elastic.Apm.AspNetCore.Tests.csproj
+++ b/test/Elastic.Apm.AspNetCore.Tests/Elastic.Apm.AspNetCore.Tests.csproj
@@ -19,6 +19,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="2.1.0" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\..\sample\WebApiSample\WebApiSample.csproj" />
     <ProjectReference Include="..\..\src\Elastic.Apm.AspNetCore\Elastic.Apm.AspNetCore.csproj" />
     <ProjectReference Include="..\..\src\Elastic.Apm\Elastic.Apm.csproj" />
     <ProjectReference Include="..\..\sample\SampleAspNetCoreApp\SampleAspNetCoreApp.csproj" />

--- a/test/Elastic.Apm.AspNetCore.Tests/Helper.cs
+++ b/test/Elastic.Apm.AspNetCore.Tests/Helper.cs
@@ -76,7 +76,7 @@ namespace Elastic.Apm.AspNetCore.Tests
 				{
 					n.Configure(app =>
 					{
-						app.UseMiddleware<ApmMiddleware>(agent.Tracer, agent.ConfigurationReader, agent.Logger);
+						app.UseMiddleware<ApmMiddleware>(agent.Tracer, agent);
 
 						app.UseDeveloperExceptionPage();
 

--- a/test/Elastic.Apm.AspNetCore.Tests/Helper.cs
+++ b/test/Elastic.Apm.AspNetCore.Tests/Helper.cs
@@ -27,7 +27,7 @@ namespace Elastic.Apm.AspNetCore.Tests
 				{
 					n.Configure(app =>
 					{
-						app.UseElasticApm(agent, new HttpDiagnosticsSubscriber(), new EfCoreDiagnosticsSubscriber());
+						app.UseElasticApm(agent,  agent.Logger, new HttpDiagnosticsSubscriber(), new EfCoreDiagnosticsSubscriber());
 
 						app.UseDeveloperExceptionPage();
 
@@ -55,7 +55,7 @@ namespace Elastic.Apm.AspNetCore.Tests
 				{
 					n.Configure(app =>
 					{
-						app.UseElasticApm(agent);
+						app.UseElasticApm(agent, agent.Logger);
 
 						app.UseMvc(routes =>
 						{
@@ -77,7 +77,7 @@ namespace Elastic.Apm.AspNetCore.Tests
 				{
 					n.Configure(app =>
 					{
-						app.UseMiddleware<ApmMiddleware>(agent.Tracer, agent.ConfigurationReader);
+						app.UseMiddleware<ApmMiddleware>(agent.Tracer, agent.ConfigurationReader, agent.Logger);
 
 						app.UseDeveloperExceptionPage();
 

--- a/test/Elastic.Apm.AspNetCore.Tests/Helper.cs
+++ b/test/Elastic.Apm.AspNetCore.Tests/Helper.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Net.Http;
+﻿using System.Net.Http;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using Elastic.Apm.DiagnosticSource;

--- a/test/Elastic.Apm.AspNetCore.Tests/MicrosoftExtensionsConfigTests.cs
+++ b/test/Elastic.Apm.AspNetCore.Tests/MicrosoftExtensionsConfigTests.cs
@@ -97,8 +97,7 @@ namespace Elastic.Apm.AspNetCore.Tests
 			Environment.SetEnvironmentVariable(ConfigConsts.ConfigKeys.ServiceName, serviceName);
 			var secretToken = "SecretToken";
 			Environment.SetEnvironmentVariable(ConfigConsts.ConfigKeys.SecretToken, secretToken);
-			var captureHeaders = false;
-			Environment.SetEnvironmentVariable(ConfigConsts.ConfigKeys.CaptureHeaders, captureHeaders.ToString());
+			Environment.SetEnvironmentVariable(ConfigConsts.ConfigKeys.CaptureHeaders, false.ToString());
 			var configBuilder = new ConfigurationBuilder()
 				.AddEnvironmentVariables()
 				.Build();
@@ -108,7 +107,7 @@ namespace Elastic.Apm.AspNetCore.Tests
 			config.ServerUrls[0].Should().Be(new Uri(serverUrl));
 			config.ServiceName.Should().Be(serviceName);
 			config.SecretToken.Should().Be(secretToken);
-			config.CaptureHeaders.Should().Be(captureHeaders);
+			config.CaptureHeaders.Should().Be(false);
 		}
 
 		/// <summary>
@@ -142,7 +141,7 @@ namespace Elastic.Apm.AspNetCore.Tests
 		{
 			_factory = factory;
 			_logger = new TestLogger();
-			_capturedPayload = new MockPayloadSender();
+			var capturedPayload = new MockPayloadSender();
 
 			//The agent is instantiated with ApmMiddlewareExtension.GetService, so we can also test the calculation of the service instance.
 			//(e.g. ASP.NET Core version)
@@ -151,12 +150,11 @@ namespace Elastic.Apm.AspNetCore.Tests
 				MicrosoftExtensionsConfigTests.GetConfig($"TestConfigs{Path.DirectorySeparatorChar}appsettings_invalid.json"), _logger);
 
 			_agent = new ApmAgent(
-				new AgentComponents(payloadSender: _capturedPayload, configurationReader: config, logger: _logger));
+				new AgentComponents(payloadSender: capturedPayload, configurationReader: config, logger: _logger));
 			_client = Helper.GetClient(_agent, _factory);
 		}
 
 		private readonly ApmAgent _agent;
-		private readonly MockPayloadSender _capturedPayload;
 		private readonly HttpClient _client;
 		private readonly WebApplicationFactory<Startup> _factory;
 		private readonly TestLogger _logger;

--- a/test/Elastic.Apm.PerfTests/Program.cs
+++ b/test/Elastic.Apm.PerfTests/Program.cs
@@ -1,5 +1,7 @@
-﻿using BenchmarkDotNet.Attributes;
+﻿using System.Diagnostics;
+using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Running;
+using Elastic.Apm.DistributedTracing;
 using Elastic.Apm.Logging;
 using Elastic.Apm.Tests.Mocks;
 
@@ -48,6 +50,15 @@ namespace Elastic.Apm.PerfTests
 					}
 				});
 			}
+		}
+
+		[Benchmark]
+		public void ParseTraceparentHeader()
+		{
+			const string traceParent = "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01";
+
+			var res = TraceParent.TryExtractTraceparent(traceParent, out var traceId, out var parentId, out var traceOptions);
+			Debug.WriteLine($"{res}, {traceId}, {parentId}, {traceOptions}");
 		}
 	}
 }

--- a/test/Elastic.Apm.Tests/DistributedTracingTests.cs
+++ b/test/Elastic.Apm.Tests/DistributedTracingTests.cs
@@ -11,14 +11,27 @@ namespace Elastic.Apm.Tests
 	{
 
 		[Fact]
-		public void ParseValidTraceParent()
+		public void ParseValidTraceParentRecorded()
 		{
 			const string traceParent = "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01";
 
-			var(parent, traceId) = TraceParent.ParseTraceParentString(traceParent);
+			var(parent, traceId, isRecorded) = TraceParent.ParseTraceParentString(traceParent);
 
 			parent.Should().Be("0af7651916cd43dd8448eb211c80319c");
 			traceId.Should().Be("b7ad6b7169203331");
+			isRecorded.Should().BeTrue();
+		}
+
+		[Fact]
+		public void ParseValidTraceParentNotRecorded()
+		{
+			const string traceParent = "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-00";
+
+			var(parent, traceId, isRecorded) = TraceParent.ParseTraceParentString(traceParent);
+
+			parent.Should().Be("0af7651916cd43dd8448eb211c80319c");
+			traceId.Should().Be("b7ad6b7169203331");
+			isRecorded.Should().BeFalse();
 		}
 
 		[Fact]

--- a/test/Elastic.Apm.Tests/DistributedTracingTests.cs
+++ b/test/Elastic.Apm.Tests/DistributedTracingTests.cs
@@ -16,6 +16,11 @@ namespace Elastic.Apm.Tests
 			traceId.Should().Be("0af7651916cd43dd8448eb211c80319c");
 			parentId.Should().Be("b7ad6b7169203331");
 			TraceParent.IsFlagRecordedActive(traceOptions).Should().BeTrue();
+
+			//try also with flag options C6
+			const string traceParent2 = "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-E7";
+			TraceParent.TryExtractTraceparent(traceParent2, out _, out _, out var traceOptions2);
+			TraceParent.IsFlagRecordedActive(traceOptions2).Should().BeTrue();
 		}
 
 		[Fact]
@@ -28,6 +33,12 @@ namespace Elastic.Apm.Tests
 			traceId.Should().Be("0af7651916cd43dd8448eb211c80319c");
 			parentId.Should().Be("b7ad6b7169203331");
 			TraceParent.IsFlagRecordedActive(traceOptions).Should().BeFalse();
+
+
+			//try also with flag options C6
+			const string traceParent2 = "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-C6";
+			TraceParent.TryExtractTraceparent(traceParent2, out _, out _, out var traceOptions2);
+			TraceParent.IsFlagRecordedActive(traceOptions2).Should().BeFalse();
 		}
 
 		[Fact]

--- a/test/Elastic.Apm.Tests/DistributedTracingTests.cs
+++ b/test/Elastic.Apm.Tests/DistributedTracingTests.cs
@@ -1,0 +1,21 @@
+using Elastic.Apm.DistributedTracing;
+using FluentAssertions;
+using Xunit;
+
+namespace Elastic.Apm.Tests
+{
+	public class DistributedTracingTests
+	{
+
+		[Fact]
+		public void ParseTraceParent()
+		{
+			var traceParent = "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01";
+
+			var(parent, traceId) = TraceParent.ParseTraceParentString(traceParent);
+
+			parent.Should().Be("0af7651916cd43dd8448eb211c80319c");
+			traceId.Should().Be("b7ad6b7169203331");
+		}
+	}
+}

--- a/test/Elastic.Apm.Tests/DistributedTracingTests.cs
+++ b/test/Elastic.Apm.Tests/DistributedTracingTests.cs
@@ -1,4 +1,7 @@
+using System.Linq;
 using Elastic.Apm.DistributedTracing;
+using Elastic.Apm.Logging;
+using Elastic.Apm.Tests.Mocks;
 using FluentAssertions;
 using Xunit;
 
@@ -8,14 +11,57 @@ namespace Elastic.Apm.Tests
 	{
 
 		[Fact]
-		public void ParseTraceParent()
+		public void ParseValidTraceParent()
 		{
-			var traceParent = "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01";
+			const string traceParent = "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01";
 
 			var(parent, traceId) = TraceParent.ParseTraceParentString(traceParent);
 
 			parent.Should().Be("0af7651916cd43dd8448eb211c80319c");
 			traceId.Should().Be("b7ad6b7169203331");
+		}
+
+		[Fact]
+		public void ValidateValidTraceParent()
+		{
+			const string traceParent = "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01";
+
+			var testLogger = new TestLogger();
+			var isValid = TraceParent.ValidateTraceParentValue(traceParent, testLogger);
+			isValid.Should().BeTrue();
+		}
+
+		[Fact]
+		public void ValidateTraceParentWithInvalidVersion()
+		{
+			const string traceParent = "99-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01";
+
+			var testLogger = new TestLogger(LogLevel.Warning);
+			var isValid = TraceParent.ValidateTraceParentValue(traceParent, testLogger);
+			isValid.Should().BeFalse();
+			testLogger.Lines.First().Should().Contain("Only version 00 of the traceparent header is supported, but was 99-");
+		}
+
+		[Fact]
+		public void ValidateTraceParentWithInvalidLength()
+		{
+			const string traceParent = "99-af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01"; //TraceId is 1 char shorter than expected
+
+			var testLogger = new TestLogger(LogLevel.Warning);
+			var isValid = TraceParent.ValidateTraceParentValue(traceParent, testLogger);
+			isValid.Should().BeFalse();
+			testLogger.Lines.First().Should().Contain("Traceparent contains invalid length, expected: 55, got: 54");
+		}
+
+		[Fact]
+		public void ValidateTraceParentWithInvalidTraceIdLength()
+		{
+			const string traceParent = "00-0af7651916cd43dd8448eb211c80319ca-7ad6b7169203331-01"; //TraceId is 1 char longer than expected, and parentId is 1 char longer
+
+			var testLogger = new TestLogger(LogLevel.Warning);
+			var isValid = TraceParent.ValidateTraceParentValue(traceParent, testLogger);
+			isValid.Should().BeFalse();
+			testLogger.Lines.First().Should().Contain("Invalid traceparent format, got: 00-0af7651916cd43dd8448eb211c80319ca-7ad6b7169203331-01");
 		}
 	}
 }

--- a/test/Elastic.Apm.Tests/DistributedTracingTests.cs
+++ b/test/Elastic.Apm.Tests/DistributedTracingTests.cs
@@ -48,10 +48,10 @@ namespace Elastic.Apm.Tests
 
 			//Best attempt, even if it's a future version we still try to read the traceId and parentId
 			var res = TraceParent.TryExtractTraceparent(traceParent, out var traceId, out var parentId, out var traceOptions);
+			res.Should().BeTrue();
 			traceId.Should().Be("0af7651916cd43dd8448eb211c80319c");
 			parentId.Should().Be("b7ad6b7169203331");
 			TraceParent.IsFlagRecordedActive(traceOptions).Should().BeTrue();
-			res.Should().BeTrue();
 		}
 
 		[Fact]


### PR DESCRIPTION
- Implements [traceparent](https://www.w3.org/TR/trace-context/#traceparent-field) from the [Trace Context draft](https://www.w3.org/TR/trace-context/)
- Two differences to the draft:
   - The name of the `traceparent` header is `elastic-apm-traceparent` and not `traceparent`. This is what other agents do. Reason: the w3c document is a draft, and it can change. To avoid breaking changes and unwanted behaviour we go with a different header name. Once the draft becomes a standard we can rename the header. 
   - We don't implement the `tracestate` header yet.
- Adds a WebApi sample, which is called from the `SampleAspNetCoreApp` via Http.
- Includes integration test based on the 2 sample apps.
