### PR TITLE
Fix nullref in HttpDiagnosticListenerFullFrameworkImpl

### DIFF
--- a/sample/AspNetFullFrameworkSampleApp/Controllers/HomeController.cs
+++ b/sample/AspNetFullFrameworkSampleApp/Controllers/HomeController.cs
@@ -23,6 +23,8 @@ namespace AspNetFullFrameworkSampleApp.Controllers
 
 		internal const string CustomChildSpanThrowsPageRelativePath = HomePageRelativePath + "/" + nameof(CustomChildSpanThrows);
 
+		internal const string ForbidHttpResponsePageRelativePath = HomePageRelativePath + "/" + nameof(ForbidHttpResponse);
+
 		internal const string CustomSpanThrowsInternalMethodName = nameof(CustomSpanThrowsInternal);
 		internal const string CustomSpanThrowsPageRelativePath = HomePageRelativePath + "/" + nameof(CustomSpanThrows);
 
@@ -63,6 +65,15 @@ namespace AspNetFullFrameworkSampleApp.Controllers
 					CaptureControllerActionAsSpanQueryStringKey);
 			}
 			return bool.Parse(captureControllerActionAsSpanValues[0]);
+		}
+
+		public async Task<ActionResult> ForbidHttpResponse()
+		{
+			//see https://github.com/elastic/apm-agent-dotnet/issues/443
+			var httpClient = new HttpClient();
+			var res = await httpClient.GetAsync("https://httpstat.us/403");
+			var retVal = new ContentResult { Content = res.IsSuccessStatusCode.ToString() };
+			return retVal;
 		}
 
 		public Task<ActionResult> Contact()

