### PR TITLE
ASP.NET Core - create transaction name based on route and group by optional values

### DIFF
--- a/sample/SampleAspNetCoreApp/Controllers/HomeController.cs
+++ b/sample/SampleAspNetCoreApp/Controllers/HomeController.cs
@@ -113,6 +113,10 @@ namespace SampleAspNetCoreApp.Controllers
 			throw new Exception("This is a test exception!");
 		}
 
+		public IActionResult Sample(int id)
+		{
+			return Ok(id);
+		}
 
 		[ResponseCache(Duration = 0, Location = ResponseCacheLocation.None, NoStore = true)]
 		public IActionResult Error() => View(new ErrorViewModel { RequestId = Activity.Current?.Id ?? HttpContext.TraceIdentifier });

--- a/sample/SampleAspNetCoreApp/Controllers/HomeController.cs
+++ b/sample/SampleAspNetCoreApp/Controllers/HomeController.cs
@@ -113,6 +113,7 @@ namespace SampleAspNetCoreApp.Controllers
 			throw new Exception("This is a test exception!");
 		}
 
+		//Used as test for optional route parameters
 		public IActionResult Sample(int id)
 		{
 			return Ok(id);

--- a/sample/WebApiSample/Controllers/ValuesController.cs
+++ b/sample/WebApiSample/Controllers/ValuesController.cs
@@ -27,5 +27,12 @@ namespace WebApiSample.Controllers
 
 			return new[] { "value1", "value2", lastValue };
 		}
+
+		// GET api/values/5
+		[HttpGet("{id}")]
+		public ActionResult<string> Get(int id)
+		{
+			return "value" + id;
+		}
 	}
 }

