### PR TITLE
Fix stacktrace

### DIFF
--- a/src/Elastic.Apm/Helpers/StacktraceHelper.cs
+++ b/src/Elastic.Apm/Helpers/StacktraceHelper.cs
@@ -28,14 +28,15 @@ namespace Elastic.Apm.Helpers
 			try
 			{
 				retVal.AddRange(from item in frames
+					let fileName = item?.GetMethod()
+						?.ReflectedType?.FullName //see: https://github.com/elastic/apm-agent-dotnet/pull/240#discussion_r289619196
+					let functionName = GetRealMethodName(item?.GetMethod())
 					select new CapturedStackFrame
 					{
-						Function = GetRealMethodName(item?.GetMethod()),
-						FileName =
-							item?.GetMethod()
-								?.ReflectedType?.FullName, //see: https://github.com/elastic/apm-agent-dotnet/pull/240#discussion_r289619196
+						Function = functionName,
+						FileName = string.IsNullOrWhiteSpace(fileName)? "unknown" : fileName,
 						Module = item?.GetMethod()?.ReflectedType?.Assembly.FullName,
-						LineNo = item?.GetFileLineNumber() ?? 0
+						LineNo = item?.GetMethod().Name == functionName ? item?.GetFileLineNumber() ?? 0 : 0
 					});
 			}
 			catch (Exception e)

--- a/src/Elastic.Apm/Helpers/StacktraceHelper.cs
+++ b/src/Elastic.Apm/Helpers/StacktraceHelper.cs
@@ -29,12 +29,12 @@ namespace Elastic.Apm.Helpers
 			{
 				retVal.AddRange(from item in frames
 					let fileName = item?.GetMethod()
-						?.ReflectedType?.FullName //see: https://github.com/elastic/apm-agent-dotnet/pull/240#discussion_r289619196
+						?.DeclaringType?.FullName //see: https://github.com/elastic/apm-agent-dotnet/pull/240#discussion_r289619196
 					let functionName = GetRealMethodName(item?.GetMethod())
 					select new CapturedStackFrame
 					{
 						Function = functionName,
-						FileName = string.IsNullOrWhiteSpace(fileName)? "unknown" : fileName,
+						FileName = string.IsNullOrWhiteSpace(fileName)? "N/A" : fileName,
 						Module = item?.GetMethod()?.ReflectedType?.Assembly.FullName,
 						LineNo = item?.GetMethod().Name == functionName ? item?.GetFileLineNumber() ?? 0 : 0
 					});

--- a/src/Elastic.Apm/Helpers/StacktraceHelper.cs
+++ b/src/Elastic.Apm/Helpers/StacktraceHelper.cs
@@ -36,7 +36,7 @@ namespace Elastic.Apm.Helpers
 						Function = functionName,
 						FileName = string.IsNullOrWhiteSpace(fileName)? "N/A" : fileName,
 						Module = item?.GetMethod()?.ReflectedType?.Assembly.FullName,
-						LineNo = item?.GetMethod().Name == functionName ? item?.GetFileLineNumber() ?? 0 : 0
+						LineNo = item?.GetFileLineNumber() ?? 0
 					});
 			}
 			catch (Exception e)

