### PR TITLE
Remove beta label in docs

### DIFF
--- a/docs/page_header.html
+++ b/docs/page_header.html
@@ -1,1 +1,0 @@
-This project is currently in beta. Use it at your own risk.


### PR DESCRIPTION
Just noticed that our docs still have the beta warning:


<img width="1189" alt="Screen Shot 2019-08-05 at 00 27 45" src="https://user-images.githubusercontent.com/1091853/62430150-8e89bb80-b718-11e9-91aa-d889d5c10e91.png">


Let's remove it.