### PR TITLE
Linux memory metrics: remove "MemFree" fallback

### DIFF
--- a/src/Elastic.Apm/Metrics/MetricsProvider/FreeAndTotalMemoryProvider.cs
+++ b/src/Elastic.Apm/Metrics/MetricsProvider/FreeAndTotalMemoryProvider.cs
@@ -50,14 +50,7 @@ namespace Elastic.Apm.Metrics.MetricsProvider
 							var (suc, res) = GetEntry(line, "MemAvailable:");
 							if (suc) retVal.Add(new MetricSample(FreeMemory, res));
 							hasMemFree = true;
-						} //Older kernels only have MemFree, we use that as fallback
-						else if (line != null && line.Contains("MemFree:"))
-						{
-							var (suc, res) = GetEntry(line, "MemFree:");
-							if (suc) retVal.Add(new MetricSample(FreeMemory, res));
-							hasMemFree = true;
 						}
-
 						if (line != null && line.Contains("MemTotal:"))
 						{
 							var (suc, res) = GetEntry(line, "MemTotal:");


### PR DESCRIPTION
Bug found by @SergeyKleyman, since `/proc/meminfo` `MemFree` potentially overwrote the value even when `MemAvailable` was present. 

Our final decision: we only look for `MemAvailable`, and don't do any fallback, since that must be present on basically any supported kernel today. 