### PR TITLE
ci(jenkins): revert none agent

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,7 +3,7 @@
 @Library('apm@current') _
 
 pipeline {
-  agent none
+  agent any
   environment {
     REPO = 'apm-agent-dotnet'
     // keep it short to avoid the 248 characters PATH limit in Windows

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,13 +1,6 @@
 #!/usr/bin/env groovy
+
 @Library('apm@current') _
-
-import groovy.transform.Field
-
-/**
-This is the git commit sha which it's required to be used in different stages.
-It does store the env GIT_SHA
-*/
-@Field def gitCommit
 
 pipeline {
   agent none
@@ -47,9 +40,6 @@ pipeline {
             deleteDir()
             gitCheckout(basedir: "${BASE_DIR}", githubNotifyFirstTimeContributor: true)
             stash allowEmpty: true, name: 'source', useDefaultExcludes: false
-            script {
-              gitCommit = env.GIT_SHA
-            }
           }
         }
         stage('Parallel'){
@@ -366,10 +356,10 @@ pipeline {
               // TODO: use commit rather than branch to be reproducible.
               build(job: env.ITS_PIPELINE, propagate: false, wait: false,
                     parameters: [string(name: 'AGENT_INTEGRATION_TEST', value: '.NET'),
-                                 string(name: 'BUILD_OPTS', value: "--dotnet-agent-version ${gitCommit}"),
+                                 string(name: 'BUILD_OPTS', value: "--dotnet-agent-version ${env.GIT_BASE_COMMIT}"),
                                  string(name: 'GITHUB_CHECK_NAME', value: env.GITHUB_CHECK_ITS_NAME),
                                  string(name: 'GITHUB_CHECK_REPO', value: env.REPO),
-                                 string(name: 'GITHUB_CHECK_SHA1', value: gitCommit)])
+                                 string(name: 'GITHUB_CHECK_SHA1', value: env.GIT_BASE_COMMIT)])
               githubNotify(context: "${env.GITHUB_CHECK_ITS_NAME}", description: "${env.GITHUB_CHECK_ITS_NAME} ...", status: 'PENDING', targetUrl: "${env.JENKINS_URL}search/?q=${env.ITS_PIPELINE.replaceAll('/','+')}")
             }
           }


### PR DESCRIPTION
This reverts commit 45778eee625fcc486b413eefce009b37fab93739 and 4305c7bf5c5ce1d009eac5d7dd7f7d101d57af86

## Highlights
- As long as we use the share step `gitCheckout` we might need to use the agent top-level to share the env variables between stages.
- It's not ideal but even though the changes were quite straight, its behavior was not as expected. 
- Let's keep the pipeline stable for now and we will figure out what's going on.