### PR TITLE
add environment property to service class

### DIFF
--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -151,7 +151,7 @@ You must use the query bar to filter for a specific environment in versions prio
 [options="header"]
 |============
 | Default                                        | Type
-| EnvironmentName from IHostingEnvironment    | String 
+| https://docs.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.hosting.ihostingenvironment.environmentname?view=aspnetcore-2.2#Microsoft_AspNetCore_Hosting_IHostingEnvironment_EnvironmentName[EnvironmentName from IHostingEnvironment] | String 
 |============
 
 [float]

--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -130,6 +130,31 @@ of the deployed revision, e.g. the output of git rev-parse HEAD.
 |============
 
 [float]
+[[config-environment]]
+==== `Environment`
+
+The name of the environment this service is deployed in, e.g. "production" or "staging".
+
+Environments allow you to easily filter data on a global level in the APM UI.
+It's important to be consistent when naming environments across agents.
+See {kibana-ref}/filters.html#environment-selector[environment selector] in the Kibana UI for more information.
+
+NOTE: This feature is fully supported in the APM UI in Kibana versions >= 7.2.
+You must use the query bar to filter for a specific environment in versions prior to 7.2.
+
+[options="header"]
+|============
+| Environment variable name      | IConfiguration key 
+| `ELASTIC_APM_ENVIRONMENT`      | `ElasticApm:Environment`
+|============
+
+[options="header"]
+|============
+| Default                                        | Type
+| EnvironmentName from IHostingEnvironment    | String 
+|============
+
+[float]
 [[config-transaction-sample-rate]]
 ==== `TransactionSampleRate`
 

--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -150,9 +150,11 @@ You must use the query bar to filter for a specific environment in versions prio
 
 [options="header"]
 |============
-| Default                                        | Type
-| https://docs.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.hosting.ihostingenvironment.environmentname?view=aspnetcore-2.2#Microsoft_AspNetCore_Hosting_IHostingEnvironment_EnvironmentName[EnvironmentName from IHostingEnvironment] | String 
+| Default        | Type
+| See note below | String 
 |============
+
+NOTE: On ASP.NET Core application the agent uses https://docs.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.hosting.ihostingenvironment.environmentname?view=aspnetcore-2.2#Microsoft_AspNetCore_Hosting_IHostingEnvironment_EnvironmentName[EnvironmentName from IHostingEnvironment] as default environment name.
 
 [float]
 [[config-transaction-sample-rate]]

--- a/src/Elastic.Apm.AspNetCore/ApmMiddlewareExtension.cs
+++ b/src/Elastic.Apm.AspNetCore/ApmMiddlewareExtension.cs
@@ -9,6 +9,7 @@ using Elastic.Apm.Config;
 using Elastic.Apm.DiagnosticSource;
 using Elastic.Apm.Logging;
 using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 
@@ -47,7 +48,7 @@ namespace Elastic.Apm.AspNetCore
 
 			var configReader = configuration == null
 				? new EnvironmentConfigurationReader(logger)
-				: new MicrosoftExtensionsConfig(configuration, logger) as IConfigurationReader;
+				: new MicrosoftExtensionsConfig(configuration, logger, builder.ApplicationServices.GetEnvironmentName()) as IConfigurationReader;
 
 			var config = new AgentComponents(configurationReader: configReader, logger: logger);
 			UpdateServiceInformation(config.Service);
@@ -70,6 +71,9 @@ namespace Elastic.Apm.AspNetCore
 			agent.Subscribe(subs.ToArray());
 			return builder.UseMiddleware<ApmMiddleware>(agent.Tracer, agent);
 		}
+
+		internal static string GetEnvironmentName(this IServiceProvider serviceProvider) =>
+			(serviceProvider.GetService(typeof(IHostingEnvironment)) as IHostingEnvironment)?.EnvironmentName;
 
 		internal static IApmLogger GetApmLogger(this IServiceProvider serviceProvider) =>
 			serviceProvider.GetService(typeof(ILoggerFactory)) is ILoggerFactory loggerFactory

