### PR TITLE
[APM-CI][.NET] Remove missing sln when running the appveyor stage

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -379,6 +379,7 @@ pipeline {
 def release(secret){
   sh(label: 'Release', script: '''
     dotnet sln remove test/Elastic.Apm.PerfTests/Elastic.Apm.PerfTests.csproj
+    dotnet sln remove src/Elastic.Apm.AspNetFullFramework/Elastic.Apm.AspNetFullFramework.csproj
     dotnet pack -c Release
     ''')
   def repo = getVaultSecret(secret: secret)


### PR DESCRIPTION
Remove `src/Elastic.Apm.AspNetFullFramework/Elastic.Apm.AspNetFullFramework.csproj` as already done with https://github.com/elastic/apm-agent-dotnet/pull/195 

Solves https://github.com/elastic/apm-agent-dotnet/issues/216
