### PR TITLE
ci(jenkins): trigger async ITs and update github check for the pull request

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -357,7 +357,7 @@ pipeline {
               log(level: 'INFO', text: 'Launching Async ITs')
               // TODO: use commit rather than branch to be reproducible.
               build(job: env.ITS_PIPELINE, propagate: false, wait: false,
-                    parameters: [string(name: 'BUILD_OPTS', value: "--dotnet-agent-repo ${env.CHANGE_FORK}/${env.REPO} --dotnet-agent-version ${env.CHANGE_BRANCH}"),
+                    parameters: [string(name: 'BUILD_OPTS', value: "--with-agent-dotnet --dotnet-agent-repo ${env.CHANGE_FORK}/${env.REPO} --dotnet-agent-version ${env.CHANGE_BRANCH}"),
                                  string(name: 'GITHUB_CHECK_NAME', value: env.GITHUB_CHECK_ITS_NAME),
                                  string(name: 'GITHUB_CHECK_REPO', value: env.REPO),
                                  string(name: 'GITHUB_CHECK_SHA1', value: env.GIT_BASE_COMMIT)])

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -357,7 +357,7 @@ pipeline {
               log(level: 'INFO', text: 'Launching Async ITs')
               // TODO: use commit rather than branch to be reproducible.
               build(job: env.ITS_PIPELINE, propagate: false, wait: false,
-                    parameters: [string(name: 'BUILD_OPTS', value: "--dotnet-agent_repo ${env.CHANGE_FORK}/${env.REPO} --dotnet_agent_version ${env.CHANGE_BRANCH}"),
+                    parameters: [string(name: 'BUILD_OPTS', value: "--dotnet-agent-repo ${env.CHANGE_FORK}/${env.REPO} --dotnet-agent-version ${env.CHANGE_BRANCH}"),
                                  string(name: 'GITHUB_CHECK_NAME', value: env.GITHUB_CHECK_ITS_NAME),
                                  string(name: 'GITHUB_CHECK_REPO', value: env.REPO),
                                  string(name: 'GITHUB_CHECK_SHA1', value: env.GIT_BASE_COMMIT)])

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -11,7 +11,7 @@ pipeline {
     JOB_GCS_BUCKET = credentials('gcs-bucket')
     CODECOV_SECRET = 'secret/apm-team/ci/apm-agent-dotnet-codecov'
     GITHUB_CHECK_ITS_NAME = 'Integration Tests'
-    ITS_PIPELINE = 'apm-integration-tests-mbp/master'
+    ITS_PIPELINE = 'apm-integration-tests-selector-mbp/master'
   }
   options {
     timeout(time: 1, unit: 'HOURS')
@@ -357,7 +357,7 @@ pipeline {
               log(level: 'INFO', text: 'Launching Async ITs')
               // TODO: use commit rather than branch to be reproducible.
               build(job: env.ITS_PIPELINE, propagate: false, wait: false,
-                    parameters: [booleanParam(name: 'Run_As_Master_Branch', value: true),
+                    parameters: [string(name: 'AGENT_INTEGRATION_TEST', value: '.NET'),
                                  string(name: 'BUILD_OPTS', value: "--dotnet-agent-version ${env.GIT_BASE_COMMIT}"),
                                  string(name: 'GITHUB_CHECK_NAME', value: env.GITHUB_CHECK_ITS_NAME),
                                  string(name: 'GITHUB_CHECK_REPO', value: env.REPO),

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -357,7 +357,7 @@ pipeline {
               log(level: 'INFO', text: 'Launching Async ITs')
               // TODO: use commit rather than branch to be reproducible.
               build(job: env.ITS_PIPELINE, propagate: false, wait: false,
-                    parameters: [string(name: 'BUILD_OPTS', value: "--with-agent-dotnet --dotnet-agent-repo ${env.CHANGE_FORK}/${env.REPO} --dotnet-agent-version ${env.CHANGE_BRANCH}"),
+                    parameters: [string(name: 'BUILD_OPTS', value: "--with-agent-dotnet --dotnet-agent-version ${env.GIT_BASE_COMMIT}"),
                                  string(name: 'GITHUB_CHECK_NAME', value: env.GITHUB_CHECK_ITS_NAME),
                                  string(name: 'GITHUB_CHECK_REPO', value: env.REPO),
                                  string(name: 'GITHUB_CHECK_SHA1', value: env.GIT_BASE_COMMIT)])

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -11,7 +11,7 @@ pipeline {
     JOB_GCS_BUCKET = credentials('gcs-bucket')
     CODECOV_SECRET = 'secret/apm-team/ci/apm-agent-dotnet-codecov'
     GITHUB_CHECK_ITS_NAME = 'Integration Tests'
-    ITS_PIPELINE = 'apm-integration-tests-mbp/PR-470'
+    ITS_PIPELINE = 'apm-integration-tests-mbp/master'
   }
   options {
     timeout(time: 1, unit: 'HOURS')

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -357,7 +357,7 @@ pipeline {
               log(level: 'INFO', text: 'Launching Async ITs')
               // TODO: use commit rather than branch to be reproducible.
               build(job: env.ITS_PIPELINE, propagate: false, wait: false,
-                    parameters: [string(name: 'BUILD_OPTS', value: "--with-agent-dotnet --dotnet-agent-version ${env.GIT_BASE_COMMIT}"),
+                    parameters: [string(name: 'BUILD_OPTS', value: "--dotnet-agent-version ${env.GIT_BASE_COMMIT}"),
                                  string(name: 'GITHUB_CHECK_NAME', value: env.GITHUB_CHECK_ITS_NAME),
                                  string(name: 'GITHUB_CHECK_REPO', value: env.REPO),
                                  string(name: 'GITHUB_CHECK_SHA1', value: env.GIT_BASE_COMMIT)])

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -357,7 +357,8 @@ pipeline {
               log(level: 'INFO', text: 'Launching Async ITs')
               // TODO: use commit rather than branch to be reproducible.
               build(job: env.ITS_PIPELINE, propagate: false, wait: false,
-                    parameters: [string(name: 'BUILD_OPTS', value: "--dotnet-agent-version ${env.GIT_BASE_COMMIT}"),
+                    parameters: [booleanParam(name: 'Run_As_Master_Branch', value: true),
+                                 string(name: 'BUILD_OPTS', value: "--dotnet-agent-version ${env.GIT_BASE_COMMIT}"),
                                  string(name: 'GITHUB_CHECK_NAME', value: env.GITHUB_CHECK_ITS_NAME),
                                  string(name: 'GITHUB_CHECK_REPO', value: env.REPO),
                                  string(name: 'GITHUB_CHECK_SHA1', value: env.GIT_BASE_COMMIT)])


### PR DESCRIPTION
fixes https://github.com/elastic/apm-integration-testing/issues/41

## Highlights
- It's triggered for each PR by default and disabled to any upstream branches.
- Trigger the Integration Tests, aka ITs, pipelines from https://github.com/elastic/apm-integration-testing based on PRs or on demand, aka manually.
- It does trigger only the `.NET` stage in the ITs.
- ITs should be async.
- This new stage notifies the GitHub check with the status of the execution.
- Depends on https://github.com/elastic/apm-integration-testing/pull/470

## Tasks
- [x] Agree with the stakeholders
- [x] It does require to support ITs from commits rather than branches.