--- a/src/Elastic.Apm.AspNetCore/Config/MicrosoftExtensionsConfig.cs
+++ b/src/Elastic.Apm.AspNetCore/Config/MicrosoftExtensionsConfig.cs
@@ -21,6 +21,7 @@ namespace Elastic.Apm.AspNetCore.Config
 			internal const string ServerUrls = "ElasticApm:ServerUrls";
 			internal const string ServiceName = "ElasticApm:ServiceName";
 			internal const string ServiceVersion = "ElasticApm:ServiceVersion";
+			internal const string Environment = "ElasticApm:Environment";
 			internal const string SecretToken = "ElasticApm:SecretToken";
 			internal const string CaptureHeaders = "ElasticApm:CaptureHeaders";
 			internal const string TransactionSampleRate = "ElasticApm:TransactionSampleRate";
@@ -32,14 +33,16 @@ namespace Elastic.Apm.AspNetCore.Config
 		}
 
 		private readonly IConfiguration _configuration;
+		private readonly string _environmentName;
 
 		private readonly Lazy<double> _spanFramesMinDurationInMilliseconds;
 
 		private readonly Lazy<int> _stackTraceLimit;
 
-		public MicrosoftExtensionsConfig(IConfiguration configuration, IApmLogger logger = null) : base(logger)
+		public MicrosoftExtensionsConfig(IConfiguration configuration, IApmLogger logger, string environmentName) : base(logger)
 		{
 			_configuration = configuration;
+			_environmentName = environmentName;
 			_configuration.GetSection("ElasticApm")
 				?
 				.GetReloadToken()
@@ -79,6 +82,8 @@ namespace Elastic.Apm.AspNetCore.Config
 		public string ServiceName => ParseServiceName(ReadFallBack(Keys.ServiceName, ConfigConsts.EnvVarNames.ServiceName));
 
 		public string ServiceVersion => ParseServiceVersion(ReadFallBack(Keys.ServiceVersion, ConfigConsts.EnvVarNames.ServiceVersion));
+
+		public string Environment => ParseEnvironment(ReadFallBack(Keys.Environment, ConfigConsts.EnvVarNames.Environment)) ?? _environmentName;
 
 		public double SpanFramesMinDurationInMilliseconds => _spanFramesMinDurationInMilliseconds.Value;
 

--- a/src/Elastic.Apm.AspNetCore/Elastic.Apm.AspNetCore.csproj
+++ b/src/Elastic.Apm.AspNetCore/Elastic.Apm.AspNetCore.csproj
@@ -28,6 +28,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Http.Extensions" Version="2.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="2.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="2.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Routing.Abstractions" Version="2.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.0.0" />

--- a/src/Elastic.Apm.AspNetFullFramework/FullFrameworkConfigReader.cs
+++ b/src/Elastic.Apm.AspNetFullFramework/FullFrameworkConfigReader.cs
@@ -31,7 +31,7 @@ namespace Elastic.Apm.AspNetFullFramework
 		{
 			try
 			{
-				return Environment.GetEnvironmentVariable("APP_POOL_ID");
+				return System.Environment.GetEnvironmentVariable("APP_POOL_ID");
 			}
 			catch (Exception ex)
 			{

--- a/src/Elastic.Apm/Api/Service.cs
+++ b/src/Elastic.Apm/Api/Service.cs
@@ -23,9 +23,11 @@ namespace Elastic.Apm.Api
 
 		public Runtime Runtime { get; set; }
 
+		public string Environment { get; set; }
+
 		public override string ToString() => new ToStringBuilder(nameof(Service))
 		{
-			{ "Name", Name }, {"Version", Version}, { "Agent", Agent }, { "Framework", Framework }, { "Language", Language },
+			{ "Name", Name }, {"Version", Version}, { "Agent", Agent }, { "Framework", Framework }, { "Language", Language }, {"Environment", Environment}
 		}.ToString();
 
 		internal static Service GetDefaultService(IConfigurationReader configurationReader, IApmLogger loggerArg)
@@ -40,7 +42,8 @@ namespace Elastic.Apm.Api
 					Name = Consts.AgentName,
 					Version = typeof(Agent).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>().InformationalVersion
 				},
-				Runtime = PlatformDetection.GetServiceRuntime(logger)
+				Runtime = PlatformDetection.GetServiceRuntime(logger),
+				Environment = configurationReader.Environment
 			};
 		}
 

