### PR TITLE
fix(jenkins): use both windows workers

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -102,7 +102,7 @@ pipeline {
                 }
               }
               stage('Windows .NET Framework'){
-                agent { label 'windows-2016' }
+                agent { label 'windows' }
                 options { skipDefaultCheckout() }
                 environment {
                   HOME = "${env.WORKSPACE}"
@@ -166,7 +166,7 @@ pipeline {
                 }
               }
               stage('Windows .NET Core'){
-                agent { label 'windows-2016' }
+                agent { label 'windows' }
                 options { skipDefaultCheckout() }
                 environment {
                   HOME = "${env.WORKSPACE}"


### PR DESCRIPTION
this speed up the build and would resolve the interlock files problem that makes the tools install stage fail.