### PR TITLE
Update docs/public-api.asciidoc

### DIFF
--- a/docs/public-api.asciidoc
+++ b/docs/public-api.asciidoc
@@ -259,6 +259,7 @@ var asyncResult = await transaction.CaptureSpan("Select FROM customer", ApiConst
 
 NOTE: The <<convenient-capture-span>> method does not start any `Task` for you, so you have to call it with the `await` keyword if you use one of the overloads that accept `Task` or `Task<T>`.
 
+NOTE: Code samples above use `Elastic.Apm.Agent.Tracer.CurrentTransaction`. In production code you should make sure the `CurrentTransaction` is not `null`.
 
 //----------------------------
 [float]

--- a/docs/public-api.asciidoc
+++ b/docs/public-api.asciidoc
@@ -56,7 +56,7 @@ Returns the currently active transaction.
 See the <<api-transaction>> to customize the current transaction.
 
 If there is no current transaction,
-this method will return null.
+this method will return `null`.
 
 [source,csharp]
 ----


### PR DESCRIPTION
Following up on #231 - there was some surprise that `Elastic.Apm.Agent.Tracer.CurrentTransaction` can be null. We mention this where [`CurrentTransaction`](https://github.com/elastic/apm-agent-dotnet/blob/master/docs/public-api.asciidoc#transaction-currenttransaction) is documented, nevertheless I think a similar note in the `CaptureSpan` part does not hurt, since we heavily use `CurrentTransaction` in the code samples. 

Plus I promised to add such a note [here](https://github.com/elastic/apm-agent-dotnet/issues/231#issuecomment-494067210). 