--- a/test/Elastic.Apm.Tests/StackTraceTests.cs
+++ b/test/Elastic.Apm.Tests/StackTraceTests.cs
@@ -49,16 +49,17 @@ namespace Elastic.Apm.Tests
 		public async Task AsyncCallStackTest()
 		{
 			var payloadSender = new MockPayloadSender();
-			var agent = new ApmAgent(new TestAgentComponents(payloadSender: payloadSender));
-
-			await Assert.ThrowsAsync<Exception>(async () =>
+			using (var agent = new ApmAgent(new TestAgentComponents(payloadSender: payloadSender)))
 			{
-				await agent.Tracer.CaptureTransaction("TestTransaction", "Test", async () =>
+				await Assert.ThrowsAsync<Exception>(async () =>
 				{
-					var classWithAsync = new ClassWithAsync();
-					await classWithAsync.TestMethodAsync();
+					await agent.Tracer.CaptureTransaction("TestTransaction", "Test", async () =>
+					{
+						var classWithAsync = new ClassWithAsync();
+						await classWithAsync.TestMethodAsync();
+					});
 				});
-			});
+			}
 
 			payloadSender.Errors.Should().NotBeEmpty();
 			(payloadSender.Errors.First() as Error).Should().NotBeNull();
@@ -73,16 +74,17 @@ namespace Elastic.Apm.Tests
 		public void CallStackWithMoveNextWithoutAsync()
 		{
 			var payloadSender = new MockPayloadSender();
-			var agent = new ApmAgent(new TestAgentComponents(payloadSender: payloadSender));
-
-			Assert.Throws<Exception>(() =>
+			using (var agent = new ApmAgent(new TestAgentComponents(payloadSender: payloadSender)))
 			{
-				agent.Tracer.CaptureTransaction("TestTransaction", "Test", () =>
+				Assert.Throws<Exception>(() =>
 				{
-					var classWithSyncMethods = new ClassWithSyncMethods();
-					classWithSyncMethods.MoveNext();
+					agent.Tracer.CaptureTransaction("TestTransaction", "Test", () =>
+					{
+						var classWithSyncMethods = new ClassWithSyncMethods();
+						classWithSyncMethods.MoveNext();
+					});
 				});
-			});
+			}
 
 			payloadSender.Errors.Should().NotBeEmpty();
 			(payloadSender.Errors.First() as Error).Should().NotBeNull();
@@ -97,30 +99,31 @@ namespace Elastic.Apm.Tests
 		public void TypeAndMethodNameTest()
 		{
 			var payloadSender = new MockPayloadSender();
-			var agent = new ApmAgent(new TestAgentComponents(payloadSender: payloadSender));
-
-			Assert.Throws<Exception>(() =>
+			using (var agent = new ApmAgent(new TestAgentComponents(payloadSender: payloadSender)))
 			{
-				agent.Tracer.CaptureTransaction("TestTransaction", "Test", () =>
+				Assert.Throws<Exception>(() =>
 				{
-					BaseTestClass testClass = new DerivedTestClass();
-					testClass.Method1();
+					agent.Tracer.CaptureTransaction("TestTransaction", "Test", () =>
+					{
+						Base testClass = new Derived();
+						testClass.Method1();
+					});
 				});
-			});
+			}
 
 			payloadSender.Errors.Should().NotBeEmpty();
 			(payloadSender.Errors.First() as Error).Should().NotBeNull();
 
 			(payloadSender.Errors.First() as Error)?.Exception.Stacktrace.Should()
-				.Contain(m => m.FileName == typeof(BaseTestClass).FullName
-					&& m.Function == nameof(BaseTestClass.Method1)
-					&& m.Module == typeof(BaseTestClass).Assembly.FullName
+				.Contain(m => m.FileName == typeof(Base).FullName
+					&& m.Function == nameof(Base.Method1)
+					&& m.Module == typeof(Base).Assembly.FullName
 				);
 
 			(payloadSender.Errors.First() as Error)?.Exception.Stacktrace.Should()
-				.Contain(m => m.FileName == typeof(DerivedTestClass).FullName
-					&& m.Function == nameof(DerivedTestClass.TestMethod)
-					&& m.Module == typeof(DerivedTestClass).Assembly.FullName);
+				.Contain(m => m.FileName == typeof(Derived).FullName
+					&& m.Function == nameof(Derived.TestMethod)
+					&& m.Module == typeof(Derived).Assembly.FullName);
 		}
 
 		/// <summary>
@@ -139,6 +142,49 @@ namespace Elastic.Apm.Tests
 			payloadSender.Errors.Should().NotBeEmpty();
 			(payloadSender.Errors.First() as Error).Should().NotBeNull();
 			(payloadSender.Errors.First() as Error)?.Exception.Stacktrace.Should().NotContain(frame => string.IsNullOrWhiteSpace(frame.FileName));
+		}
+
+		[Fact]
+		public void InheritedChainWithVirtualMethod()
+		{
+			Base testClass = new Derived();
+
+			var payloadSender = new MockPayloadSender();
+
+			using (var agent = new ApmAgent(new TestAgentComponents(payloadSender: payloadSender)))
+			{
+				Assert.Throws<Exception>(() => { agent.Tracer.CaptureTransaction("TestTransaction", "Test", () => { testClass.MyMethod(); }); });
+			}
+
+			payloadSender.Errors.First().Should().NotBeNull();
+			payloadSender.Errors.First().Should().BeOfType(typeof(Error));
+
+			//note: since filename is used on the UI (and there is no other way to show the classname, we misuse this field
+			(payloadSender.Errors.First() as Error)?.Exception.Stacktrace[0].FileName.Should().Be(typeof(Derived).FullName);
+			(payloadSender.Errors.First() as Error)?.Exception.Stacktrace[0].Function.Should().Be(nameof(Derived.MethodThrowingIDerived));
+
+			(payloadSender.Errors.First() as Error)?.Exception.Stacktrace[1].FileName.Should().Be(typeof(Derived).FullName);
+			(payloadSender.Errors.First() as Error)?.Exception.Stacktrace[1].Function.Should().Be(nameof(Base.MyMethod));
+		}
+
+		[Fact]
+		public void InheritedChain()
+		{
+			Base testClass = new Derived();
+
+			var payloadSender = new MockPayloadSender();
+
+			using (var agent = new ApmAgent(new TestAgentComponents(payloadSender: payloadSender)))
+			{
+				Assert.Throws<Exception>(() => { agent.Tracer.CaptureTransaction("TestTransaction", "Test", () => { testClass.JustThrow(); }); });
+			}
+
+			payloadSender.Errors.First().Should().NotBeNull();
+			payloadSender.Errors.First().Should().BeOfType(typeof(Error));
+
+			//note: since filename is used on the UI (and there is no other way to show the classname, we misuse this field
+			(payloadSender.Errors.First() as Error)?.Exception.Stacktrace[0].FileName.Should().Be(typeof(Base).FullName);
+			(payloadSender.Errors.First() as Error)?.Exception.Stacktrace[0].Function.Should().Be(nameof(Base.JustThrow));
 		}
 
 		private void TestMethod() => InnerTestMethod(() => throw new Exception("TestException"));
@@ -175,16 +221,34 @@ namespace Elastic.Apm.Tests
 		}
 	}
 
