### PR TITLE
Free memory on Linux: Use MemAvailable instead of MemFree

### DIFF
--- a/src/Elastic.Apm/Metrics/MetricsProvider/FreeAndTotalMemoryProvider.cs
+++ b/src/Elastic.Apm/Metrics/MetricsProvider/FreeAndTotalMemoryProvider.cs
@@ -44,12 +44,20 @@ namespace Elastic.Apm.Metrics.MetricsProvider
 
 					while (line != null || retVal.Count != 2)
 					{
-						if (line != null && line.Contains("MemFree:"))
+						//See: https://github.com/elastic/beats/issues/4202
+						if (line != null && line.Contains("MemAvailable:"))
+						{
+							var (suc, res) = GetEntry(line, "MemAvailable:");
+							if (suc) retVal.Add(new MetricSample(FreeMemory, res));
+							hasMemFree = true;
+						} //Older kernels only have MemFree, we use that as fallback
+						else if (line != null && line.Contains("MemFree:"))
 						{
 							var (suc, res) = GetEntry(line, "MemFree:");
 							if (suc) retVal.Add(new MetricSample(FreeMemory, res));
 							hasMemFree = true;
 						}
+
 						if (line != null && line.Contains("MemTotal:"))
 						{
 							var (suc, res) = GetEntry(line, "MemTotal:");


### PR DESCRIPTION
The [Java agent does the same](https://github.com/elastic/apm-agent-java/blob/62acdb1f349474ade1fe037e10bfbe803e7ca580/apm-agent-core/src/main/java/co/elastic/apm/agent/metrics/builtin/SystemMetrics.java#L152-L155).

Inspired by a discussion with @watson @felixbarny and @SergeyKleyman.