### PR TITLE
Handle labels with `null`

### DIFF
--- a/src/Elastic.Apm/Api/IExecutionSegment.cs
+++ b/src/Elastic.Apm/Api/IExecutionSegment.cs
@@ -25,9 +25,25 @@ namespace Elastic.Apm.Api
 		string Id { get; }
 
 		/// <summary>
+		/// It's true if and only of this segment is sampled.
+		/// </summary>
+		bool IsSampled { get; }
+
+		/// <summary>
+		/// A flat mapping of user-defined labels with string values.
+		/// </summary>
+		/// <exception cref="ArgumentException"><c>null</c> as key is not allowed.</exception>
+		Dictionary<string, string> Labels { get; }
+
+		/// <summary>
 		/// The name of the item.
 		/// </summary>
 		string Name { get; set; }
+
+		/// <summary>
+		/// Distributed tracing data for this segment as the distributed tracing caller.
+		/// </summary>
+		DistributedTracingData OutgoingDistributedTracingData { get; }
 
 		/// <summary>
 		/// Hex encoded 64 random bits ID of the parent transaction or span.
@@ -35,24 +51,9 @@ namespace Elastic.Apm.Api
 		string ParentId { get; }
 
 		/// <summary>
-		/// A flat mapping of user-defined labels with string values.
-		/// </summary>
-		Dictionary<string, string> Labels { get; }
-
-		/// <summary>
 		/// Hex encoded 128 random bits ID of the correlated trace.
 		/// </summary>
 		string TraceId { get; }
-
-		/// <summary>
-		/// It's true if and only of this segment is sampled.
-		/// </summary>
-		bool IsSampled { get; }
-
-		/// <summary>
-		/// Distributed tracing data for this segment as the distributed tracing caller.
-		/// </summary>
-		DistributedTracingData OutgoingDistributedTracingData { get; }
 
 		/// <summary>
 		/// Captures a custom error and reports it to the APM server.
@@ -79,7 +80,8 @@ namespace Elastic.Apm.Api
 		void CaptureException(Exception exception, string culprit = null, bool isHandled = false, string parentId = null);
 
 		/// <summary>
-		/// This is a convenient method which starts and ends a span on the given execution segment and captures unhandled exceptions
+		/// This is a convenient method which starts and ends a span on the given execution segment and captures unhandled
+		/// exceptions
 		/// and schedules it to be reported to the APM Server.
 		/// The created span will be a child span of this execution segment.
 		/// </summary>
@@ -94,7 +96,8 @@ namespace Elastic.Apm.Api
 		void CaptureSpan(string name, string type, Action<ISpan> capturedAction, string subType = null, string action = null);
 
 		/// <summary>
-		/// This is a convenient method which starts and ends a span on the given execution segment and captures unhandled exceptions
+		/// This is a convenient method which starts and ends a span on the given execution segment and captures unhandled
+		/// exceptions
 		/// and schedules it to be reported to the APM Server.
 		/// The created span will be a child span of this execution segment.
 		/// </summary>
@@ -106,7 +109,8 @@ namespace Elastic.Apm.Api
 		void CaptureSpan(string name, string type, Action capturedAction, string subType = null, string action = null);
 
 		/// <summary>
-		/// This is a convenient method which starts and ends a span on the given execution segment and captures unhandled exceptions
+		/// This is a convenient method which starts and ends a span on the given execution segment and captures unhandled
+		/// exceptions
 		/// and schedules it to be reported to the APM Server.
 		/// The created span will be a child span of this execution segment.
 		/// </summary>
@@ -127,7 +131,8 @@ namespace Elastic.Apm.Api
 		T CaptureSpan<T>(string name, string type, Func<ISpan, T> func, string subType = null, string action = null);
 
 		/// <summary>
-		/// This is a convenient method which starts and ends a span on the given execution segment and captures unhandled exceptions
+		/// This is a convenient method which starts and ends a span on the given execution segment and captures unhandled
+		/// exceptions
 		/// and schedules it to be reported to the APM Server.
 		/// The created span will be a child span of this execution segment.
 		/// </summary>
