### PR TITLE
use logger created from logger factory instead of console logger

### DIFF
--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -36,7 +36,34 @@ With this you can use any configuration source that you configured on the `IConf
 
 NOTE: By simply calling `app.UseElasticApm()` without the overload, the agent will read configurations only from environment variables.
 
-This is a typical `appsettings.json` file that contains some sample configuration. The part below `ElasticApm` is fetched by the agent if the corresponding `IConfiguration` is passed to the agent.
+[float]
+[[sample-config]]
+==== Sample configuration file
+
+Below is a sample `appsettings.json` configuration file for a typical ASP.NET Core application. There are two important takeaways:
+1. The part below `ElasticApm` is fetched by the agent if the corresponding `IConfiguration` is passed to the agent.
+2. With ASP.NET Core, you must set `LogLevel for the internal APM logger in the standard `Logging` section with the `ElasticApm` category name.
+
+[source,js]
+----
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Warning",
+      "Elastic.Apm": "Debug"
+    }
+  },
+  "AllowedHosts": "*",
+  "ElasticApm":
+    {
+      "ServerUrls":  "http://myapmserver:8200",
+      "TransactionSampleRate": 1.0
+    }
+}
+----
+
+In certain scenarios -- like when you're not using ASP.NET Core -- you wont activate the agent with the `UseElasticApm()` method.
+In this case, you can set the log level of the agent with `ElasticApm:LogLevel`, as shown in the following `appsettings.json` file:
 
 [source,js]
 ----

--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -41,6 +41,7 @@ NOTE: By simply calling `app.UseElasticApm()` without the overload, the agent wi
 ==== Sample configuration file
 
 Below is a sample `appsettings.json` configuration file for a typical ASP.NET Core application. There are two important takeaways:
