### PR TITLE
Fix version in docs

### DIFF
--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -170,7 +170,7 @@ Valid options: `Error`, `Warning`, `Info`, `Debug`.
 
 [float]
 [[config-metrics-interval]]
-==== `MetricsInterval` (added[1.0.0-beta])
+==== `MetricsInterval` (added[1.0.0-beta1])
 
 The interval at which the agent sends metrics to the APM Server.
 Must be at least `1s`.


### PR DESCRIPTION
The correct version number is `1.0.0-beta1` - aligned with the versioning we use company wide.