### PR TITLE
ci(jenkins): this is required to avoid using a common worker

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -50,7 +50,6 @@ pipeline {
             script {
               gitBaseCommit = env.GIT_BASE_COMMIT
             }
-            sh 'env | sort'
           }
         }
         stage('Parallel'){

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -50,6 +50,7 @@ pipeline {
             script {
               gitBaseCommit = env.GIT_BASE_COMMIT
             }
+            sh 'env | sort'
           }
         }
         stage('Parallel'){

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,13 @@
 #!/usr/bin/env groovy
-
 @Library('apm@current') _
+
+import groovy.transform.Field
+
+/**
+This is the git commit sha which it's required to be used in different stages.
+It does store the env GIT_BASE_COMMIT
+*/
+@Field def gitBaseCommit
 
 pipeline {
   agent none
@@ -40,6 +47,9 @@ pipeline {
             deleteDir()
             gitCheckout(basedir: "${BASE_DIR}", githubNotifyFirstTimeContributor: true)
             stash allowEmpty: true, name: 'source', useDefaultExcludes: false
+            script {
+              gitBaseCommit = env.GIT_BASE_COMMIT
+            }
           }
         }
         stage('Parallel'){
@@ -356,10 +366,10 @@ pipeline {
               // TODO: use commit rather than branch to be reproducible.
               build(job: env.ITS_PIPELINE, propagate: false, wait: false,
                     parameters: [string(name: 'AGENT_INTEGRATION_TEST', value: '.NET'),
-                                 string(name: 'BUILD_OPTS', value: "--dotnet-agent-version ${env.GIT_BASE_COMMIT}"),
+                                 string(name: 'BUILD_OPTS', value: "--dotnet-agent-version ${gitBaseCommit}"),
                                  string(name: 'GITHUB_CHECK_NAME', value: env.GITHUB_CHECK_ITS_NAME),
                                  string(name: 'GITHUB_CHECK_REPO', value: env.REPO),
-                                 string(name: 'GITHUB_CHECK_SHA1', value: env.GIT_BASE_COMMIT)])
+                                 string(name: 'GITHUB_CHECK_SHA1', value: gitBaseCommit)])
               githubNotify(context: "${env.GITHUB_CHECK_ITS_NAME}", description: "${env.GITHUB_CHECK_ITS_NAME} ...", status: 'PENDING', targetUrl: "${env.JENKINS_URL}search/?q=${env.ITS_PIPELINE.replaceAll('/','+')}")
             }
           }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,9 +5,9 @@ import groovy.transform.Field
 
 /**
 This is the git commit sha which it's required to be used in different stages.
-It does store the env GIT_COMMIT
+It does store the env GIT_BASE_COMMIT
 */
-@Field def gitCommit
+@Field def gitBaseCommit
 
 pipeline {
   agent none
@@ -48,7 +48,7 @@ pipeline {
             gitCheckout(basedir: "${BASE_DIR}", githubNotifyFirstTimeContributor: true)
             stash allowEmpty: true, name: 'source', useDefaultExcludes: false
             script {
-              gitCommit = env.GIT_COMMIT
+              gitBaseCommit = env.GIT_BASE_COMMIT
             }
           }
         }
@@ -366,10 +366,10 @@ pipeline {
               // TODO: use commit rather than branch to be reproducible.
               build(job: env.ITS_PIPELINE, propagate: false, wait: false,
                     parameters: [string(name: 'AGENT_INTEGRATION_TEST', value: '.NET'),
-                                 string(name: 'BUILD_OPTS', value: "--dotnet-agent-version ${gitCommit}"),
+                                 string(name: 'BUILD_OPTS', value: "--dotnet-agent-version ${gitBaseCommit}"),
                                  string(name: 'GITHUB_CHECK_NAME', value: env.GITHUB_CHECK_ITS_NAME),
                                  string(name: 'GITHUB_CHECK_REPO', value: env.REPO),
-                                 string(name: 'GITHUB_CHECK_SHA1', value: gitCommit)])
+                                 string(name: 'GITHUB_CHECK_SHA1', value: gitBaseCommit)])
               githubNotify(context: "${env.GITHUB_CHECK_ITS_NAME}", description: "${env.GITHUB_CHECK_ITS_NAME} ...", status: 'PENDING', targetUrl: "${env.JENKINS_URL}search/?q=${env.ITS_PIPELINE.replaceAll('/','+')}")
             }
           }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,9 +5,9 @@ import groovy.transform.Field
 
 /**
 This is the git commit sha which it's required to be used in different stages.
-It does store the env GIT_BASE_COMMIT
+It does store the env GIT_SHA
 */