-	internal class BaseTestClass
+	internal class Base
 	{
+		[MethodImpl(MethodImplOptions.NoInlining)]
+		public void JustThrow() => throw new Exception("Test exception in Base.JustThrow");
+
+		[MethodImpl(MethodImplOptions.NoInlining)]
+		public virtual void MyMethod()
+			=> MethodThrowingInBase();
+
+		[MethodImpl(MethodImplOptions.NoInlining)]
+		private void MethodThrowingInBase() => throw new Exception("Test exception in Base");
+
+		[MethodImpl(MethodImplOptions.NoInlining)]
 		internal void Method1() => TestMethod();
 
+		[MethodImpl(MethodImplOptions.NoInlining)]
 		internal virtual void TestMethod()
 			=> Debug.WriteLine("test");
 	}
 
-	internal class DerivedTestClass : BaseTestClass
+	internal class Derived : Base
 	{
+		[MethodImpl(MethodImplOptions.NoInlining)]
+		public override void MyMethod() => MethodThrowingIDerived();
+
+		[MethodImpl(MethodImplOptions.NoInlining)]
+		public void MethodThrowingIDerived() => throw new Exception("Test exception in Derived");
+
 		internal override void TestMethod() => throw new Exception("TestException");
 	}
 }

--- a/test/Elastic.Apm.Tests/StackTraceTests.cs
+++ b/test/Elastic.Apm.Tests/StackTraceTests.cs
@@ -42,8 +42,8 @@ namespace Elastic.Apm.Tests
 
 		/// <summary>
 		/// Makes sure that the name of the async method is captured correctly
-		/// Also asserts that the line number is 0 in this case - that is because the fixed method name
-		/// does not match the line number in the state machine, so the agent sends LineNo 0.
+		/// Also asserts that the line number is not 0 in this case.
+		/// See: https://github.com/elastic/apm-agent-dotnet/pull/253#discussion_r291835766
 		/// </summary>
 		[Fact]
 		public async Task AsyncCallStackTest()
@@ -64,7 +64,7 @@ namespace Elastic.Apm.Tests
 			payloadSender.Errors.Should().NotBeEmpty();
 			(payloadSender.Errors.First() as Error).Should().NotBeNull();
 			(payloadSender.Errors.First() as Error)?.Exception.Stacktrace.Should()
-				.Contain(m => m.Function == nameof(ClassWithAsync.TestMethodAsync) && m.LineNo == 0);
+				.Contain(m => m.Function == nameof(ClassWithAsync.TestMethodAsync) && m.LineNo != 0);
 		}
 
 		/// <summary>


### PR DESCRIPTION
We introduced 2 issues in elastic/apm-agent-dotnet#240 - fixing those. 

1: Never send null or empty `FileName` (since it's required)
2: ~Only send LineNo when the methodname was not changed manually (e.g. due to being async mehtod) - otherwise the LineNo would not match the method name~ This seems to work, so we send those, and will be further investigated in https://github.com/elastic/apm-agent-dotnet/issues/266, discussion: https://github.com/elastic/apm-agent-dotnet/pull/253#discussion_r291755759

+tests