--- a/src/Elastic.Apm/DiagnosticListeners/HttpDiagnosticListenerFullFrameworkImpl.cs
+++ b/src/Elastic.Apm/DiagnosticListeners/HttpDiagnosticListenerFullFrameworkImpl.cs
@@ -37,13 +37,13 @@ namespace Elastic.Apm.DiagnosticListeners
 		/// </summary>
 		protected override void ProcessExceptionEvent(object eventValue, Uri requestUrl)
 		{
-			_logger.Trace()?.Log("Processing stop.ex event... Request URL: {RequestUrl}", requestUrl);
+			Logger.Trace()?.Log("Processing stop.ex event... Request URL: {RequestUrl}", requestUrl);
 
 			var requestObject = eventValue.GetType().GetTypeInfo().GetDeclaredProperty(EventRequestPropertyName)?.GetValue(eventValue);
 
 			if (!(requestObject is HttpWebRequest request))
 			{
-				_logger.Trace()
+				Logger.Trace()
 					?.Log("Actual type of object ({EventRequestPropertyActualType}) in event's {EventRequestPropertyName} property " +
 						"doesn't match the expected type ({EventRequestPropertyExpectedType}) - exiting",
 						requestObject.GetType().FullName, EventRequestPropertyName, typeof(HttpWebRequest).FullName);
@@ -51,7 +51,7 @@ namespace Elastic.Apm.DiagnosticListeners
 			}
 			if (!ProcessingRequests.TryRemove(request, out var span))
 			{
-				_logger.Warning()
+				Logger.Warning()
 					?.Log("Failed capturing request (failed to remove from ProcessingRequests) - " +
 						"This Span will be skipped in case it wasn't captured before. " +
 						"Request: method: {HttpMethod}, URL: {RequestUrl}", RequestGetMethod(request), requestUrl);
@@ -74,7 +74,7 @@ namespace Elastic.Apm.DiagnosticListeners
 					}
 					else
 					{
-						_logger.Trace()
+						Logger.Trace()
 							?.Log("Actual type of object ({EventStatusCodePropertyActualType}) in event's {EventStatusCodePropertyName} property " +
 								"doesn't match the expected type ({EventStatusCodeePropertyExpectedType})",
 								statusCodeObject.GetType().FullName, "StatusCode", typeof(HttpStatusCode).FullName);

--- a/src/Elastic.Apm/DiagnosticListeners/HttpDiagnosticListenerFullFrameworkImpl.cs
+++ b/src/Elastic.Apm/DiagnosticListeners/HttpDiagnosticListenerFullFrameworkImpl.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Net;
+using System.Reflection;
+using Elastic.Apm.Logging;
 
 namespace Elastic.Apm.DiagnosticListeners
 {
@@ -28,5 +30,59 @@ namespace Elastic.Apm.DiagnosticListeners
 			request.Headers.Add(headerName, headerValue);
 
 		protected override int ResponseGetStatusCode(HttpWebResponse response) => (int)response.StatusCode;
+
+		/// <summary>
+		/// In Full Framework "System.Net.Http.Desktop.HttpRequestOut.Ex.Stop" does not send the exception property.
+		/// Therefore we have a specialized ProcessExceptionEvent for Full Framework. 
+		/// </summary>
+		protected override void ProcessExceptionEvent(object eventValue, Uri requestUrl)
+		{
+			_logger.Trace()?.Log("Processing stop.ex event... Request URL: {RequestUrl}", requestUrl);
+
+			var requestObject = eventValue.GetType().GetTypeInfo().GetDeclaredProperty(EventRequestPropertyName)?.GetValue(eventValue);
+
+			if (!(requestObject is HttpWebRequest request))
+			{
+				_logger.Trace()
+					?.Log("Actual type of object ({EventRequestPropertyActualType}) in event's {EventRequestPropertyName} property " +
+						"doesn't match the expected type ({EventRequestPropertyExpectedType}) - exiting",
+						requestObject.GetType().FullName, EventRequestPropertyName, typeof(HttpWebRequest).FullName);
+				return;
+			}
+			if (!ProcessingRequests.TryRemove(request, out var span))
+			{
+				_logger.Warning()
+					?.Log("Failed capturing request (failed to remove from ProcessingRequests) - " +
+						"This Span will be skipped in case it wasn't captured before. " +
+						"Request: method: {HttpMethod}, URL: {RequestUrl}", RequestGetMethod(request), requestUrl);
+				return;
+			}
+
+			// if span.Context.Http == null that means the transaction is not sampled (see ProcessStartEvent)
+			if (span.Context.Http != null)
+			{
+				var statusCodeObject = eventValue.GetType().GetTypeInfo().GetDeclaredProperty("StatusCode")?.GetValue(eventValue);
+				if (statusCodeObject != null)
+				{
+					if (statusCodeObject is HttpStatusCode statusCode)
+					{
+						span.Context.Http.StatusCode = (int)statusCode;
+
+						if (span.Context.Http.StatusCode >= 300)
+							span.CaptureError($"Failed outgoing HTTP call with HttpClient - StatusCode: {statusCode.ToString()}",
+								$"HTTP {statusCode}", null);
+					}
+					else
+					{
+						_logger.Trace()
+							?.Log("Actual type of object ({EventStatusCodePropertyActualType}) in event's {EventStatusCodePropertyName} property " +
+								"doesn't match the expected type ({EventStatusCodeePropertyExpectedType})",
+								statusCodeObject.GetType().FullName, "StatusCode", typeof(HttpStatusCode).FullName);
+					}
+				}
+			}
+
+			span.End();
+		}
 	}
 }

--- a/src/Elastic.Apm/DiagnosticListeners/HttpDiagnosticListenerFullFrameworkImpl.cs
+++ b/src/Elastic.Apm/DiagnosticListeners/HttpDiagnosticListenerFullFrameworkImpl.cs
@@ -33,7 +33,7 @@ namespace Elastic.Apm.DiagnosticListeners
 
 		/// <summary>
 		/// In Full Framework "System.Net.Http.Desktop.HttpRequestOut.Ex.Stop" does not send the exception property.
-		/// Therefore we have a specialized ProcessExceptionEvent for Full Framework. 
+		/// Therefore we have a specialized ProcessExceptionEvent for Full Framework.
 		/// </summary>
 		protected override void ProcessExceptionEvent(object eventValue, Uri requestUrl)
 		{
@@ -46,7 +46,7 @@ namespace Elastic.Apm.DiagnosticListeners
 				Logger.Trace()
 					?.Log("Actual type of object ({EventRequestPropertyActualType}) in event's {EventRequestPropertyName} property " +
 						"doesn't match the expected type ({EventRequestPropertyExpectedType}) - exiting",
-						requestObject.GetType().FullName, EventRequestPropertyName, typeof(HttpWebRequest).FullName);
+						requestObject?.GetType().FullName, EventRequestPropertyName, typeof(HttpWebRequest).FullName);
 				return;
 			}
 			if (!ProcessingRequests.TryRemove(request, out var span))
