### PR TITLE
Add GetCustomAttribute<AssemblyInformationalVersionAttribute>() nullcheck

### DIFF
--- a/src/Elastic.Apm/Config/AbstractConfigurationReader.cs
+++ b/src/Elastic.Apm/Config/AbstractConfigurationReader.cs
@@ -355,7 +355,7 @@ namespace Elastic.Apm.Config
 		{
 			var entryAssembly = Assembly.GetEntryAssembly();
 			if (entryAssembly != null && !IsMsOrElastic(entryAssembly.GetName().GetPublicKeyToken()))
-				return entryAssembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>().InformationalVersion;
+				return entryAssembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion;
 
 			return null;
 		}


### PR DESCRIPTION
Followup from #393 

I noticed this while working on something different on Full Framework:

<img width="1644" alt="Screen Shot 2019-08-23 at 12 18 31" src="https://user-images.githubusercontent.com/1091853/63586710-4a186f80-c5a2-11e9-8348-1bd9d78af073.png">

`InformationalVersion` is optional and it's possible that it's not there. An alternative approach would be to add `FileVersion` as fallback.

cc @vhatsura 