@@ -148,7 +153,8 @@ namespace Elastic.Apm.Api
 		T CaptureSpan<T>(string name, string type, Func<T> func, string subType = null, string action = null);
 
 		/// <summary>
-		/// This is a convenient method which starts and ends a span on the given execution segment and captures unhandled exceptions
+		/// This is a convenient method which starts and ends a span on the given execution segment and captures unhandled
+		/// exceptions
 		/// and schedules it to be reported to the APM Server.
 		/// The created span will be a child span of this execution segment.
 		/// </summary>
@@ -161,7 +167,8 @@ namespace Elastic.Apm.Api
 		Task CaptureSpan(string name, string type, Func<Task> func, string subType = null, string action = null);
 
 		/// <summary>
-		/// This is a convenient method which starts and ends a span on the given execution segment and captures unhandled exceptions
+		/// This is a convenient method which starts and ends a span on the given execution segment and captures unhandled
+		/// exceptions
 		/// and schedules it to be reported to the APM Server.
 		/// The created span will be a child span of this execution segment.
 		/// </summary>
@@ -177,7 +184,8 @@ namespace Elastic.Apm.Api
 		Task CaptureSpan(string name, string type, Func<ISpan, Task> func, string subType = null, string action = null);
 
 		/// <summary>
-		/// This is a convenient method which starts and ends a span on the given execution segment and captures unhandled exceptions
+		/// This is a convenient method which starts and ends a span on the given execution segment and captures unhandled
+		/// exceptions
 		/// and schedules it to be reported to the APM Server.
 		/// The created span will be a child span of this execution segment.
 		/// </summary>
@@ -194,7 +202,8 @@ namespace Elastic.Apm.Api
 		Task<T> CaptureSpan<T>(string name, string type, Func<Task<T>> func, string subType = null, string action = null);
 
 		/// <summary>
-		/// This is a convenient method which starts and ends a span on the given execution segment and captures unhandled exceptions
+		/// This is a convenient method which starts and ends a span on the given execution segment and captures unhandled
+		/// exceptions
 		/// and schedules it to be reported to the APM Server.
 		/// The created span will be a child span of this execution segment.
 		/// </summary>

--- a/src/Elastic.Apm/Report/Serialization/LabelsJsonConverter.cs
+++ b/src/Elastic.Apm/Report/Serialization/LabelsJsonConverter.cs
@@ -12,7 +12,11 @@ namespace Elastic.Apm.Report.Serialization
 			foreach (var keyValue in labels)
 			{
 				writer.WritePropertyName(SerializationUtils.TrimToPropertyMaxLength(keyValue.Key));
-				writer.WriteValue(string.IsNullOrEmpty(keyValue.Value) ? "null" : SerializationUtils.TrimToPropertyMaxLength(keyValue.Value));
+
+				if (keyValue.Value != null)
+					writer.WriteValue(SerializationUtils.TrimToPropertyMaxLength(keyValue.Value));
+				else
+					writer.WriteNull();
 			}
 			writer.WriteEndObject();
 		}

--- a/src/Elastic.Apm/Report/Serialization/LabelsJsonConverter.cs
+++ b/src/Elastic.Apm/Report/Serialization/LabelsJsonConverter.cs
@@ -12,7 +12,7 @@ namespace Elastic.Apm.Report.Serialization
 			foreach (var keyValue in labels)
 			{
 				writer.WritePropertyName(SerializationUtils.TrimToPropertyMaxLength(keyValue.Key));
-				writer.WriteValue(SerializationUtils.TrimToPropertyMaxLength(keyValue.Value));
+				writer.WriteValue(string.IsNullOrEmpty(keyValue.Value) ? "null" : SerializationUtils.TrimToPropertyMaxLength(keyValue.Value));
 			}
 			writer.WriteEndObject();
 		}

