### PR TITLE
Implement ServerUrls configuration option limitation

### DIFF
--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -172,9 +172,9 @@ Use this setting in case the APM Server requires a token (e.g. APM Server in Ela
 | `http://localhost:8200` | List
 |============
 
-The URLs for your APM Servers. The URLs must be fully qualified, including protocol (`http` or `https`) and port. To add multiple servers, separate them with a comma (`,`).
+The URLs for your APM Servers. The URLs must be fully qualified, including protocol (`http` or `https`) and port.
 
-NOTE: Providing multiple URLs only works with APM Server v6.5+.
+NOTE: Providing multiple URLs is not supported by the agent yet. If multiple URLs are provided only the first one will be used.
 
 [float]
 [[config-log-level]]

--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -169,10 +169,10 @@ Use this setting in case the APM Server requires a token (e.g. APM Server in Ela
 [options="header"]
 |============
 | Default                 | Type
-| `http://localhost:8200` | List
+| `http://localhost:8200` | String
 |============
 
-The URLs for your APM Servers. The URLs must be fully qualified, including protocol (`http` or `https`) and port.
+The URL for your APM Server. The URL must be fully qualified, including protocol (`http` or `https`) and port.
 
 NOTE: Providing multiple URLs is not supported by the agent yet. If multiple URLs are provided only the first one will be used.
 

--- a/src/Elastic.Apm.AspNetCore/Config/MicrosoftExtensionsConfig.cs
+++ b/src/Elastic.Apm.AspNetCore/Config/MicrosoftExtensionsConfig.cs
@@ -12,7 +12,7 @@ namespace Elastic.Apm.AspNetCore.Config
 	/// </summary>
 	internal class MicrosoftExtensionsConfig : AbstractConfigurationReader, IConfigurationReader
 	{
-		internal const string Origin = "Configuration Provider";
+		internal const string Origin = "Microsoft.Extensions.Configuration";
 
 		internal static class Keys
 		{
@@ -70,7 +70,7 @@ namespace Elastic.Apm.AspNetCore.Config
 			var primary = Read(key);
 			if (!string.IsNullOrWhiteSpace(primary.Value)) return primary;
 
-			var secondary = Kv(key, _configuration[fallBackEnvVarName], EnvironmentConfigurationReader.Origin);
+			var secondary = Kv(fallBackEnvVarName, _configuration[fallBackEnvVarName], EnvironmentConfigurationReader.Origin);
 			return secondary;
 		}
 

--- a/src/Elastic.Apm/Helpers/LazyContextualInit.cs
+++ b/src/Elastic.Apm/Helpers/LazyContextualInit.cs
@@ -1,0 +1,47 @@
+using System;
+using System.Threading;
+
+namespace Elastic.Apm.Helpers
+{
+	internal class LazyContextualInit<T>
+	{
+		private T _value;
+		private bool _isInited;
+
+		/// <summary>
+		/// Lock object is created on demand by LazyInitializer.EnsureInitialized
+		/// https://docs.microsoft.com/en-us/dotnet/api/system.threading.lazyinitializer.ensureinitialized?view=netframework-4.8#System_Threading_LazyInitializer_EnsureInitialized__1___0__System_Boolean__System_Object__System_Func___0__
+		/// </summary>
+		private object _lock;
+
+		internal bool IsInited => Volatile.Read(ref _isInited);
+
+		internal T Value => _value;
+
+		/// <summary>
+		/// This method allows to optimize creating <c>producer</c>
+		/// To use in the following manner: <c>ctxLazy.IfNotInited?.InitOrGet( ... ) ?? ctxLazy.Value</c>
+		/// <returns><c>null</c> if value is already initialized and some non-<c>null</c> object otherwise</returns>>
+		/// </summary>
+		internal IfNotInitedHelper? IfNotInited => IsInited ? (IfNotInitedHelper?)null : new IfNotInitedHelper(this);
+
+		internal T InitOrGet(Func<T> producer)
+		{
+			producer.ThrowIfArgumentNull(nameof(producer));
+
+			return LazyInitializer.EnsureInitialized(ref _value, ref _isInited, ref _lock, producer);
+		}
+
+		internal readonly struct IfNotInitedHelper
+		{
+			private readonly LazyContextualInit<T> _owner;
+
+			internal IfNotInitedHelper(LazyContextualInit<T> owner)
+			{
+				_owner = owner;
+			}
+
+			internal T InitOrGet(Func<T> producer) => _owner.InitOrGet(producer);
+		}
+	}
+}

--- a/src/Elastic.Apm/Report/PayloadSenderV2.cs
+++ b/src/Elastic.Apm/Report/PayloadSenderV2.cs
@@ -173,7 +173,8 @@ namespace Elastic.Apm.Report
 			{
 				_logger?.Warning()
 					?.LogException(
-						e, "Failed sending events. Following events were not transferred successfully to the server:\n{items}",
+						e, "Failed sending events. Following events were not transferred successfully to the server ({ApmServerUrl}):\n{items}",
+						_httpClient.BaseAddress,
 						string.Join($",{Environment.NewLine}", queueItems.ToArray()));
 			}
 		}

--- a/test/Elastic.Apm.Tests/HelpersTests/LazyContextualInitTests.cs
+++ b/test/Elastic.Apm.Tests/HelpersTests/LazyContextualInitTests.cs
@@ -1,0 +1,93 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using Elastic.Apm.Helpers;
+using FluentAssertions;
+using Xunit;
+
+namespace Elastic.Apm.Tests.HelpersTests
+{
+	public class LazyContextualInitTests
+	{
+		[Theory]
+		[MemberData(nameof(WaysToCallInitOrGetString))]
+		internal void InitializedOnlyOnceOnFirstAccess(string dbgWayToCallDesc, Func<LazyContextualInit<string>, Func<string>, string> wayToCall)
+		{
+			var counter = new ThreadSafeCounter();
+			var ctxLazy = new LazyContextualInit<string>();
+			ctxLazy.IsInited.Should().BeFalse();
+			ctxLazy.IfNotInited.Should().NotBeNull();
+			var val1 = wayToCall(ctxLazy, () => counter.Increment().ToString());
+			ctxLazy.IsInited.Should().BeTrue($"{nameof(dbgWayToCallDesc)}: {dbgWayToCallDesc}");
+			ctxLazy.IfNotInited.Should().BeNull();
+			val1.Should().Be("1");
+			counter.Value.Should().Be(1);
+
+			var val2 = wayToCall(ctxLazy, () => counter.Increment().ToString());
+			ctxLazy.IsInited.Should().BeTrue();
+			val2.Should().Be("1");
+			counter.Value.Should().Be(1);
+		}
+
+		[Theory]
+		[MemberData(nameof(WaysToCallInitOrGetString))]
+		internal void InitializedOnlyOnceFromMultipleThreads(string dbgWayToCallDesc, Func<LazyContextualInit<string>, Func<string>, string> wayToCall)
+		{
+			var counter = new ThreadSafeCounter();
+			var ctxLazy = new LazyContextualInit<string>();
+			var numberOfThreads = Math.Max(Environment.ProcessorCount, 2);
+			var threadIndexesAndValues = new ConcurrentBag<ValueTuple<int, string>>();
+			var barrier = new Barrier(numberOfThreads);
+			var expectedThreadIndexes = Enumerable.Range(1, numberOfThreads);
+			var threads = expectedThreadIndexes.Select(i => new Thread(() => EachThreadDo(i))).ToList();
+			foreach (var thread in threads) thread.Start();
+			foreach (var thread in threads) thread.Join();
+
+			ctxLazy.IsInited.Should().BeTrue($"{nameof(dbgWayToCallDesc)}: {dbgWayToCallDesc}");
+			counter.Value.Should().Be(1);
+			threadIndexesAndValues.Should().HaveCount(numberOfThreads);
+			var actualThreadIndexes = new HashSet<int>();
+			foreach (var (threadIndex, value) in threadIndexesAndValues)
+			{
+				value.Should().Be("1");
+				actualThreadIndexes.Add(threadIndex);
+			}
+			actualThreadIndexes.Should().HaveCount(numberOfThreads);
+			foreach (var expectedThreadIndex in expectedThreadIndexes) actualThreadIndexes.Should().Contain(expectedThreadIndex);
+
+			void EachThreadDo(int threadIndex)
+			{
+				barrier.SignalAndWait();
+				var value = wayToCall(ctxLazy, () => counter.Increment().ToString());
+				threadIndexesAndValues.Add((threadIndex, value));
+			}
+		}
+
+		private class ThreadSafeCounter
+		{
+			internal ThreadSafeCounter(int initialValue = 0) => _value = initialValue;
+
+			private int _value;
+
+			internal int Value => Interlocked.CompareExchange(ref _value, 0, 0);
+
+			internal int Increment() => Interlocked.Increment(ref _value);
+		}
+
+		// ReSharper disable once MemberCanBeProtected.Global
+		public static IEnumerable<object[]> WaysToCallInitOrGet<T>() where T: class
+		{
+			ValueTuple<string, Func<LazyContextualInit<T>, Func<T>, T>>[] waysToCall =
+			{
+				("IfNotInited?.InitOrGet ?? Value", (lazyValue, valueProducer) => lazyValue.IfNotInited?.InitOrGet(valueProducer) ?? lazyValue.Value),
+				("InitOrGet", (lazyValue, valueProducer) => lazyValue.InitOrGet(valueProducer))
+			};
+
+			foreach (var (dbgWayToCallDesc, wayToCall) in waysToCall) yield return new object[] { dbgWayToCallDesc, wayToCall };
+		}
+
+		public static IEnumerable<object[]> WaysToCallInitOrGetString() => WaysToCallInitOrGet<string>();
+	}
+}


### PR DESCRIPTION
Closes elastic/apm-agent-dotnet#376

- Document ServerUrls configuration option limitation
- Log warning if user specified more than URL is in the configuration
