### PR TITLE
Increase version to 1.0.0-beta1

### DIFF
--- a/src/Elastic.Apm.All/Elastic.Apm.All.csproj
+++ b/src/Elastic.Apm.All/Elastic.Apm.All.csproj
@@ -4,7 +4,7 @@
     <AssemblyName>Elastic.Apm.All</AssemblyName>
     <RootNamespace>Elastic.Apm.All</RootNamespace>
     <AssemblyVersion>1.0.0</AssemblyVersion>
-    <InformationalVersion>1.0.0</InformationalVersion>
+    <InformationalVersion>1.0.0-beta1</InformationalVersion>
     <FileVersion>1.0.0</FileVersion>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\build\elasticapm.snk</AssemblyOriginatorKeyFile>

--- a/src/Elastic.Apm.All/Elastic.Apm.All.csproj
+++ b/src/Elastic.Apm.All/Elastic.Apm.All.csproj
@@ -3,13 +3,13 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <AssemblyName>Elastic.Apm.All</AssemblyName>
     <RootNamespace>Elastic.Apm.All</RootNamespace>
-    <AssemblyVersion>0.0.2.0</AssemblyVersion>
-    <InformationalVersion>0.0.2.0</InformationalVersion>
-    <FileVersion>0.0.2.0</FileVersion>
+    <AssemblyVersion>1.0.0</AssemblyVersion>
+    <InformationalVersion>1.0.0</InformationalVersion>
+    <FileVersion>1.0.0</FileVersion>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\build\elasticapm.snk</AssemblyOriginatorKeyFile>
     <DelaySign>false</DelaySign>
-    <PackageVersion>0.0.2.0-alpha</PackageVersion>
+    <PackageVersion>1.0.0-beta1</PackageVersion>
     <Authors>Elastic and contributors</Authors>    
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <PackageId>Elastic.Apm.All</PackageId>

--- a/src/Elastic.Apm.AspNetCore/Elastic.Apm.AspNetCore.csproj
+++ b/src/Elastic.Apm.AspNetCore/Elastic.Apm.AspNetCore.csproj
@@ -3,7 +3,7 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <AssemblyName>Elastic.Apm.AspNetCore</AssemblyName>
     <AssemblyVersion>1.0.0</AssemblyVersion>
-    <InformationalVersion>1.0.0</InformationalVersion>
+    <InformationalVersion>1.0.0-beta1</InformationalVersion>
     <FileVersion>1.0.0</FileVersion>
     <RootNamespace>Elastic.Apm.AspNetCore</RootNamespace>
     <SignAssembly>true</SignAssembly>

--- a/src/Elastic.Apm.AspNetCore/Elastic.Apm.AspNetCore.csproj
+++ b/src/Elastic.Apm.AspNetCore/Elastic.Apm.AspNetCore.csproj
@@ -2,14 +2,14 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <AssemblyName>Elastic.Apm.AspNetCore</AssemblyName>
-    <AssemblyVersion>0.0.2.0</AssemblyVersion>
-    <InformationalVersion>0.0.2.0</InformationalVersion>
-    <FileVersion>0.0.2.0</FileVersion>
+    <AssemblyVersion>1.0.0</AssemblyVersion>
+    <InformationalVersion>1.0.0</InformationalVersion>
+    <FileVersion>1.0.0</FileVersion>
     <RootNamespace>Elastic.Apm.AspNetCore</RootNamespace>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\build\elasticapm.snk</AssemblyOriginatorKeyFile>
     <DelaySign>false</DelaySign>
-    <PackageVersion>0.0.2.0-alpha</PackageVersion>
+    <PackageVersion>1.0.0-beta1</PackageVersion>
     <Authors>Elastic and contributors</Authors>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <PackageId>Elastic.Apm.AspNetCore</PackageId>

--- a/src/Elastic.Apm.EntityFrameworkCore/Elastic.Apm.EntityFrameworkCore.csproj
+++ b/src/Elastic.Apm.EntityFrameworkCore/Elastic.Apm.EntityFrameworkCore.csproj
@@ -3,13 +3,13 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <RootNamespace>Elastic.Apm.EntityFrameworkCore</RootNamespace>
     <AssemblyName>Elastic.Apm.EntityFrameworkCore</AssemblyName>
-    <AssemblyVersion>0.0.2.0</AssemblyVersion>
-    <InformationalVersion>0.0.2.0</InformationalVersion>
-    <FileVersion>0.0.2.0</FileVersion>
+    <AssemblyVersion>1.0.0</AssemblyVersion>
+    <InformationalVersion>1.0.0</InformationalVersion>
+    <FileVersion>1.0.0</FileVersion>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\build\elasticapm.snk</AssemblyOriginatorKeyFile>
     <DelaySign>false</DelaySign>
-    <PackageVersion>0.0.2.0-alpha</PackageVersion>
+    <PackageVersion>1.0.0-beta1</PackageVersion>
     <Authors>Elastic and contributors</Authors>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <PackageId>Elastic.Apm.EntityFrameworkCore</PackageId>