--- a/test/Elastic.Apm.Tests/SerializationTests.cs
+++ b/test/Elastic.Apm.Tests/SerializationTests.cs
@@ -138,7 +138,23 @@ namespace Elastic.Apm.Tests
 			var deserializedContext = JsonConvert.DeserializeObject(json) as JObject;
 
 			Assert.NotNull(deserializedContext);
-			deserializedContext["foo"].Should().BeNull();
+			deserializedContext["tags"]["foo"].Value<string>().Should().BeNull();
+		}
+
+		/// <summary>
+		/// Makes sure that labels with an empty string are captured and not causing any trouble
+		/// </summary>
+		[Fact]
+		public void LabelWithEmptyStringShouldBeCaptured()
+		{
+			var context = new SpanContext();
+			context.Labels["foo"] = string.Empty;
+
+			var json = SerializePayloadItem(context);
+			var deserializedContext = JsonConvert.DeserializeObject(json) as JObject;
+
+			Assert.NotNull(deserializedContext);
+			deserializedContext["tags"]["foo"].Value<string>().Should().BeEmpty();
 		}
 
 		/// <summary>

--- a/test/Elastic.Apm.Tests/SerializationTests.cs
+++ b/test/Elastic.Apm.Tests/SerializationTests.cs
@@ -133,7 +133,7 @@ namespace Elastic.Apm.Tests
 		{
 			var context = new SpanContext();
 			context.Labels["foo"] = null;
-			
+
 			var json = SerializePayloadItem(context);
 			var deserializedContext = JsonConvert.DeserializeObject(json) as JObject;
 
@@ -184,8 +184,8 @@ namespace Elastic.Apm.Tests
 		}
 
 		/// <summary>
-		/// 	Creates a service instance with a name that is longer than <see cref="Consts.PropertyMaxLength" />.
-		///  Makes sure the name is truncated.
+		/// Creates a service instance with a name that is longer than <see cref="Consts.PropertyMaxLength" />.
+		/// Makes sure the name is truncated.
 		/// </summary>
 		[Fact]
 		public void ServiceNameLengthTest()

--- a/test/Elastic.Apm.Tests/SerializationTests.cs
+++ b/test/Elastic.Apm.Tests/SerializationTests.cs
@@ -16,6 +16,16 @@ namespace Elastic.Apm.Tests
 	/// </summary>
 	public class SerializationTests
 	{
+		// ReSharper disable once MemberCanBePrivate.Global
+		public static TheoryData SerializationUtilsTrimToPropertyMaxLengthVariantsToTest => new TheoryData<string, string>
+		{
+			{ "", "" },
+			{ "A", "A" },
+			{ "B".Repeat(Consts.PropertyMaxLength), "B".Repeat(Consts.PropertyMaxLength) },
+			{ "C".Repeat(Consts.PropertyMaxLength + 1), "C".Repeat(Consts.PropertyMaxLength - 3) + "..." },
+			{ "D".Repeat(Consts.PropertyMaxLength * 2), "D".Repeat(Consts.PropertyMaxLength - 3) + "..." }
+		};
+
 		/// <summary>
 		/// Tests the <see cref="TrimmedStringJsonConverter" />. It serializes a transaction with Transaction.Name.Length > 1024.
 		/// Makes sure that the Transaction.Name is truncated correctly.
@@ -116,6 +126,22 @@ namespace Elastic.Apm.Tests
 		}
 
 		/// <summary>
+		/// Makes sure that labels with `null` don't cause exception during serialization
+		/// </summary>
+		[Fact]
+		public void LabelWithNullValueShouldBeCaptured()
+		{
+			var context = new SpanContext();
+			context.Labels["foo"] = null;
+			
+			var json = SerializePayloadItem(context);
+			var deserializedContext = JsonConvert.DeserializeObject(json) as JObject;
+
+			Assert.NotNull(deserializedContext);
+			deserializedContext["foo"].Should().BeNull();
+		}
+
+		/// <summary>
 		/// It creates an instance of <see cref="DummyType" /> with a <see cref="DummyType.DictionaryProp" /> that has a value
 		/// which is longer than <see cref="Consts.PropertyMaxLength" />.
 		/// Makes sure that the serialized instance still contains the whole value (aka it was not trimmed), since
