### PR TITLE
Add net461 as a separate target for Elastic.Apm

### DIFF
--- a/src/Elastic.Apm.AspNetFullFramework/Elastic.Apm.AspNetFullFramework.csproj
+++ b/src/Elastic.Apm.AspNetFullFramework/Elastic.Apm.AspNetFullFramework.csproj
@@ -45,7 +45,6 @@
     <Reference Include="System.Core" />
     <Reference Include="System.Web" />
     <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Net.Http" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="ElasticApmModule.cs" />

--- a/src/Elastic.Apm.AspNetFullFramework/ElasticApmModule.cs
+++ b/src/Elastic.Apm.AspNetFullFramework/ElasticApmModule.cs
@@ -39,7 +39,7 @@ namespace Elastic.Apm.AspNetFullFramework
 		private HttpApplication _httpApp;
 
 		private static Version AspNetVersion => typeof(HttpRuntime).Assembly.GetName().Version;
-		private static string ClrDescription => RuntimeInformation.FrameworkDescription;
+		private static string ClrDescription => "aaa";  // RuntimeInformation.FrameworkDescription;
 		private static Version IisVersion => HttpRuntime.IISVersion;
 
 		private static void SetServiceInformation(Service service)

--- a/src/Elastic.Apm.AspNetFullFramework/ElasticApmModule.cs
+++ b/src/Elastic.Apm.AspNetFullFramework/ElasticApmModule.cs
@@ -1,11 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Collections.Specialized;
-using System.Runtime.InteropServices;
 using System.Web;
 using Elastic.Apm.Api;
 using Elastic.Apm.DiagnosticSource;
 using Elastic.Apm.DistributedTracing;
+using Elastic.Apm.Helpers;
 using Elastic.Apm.Logging;
 using Elastic.Apm.Model;
 
@@ -39,7 +39,7 @@ namespace Elastic.Apm.AspNetFullFramework
 		private HttpApplication _httpApp;
 
 		private static Version AspNetVersion => typeof(HttpRuntime).Assembly.GetName().Version;
-		private static string ClrDescription => "aaa";  // RuntimeInformation.FrameworkDescription;
+		private static string ClrDescription => PlatformDetection.FrameworkDescription;
 		private static Version IisVersion => HttpRuntime.IISVersion;
 
 		private static void SetServiceInformation(Service service)

--- a/src/Elastic.Apm/Elastic.Apm.csproj
+++ b/src/Elastic.Apm/Elastic.Apm.csproj
@@ -1,31 +1,25 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
-    <RootNamespace>Elastic.Apm</RootNamespace>
-    <AssemblyName>Elastic.Apm</AssemblyName>
-    <AssemblyVersion>0.0.2.0</AssemblyVersion>
-    <InformationalVersion>0.0.2.0</InformationalVersion>
-    <FileVersion>0.0.2.0</FileVersion>
+    <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
+ 
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\build\elasticapm.snk</AssemblyOriginatorKeyFile>
     <DelaySign>false</DelaySign>
-    <PackageVersion>0.0.2.0-alpha</PackageVersion>
-    <Authors>Elastic and contributors</Authors>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
-    <PackageId>Elastic.Apm</PackageId>
-    <copyright>2019 Elasticsearch BV</copyright>
-    <PackageLicenseUrl>https://github.com/elastic/apm-agent-dotnet/blob/master/LICENSE</PackageLicenseUrl>
-    <PackageProjectUrl>https://github.com/elastic/apm-agent-dotnet</PackageProjectUrl>
-    <PackageIconUrl>https://raw.githubusercontent.com/elastic/apm-agent-dotnet/master/build/nuget-icon.png</PackageIconUrl>
-    <Description>Elastic APM .NET Agent base package. This package provides core functionality for transmitting of all Elastic APM types and is a dependent package for all other Elastic APM package. Additionally this package contains the public Agent API that allows you to manually capture transactions and spans. Please install the platform specific package for the best experience. See: https://github.com/elastic/apm-agent-dotnet/tree/master/docs</Description>
-    <PackageTags>apm, monitoring, elastic, elasticapm, analytics, sdk</PackageTags>
-    <LangVersion>latest</LangVersion>
+    
+    <OutputType>Library</OutputType>
+    <StartupObject />
   </PropertyGroup>
+
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <PackageReference Include="System.Diagnostics.PerformanceCounter" Version="4.6.0-preview5.19224.8" />
+  </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
     <!-- TODO: Are we ok with this reference/version? -->
+
+
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="4.0.0" />
-    <PackageReference Include="System.Diagnostics.PerformanceCounter" Version="4.5.0" />
     <PackageReference Include="System.Threading.Tasks.Dataflow" Version="4.9.0" />
   </ItemGroup>
 </Project>

