### PR TITLE
MetricsWithRealAgent - add XunitOutputLogger and increase timeout

### DIFF
--- a/src/Elastic.Apm/Metrics/MetricsCollector.cs
+++ b/src/Elastic.Apm/Metrics/MetricsCollector.cs
@@ -73,6 +73,8 @@ namespace Elastic.Apm.Metrics
 			var sync = Interlocked.CompareExchange(ref _syncPoint, 1, 0);
 			if (sync != 0) return;
 
+			_logger.Trace()?.Log("CollectAllMetrics started");
+
 			try
 			{
 				var samplesFromAllProviders = new List<MetricSample>();
@@ -84,12 +86,16 @@ namespace Elastic.Apm.Metrics
 
 					try
 					{
+						_logger.Trace()?.Log("Start collecting {MetricsProviderName}", metricsProvider.DbgName);
 						var samplesFromCurrentProvider = metricsProvider.GetSamples();
 						if (samplesFromCurrentProvider != null)
 						{
 							var sampleArray = samplesFromCurrentProvider as MetricSample[] ?? samplesFromCurrentProvider.ToArray();
 							if (sampleArray.Any())
+							{
+								_logger.Trace()?.Log("Collected {MetricsProviderName} - adding it to MetricSet", metricsProvider.DbgName);
 								samplesFromAllProviders.AddRange(sampleArray);
+							}
 
 							metricsProvider.ConsecutiveNumberOfFailedReads = 0;
 						}

--- a/src/Elastic.Apm/Metrics/MetricsProvider/ProcessTotalCpuTimeProvider.cs
+++ b/src/Elastic.Apm/Metrics/MetricsProvider/ProcessTotalCpuTimeProvider.cs
@@ -9,12 +9,11 @@ namespace Elastic.Apm.Metrics.MetricsProvider
 {
 	internal class ProcessTotalCpuTimeProvider : IMetricsProvider
 	{
-		private readonly IApmLogger _logger;
 		internal const string ProcessCpuTotalPct = "system.process.cpu.total.norm.pct";
 
 		public ProcessTotalCpuTimeProvider(IApmLogger logger)
 		{
-			_logger = logger.Scoped(nameof(ProcessTotalCpuTimeProvider));
+			IApmLogger loggerInCtor = logger.Scoped(nameof(ProcessTotalCpuTimeProvider));
 
 			try
 			{
@@ -23,7 +22,7 @@ namespace Elastic.Apm.Metrics.MetricsProvider
 			}
 			catch (Exception e)
 			{
-				_logger.Error()?.LogException(e, "Failed reading Process Total CPU Time");
+				loggerInCtor.Error()?.LogException(e, "Failed reading Process Total CPU Time");
 			}
 		}
 

--- a/src/Elastic.Apm/Metrics/MetricsProvider/SystemTotalCpuProvider.cs
+++ b/src/Elastic.Apm/Metrics/MetricsProvider/SystemTotalCpuProvider.cs
@@ -12,6 +12,7 @@ namespace Elastic.Apm.Metrics.MetricsProvider
 {
 	internal class SystemTotalCpuProvider : IMetricsProvider, IDisposable
 	{
+		// ReSharper disable once PrivateFieldCanBeConvertedToLocalVariable
 		private readonly IApmLogger _logger;
 		internal const string SystemCpuTotalPct = "system.cpu.total.norm.pct";
 		private readonly PerformanceCounter _processorTimePerfCounter;

--- a/test/Elastic.Apm.Tests/MetricsTests.cs
+++ b/test/Elastic.Apm.Tests/MetricsTests.cs
@@ -11,13 +11,19 @@ using Elastic.Apm.Logging;
 using Elastic.Apm.Metrics;
 using Elastic.Apm.Metrics.MetricsProvider;
 using Elastic.Apm.Tests.Mocks;
+using Elastic.Apm.Tests.TestHelpers;
 using FluentAssertions;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Elastic.Apm.Tests
 {
 	public class MetricsTests
 	{
+		private readonly ITestOutputHelper _testOutputHelper;
+
+		public MetricsTests(ITestOutputHelper testOutputHelper) => _testOutputHelper = testOutputHelper;
+
 		[Fact]
 		public void CollectAllMetrics()
 		{
@@ -100,12 +106,12 @@ namespace Elastic.Apm.Tests
 		[Fact]
 		public async Task MetricsWithRealAgent()
 		{
-			var logger = new TestLogger();
+			var logger = new XunitOutputLogger(_testOutputHelper);
 			var payloadSender = new MockPayloadSender();
-			var configReader = new TestAgentConfigurationReader(logger, metricsInterval: "1s");
+			var configReader = new TestAgentConfigurationReader(logger, metricsInterval: "1s", logLevel: "Debug");
 			using (var agent = new ApmAgent(new AgentComponents(payloadSender: payloadSender, logger: logger, configurationReader: configReader)))
 			{
-				await Task.Delay(2200); //make sure we wait enough to collect 1 set of metrics
+				await Task.Delay(10000); //make sure we wait enough to collect 1 set of metrics
 				agent.ConfigurationReader.MetricsIntervalInMillisecond.Should().Be(1000);
 			}
 
@@ -143,7 +149,7 @@ namespace Elastic.Apm.Tests
 
 		private class TestSystemTotalCpuProvider : SystemTotalCpuProvider
 		{
-			public TestSystemTotalCpuProvider(string procStatContent) : base( new NoopLogger(),
+			public TestSystemTotalCpuProvider(string procStatContent) : base(new NoopLogger(),
 				new StreamReader(new MemoryStream(Encoding.UTF8.GetBytes(procStatContent)))) { }
 		}
 	}


### PR DESCRIPTION
Addressing #378

- Increased timeout
- Added `XunitOutputLogger` with debug logs which hopefully will tell us how far the metrics collection went in case it fails again