--- a/src/Elastic.Apm/Api/Service.cs
+++ b/src/Elastic.Apm/Api/Service.cs
@@ -23,6 +23,7 @@ namespace Elastic.Apm.Api
 
 		public Runtime Runtime { get; set; }
 
+		[JsonConverter(typeof(TrimmedStringJsonConverter))]
 		public string Environment { get; set; }
 
 		public override string ToString() => new ToStringBuilder(nameof(Service))

--- a/src/Elastic.Apm/Config/AbstractConfigurationReader.cs
+++ b/src/Elastic.Apm/Config/AbstractConfigurationReader.cs
@@ -382,6 +382,13 @@ namespace Elastic.Apm.Config
 			return null;
 		}
 
+		protected string ParseEnvironment(ConfigurationKeyValue kv)
+		{
+			if (kv == null || string.IsNullOrEmpty(kv.Value)) return null;
+
+			return kv.Value;
+		}
+
 		private static bool TryParseFloatingPoint(string valueAsString, out double result) =>
 			double.TryParse(valueAsString, NumberStyles.Float, CultureInfo.InvariantCulture, out result);
 

--- a/src/Elastic.Apm/Config/ConfigConsts.cs
+++ b/src/Elastic.Apm/Config/ConfigConsts.cs
@@ -36,6 +36,7 @@ namespace Elastic.Apm.Config
 			public const string ServerUrls = Prefix + "SERVER_URLS";
 			public const string ServiceName = Prefix + "SERVICE_NAME";
 			public const string ServiceVersion = Prefix + "SERVICE_VERSION";
+			public const string Environment = Prefix + "ENVIRONMENT";
 			public const string SpanFramesMinDuration = Prefix + "SPAN_FRAMES_MIN_DURATION";
 			public const string StackTraceLimit = Prefix + "STACK_TRACE_LIMIT";
 			public const string TransactionSampleRate = Prefix + "TRANSACTION_SAMPLE_RATE";

--- a/src/Elastic.Apm/Config/EnvironmentConfigurationReader.cs
+++ b/src/Elastic.Apm/Config/EnvironmentConfigurationReader.cs
@@ -35,6 +35,8 @@ namespace Elastic.Apm.Config
 
 		public string ServiceVersion => ParseServiceVersion(Read(ConfigConsts.EnvVarNames.ServiceVersion));
 
+		public string Environment => ParseEnvironment(Read(ConfigConsts.EnvVarNames.Environment));
+
 		public double SpanFramesMinDurationInMilliseconds => _spanFramesMinDurationInMilliseconds.Value;
 
 		public int StackTraceLimit => _stackTraceLimit.Value;
@@ -46,6 +48,6 @@ namespace Elastic.Apm.Config
 		public List<string> CaptureBodyContentTypes => ParseCaptureBodyContentTypes(Read(ConfigConsts.EnvVarNames.CaptureBodyContentTypes), CaptureBody);
 
 		private static ConfigurationKeyValue Read(string key) =>
-			new ConfigurationKeyValue(key, Environment.GetEnvironmentVariable(key)?.Trim(), Origin);
+			new ConfigurationKeyValue(key, System.Environment.GetEnvironmentVariable(key)?.Trim(), Origin);
 	}
 }

--- a/src/Elastic.Apm/Config/IAgentConfigReader.cs
+++ b/src/Elastic.Apm/Config/IAgentConfigReader.cs
@@ -13,6 +13,7 @@ namespace Elastic.Apm.Config
 		IReadOnlyList<Uri> ServerUrls { get; }
 		string ServiceName { get; }
 		string ServiceVersion { get; }
+		string Environment { get; }
 
 		/// <summary>
 		/// The agent limits stack trace collection to spans with durations equal or longer than the given value

--- a/test/Elastic.Apm.AspNetCore.Tests/MicrosoftExtensionsConfigTests.cs
+++ b/test/Elastic.Apm.AspNetCore.Tests/MicrosoftExtensionsConfigTests.cs
@@ -35,6 +35,7 @@ namespace Elastic.Apm.AspNetCore.Tests
 			config.ServerUrls[0].Should().Be(new Uri("http://myServerFromTheConfigFile:8080"));
 			config.ServiceName.Should().Be("My_Test_Application");
 			config.ServiceVersion.Should().Be("2.1.0.5");
