### PR TITLE
Add override for AspNetCore UseElasticApm that enables HttpDiagnosticsSubscriber by default

### DIFF
--- a/src/Elastic.Apm.AspNetCore/ApmMiddlewareExtension.cs
+++ b/src/Elastic.Apm.AspNetCore/ApmMiddlewareExtension.cs
@@ -16,6 +16,22 @@ namespace Elastic.Apm.AspNetCore
 	public static class ApmMiddlewareExtension
 	{
 		/// <summary>
+		/// Adds the Elastic APM Middleware to the ASP.NET Core pipeline and enables <see cref="HttpDiagnosticsSubscriber" />.
+		/// </summary>
+		/// <returns>The elastic apm.</returns>
+		/// <param name="builder">Builder.</param>
+		/// <param name="configuration">
+		/// You can optionally pass the IConfiguration of your application to the Elastic APM Agent. By
+		/// doing this the agent will read agent related configurations through this IConfiguration instance.
+		/// If no <see cref="IConfiguration" /> is passed to the agent then it will read configs from environment variables.
+		/// </param>
+		public static IApplicationBuilder UseElasticApm(
+			this IApplicationBuilder builder,
+			IConfiguration configuration = null
+		) =>
+			UseElasticApm(builder, configuration, new HttpDiagnosticsSubscriber());
+
+		/// <summary>
 		/// Adds the Elastic APM Middleware to the ASP.NET Core pipeline
 		/// </summary>
 		/// <returns>The elastic apm.</returns>


### PR DESCRIPTION
It does not add additional dependencies so I don't see a reason not to enable it by default