### PR TITLE
[wip] debugging purposes of the env variable for the CI

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -127,7 +127,8 @@ pipeline {
                       }
                       // Debugging purposes
                       echo "DEBUG -> ${RUN_DISPLAY_URL}"
-                      powershell label: 'Debug', script: "Get-ChildItem Env"
+                      bat label: 'Debug Variables', script: 'SET'
+                      powershell label: 'Version', script: '$PSVersionTable.PSVersion'
                       powershell label: 'DebugURL', script: "[System.Net.HttpWebRequest]::Create('${RUN_DISPLAY_URL}').GetResponse().ResponseUri.AbsoluteUri"
                     }
                   }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -130,6 +130,7 @@ pipeline {
                       bat label: 'Debug Variables', script: 'SET'
                       powershell label: 'Version', script: '$PSVersionTable.PSVersion'
                       powershell label: 'DebugURL', script: "[System.Net.HttpWebRequest]::Create('${RUN_DISPLAY_URL}').GetResponse().ResponseUri.AbsoluteUri"
+                      powershell label: 'DebugURL harcoded', script: '''[System.Net.HttpWebRequest]::Create('https://apm-ci.elastic.co/job/apm-agent-dotnet/job/apm-agent-dotnet-mbp/job/PR-279/1/display/redirect').GetResponse().ResponseUri.AbsoluteUri'''
                     }
                   }
                   /**

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -112,6 +112,7 @@ pipeline {
                   MSBuildSDKsPath = "${env.DOTNET_ROOT}\\sdk\\2.1.505\\Sdks"
                   PATH = "${env.PATH};${env.HOME}\\bin;${env.DOTNET_ROOT};${env.DOTNET_ROOT}\\tools;\"${env.VS_HOME}\\MSBuild\\15.0\\Bin\""
                   MSBUILDDEBUGPATH = "${env.WORKSPACE}"
+                  RUN_DISPLAY_URL  = "${env.RUN_DISPLAY_URL}"
                 }
                 stages{
                   /**
@@ -124,6 +125,10 @@ pipeline {
                       dir("${HOME}"){
                         powershell label: 'Install tools', script: "${BASE_DIR}\\.ci\\windows\\tools.ps1"
                       }
+                      // Debugging purposes
+                      echo "DEBUG -> ${RUN_DISPLAY_URL}"
+                      powershell label: 'Debug', script: "Get-ChildItem Env"
+                      powershell label: 'DebugURL', script: "[System.Net.HttpWebRequest]::Create('${RUN_DISPLAY_URL}').GetResponse().ResponseUri.AbsoluteUri"
                     }
                   }
                   /**


### PR DESCRIPTION
For some reason, the CI pipeline returns a different URL when running in a windows worker rather than in linux