--- a/src/Elastic.Apm/Elastic.Apm.csproj
+++ b/src/Elastic.Apm/Elastic.Apm.csproj
@@ -1,24 +1,36 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup>
+  <PropertyGroup Condition=" '$(OS)' != 'Windows_NT' ">
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(OS)' == 'Windows_NT' ">
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
- 
+  </PropertyGroup>
+  <PropertyGroup>
+    <RootNamespace>Elastic.Apm</RootNamespace>
+    <AssemblyName>Elastic.Apm</AssemblyName>
+    <AssemblyVersion>0.0.2.0</AssemblyVersion>
+    <InformationalVersion>0.0.2.0</InformationalVersion>
+    <FileVersion>0.0.2.0</FileVersion>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\build\elasticapm.snk</AssemblyOriginatorKeyFile>
     <DelaySign>false</DelaySign>
-    
-    <OutputType>Library</OutputType>
-    <StartupObject />
+    <PackageVersion>0.0.2.0-alpha</PackageVersion>
+    <Authors>Elastic and contributors</Authors>
+    <PackageId>Elastic.Apm</PackageId>
+    <copyright>2019 Elasticsearch BV</copyright>
+    <PackageLicenseUrl>https://github.com/elastic/apm-agent-dotnet/blob/master/LICENSE</PackageLicenseUrl>
+    <PackageProjectUrl>https://github.com/elastic/apm-agent-dotnet</PackageProjectUrl>
+    <PackageIconUrl>https://raw.githubusercontent.com/elastic/apm-agent-dotnet/master/build/nuget-icon.png</PackageIconUrl>
+    <Description>Elastic APM .NET Agent base package. This package provides core functionality for transmitting of all Elastic APM types and is a dependent package for all other Elastic APM package. Additionally this package contains the public Agent API that allows you to manually capture transactions and spans. Please install the platform specific package for the best experience. See: https://github.com/elastic/apm-agent-dotnet/tree/master/docs</Description>
+    <PackageTags>apm, monitoring, elastic, elasticapm, analytics, sdk</PackageTags>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
-
-
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-    <PackageReference Include="System.Diagnostics.PerformanceCounter" Version="4.6.0-preview5.19224.8" />
+    <PackageReference Include="System.Diagnostics.PerformanceCounter" Version="4.5.0" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
     <!-- TODO: Are we ok with this reference/version? -->
-
-
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="4.0.0" />
     <PackageReference Include="System.Threading.Tasks.Dataflow" Version="4.9.0" />
   </ItemGroup>

--- a/src/Elastic.Apm/Helpers/PlatformDetection.cs
+++ b/src/Elastic.Apm/Helpers/PlatformDetection.cs
@@ -7,5 +7,6 @@ namespace Elastic.Apm.Helpers
 	{
 		// Taken from https://github.com/dotnet/corefx/blob/master/src/CoreFx.Private.TestUtilities/src/System/PlatformDetection.cs
 		internal static readonly bool IsFullFramework = RuntimeInformation.FrameworkDescription.StartsWith(".NET Framework", StringComparison.OrdinalIgnoreCase);
+		internal static readonly string FrameworkDescription = RuntimeInformation.FrameworkDescription;
 	}
 }


### PR DESCRIPTION
#248 seems to break our Full Framework code, mainly because it adds `System.Diagnostics.PerformanceCounter` as a dependency to `Elastic.Apm`. We use the `PerformanceCounter` type from this package, but it turns out that this type is in `System.dll` in case of `net461`. The problem itself isn't specific to this class, I suspect we'd have this later with other things (so as a quick and sloppy summary: using `netstandard2.0` on `net461` is a pain, `net461` should be a separate target, and that's what this PR proposes).

[The recommendation from Microsoft is also](https://docs.microsoft.com/en-us/dotnet/standard/library-guidance/cross-platform-targeting#multi-targeting) to target `net461` and `netstandard2.0` separately. 

Current problems/questions: 
- if we simply add `<TargetFrameworks>netstandard2.0;net461</TargetFrameworks>` to `Elastic.Apm` builds will fail on Linux (CI) and macOS (my dev machine). Therefore I added `<PropertyGroup Condition=" '$(OS)' == 'Windows_NT' ">` checks to only build `net461` on Windows. I'm not 100% sure this is a good idea, because in this case the generated NuGet packages contain an additional `net461` dll on Windows, but those are missing when we generate the packages on a non Windows OSs. I think this is very dangerous, because we may end up with a release where the `net461` `Elastic.Apm` dll is missing. Open for ideas on how to solve this, otherwise we can go with this and think about it later.
- Do we want to include this in the beta release? This changes things on Full Framework, so that's a risk, on the other hand, this is probably the way to go, so if we spend time to test it, I don't see any reason not to do the beta release including this change.

@SergeyKleyman feel free to push your fix to the `RuntimeInformation.FrameworkDescription` issue.  