--- a/src/Elastic.Apm.AspNetCore/ApmMiddleware.cs
+++ b/src/Elastic.Apm.AspNetCore/ApmMiddleware.cs
@@ -11,6 +11,7 @@ using Elastic.Apm.Helpers;
 using Elastic.Apm.Logging;
 using Elastic.Apm.Model.Payload;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
 
 [assembly:
 	InternalsVisibleTo(
@@ -109,6 +110,24 @@ namespace Elastic.Apm.AspNetCore
 			catch (Exception e) when (ExceptionFilter.Capture(e, transaction)) { }
 			finally
 			{
+				var routeData = (context.Features[typeof(IRoutingFeature)] as IRoutingFeature)?.RouteData;
+				if (routeData != null)
+				{
+					//WIP!!
+					if (routeData.Values.Count >= 3)
+					{
+						try
+						{
+							transaction.Name =
+								$"{context.Request.Method} {routeData.Values["controller"]}/{routeData.Values["action"]}/{{id}}";
+						}
+						catch
+						{
+							_logger.Debug()?.Log("failed calculating transaction name based on route values");
+						}
+					}
+				}
+
 				Dictionary<string, string> responseHeaders = null;
 
 				if (_configurationReader.CaptureHeaders)

--- a/src/Elastic.Apm.AspNetCore/Elastic.Apm.AspNetCore.csproj
+++ b/src/Elastic.Apm.AspNetCore/Elastic.Apm.AspNetCore.csproj
@@ -27,6 +27,7 @@
     <!-- We should probably lower the version number -->
     <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="2.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Routing.Abstractions" Version="2.0.0" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Config\" />

--- a/test/Elastic.Apm.AspNetCore.Tests/AspNetCoreMiddlewareTests.cs
+++ b/test/Elastic.Apm.AspNetCore.Tests/AspNetCoreMiddlewareTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using System.Net.Http;
 using System.Reflection;
 using System.Threading.Tasks;
@@ -66,7 +67,7 @@ namespace Elastic.Apm.AspNetCore.Tests
 
 			_capturedPayload.Transactions.Should().ContainSingle();
 			var transaction = _capturedPayload.FirstTransaction;
-			var transactionName = $"{response.RequestMessage.Method} {response.RequestMessage.RequestUri.AbsolutePath}";
+			var transactionName = $"{response.RequestMessage.Method} Home/SimplePage";
 			transaction.Name.Should().Be(transactionName);
 			transaction.Result.Should().Be("HTTP 2xx");
 			transaction.Duration.Should().BeGreaterThan(0);

--- a/test/Elastic.Apm.AspNetCore.Tests/TransactionNameTests.cs
+++ b/test/Elastic.Apm.AspNetCore.Tests/TransactionNameTests.cs
@@ -1,0 +1,77 @@
+using System;
+using System.Threading.Tasks;
+using Elastic.Apm.Tests.Mocks;
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc.Testing;
+using SampleAspNetCoreApp;
+using Xunit;
+
+namespace Elastic.Apm.AspNetCore.Tests
+{
+	/// <summary>
+	/// Tests the transaction name in ASP.NET Core.
+	/// Specifically: optional parameters in the route should be templateed in the Transaction.Name.
+	/// E.g. url localhost/user/info/1 should get have Transaction.Name GET user/info {id}
+	/// </summary>
+	[Collection("DiagnosticListenerTest")]
+	public class TransactionNameTests : IClassFixture<WebApplicationFactory<Startup>>, IDisposable
+	{
+		private readonly ApmAgent _agent;
+		private readonly WebApplicationFactory<Startup> _factory;
+		private readonly MockPayloadSender _payloadSender = new MockPayloadSender();
+
+		public TransactionNameTests(WebApplicationFactory<Startup> factory)
+		{
+			_factory = factory;
+			_agent = new ApmAgent(new TestAgentComponents(payloadSender: _payloadSender));
+			ApmMiddlewareExtension.UpdateServiceInformation(_agent.Service);
+		}
+
+		/// <summary>
+		/// Calls a URL that maps to a route with optional parameter (id).
+		/// Makes sure the Transaction.Name contains "{id}" instead of the value.
+		/// </summary>
+		[Fact]
+		public async Task OptionalRouteParameter()
+		{
+			var httpClient = Helper.GetClient(_agent, _factory);
+			await httpClient.GetAsync("home/sample/3");
+			await httpClient.GetAsync("home/sample/2");
+
+			_payloadSender.Transactions.Should().OnlyContain(n => n.Name == "GET home/sample {id}");
+		}
+
+		/// <summary>
+		/// Calls a URL that would map to a route with optional parameter (id), but does not pass the id value.
+		/// Makes sure no template value is captured in Transaction.Name.
+		/// </summary>
+		[Fact]
+		public async Task OptionalRouteParameterWithNull()
+		{
+			var httpClient = Helper.GetClient(_agent, _factory);
+			await httpClient.GetAsync("home/sample");
+
+			_payloadSender.Transactions.Should().OnlyContain(n => n.Name == "GET home/sample");
+		}
+
+		/// <summary>
+		/// Tests a URL that maps to a route with default values. Calls "/", which maps to "home/index".
+		/// Makes sure "Home/Index" is in the Transaction.Name.
+		/// </summary>
+		[Fact]
+		public async Task DefaultRouteParameterValues()
+		{
+			var httpClient = Helper.GetClient(_agent, _factory);
+			await httpClient.GetAsync("/");
+
+			_payloadSender.FirstTransaction.Name.Should().Be("GET Home/Index");
+			_payloadSender.FirstTransaction.Context.Request.Url.Full.Should().Be("/");
+		}
+
+		public void Dispose()
+		{
+			_agent?.Dispose();
+			_factory?.Dispose();
+		}
+	}
+}


### PR DESCRIPTION
Addresses #84 

Very much inspired by what [Application insights is doing](https://github.com/Microsoft/ApplicationInsights-aspnetcore/blob/883589c8a99fded1b754c5ed688734274c9243e9/src/Microsoft.ApplicationInsights.AspNetCore/DiagnosticListeners/Implementation/MvcDiagnosticsListener.cs#L41).

Prior to this PR we simply used the URL as the transaction name in ASP.NET Core. As #84 and #166 describe this is not optimal in scenarios where part of the URL is a parameter like `/user/info/42`, because our UI creates new transaction groups for each URL.

This PR uses the ASP.NET routing information to create the transaction name. We resolve the `controller` and `action` names, and also the `page` in case of razor pages, so those will be in the transaction name, everything else is not resolved, instead, in case of optional route parameters the name of the parameter will be captured.

Example:
`/home/sample/1`, where the route map is the default `"{controller=Home}/{action=Index}/{id?}"` becomes `GET home/sample {id}`.

Constants are not part of the transaction name:
```
[Route("api/[controller]")]
[ApiController]
public class ValuesController : ControllerBase
{
	
  // GET api/values/5
  [HttpGet("{id}")]
  public ActionResult<string> Get(int id)
  {
     return "value" + id;
  }
```

In this case `api/values/42` will be `GET Values/Get`, since that is the name of the controller/action. This is ideal for developers, because the URL is captured and shown in Kibana for each transaction and the transaction name reveals the name of the Controller/Action that served the request.

This will be a braking change in the sense that grouping on transaction name will be different after this PR, in fact transaction names in some cases could look very different. I think this is acceptable, since this solves an important issue, and there is no reason to maintain compatibility with the previous version. Plus we are in alpha, so let's use it as an excuse 😇 . 