+
 1. The part below `ElasticApm` is fetched by the agent if the corresponding `IConfiguration` is passed to the agent.
 2. With ASP.NET Core, you must set `LogLevel for the internal APM logger in the standard `Logging` section with the `ElasticApm` category name.
 

--- a/sample/SampleAspNetCoreApp/appsettings.json
+++ b/sample/SampleAspNetCoreApp/appsettings.json
@@ -1,12 +1,12 @@
 {
   "Logging": {
     "LogLevel": {
-      "Default": "Warning"
+      "Default": "Warning",
+      "Elastic.Apm": "Error"
     }
   },
   "AllowedHosts": "*",
   "ElasticApm": {
-    "LogLevel": "Error",
     "ServerUrls": "http://localhost:8200",
     "TransactionSampleRate": 1.0
   }

--- a/sample/WebApiSample/appsettings.json
+++ b/sample/WebApiSample/appsettings.json
@@ -1,12 +1,12 @@
 {
   "Logging": {
     "LogLevel": {
-      "Default": "Warning"
+      "Default": "Warning",
+      "Elastic.Apm": "Error"
     }
   },
   "AllowedHosts": "*",
   "ElasticApm": {
-    "LogLevel": "Error",
     "ServerUrls": "http://localhost:8200"
   }
 }

--- a/src/Elastic.Apm.AspNetCore/AspNetCoreLogger.cs
+++ b/src/Elastic.Apm.AspNetCore/AspNetCoreLogger.cs
@@ -1,0 +1,39 @@
+using System;
+using Elastic.Apm.AspNetCore.Extensions;
+using Elastic.Apm.Logging;
+using Microsoft.Extensions.Logging;
+using LogLevel = Elastic.Apm.Logging.LogLevel;
+
+namespace Elastic.Apm.AspNetCore
+{
+	internal class AspNetCoreLogger : IApmLogger
+	{
+		private readonly ILogger _logger;
+
+		public AspNetCoreLogger(ILoggerFactory loggerFactory)
+		{
+			_logger = loggerFactory?.CreateLogger("Elastic.Apm") ?? throw new ArgumentNullException(nameof(loggerFactory));
+			Level = _logger.GetMinLogLevel();
+		}
+
+		public LogLevel Level { get; }
+
+		public void Log<TState>(LogLevel level, TState state, Exception e, Func<TState, Exception, string> formatter) =>
+			_logger.Log(Convert(level), new EventId(), state, e, formatter);
+
+		private static Microsoft.Extensions.Logging.LogLevel Convert(LogLevel logLevel)
+		{
+			switch (logLevel)
+			{
+				case LogLevel.Trace: return Microsoft.Extensions.Logging.LogLevel.Trace;
+				case LogLevel.Debug: return Microsoft.Extensions.Logging.LogLevel.Debug;
+				case LogLevel.Information: return Microsoft.Extensions.Logging.LogLevel.Information;
+				case LogLevel.Warning: return Microsoft.Extensions.Logging.LogLevel.Warning;
+				case LogLevel.Error: return Microsoft.Extensions.Logging.LogLevel.Error;
+				case LogLevel.Critical: return Microsoft.Extensions.Logging.LogLevel.Critical;
+				case LogLevel.None:
+				default: return Microsoft.Extensions.Logging.LogLevel.None;
+			}
+		}
+	}
+}

--- a/src/Elastic.Apm.AspNetCore/Elastic.Apm.AspNetCore.csproj
+++ b/src/Elastic.Apm.AspNetCore/Elastic.Apm.AspNetCore.csproj
@@ -29,6 +29,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="2.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Routing.Abstractions" Version="2.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Http.Extensions" Version="2.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.0.0" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Config\" />

--- a/src/Elastic.Apm.AspNetCore/Extensions/LoggerExtensions.cs
+++ b/src/Elastic.Apm.AspNetCore/Extensions/LoggerExtensions.cs
@@ -1,0 +1,26 @@
+using System;
+using Microsoft.Extensions.Logging;
+using LogLevel = Elastic.Apm.Logging.LogLevel;
+
+namespace Elastic.Apm.AspNetCore.Extensions
+{
+	internal static class LoggerExtensions
+	{
+		internal static LogLevel GetMinLogLevel(this ILogger logger)
+		{
+			if (logger == null) throw new ArgumentNullException(nameof(logger));
+
+			if (logger.IsEnabled(Microsoft.Extensions.Logging.LogLevel.Trace)) return LogLevel.Trace;
+
+			if (logger.IsEnabled(Microsoft.Extensions.Logging.LogLevel.Debug)) return LogLevel.Debug;
+
+			if (logger.IsEnabled(Microsoft.Extensions.Logging.LogLevel.Information)) return LogLevel.Information;
+
+			if (logger.IsEnabled(Microsoft.Extensions.Logging.LogLevel.Warning)) return LogLevel.Warning;
+
+			if (logger.IsEnabled(Microsoft.Extensions.Logging.LogLevel.Error)) return LogLevel.Error;
+
+			return logger.IsEnabled(Microsoft.Extensions.Logging.LogLevel.Critical) ? LogLevel.Critical : LogLevel.None;
+		}
+	}
+}

--- a/test/Elastic.Apm.AspNetCore.Tests/ApmMiddlewareExtensionTest.cs
+++ b/test/Elastic.Apm.AspNetCore.Tests/ApmMiddlewareExtensionTest.cs
@@ -1,0 +1,33 @@
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Elastic.Apm.AspNetCore.Tests
+{
+	/// <summary>
+	/// Tests the <see cref="Elastic.Apm.AspNetCore.ApmMiddlewareExtension"/> type.
+	/// </summary>
+	public class ApmMiddlewareExtensionTest
+	{
+		[Fact]
+		public void UseElasticApmShouldUseAspNetLoggerWhenLoggingIsConfigured()
+		{
+			var services = new ServiceCollection()
+				.AddLogging();
+
+			var logger = services.BuildServiceProvider().GetApmLogger();
+
+			Assert.IsType<AspNetCoreLogger>(logger);
+		}
+
+		[Fact]
+		public void UseElasticApmShouldUseConsoleLoggerInstanceWhenLoggingIsNotConfigured()
+		{
+			var services = new ServiceCollection();
+
+			var logger = services.BuildServiceProvider().GetApmLogger();
+
+			Assert.IsType<Logging.ConsoleLogger>(logger);
+			Assert.Same(Logging.ConsoleLogger.Instance, logger);
+		}
+	}
+}

--- a/test/Elastic.Apm.AspNetCore.Tests/AspNetCoreLoggerTests.cs
+++ b/test/Elastic.Apm.AspNetCore.Tests/AspNetCoreLoggerTests.cs
@@ -1,0 +1,48 @@
+using System;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace Elastic.Apm.AspNetCore.Tests
+{
+	/// <summary>
+	/// Tests the <see cref="Elastic.Apm.AspNetCore.AspNetCoreLogger"/> type.
+	/// </summary>
+	public class AspNetCoreLoggerTests
+	{
+		[Fact]
+		public void AspNetCoreLoggerShouldThrowExceptionWhenLoggerFactoryIsNull()
+			=> Assert.Throws<ArgumentNullException>(() => new AspNetCoreLogger(null));
+
+		[Fact]
+		public void AspNetCoreLoggerShouldGetLoggerFromFactoryWithProperCategoryName()
+		{
+			var loggerFactoryMock = new Mock<ILoggerFactory>();
+			loggerFactoryMock.Setup(x => x.CreateLogger(It.IsAny<string>()))
+				.Returns(() => Mock.Of<ILogger>());
+
+			// ReSharper disable UnusedVariable
+			var logger = new AspNetCoreLogger(loggerFactoryMock.Object);
+			// ReSharper restore UnusedVariable
+
+			loggerFactoryMock.Verify(x => x.CreateLogger(It.Is<string>(s => s.Equals("Elastic.Apm"))), Times.Once);
+		}
+
+		[Fact]
+		public void AspNetCoreLoggerShouldCalculateMinLogLevelOnCreation()
+		{
+			var loggerFactoryMock = new Mock<ILoggerFactory>();
+			var loggerMock = new Mock<ILogger>();
+			loggerFactoryMock.Setup(x => x.CreateLogger(It.IsAny<string>()))
+				.Returns(() => loggerMock.Object);
+
+			var logger = new AspNetCoreLogger(loggerFactoryMock.Object);
+
+			loggerMock.Verify(x => x.IsEnabled(It.Is<LogLevel>(l => l == LogLevel.Trace)), Times.Once);
+			// ReSharper disable UnusedVariable
+			var level = logger.Level;
+			// ReSharper restore UnusedVariable
+			loggerMock.Verify(x => x.IsEnabled(It.Is<LogLevel>(l => l == LogLevel.Trace)), Times.Once);
+		}
+	}
+}

--- a/test/Elastic.Apm.AspNetCore.Tests/Elastic.Apm.AspNetCore.Tests.csproj
+++ b/test/Elastic.Apm.AspNetCore.Tests/Elastic.Apm.AspNetCore.Tests.csproj
@@ -13,6 +13,7 @@
     <PackageReference Include="FluentAssertions" Version="5.6.0" />
     <PackageReference Include="FluentAssertions.Analyzers" Version="0.11.4" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
+    <PackageReference Include="Moq" Version="4.12.0" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />

--- a/test/Elastic.Apm.AspNetCore.Tests/LoggerExtensionsTests.cs
+++ b/test/Elastic.Apm.AspNetCore.Tests/LoggerExtensionsTests.cs
@@ -1,0 +1,42 @@
+using System.Collections.Generic;
+using Elastic.Apm.AspNetCore.Extensions;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Xunit;
+using LogLevel = Elastic.Apm.Logging.LogLevel;
+
+namespace Elastic.Apm.AspNetCore.Tests
+{
+	/// <summary>
+	/// Tests the <see cref="Elastic.Apm.AspNetCore.Extensions.LoggerExtensions"/> type.
+	/// </summary>
+	public class LoggerExtensionsTests
+	{
+		[Theory]
+		[InlineData(Microsoft.Extensions.Logging.LogLevel.Trace, LogLevel.Trace)]
+		[InlineData(Microsoft.Extensions.Logging.LogLevel.Debug, LogLevel.Debug)]
+		[InlineData(Microsoft.Extensions.Logging.LogLevel.Information, LogLevel.Information)]
+		[InlineData(Microsoft.Extensions.Logging.LogLevel.Warning, LogLevel.Warning)]
+		[InlineData(Microsoft.Extensions.Logging.LogLevel.Error, LogLevel.Error)]
+		[InlineData(Microsoft.Extensions.Logging.LogLevel.Critical, LogLevel.Critical)]
+		[InlineData(Microsoft.Extensions.Logging.LogLevel.None, LogLevel.None)]
+		public void GetMinLogLevelTest(Microsoft.Extensions.Logging.LogLevel level, LogLevel expected)
+		{
+			var configuration = new ConfigurationBuilder()
+				.AddInMemoryCollection(new[]{new KeyValuePair<string, string>("Logging:LogLevel:Default", level.ToString()), })
+				.Build();
+
+			var serviceProvider = new ServiceCollection()
+				.AddLogging(builder => builder.AddConfiguration(configuration.GetSection("Logging")).AddConsole())
+				.AddOptions()
+				.BuildServiceProvider();
+
+			var logger = serviceProvider.GetService<ILoggerFactory>().CreateLogger<LoggerExtensionsTests>();
+
+			var minLogLevel = logger.GetMinLogLevel();
+
+			Assert.Equal(expected, minLogLevel);
+		}
+	}
+}


### PR DESCRIPTION
related to #228.

What was done:
1. Use logger created from `ILoggerFactory` inside `Elastic.Apm` infrastructure.
2. Additional dependency to `Microsoft.Extensions.Logging.Abstractions`

Open questions:
1. `IApmLogger` has `Level` property in interface definition. In case of asp.net core philosophy, configuration per logger category is splitted from `ILogger` functionality.
2. `Elastic.Apm.AspNetCore` project doesn't have extensions for `IServiceCollection`. Instead of directly creation of some instances, there are can be configured through dependency injection. It's allow to simplify configuration in the future and replace some parts of `Elastic.Apm` by users.

@gregkalapos, what do you think about my changes? Is it aligned with your thoughts?
