### PR TITLE
Fix failing PayloadSentWithBearerToken test

### DIFF
--- a/test/Elastic.Apm.Tests/BasicAgentTests.cs
+++ b/test/Elastic.Apm.Tests/BasicAgentTests.cs
@@ -47,34 +47,34 @@ namespace Elastic.Apm.Tests
 			}
 		}
 
-//		[Fact]
-//		public async Task PayloadSentWithBearerToken()
-//		{
-//			AuthenticationHeaderValue authHeader = null;
-//			var handler = new MockHttpMessageHandler((r, c) =>
-//			{
-//				authHeader = r.Headers.Authorization;
-//				return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK));
-//			});
-//
-//			const string secretToken = "SecretToken";
-//			var logger = ConsoleLogger.Instance;
-//			var payloadSender = new PayloadSenderV2(logger, new TestAgentConfigurationReader(logger, secretToken: secretToken),
-//				Service.GetDefaultService(new TestAgentConfigurationReader(logger)), handler);
-//
-//			using (var agent = new ApmAgent(new TestAgentComponents(secretToken: secretToken, payloadSender: payloadSender)))
-//			{
-//				Thread.Sleep(300); //temporary solution. See https://github.com/elastic/apm-agent-dotnet/issues/174
-//				agent.PayloadSender.QueueTransaction(new Transaction(agent, "TestName", "TestType"));
-//				Thread.Sleep(300); //temporary solution. See https://github.com/elastic/apm-agent-dotnet/issues/174
-//				await payloadSender.FlushAndFinishAsync();
-//			}
-//
-//			Thread.Sleep(300); //temporary solution. See https://github.com/elastic/apm-agent-dotnet/issues/174
-//			authHeader.Should().NotBeNull();
-//			authHeader.Scheme.Should().Be("Bearer");
-//			authHeader.Parameter.Should().Be(secretToken);
-//		}
+		[Fact]
+		public async Task PayloadSentWithBearerToken()
+		{
+			var isRequestFinished = new TaskCompletionSource<object>();
+
+			AuthenticationHeaderValue authHeader = null;
+			var handler = new MockHttpMessageHandler((r, c) =>
+			{
+				authHeader = r.Headers.Authorization;
+				isRequestFinished.SetResult(null);
+				return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK));
+			});
+
+			const string secretToken = "SecretToken";
+			var logger = ConsoleLogger.Instance;
+			var payloadSender = new PayloadSenderV2(logger, new TestAgentConfigurationReader(logger, secretToken: secretToken),
+				Service.GetDefaultService(new TestAgentConfigurationReader(logger)), handler);
+
+			using (var agent = new ApmAgent(new TestAgentComponents(secretToken: secretToken, payloadSender: payloadSender)))
+			{
+				agent.PayloadSender.QueueTransaction(new Transaction(agent, "TestName", "TestType"));
+			}
+
+			await isRequestFinished.Task;
+			authHeader.Should().NotBeNull();
+			authHeader.Scheme.Should().Be("Bearer");
+			authHeader.Parameter.Should().Be(secretToken);
+		}
 
 		/// <summary>
 		/// Creates 1 span and 1 transaction.


### PR DESCRIPTION
Solves  #174.

Instead of the very complicated `FlushAndFinishAsync` method, `TaskCompletionSource` is used to make sure that the http request was sent before we execute the asserts.