@@ -158,8 +184,8 @@ namespace Elastic.Apm.Tests
 		}
 
 		/// <summary>
-		///	Creates a service instance with a name that is longer than <see cref="Consts.PropertyMaxLength"/>.
-		/// Makes sure the name is truncated.
+		/// 	Creates a service instance with a name that is longer than <see cref="Consts.PropertyMaxLength" />.
+		///  Makes sure the name is truncated.
 		/// </summary>
 		[Fact]
 		public void ServiceNameLengthTest()
@@ -186,13 +212,13 @@ namespace Elastic.Apm.Tests
 			var agent = new TestAgentComponents();
 			// Create a transaction that is sampled (because the sampler is constant sampling-everything sampler
 			var sampledTransaction = new Transaction(agent.Logger, "dummy_name", "dumm_type", new Sampler(1.0), /* distributedTracingData: */ null,
-			    agent.PayloadSender, new TestAgentConfigurationReader(new NoopLogger()), agent.TracerInternal.CurrentExecutionSegmentsContainer);
+				agent.PayloadSender, new TestAgentConfigurationReader(new NoopLogger()), agent.TracerInternal.CurrentExecutionSegmentsContainer);
 			sampledTransaction.Context.Request = new Request("GET",
 				new Url { Full = "https://elastic.co", Raw = "https://elastic.co", HostName = "elastic.co", Protocol = "HTTP" });
 
 			// Create a transaction that is not sampled (because the sampler is constant not-sampling-anything sampler
 			var nonSampledTransaction = new Transaction(agent.Logger, "dummy_name", "dumm_type", new Sampler(0.0), /* distributedTracingData: */ null,
-			    agent.PayloadSender, new TestAgentConfigurationReader(new NoopLogger()), agent.TracerInternal.CurrentExecutionSegmentsContainer);
+				agent.PayloadSender, new TestAgentConfigurationReader(new NoopLogger()), agent.TracerInternal.CurrentExecutionSegmentsContainer);
 			nonSampledTransaction.Context.Request = sampledTransaction.Context.Request;
 
 			var serializedSampledTransaction = SerializePayloadItem(sampledTransaction);
@@ -233,16 +259,6 @@ namespace Elastic.Apm.Tests
 		[InlineData("ABCDEFGH", 7, "ABCD...")]
 		public void SerializationUtilsTrimToLengthTests(string original, int maxLength, string expectedTrimmed) =>
 			SerializationUtils.TrimToLength(original, maxLength).Should().Be(expectedTrimmed);
-
-		// ReSharper disable once MemberCanBePrivate.Global
-		public static TheoryData SerializationUtilsTrimToPropertyMaxLengthVariantsToTest => new TheoryData<string, string>
-		{
-			{ "", "" },
-			{ "A", "A" },
-			{ "B".Repeat(Consts.PropertyMaxLength), "B".Repeat(Consts.PropertyMaxLength) },
-			{ "C".Repeat(Consts.PropertyMaxLength + 1), "C".Repeat(Consts.PropertyMaxLength - 3) + "..." },
-			{ "D".Repeat(Consts.PropertyMaxLength * 2), "D".Repeat(Consts.PropertyMaxLength - 3) + "..." },
-		};
 
 		[Theory]
 		[MemberData(nameof(SerializationUtilsTrimToPropertyMaxLengthVariantsToTest))]


### PR DESCRIPTION
Fixing #428

Idea: 
- In case a label is `null` we serialize it as `null` (string), so `Agent.Tracer.CurrentTransaction.Labels["foo"] = null;` is valid and we send `null` (as string) to the server.
- Keys as null are not valid, and that's because adding `null` as key to a `Dictionary` throws an exception and we just follow this. 