### PR TITLE
Fix missing ELASTIC_APM_ prefix in CAPTURE_BODY and CAPTURE_BODY_CONTENT_TYPES configuration options environment variable names

### DIFF
--- a/src/Elastic.Apm/Config/ConfigConsts.cs
+++ b/src/Elastic.Apm/Config/ConfigConsts.cs
@@ -27,18 +27,20 @@ namespace Elastic.Apm.Config
 
 		public static class EnvVarNames
 		{
-			public const string CaptureHeaders = "ELASTIC_APM_CAPTURE_HEADERS";
-			public const string LogLevel = "ELASTIC_APM_LOG_LEVEL";
-			public const string MetricsInterval = "ELASTIC_APM_METRICS_INTERVAL";
-			public const string SecretToken = "ELASTIC_APM_SECRET_TOKEN";
-			public const string ServerUrls = "ELASTIC_APM_SERVER_URLS";
-			public const string ServiceName = "ELASTIC_APM_SERVICE_NAME";
-			public const string ServiceVersion = "ELASTIC_APM_SERVICE_VERSION";
-			public const string SpanFramesMinDuration = "ELASTIC_APM_SPAN_FRAMES_MIN_DURATION";
-			public const string StackTraceLimit = "ELASTIC_APM_STACK_TRACE_LIMIT";
-			public const string TransactionSampleRate = "ELASTIC_APM_TRANSACTION_SAMPLE_RATE";
-			public const string CaptureBody = "CAPTURE_BODY";
-			public const string CaptureBodyContentTypes = "CAPTURE_BODY_CONTENT_TYPES";
+			public const string Prefix = "ELASTIC_APM_";
+
+			public const string CaptureHeaders = Prefix + "CAPTURE_HEADERS";
+			public const string LogLevel = Prefix + "LOG_LEVEL";
+			public const string MetricsInterval = Prefix + "METRICS_INTERVAL";
+			public const string SecretToken = Prefix + "SECRET_TOKEN";
+			public const string ServerUrls = Prefix + "SERVER_URLS";
+			public const string ServiceName = Prefix + "SERVICE_NAME";
+			public const string ServiceVersion = Prefix + "SERVICE_VERSION";
+			public const string SpanFramesMinDuration = Prefix + "SPAN_FRAMES_MIN_DURATION";
+			public const string StackTraceLimit = Prefix + "STACK_TRACE_LIMIT";
+			public const string TransactionSampleRate = Prefix + "TRANSACTION_SAMPLE_RATE";
+			public const string CaptureBody = Prefix + "CAPTURE_BODY";
+			public const string CaptureBodyContentTypes = Prefix + "CAPTURE_BODY_CONTENT_TYPES";
 		}
 
 		public static class SupportedValues


### PR DESCRIPTION
Fixes #453