+			config.Environment.Should().Be("staging");
 			config.CaptureHeaders.Should().Be(false);
 			config.TransactionSampleRate.Should().Be(0.456);
 			config.CaptureBody.Should().Be(ConfigConsts.SupportedValues.CaptureBodyAll);
@@ -64,8 +65,8 @@ namespace Elastic.Apm.AspNetCore.Tests
 					"Defaulting to "
 				);
 
+			config.Environment.Should().Be("test");
 			config.CaptureHeaders.Should().Be(true);
-
 			config.TransactionSampleRate.Should().Be(1.0);
 		}
 
@@ -108,6 +109,8 @@ namespace Elastic.Apm.AspNetCore.Tests
 			Environment.SetEnvironmentVariable(ConfigConsts.EnvVarNames.ServiceName, serviceName);
 			var serviceVersion = "2.1.0.5";
 			Environment.SetEnvironmentVariable(ConfigConsts.EnvVarNames.ServiceVersion, serviceVersion);
+			var environment = "staging";
+			Environment.SetEnvironmentVariable(ConfigConsts.EnvVarNames.Environment, environment);
 			var secretToken = "SecretToken";
 			Environment.SetEnvironmentVariable(ConfigConsts.EnvVarNames.SecretToken, secretToken);
 			Environment.SetEnvironmentVariable(ConfigConsts.EnvVarNames.CaptureHeaders, false.ToString());
@@ -121,6 +124,7 @@ namespace Elastic.Apm.AspNetCore.Tests
 			config.ServerUrls[0].Should().Be(new Uri(serverUrl));
 			config.ServiceName.Should().Be(serviceName);
 			config.ServiceVersion.Should().Be(serviceVersion);
+			config.Environment.Should().Be(environment);
 			config.SecretToken.Should().Be(secretToken);
 			config.CaptureHeaders.Should().Be(false);
 			config.TransactionSampleRate.Should().Be(0.123);

--- a/test/Elastic.Apm.AspNetCore.Tests/MicrosoftExtensionsConfigTests.cs
+++ b/test/Elastic.Apm.AspNetCore.Tests/MicrosoftExtensionsConfigTests.cs
@@ -55,8 +55,7 @@ namespace Elastic.Apm.AspNetCore.Tests
 				"test");
 			config.LogLevel.Should().Be(LogLevel.Error);
 			logger.Lines.Should().NotBeEmpty();