-@Field def gitBaseCommit
+@Field def gitCommit
 
 pipeline {
   agent none
@@ -48,7 +48,7 @@ pipeline {
             gitCheckout(basedir: "${BASE_DIR}", githubNotifyFirstTimeContributor: true)
             stash allowEmpty: true, name: 'source', useDefaultExcludes: false
             script {
-              gitBaseCommit = env.GIT_BASE_COMMIT
+              gitCommit = env.GIT_SHA
             }
           }
         }
@@ -366,10 +366,10 @@ pipeline {
               // TODO: use commit rather than branch to be reproducible.
               build(job: env.ITS_PIPELINE, propagate: false, wait: false,
                     parameters: [string(name: 'AGENT_INTEGRATION_TEST', value: '.NET'),
-                                 string(name: 'BUILD_OPTS', value: "--dotnet-agent-version ${gitBaseCommit}"),
+                                 string(name: 'BUILD_OPTS', value: "--dotnet-agent-version ${gitCommit}"),
                                  string(name: 'GITHUB_CHECK_NAME', value: env.GITHUB_CHECK_ITS_NAME),
                                  string(name: 'GITHUB_CHECK_REPO', value: env.REPO),
-                                 string(name: 'GITHUB_CHECK_SHA1', value: gitBaseCommit)])
+                                 string(name: 'GITHUB_CHECK_SHA1', value: gitCommit)])
               githubNotify(context: "${env.GITHUB_CHECK_ITS_NAME}", description: "${env.GITHUB_CHECK_ITS_NAME} ...", status: 'PENDING', targetUrl: "${env.JENKINS_URL}search/?q=${env.ITS_PIPELINE.replaceAll('/','+')}")
             }
           }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,9 +5,9 @@ import groovy.transform.Field
 
 /**
 This is the git commit sha which it's required to be used in different stages.
-It does store the env GIT_BASE_COMMIT
+It does store the env GIT_COMMIT
 */
-@Field def gitBaseCommit
+@Field def gitCommit
 
 pipeline {
   agent none
@@ -48,7 +48,7 @@ pipeline {
             gitCheckout(basedir: "${BASE_DIR}", githubNotifyFirstTimeContributor: true)
             stash allowEmpty: true, name: 'source', useDefaultExcludes: false
             script {
-              gitBaseCommit = env.GIT_BASE_COMMIT
+              gitCommit = env.GIT_COMMIT
             }
           }
         }
@@ -366,10 +366,10 @@ pipeline {
               // TODO: use commit rather than branch to be reproducible.
               build(job: env.ITS_PIPELINE, propagate: false, wait: false,
                     parameters: [string(name: 'AGENT_INTEGRATION_TEST', value: '.NET'),
-                                 string(name: 'BUILD_OPTS', value: "--dotnet-agent-version ${gitBaseCommit}"),
+                                 string(name: 'BUILD_OPTS', value: "--dotnet-agent-version ${gitCommit}"),
                                  string(name: 'GITHUB_CHECK_NAME', value: env.GITHUB_CHECK_ITS_NAME),
                                  string(name: 'GITHUB_CHECK_REPO', value: env.REPO),
-                                 string(name: 'GITHUB_CHECK_SHA1', value: gitBaseCommit)])
+                                 string(name: 'GITHUB_CHECK_SHA1', value: gitCommit)])
               githubNotify(context: "${env.GITHUB_CHECK_ITS_NAME}", description: "${env.GITHUB_CHECK_ITS_NAME} ...", status: 'PENDING', targetUrl: "${env.JENKINS_URL}search/?q=${env.ITS_PIPELINE.replaceAll('/','+')}")
             }
           }


### PR DESCRIPTION
## Highlights
- https://github.com/elastic/apm-agent-dotnet/pull/447 caused a regression as the env variable is defined at the worker level.
- `@Field` helps to create global variables, therefore `gitCommit` is the new variable which does substitute the environment variable.
- GIT_SHA rather than GIT_BASE_COMMIT as the last one is caused when doing a merge within a PR.