### PR TITLE
Change "Unrecognized key" log from error to trace

### DIFF
--- a/src/Elastic.Apm/DiagnosticListeners/HttpDiagnosticListenerImplBase.cs
+++ b/src/Elastic.Apm/DiagnosticListeners/HttpDiagnosticListenerImplBase.cs
@@ -114,7 +114,7 @@ namespace Elastic.Apm.DiagnosticListeners
 			else if (kv.Key.Equals(ExceptionEventKey))
 				ProcessExceptionEvent(kv.Value, request, requestUrl);
 			else
-				_logger.Error()?.Log("Unrecognized key `{DiagnosticEventKey}'", kv.Key);
+				_logger.Trace()?.Log("Unrecognized key `{DiagnosticEventKey}'", kv.Key);
 		}
 
 		private void ProcessStartEvent(object eventValue, TRequest request, Uri requestUrl)


### PR DESCRIPTION
I noticed this during development... we basically always log errors when an outgoing http request happens.

```
[2019-05-06 10:48:31][Error] - {HttpDiagnosticListenerImplBase} Unrecognized key `System.Net.Http.Request'
```

This was introduced in #195 [here](https://github.com/elastic/apm-agent-dotnet/pull/195/files#r281350580).

2 issues with error here:
- There can be other events that we don't capture (e.g. new events introduced later) - that's normal, and it's not an error.
- ~We register both inheritors in HttpDiagnosticListener, 1 of them will receive keys that are unknown to it. That's also normal, and it's not an error~ update: this isn't really the case. Still the 1. point applies...

So I think this log is ok for debugging, but if that happens that is not an error, so I change it to a Debug log. 

cc @SergeyKleyman 