@@ -69,8 +69,10 @@ namespace Elastic.Apm.DiagnosticListeners
 						span.Context.Http.StatusCode = (int)statusCode;
 
 						if (span.Context.Http.StatusCode >= 300)
+						{
 							span.CaptureError($"Failed outgoing HTTP call with HttpClient - StatusCode: {statusCode.ToString()}",
 								$"HTTP {statusCode}", null);
+						}
 					}
 					else
 					{

--- a/src/Elastic.Apm/DiagnosticListeners/HttpDiagnosticListenerImplBase.cs
+++ b/src/Elastic.Apm/DiagnosticListeners/HttpDiagnosticListenerImplBase.cs
@@ -28,12 +28,12 @@ namespace Elastic.Apm.DiagnosticListeners
 		internal readonly ConcurrentDictionary<TRequest, ISpan> ProcessingRequests = new ConcurrentDictionary<TRequest, ISpan>();
 
 		private readonly IApmAgent _agent;
-		protected readonly ScopedLogger _logger;
+		protected readonly ScopedLogger Logger;
 
 		protected HttpDiagnosticListenerImplBase(IApmAgent agent)
 		{
 			_agent = agent;
-			_logger = _agent.Logger?.Scoped("HttpDiagnosticListenerImplBase");
+			Logger = _agent.Logger?.Scoped("HttpDiagnosticListenerImplBase");
 		}
 
 		protected abstract string RequestGetMethod(TRequest request);
@@ -54,34 +54,34 @@ namespace Elastic.Apm.DiagnosticListeners
 
 		public void OnCompleted() { }
 
-		public void OnError(Exception error) => _logger.Error()?.LogExceptionWithCaller(error, nameof(OnError));
+		public void OnError(Exception error) => Logger.Error()?.LogExceptionWithCaller(error, nameof(OnError));
 
 		public void OnNext(KeyValuePair<string, object> kv)
 		{
-			_logger.Trace()?.Log("Called with key: `{DiagnosticEventKey}', value: `{DiagnosticEventValue}'", kv.Key, kv.Value);
+			Logger.Trace()?.Log("Called with key: `{DiagnosticEventKey}', value: `{DiagnosticEventValue}'", kv.Key, kv.Value);
 
 			if (string.IsNullOrEmpty(kv.Key))
 			{
-				_logger.Trace()?.Log($"Key is {(kv.Key == null ? "null" : "an empty string")} - exiting");
+				Logger.Trace()?.Log($"Key is {(kv.Key == null ? "null" : "an empty string")} - exiting");
 				return;
 			}
 
 			if (kv.Value == null)
 			{
-				_logger.Trace()?.Log("Value is null - exiting");
+				Logger.Trace()?.Log("Value is null - exiting");
 				return;
 			}
 
 			var requestObject = kv.Value.GetType().GetTypeInfo().GetDeclaredProperty(EventRequestPropertyName)?.GetValue(kv.Value);
 			if (requestObject == null)
 			{
-				_logger.Trace()?.Log("Event's {EventRequestPropertyName} property is null - exiting", EventRequestPropertyName);
+				Logger.Trace()?.Log("Event's {EventRequestPropertyName} property is null - exiting", EventRequestPropertyName);
 				return;
 			}
 
 			if (!(requestObject is TRequest request))
 			{
-				_logger.Trace()
+				Logger.Trace()
 					?.Log("Actual type of object ({EventRequestPropertyActualType}) in event's {EventRequestPropertyName} property " +
 						"doesn't match the expected type ({EventRequestPropertyExpectedType}) - exiting",
 						requestObject.GetType().FullName, EventRequestPropertyName, typeof(TRequest).FullName);
@@ -91,13 +91,13 @@ namespace Elastic.Apm.DiagnosticListeners
 			var requestUrl = RequestGetUri(request);
 			if (requestUrl == null)
 			{
-				_logger.Trace()?.Log("Request URL is null - exiting", EventRequestPropertyName);
+				Logger.Trace()?.Log("Request URL is null - exiting", EventRequestPropertyName);
 				return;
 			}
 
 			if (IsRequestFilteredOut(requestUrl))
 			{
-				_logger.Trace()?.Log("Request URL ({RequestUrl}) is filtered out - exiting", requestUrl);
+				Logger.Trace()?.Log("Request URL ({RequestUrl}) is filtered out - exiting", requestUrl);
 				return;
 			}
 
@@ -108,17 +108,17 @@ namespace Elastic.Apm.DiagnosticListeners
 			else if (kv.Key.Equals(ExceptionEventKey))
 				ProcessExceptionEvent(kv.Value, requestUrl);
 			else
-				_logger.Trace()?.Log("Unrecognized key `{DiagnosticEventKey}'", kv.Key);
+				Logger.Trace()?.Log("Unrecognized key `{DiagnosticEventKey}'", kv.Key);
 		}
 
 		private void ProcessStartEvent(TRequest request, Uri requestUrl)
 		{
-			_logger.Trace()?.Log("Processing start event... Request URL: {RequestUrl}", requestUrl);
+			Logger.Trace()?.Log("Processing start event... Request URL: {RequestUrl}", requestUrl);
 
 			var transaction = _agent.Tracer.CurrentTransaction;
 			if (transaction == null)
 			{
-				_logger.Debug()?.Log("No current transaction, skip creating span for outgoing HTTP request");
+				Logger.Debug()?.Log("No current transaction, skip creating span for outgoing HTTP request");
 				return;
 			}
 
@@ -131,7 +131,7 @@ namespace Elastic.Apm.DiagnosticListeners
 			if (!ProcessingRequests.TryAdd(request, span))
 			{
 				// Consider improving error reporting - see https://github.com/elastic/apm-agent-dotnet/issues/280
-				_logger.Error()?.Log("Failed to add to ProcessingRequests - ???");
+				Logger.Error()?.Log("Failed to add to ProcessingRequests - ???");
 				return;
 			}
 
@@ -146,11 +146,11 @@ namespace Elastic.Apm.DiagnosticListeners
 
 		private void ProcessStopEvent(object eventValue, TRequest request, Uri requestUrl)
 		{
-			_logger.Trace()?.Log("Processing stop event... Request URL: {RequestUrl}", requestUrl);
+			Logger.Trace()?.Log("Processing stop event... Request URL: {RequestUrl}", requestUrl);
 
 			if (!ProcessingRequests.TryRemove(request, out var span))
 			{
-				_logger.Warning()
+				Logger.Warning()
 					?.Log("Failed capturing request (failed to remove from ProcessingRequests) - " +
 						"This Span will be skipped in case it wasn't captured before. " +
 						"Request: method: {HttpMethod}, URL: {RequestUrl}", RequestGetMethod(request), requestUrl);
@@ -170,7 +170,7 @@ namespace Elastic.Apm.DiagnosticListeners
 						span.Context.Http.StatusCode = ResponseGetStatusCode(response);
 					else
 					{
-						_logger.Trace()
+						Logger.Trace()
 							?.Log("Actual type of object ({EventResponsePropertyActualType}) in event's {EventResponsePropertyName} property " +
 								"doesn't match the expected type ({EventResponsePropertyExpectedType})",
 								responseObject.GetType().FullName, EventResponsePropertyName, typeof(TResponse).FullName);
@@ -183,11 +183,11 @@ namespace Elastic.Apm.DiagnosticListeners
 
 		protected virtual void ProcessExceptionEvent(object eventValue, Uri requestUrl)
 		{
-			_logger.Trace()?.Log("Processing exception event... Request URL: {RequestUrl}", requestUrl);
+			Logger.Trace()?.Log("Processing exception event... Request URL: {RequestUrl}", requestUrl);
 
 			if (!(eventValue.GetType().GetTypeInfo().GetDeclaredProperty(EventExceptionPropertyName)?.GetValue(eventValue) is Exception exception))
 			{
-				_logger.Trace()?.Log("Failed reading exception property");
+				Logger.Trace()?.Log("Failed reading exception property");
 				return;
 			}
 

--- a/test/Elastic.Apm.AspNetFullFramework.Tests/ErrorsTests.cs
+++ b/test/Elastic.Apm.AspNetFullFramework.Tests/ErrorsTests.cs
@@ -52,6 +52,22 @@ namespace Elastic.Apm.AspNetFullFramework.Tests
 		}
 
 		[AspNetFullFrameworkFact]
+		public async Task HttpCallWithResponseForbidden()
+		{
+			var forbidResponsePageData = SampleAppUrlPaths.ForbidHttpResponsePageDescriptionPage;
+			await SendGetRequestToSampleAppAndVerifyResponseStatusCode(forbidResponsePageData.RelativeUrlPath, forbidResponsePageData.StatusCode);
+
+			VerifyDataReceivedFromAgent(receivedData =>
+			{
+				TryVerifyDataReceivedFromAgent(forbidResponsePageData, receivedData);
+
+				receivedData.Spans.First().Should().NotBeNull();
+				receivedData.Spans.First().Context.Http.Should().NotBeNull();
+				receivedData.Spans.First().Context.Http.StatusCode.Should().Be(403);
+			});
+		}
+
+		[AspNetFullFrameworkFact]
 		public async Task CustomChildSpanThrowsTest()
 		{
 			var errorPageData = SampleAppUrlPaths.CustomChildSpanThrowsExceptionPage;

--- a/test/Elastic.Apm.AspNetFullFramework.Tests/TestsBase.cs
+++ b/test/Elastic.Apm.AspNetFullFramework.Tests/TestsBase.cs
@@ -94,6 +94,9 @@ namespace Elastic.Apm.AspNetFullFramework.Tests
 			internal static readonly SampleAppUrlPathData GetDotNetRuntimeDescriptionPage =
 				new SampleAppUrlPathData(HomeController.GetDotNetRuntimeDescriptionPageRelativePath, 200);
 
+			internal static readonly SampleAppUrlPathData ForbidHttpResponsePageDescriptionPage =
+			new SampleAppUrlPathData(HomeController.ForbidHttpResponsePageRelativePath, 200, spansCount: 1, errorsCount: 1);
+
 			internal static readonly List<SampleAppUrlPathData> AllPaths = new List<SampleAppUrlPathData>()
 			{
 				new SampleAppUrlPathData("", 200),

--- a/test/Elastic.Apm.Tests.MockApmServer/AssertValidExtensions.cs
+++ b/test/Elastic.Apm.Tests.MockApmServer/AssertValidExtensions.cs
@@ -217,7 +217,16 @@ namespace Elastic.Apm.Tests.MockApmServer
 
 			thisObj.Code?.AssertValid();
 			thisObj.StackTrace?.AssertValid();
-			thisObj.Type.AssertValid();
+
+			if (string.IsNullOrEmpty(thisObj.Type))
+				thisObj.Message.AssertValid();
+			else
+				thisObj.Message?.AssertValid();
+
+			if (string.IsNullOrEmpty(thisObj.Message))
+				thisObj.Type.AssertValid();
+			else
+				thisObj.Type?.AssertValid();
 		}
 
 		internal static void AssertValid(this Database thisObj)


### PR DESCRIPTION
Proposed fix for #443. 

General thoughts:
- This problem is in `Elastic.Apm` and it causes a NullRef exception, so if possible we should address it fairly soon.
- Therefore, I'd suggest to only focus on fixing this issue here - happy to open follow ups. 


Idea:
I made `ProcessExceptionEvent` in `HttpDiagnosticListenerImplBase` `virtual` and I have a specialized implantation of that method in `HttpDiagnosticListenerFullFrameworkImpl` - that takes care of the case that currently causes the nullref.

By seeing the code, I think having a common base for the 2 cases (.NET Core and Full Framework) is maybe not the best way to go. ApplicationInsights for example does not have that common base class either ([Full Framework](https://github.com/microsoft/ApplicationInsights-dotnet-server/blob/3cc166e3c9ec9d3f4ce77f48d3ab8c6bd6218808/Src/DependencyCollector/Shared/Implementation/HttpDesktopDiagnosticSourceListener.cs), [.NET Core](https://github.com/microsoft/ApplicationInsights-dotnet-server/blob/055bcaaec7249cf91ca3e1e59e8bcc08393e10e7/Src/DependencyCollector/Shared/HttpCoreDiagnosticSourceListener.cs)). I think we have unnecessary complexity in our code by adding the common base with little benefit. I think the cleanest way would be to have 2 separate implementations. Nevertheless to address the main issue (which is in my opinion the nullref in the current release) I'd propose to merge this short fix and maybe address other things later.

Also added a test to cover the specific case that caused the nullref.