-			logger.Lines[0]
-				.Should()
+			logger.Lines[0].Should()
 				.ContainAll(
 					$"{{{nameof(MicrosoftExtensionsConfig)}}}",
 					"Failed parsing log level from",
@@ -83,8 +82,7 @@ namespace Elastic.Apm.AspNetCore.Tests
 			config.LogLevel.Should().Be(LogLevel.Error);
 
 			logger.Lines.Should().NotBeEmpty();
-			logger.Lines[0]
-				.Should()
+			logger.Lines[0].Should()
 				.ContainAll(
 					$"{{{nameof(MicrosoftExtensionsConfig)}}}",
 					"Failed parsing log level from",
@@ -187,8 +185,7 @@ namespace Elastic.Apm.AspNetCore.Tests
 			var response = await _client.GetAsync("/Home/Index");
 			response.IsSuccessStatusCode.Should().BeTrue();
 
-			_logger.Lines.Should()
-				.NotBeEmpty()
+			_logger.Lines.Should().NotBeEmpty()
 				.And.Contain(n => n.Contains("Failed parsing server URL from"));
 		}
 

--- a/test/Elastic.Apm.AspNetCore.Tests/MicrosoftExtensionsConfigTests.cs
+++ b/test/Elastic.Apm.AspNetCore.Tests/MicrosoftExtensionsConfigTests.cs
@@ -30,7 +30,7 @@ namespace Elastic.Apm.AspNetCore.Tests
 		public void ReadValidConfigsFromAppSettingsJson()
 		{
 			var config = new MicrosoftExtensionsConfig(GetConfig($"TestConfigs{Path.DirectorySeparatorChar}appsettings_valid.json"),
-				new TestLogger());
+				new NoopLogger(), "test");
 			config.LogLevel.Should().Be(LogLevel.Debug);
 			config.ServerUrls[0].Should().Be(new Uri("http://myServerFromTheConfigFile:8080"));
 			config.ServiceName.Should().Be("My_Test_Application");
@@ -50,10 +50,12 @@ namespace Elastic.Apm.AspNetCore.Tests
 		public void ReadInvalidLogLevelConfigFromAppsettingsJson()
 		{
 			var logger = new TestLogger();
-			var config = new MicrosoftExtensionsConfig(GetConfig($"TestConfigs{Path.DirectorySeparatorChar}appsettings_invalid.json"), logger);
+			var config = new MicrosoftExtensionsConfig(GetConfig($"TestConfigs{Path.DirectorySeparatorChar}appsettings_invalid.json"), logger,
+				"test");
 			config.LogLevel.Should().Be(LogLevel.Error);
 			logger.Lines.Should().NotBeEmpty();
-			logger.Lines[0].Should()
+			logger.Lines[0]
+				.Should()
 				.ContainAll(
 					$"{{{nameof(MicrosoftExtensionsConfig)}}}",
 					"Failed parsing log level from",
@@ -75,11 +77,13 @@ namespace Elastic.Apm.AspNetCore.Tests
 		public void ReadInvalidServerUrlsConfigFromAppsettingsJson()
 		{
 			var logger = new TestLogger();
-			var config = new MicrosoftExtensionsConfig(GetConfig($"TestConfigs{Path.DirectorySeparatorChar}appsettings_invalid.json"), logger);
+			var config = new MicrosoftExtensionsConfig(GetConfig($"TestConfigs{Path.DirectorySeparatorChar}appsettings_invalid.json"), logger,
+				"test");
 			config.LogLevel.Should().Be(LogLevel.Error);
 
 			logger.Lines.Should().NotBeEmpty();
-			logger.Lines[0].Should()
+			logger.Lines[0]
+				.Should()
 				.ContainAll(
 					$"{{{nameof(MicrosoftExtensionsConfig)}}}",
 					"Failed parsing log level from",
@@ -112,7 +116,7 @@ namespace Elastic.Apm.AspNetCore.Tests
 				.AddEnvironmentVariables()
 				.Build();
 
-			var config = new MicrosoftExtensionsConfig(configBuilder, new TestLogger());
+			var config = new MicrosoftExtensionsConfig(configBuilder, new NoopLogger(), "test");
 			config.LogLevel.Should().Be(LogLevel.Debug);
 			config.ServerUrls[0].Should().Be(new Uri(serverUrl));
 			config.ServiceName.Should().Be(serviceName);
@@ -130,7 +134,8 @@ namespace Elastic.Apm.AspNetCore.Tests
 		public void LoggerNotNull()
 		{
 			var testLogger = new TestLogger();
-			var config = new MicrosoftExtensionsConfig(GetConfig($"TestConfigs{Path.DirectorySeparatorChar}appsettings_invalid.json"), testLogger);
+			var config = new MicrosoftExtensionsConfig(GetConfig($"TestConfigs{Path.DirectorySeparatorChar}appsettings_invalid.json"), testLogger,
+				"test");
 			var serverUrl = config.ServerUrls.FirstOrDefault();
 			serverUrl.Should().NotBeNull();
 			testLogger.Lines.Should().NotBeEmpty();
@@ -156,7 +161,7 @@ namespace Elastic.Apm.AspNetCore.Tests
 			var capturedPayload = new MockPayloadSender();
 
 			var config = new MicrosoftExtensionsConfig(
-				MicrosoftExtensionsConfigTests.GetConfig($"TestConfigs{Path.DirectorySeparatorChar}appsettings_invalid.json"), _logger);
+				MicrosoftExtensionsConfigTests.GetConfig($"TestConfigs{Path.DirectorySeparatorChar}appsettings_invalid.json"), _logger, "test");
 
 			_agent = new ApmAgent(
 				new AgentComponents(payloadSender: capturedPayload, configurationReader: config, logger: _logger));
@@ -178,7 +183,8 @@ namespace Elastic.Apm.AspNetCore.Tests
 			var response = await _client.GetAsync("/Home/Index");
 			response.IsSuccessStatusCode.Should().BeTrue();
 
-			_logger.Lines.Should().NotBeEmpty()
+			_logger.Lines.Should()
+				.NotBeEmpty()
 				.And.Contain(n => n.Contains("Failed parsing server URL from"));
 		}
 

--- a/test/Elastic.Apm.AspNetCore.Tests/TestConfigs/appsettings_valid.json
+++ b/test/Elastic.Apm.AspNetCore.Tests/TestConfigs/appsettings_valid.json
@@ -10,6 +10,7 @@
     "ServerUrls": "http://myServerFromTheConfigFile:8080",
     "ServiceName": "My.Test.Application",
     "ServiceVersion": "2.1.0.5",
+    "Environment": "staging",
     "CaptureHeaders": "false",
     "TransactionSampleRate": 0.456,
     "CaptureBody": "all",

--- a/test/Elastic.Apm.AspNetFullFramework.Tests/CustomEnvironmentViaSettings.cs
+++ b/test/Elastic.Apm.AspNetFullFramework.Tests/CustomEnvironmentViaSettings.cs
@@ -7,14 +7,14 @@ using Xunit.Abstractions;
 namespace Elastic.Apm.AspNetFullFramework.Tests
 {
 	[Collection("AspNetFullFrameworkTests")]
-	public class CustomServiceNameSetViaSettings : TestsBase
+	public class CustomEnvironmentViaSettings : TestsBase
 	{
-		private const string CustomServiceName = "AspNetFullFramework.Tests.CustomServiceName";
+		private const string CustomEnvironment = "Staging";
 
-		public CustomServiceNameSetViaSettings(ITestOutputHelper xUnitOutputHelper)
+		public CustomEnvironmentViaSettings(ITestOutputHelper xUnitOutputHelper)
 			: base(xUnitOutputHelper,
-				envVarsToSetForSampleAppPool: new Dictionary<string, string> { { ConfigConsts.EnvVarNames.ServiceName, CustomServiceName } }) =>
-			AgentConfig.ServiceName = AbstractConfigurationReader.AdaptServiceName(CustomServiceName);
+				envVarsToSetForSampleAppPool: new Dictionary<string, string> { { ConfigConsts.EnvVarNames.Environment, CustomEnvironment } }) =>
+			AgentConfig.Environment = CustomEnvironment;
 
 		[AspNetFullFrameworkTheory]
 		[MemberData(nameof(AllSampleAppUrlPaths))]

--- a/test/Elastic.Apm.AspNetFullFramework.Tests/TestsBase.cs
+++ b/test/Elastic.Apm.AspNetFullFramework.Tests/TestsBase.cs
@@ -95,7 +95,7 @@ namespace Elastic.Apm.AspNetFullFramework.Tests
 				new SampleAppUrlPathData(HomeController.GetDotNetRuntimeDescriptionPageRelativePath, 200);
 
 			internal static readonly SampleAppUrlPathData ForbidHttpResponsePageDescriptionPage =
-			new SampleAppUrlPathData(HomeController.ForbidHttpResponsePageRelativePath, 200, spansCount: 1, errorsCount: 1);
+				new SampleAppUrlPathData(HomeController.ForbidHttpResponsePageRelativePath, 200, spansCount: 1, errorsCount: 1);
 
 			internal static readonly List<SampleAppUrlPathData> AllPaths = new List<SampleAppUrlPathData>()
 			{
@@ -348,12 +348,12 @@ namespace Elastic.Apm.AspNetFullFramework.Tests
 
 			FullFwAssertValid(service.Framework);
 
-			string expectedServiceName;
-			if (AgentConfig.ServiceName == null)
-				expectedServiceName = AbstractConfigurationReader.AdaptServiceName($"{Consts.SampleApp.SiteName}_{Consts.SampleApp.AppPoolName}");
-			else
-				expectedServiceName = AgentConfig.ServiceName;
+			var expectedServiceName = AgentConfig.ServiceName
+				?? AbstractConfigurationReader.AdaptServiceName($"{Consts.SampleApp.SiteName}_{Consts.SampleApp.AppPoolName}");
+			var expectedEnvironment = AgentConfig.Environment;
+
 			service.Name.Should().Be(expectedServiceName);
+			service.Environment.Should().Be(expectedEnvironment);
 		}
 
 		private void FullFwAssertValid(Framework framework)
@@ -497,6 +497,7 @@ namespace Elastic.Apm.AspNetFullFramework.Tests
 		{
 			internal bool CaptureHeaders = true;
 			internal string ServiceName;
+			internal string Environment;
 		}
 
 		public class SampleAppUrlPathData

--- a/test/Elastic.Apm.Tests/ConstructorTests.cs
+++ b/test/Elastic.Apm.Tests/ConstructorTests.cs
@@ -16,6 +16,7 @@ namespace Elastic.Apm.Tests
 			public IReadOnlyList<Uri> ServerUrls => new List<Uri> { ConfigConsts.DefaultValues.ServerUri };
 			public string ServiceName { get; }
 			public string ServiceVersion { get; }
+			public string Environment { get; }
 			public string SecretToken { get; }
 			public bool CaptureHeaders { get; }
 			public double TransactionSampleRate { get; }

--- a/test/Elastic.Apm.Tests/Mocks/TestAgentConfigurationReader.cs
+++ b/test/Elastic.Apm.Tests/Mocks/TestAgentConfigurationReader.cs
@@ -13,6 +13,7 @@ namespace Elastic.Apm.Tests.Mocks
 		private readonly string _serverUrls;
 		private readonly string _serviceName;
 		private readonly string _serviceVersion;
+		private readonly string _environment;
 		private readonly string _secretToken;
 		private readonly string _captureHeaders;
 		private readonly string _transactionSampleRate;
@@ -28,6 +29,7 @@ namespace Elastic.Apm.Tests.Mocks
 			string serverUrls = null,
 			string serviceName = null,
 			string serviceVersion = null,
+			string environment = null,
 			string secretToken = null,
 			string captureHeaders = null,
 			string transactionSampleRate = null,
@@ -43,6 +45,7 @@ namespace Elastic.Apm.Tests.Mocks
 			_logLevel = logLevel;
 			_serviceName = serviceName;
 			_serviceVersion = serviceVersion;
+			_environment = environment;
 			_secretToken = secretToken;
 			_captureHeaders = captureHeaders;
 			_transactionSampleRate = transactionSampleRate;
@@ -58,6 +61,7 @@ namespace Elastic.Apm.Tests.Mocks
 		public IReadOnlyList<Uri> ServerUrls => ParseServerUrls(Kv(ConfigConsts.EnvVarNames.ServerUrls, _serverUrls, Origin));
 		public string ServiceName => ParseServiceName(Kv(ConfigConsts.EnvVarNames.ServiceName, _serviceName, Origin));
 		public string ServiceVersion => ParseServiceVersion(Kv(ConfigConsts.EnvVarNames.ServiceVersion, _serviceVersion,  Origin));
+		public string Environment => ParseEnvironment(Kv(ConfigConsts.EnvVarNames.Environment, _environment, Origin));
 		public string SecretToken => ParseSecretToken(Kv(ConfigConsts.EnvVarNames.SecretToken, _secretToken, Origin));
 		public bool CaptureHeaders => ParseCaptureHeaders(Kv(ConfigConsts.EnvVarNames.CaptureHeaders, _captureHeaders, Origin));
 		public double TransactionSampleRate => ParseTransactionSampleRate(Kv(ConfigConsts.EnvVarNames.TransactionSampleRate, _transactionSampleRate, Origin));


### PR DESCRIPTION
closes #320 

Changes:
1. Add `environment` property to service class
2. Make `logger` in `MicrosoftExtensionsConfig` as required
3. Add `environmentName` parameter of `string` type to `MicrosoftExtensionsConfig`
4. Add dependency to `Microsoft.AspNetCore.Hosting.Abstractions`

In case of ASP.Net Core application `environment` is read from `appsettings` configuration with fallback to environment variable. If configuration and environment variable don't have value, parameter is read from `IHostingEnvironment`, that can be an issue due to in .Net Core 3.0 [`IHostingEnvironment` is obsolete](https://docs.microsoft.com/en-us/dotnet/api/microsoft.extensions.hosting.ihostingenvironment?view=aspnetcore-3.0) and [`IHostEnvironment` should be used instead](https://docs.microsoft.com/en-us/aspnet/core/fundamentals/host/generic-host?view=aspnetcore-3.0#ihostenvironment).
However, to official support of .Net Core 3.0 in elastic apm library, all dependencies in `Elastic.Apm.AspNetCore` should be updated to 3.0, which means `IHostingEnvironment` can be used right now.


What should be done after review of draft pull request?
1. Update documentation
2. Write unit tests