### PR TITLE
Fix TrimToLength and move it to SerializationUtils

### DIFF
--- a/src/Elastic.Apm/Helpers/StringExtensions.cs
+++ b/src/Elastic.Apm/Helpers/StringExtensions.cs
@@ -9,12 +9,12 @@ namespace Elastic.Apm.Helpers
 			input.ThrowIfArgumentNull(nameof(input));
 
 			if (input.Length > maxLength)
-				input = $"{input.Substring(0, Consts.PropertyMaxLength - 3)}...";
+				input = $"{input.Substring(0, maxLength - 3)}...";
 
 			return input;
 		}
 
-		internal static string TrimToMaxLength(this string input) => input.TrimToLength(Consts.PropertyMaxLength);
+		internal static string TrimToPropertyMaxLength(this string input) => input.TrimToLength(Consts.PropertyMaxLength);
 
 		public static bool IsEmpty(this string input)
 		{

--- a/src/Elastic.Apm/Helpers/StringExtensions.cs
+++ b/src/Elastic.Apm/Helpers/StringExtensions.cs
@@ -4,18 +4,6 @@ namespace Elastic.Apm.Helpers
 {
 	internal static class StringExtensions
 	{
-		private static string TrimToLength(this string input, int maxLength)
-		{
-			input.ThrowIfArgumentNull(nameof(input));
-
-			if (input.Length > maxLength)
-				input = $"{input.Substring(0, maxLength - 3)}...";
-
-			return input;
-		}
-
-		internal static string TrimToPropertyMaxLength(this string input) => input.TrimToLength(Consts.PropertyMaxLength);
-
 		public static bool IsEmpty(this string input)
 		{
 			input.ThrowIfArgumentNull(nameof(input));

--- a/src/Elastic.Apm/Report/Serialization/SerializationUtils.cs
+++ b/src/Elastic.Apm/Report/Serialization/SerializationUtils.cs
@@ -1,0 +1,20 @@
+using Elastic.Apm.Helpers;
+
+namespace Elastic.Apm.Report.Serialization
+{
+	internal static class SerializationUtils
+	{
+		internal static string TrimToLength(string input, int maxLength)
+		{
+			input.ThrowIfArgumentNull(nameof(input));
+
+			if (input.Length <= maxLength) return input;
+
+			if (maxLength <= 5) return input.Substring(0, maxLength);
+
+			return $"{input.Substring(0, maxLength - 3)}...";
+		}
+
+		internal static string TrimToPropertyMaxLength(string input) => TrimToLength(input, Consts.PropertyMaxLength);
+	}
+}

--- a/src/Elastic.Apm/Report/Serialization/TagsJsonConverter.cs
+++ b/src/Elastic.Apm/Report/Serialization/TagsJsonConverter.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using Elastic.Apm.Helpers;
 using Newtonsoft.Json;
 
 namespace Elastic.Apm.Report.Serialization
@@ -12,8 +11,8 @@ namespace Elastic.Apm.Report.Serialization
 			writer.WriteStartObject();
 			foreach (var keyValue in tags)
 			{
-				writer.WritePropertyName(keyValue.Key.TrimToPropertyMaxLength());
-				writer.WriteValue(keyValue.Value.TrimToPropertyMaxLength());
+				writer.WritePropertyName(SerializationUtils.TrimToPropertyMaxLength(keyValue.Key));
+				writer.WriteValue(SerializationUtils.TrimToPropertyMaxLength(keyValue.Value));
 			}
 			writer.WriteEndObject();
 		}

--- a/src/Elastic.Apm/Report/Serialization/TagsJsonConverter.cs
+++ b/src/Elastic.Apm/Report/Serialization/TagsJsonConverter.cs
@@ -12,8 +12,8 @@ namespace Elastic.Apm.Report.Serialization
 			writer.WriteStartObject();
 			foreach (var keyValue in tags)
 			{
-				writer.WritePropertyName(keyValue.Key.TrimToMaxLength());
-				writer.WriteValue(keyValue.Value.TrimToMaxLength());
+				writer.WritePropertyName(keyValue.Key.TrimToPropertyMaxLength());
+				writer.WriteValue(keyValue.Value.TrimToPropertyMaxLength());
 			}
 			writer.WriteEndObject();
 		}

--- a/src/Elastic.Apm/Report/Serialization/TrimmedStringJsonConverter.cs
+++ b/src/Elastic.Apm/Report/Serialization/TrimmedStringJsonConverter.cs
@@ -7,7 +7,7 @@ namespace Elastic.Apm.Report.Serialization
 {
 	internal class TrimmedStringJsonConverter : JsonConverter<string>
 	{
-		public override void WriteJson(JsonWriter writer, string value, JsonSerializer serializer) => writer.WriteValue(value.TrimToMaxLength());
+		public override void WriteJson(JsonWriter writer, string value, JsonSerializer serializer) => writer.WriteValue(value.TrimToPropertyMaxLength());
 
 		public override string ReadJson(JsonReader reader, Type objectType, string existingValue, bool hasExistingValue, JsonSerializer serializer) =>
 			reader.Value as string;

--- a/src/Elastic.Apm/Report/Serialization/TrimmedStringJsonConverter.cs
+++ b/src/Elastic.Apm/Report/Serialization/TrimmedStringJsonConverter.cs
@@ -1,13 +1,12 @@
 using System;
-using System.Collections.Generic;
-using Elastic.Apm.Helpers;
 using Newtonsoft.Json;
 
 namespace Elastic.Apm.Report.Serialization
 {
 	internal class TrimmedStringJsonConverter : JsonConverter<string>
 	{
-		public override void WriteJson(JsonWriter writer, string value, JsonSerializer serializer) => writer.WriteValue(value.TrimToPropertyMaxLength());
+		public override void WriteJson(JsonWriter writer, string value, JsonSerializer serializer) =>
+			writer.WriteValue(SerializationUtils.TrimToPropertyMaxLength(value));
 
 		public override string ReadJson(JsonReader reader, Type objectType, string existingValue, bool hasExistingValue, JsonSerializer serializer) =>
 			reader.Value as string;

--- a/test/Elastic.Apm.Tests/SerializationTests.cs
+++ b/test/Elastic.Apm.Tests/SerializationTests.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using Elastic.Apm.Api;
+using Elastic.Apm.Helpers;
 using Elastic.Apm.Model;
 using Elastic.Apm.Report.Serialization;
 using Elastic.Apm.Tests.Mocks;
@@ -157,6 +158,47 @@ namespace Elastic.Apm.Tests
 
 			deserializedNonSampledTransaction["sampled"].Value<bool>().Should().BeFalse();
 			deserializedNonSampledTransaction.Should().NotContainKey("context");
+		}
+
+		[Theory]
+		[InlineData("", 0, "")]
+		[InlineData("A", 0, "")]
+		[InlineData("ABC", 0, "")]
+		[InlineData("B", 1, "B")]
+		[InlineData("", 1, "")]
+		[InlineData("ABC", 1, "A")]
+		[InlineData("ABC", 2, "AB")]
+		[InlineData("ABC", 3, "ABC")]
+		[InlineData("", 3, "")]
+		[InlineData("ABCE", 3, "ABC")]
+		[InlineData("ABCD", 4, "ABCD")]
+		[InlineData("ABCDE", 4, "ABCD")]
+		[InlineData("ABCDE", 5, "ABCDE")]
+		[InlineData("ABCDEF", 5, "ABCDE")]
+		[InlineData("ABCDEF", 6, "ABCDEF")]
+		[InlineData("ABCDEFG", 6, "ABC...")]
+		[InlineData("ABCDEFGH", 6, "ABC...")]
+		[InlineData("ABCDEFGH", 7, "ABCD...")]
+		public void SerializationUtilsTrimToLengthTests(string original, int maxLength, string expectedTrimmed)
+		{
+			SerializationUtils.TrimToLength(original, maxLength).Should().Be(expectedTrimmed);
+		}
+
+		public static IEnumerable<object[]> SerializationUtilsTrimToPropertyMaxLengthVariantsToTest()
+		{
+			yield return new object[] { "", "" };
+			yield return new object[] { "A", "A" };
+			yield return new object[] { "B".Repeat(Consts.PropertyMaxLength), "B".Repeat(Consts.PropertyMaxLength) };
+			yield return new object[] { "C".Repeat(Consts.PropertyMaxLength + 1), "C".Repeat(Consts.PropertyMaxLength-3) + "..." };
+			yield return new object[] { "D".Repeat(Consts.PropertyMaxLength * 2), "D".Repeat(Consts.PropertyMaxLength-3) + "..." };
+		}
+
+		[Theory]
+		[MemberData(nameof(SerializationUtilsTrimToPropertyMaxLengthVariantsToTest))]
+		public void SerializationUtilsTrimToPropertyMaxLengthTests(string original, string expectedTrimmed)
+		{
+			Consts.PropertyMaxLength.Should().BeGreaterThan(3);
+			SerializationUtils.TrimToPropertyMaxLength(original).Should().Be(expectedTrimmed);
 		}
 
 		private static string SerializePayloadItem(object item) =>


### PR DESCRIPTION
- Fixed `TrimToLength` not using `maxLength` parameter
- Moved `TrimToLength` and `TrimToPropertyMaxLength` from `StringExtensions` to `SerializationUtils` since both are very specific to serialization so it would make more sense to place it there
- Added tests
