### PR TITLE
Remove DiagnosticSource dependency from Elastic.Apm.EntityFrameworkCore

### DIFF
--- a/src/Elastic.Apm.EntityFrameworkCore/Elastic.Apm.EntityFrameworkCore.csproj
+++ b/src/Elastic.Apm.EntityFrameworkCore/Elastic.Apm.EntityFrameworkCore.csproj
@@ -21,7 +21,6 @@
     <PackageTags>apm, monitoring, elastic, elasticapm, analytics, entiryframeworkcore, efcore</PackageTags>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="4.5.1"/>
     <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="2.0.0"/>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
The same dependency with a lower version ("4.0.0") is added through the Elastic.Apm package, so there is no need for this dependency - and having it seems to cause problems when an application references the agent - see [this thread](https://github.com/elastic/apm-agent-dotnet/pull/226#discussion_r282425172).

Found by @NeoXtreem, addressed in #226, adding a separate PR to make sure this gets in before the Beta release. 
