### PR TITLE
[docs] Fix duplication

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -1,17 +1,16 @@
+:branch: current
+:server-branch: 6.5
+include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
+
 ifdef::env-github[]
 NOTE: For the best reading experience,
 please view this documentation at https://www.elastic.co/guide/en/apm/agent/dotnet[elastic.co]
 endif::[]
 
 = APM .NET Agent Reference (Prototype)
-:branch: current
-:server-branch: 6.5
-include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 
-ifndef::env-github[]
 include::./intro.asciidoc[Introduction]
 include::./setup.asciidoc[Set Up]
 include::./configuration.asciidoc[Configuration]
 include::./public-api.asciidoc[API documentation]
 include::./release-notes.asciidoc[Release notes]
-endif::[]

--- a/docs/intro.asciidoc
+++ b/docs/intro.asciidoc
@@ -4,7 +4,6 @@ please view this documentation at https://www.elastic.co/guide/en/apm/agent/dotn
 endif::[]
 
 [[intro]]
-
 == Introduction
 
 WARNING: **This project is currently a prototype.

--- a/docs/release-notes.asciidoc
+++ b/docs/release-notes.asciidoc
@@ -1,4 +1,4 @@
 [[release-notes]]
 == Release notes
 
-Release notes are published on the https://github.com/elastic/apm-agent-dotnet/releases[ GitHub releases page].
+Release notes are published on the https://github.com/elastic/apm-agent-dotnet/releases[GitHub releases page].


### PR DESCRIPTION
Weird little bug. Asciidoctor was duplicating the TOC. Had to remove the `ifndef` around the include files, and move the branch attributes to the top of the file to get the duplication to go away.

Also removed an errant space for funsies.