### PR TITLE
ci(jenkins): avoid builds in the master worker

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -34,7 +34,7 @@ pipeline {
     stage('Initializing'){
       stages{
         stage('Checkout') {
-          agent { label 'master || immutable' }
+          agent { label 'immutable' }
           options { skipDefaultCheckout() }
           steps {
             deleteDir()


### PR DESCRIPTION
## Highlights
- `master` worker could be used but causes bottlenecks in some cases.
- This will allow to use of another worker and get rid of any potential bottlenecks when the build queue is massive.