--- a/src/Elastic.Apm.EntityFrameworkCore/Elastic.Apm.EntityFrameworkCore.csproj
+++ b/src/Elastic.Apm.EntityFrameworkCore/Elastic.Apm.EntityFrameworkCore.csproj
@@ -4,7 +4,7 @@
     <RootNamespace>Elastic.Apm.EntityFrameworkCore</RootNamespace>
     <AssemblyName>Elastic.Apm.EntityFrameworkCore</AssemblyName>
     <AssemblyVersion>1.0.0</AssemblyVersion>
-    <InformationalVersion>1.0.0</InformationalVersion>
+    <InformationalVersion>1.0.0-beta1</InformationalVersion>
     <FileVersion>1.0.0</FileVersion>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\build\elasticapm.snk</AssemblyOriginatorKeyFile>

--- a/src/Elastic.Apm/Api/Service.cs
+++ b/src/Elastic.Apm/Api/Service.cs
@@ -1,4 +1,6 @@
-﻿using Elastic.Apm.Config;
+﻿using System.Diagnostics;
+using System.Reflection;
+using Elastic.Apm.Config;
 
 namespace Elastic.Apm.Api
 {
@@ -18,7 +20,7 @@ namespace Elastic.Apm.Api
 				Agent = new AgentC
 				{
 					Name = Consts.AgentName,
-					Version = typeof(Agent).Assembly.GetName().Version?.ToString() ?? "n/a"
+					Version = typeof(Agent).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>().InformationalVersion
 				}
 			};
 

--- a/src/Elastic.Apm/Elastic.Apm.csproj
+++ b/src/Elastic.Apm/Elastic.Apm.csproj
@@ -8,13 +8,13 @@
   <PropertyGroup>
     <RootNamespace>Elastic.Apm</RootNamespace>
     <AssemblyName>Elastic.Apm</AssemblyName>
-    <AssemblyVersion>0.0.2.0</AssemblyVersion>
-    <InformationalVersion>0.0.2.0</InformationalVersion>
-    <FileVersion>0.0.2.0</FileVersion>
+    <AssemblyVersion>1.0.0</AssemblyVersion>
+    <InformationalVersion>1.0.0</InformationalVersion>
+    <FileVersion>1.0.0</FileVersion>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\build\elasticapm.snk</AssemblyOriginatorKeyFile>
     <DelaySign>false</DelaySign>
-    <PackageVersion>0.0.2.0-alpha</PackageVersion>
+    <PackageVersion>1.0.0-beta1</PackageVersion>
     <Authors>Elastic and contributors</Authors>
     <PackageId>Elastic.Apm</PackageId>
     <copyright>2019 Elasticsearch BV</copyright>

--- a/src/Elastic.Apm/Elastic.Apm.csproj
+++ b/src/Elastic.Apm/Elastic.Apm.csproj
@@ -9,7 +9,7 @@
     <RootNamespace>Elastic.Apm</RootNamespace>
     <AssemblyName>Elastic.Apm</AssemblyName>
     <AssemblyVersion>1.0.0</AssemblyVersion>
-    <InformationalVersion>1.0.0</InformationalVersion>
+    <InformationalVersion>1.0.0-beta1</InformationalVersion>
     <FileVersion>1.0.0</FileVersion>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\build\elasticapm.snk</AssemblyOriginatorKeyFile>

--- a/test/Elastic.Apm.AspNetCore.Tests/AspNetCoreMiddlewareTests.cs
+++ b/test/Elastic.Apm.AspNetCore.Tests/AspNetCoreMiddlewareTests.cs
@@ -58,7 +58,7 @@ namespace Elastic.Apm.AspNetCore.Tests
 				.And.NotBe(ConfigConsts.DefaultValues.UnknownServiceName);
 
 			_agent.Service.Agent.Name.Should().Be(Elastic.Apm.Consts.AgentName);
-			var apmVersion = Assembly.Load("Elastic.Apm").GetName().Version.ToString();
+			var apmVersion = typeof(Agent).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>().InformationalVersion;
 			_agent.Service.Agent.Version.Should().Be(apmVersion);
 
 			_agent.Service.Framework.Name.Should().Be("ASP.NET Core");

--- a/test/Elastic.Apm.Tests/BasicAgentTests.cs
+++ b/test/Elastic.Apm.Tests/BasicAgentTests.cs
@@ -47,7 +47,7 @@ namespace Elastic.Apm.Tests
 			using (var agent = new ApmAgent(new TestAgentComponents(payloadSender: payloadSender)))
 			{
 				agent.Tracer.CaptureTransaction("TestName", "TestType", () => { Thread.Sleep(5); });
-				agent.Service.Agent.Version.Should().Be(Assembly.Load("Elastic.Apm").GetName().Version.ToString());
+				agent.Service.Agent.Version.Should().Be(typeof(Agent).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>().InformationalVersion);
 			}
 		}
 


### PR DESCRIPTION
Part of #298.

- Use `InformationalVersion` as agent version, since that's the one that also contains the `beta` postfix. 

We already have an issue to automate this - since that's not done yet, we do this manually this time.