### PR TITLE
ci(jenkins): Fix environment variable used to calculate git commit

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,7 +5,7 @@ import groovy.transform.Field
 
 /**
 This is the git commit sha which it's required to be used in different stages.
-It does store the env GIT_SHA
+It does store the env GIT_BASE_COMMIT
 */
 @Field def gitCommit
 
@@ -48,7 +48,7 @@ pipeline {
             gitCheckout(basedir: "${BASE_DIR}", githubNotifyFirstTimeContributor: true)
             stash allowEmpty: true, name: 'source', useDefaultExcludes: false
             script {
-              gitCommit = env.GIT_SHA
+              gitCommit = env.GIT_BASE_COMMIT
             }
           }
         }


### PR DESCRIPTION
## Highlights
- GIT_SHA contains the git merge commit therefore it does not exist in the upstream repo.
- GIT_BASE_COMMIT contains the git commit from the upstream repo.

