### PR TITLE
Add support for Server certificate verification

### DIFF
--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -394,6 +394,26 @@ Both the agents and the APM server have to be configured with the same secret to
 Use this setting in case the APM Server requires a token (e.g. APM Server in Elastic Cloud).
 
 [float]
+[[config-verify-server-cert]]
+==== `VerifyServerCert`
+
+[options="header"]
+|============
+| Environment variable name        | IConfiguration or Web.config key
+| `ELASTIC_APM_VERIFY_SERVER_CERT` | `ElasticApm:VerifyServerCert`
+|============
+
+[options="header"]
+|============
+| Default                 | Type
+| `true`                  | Boolean
+|============
+
+By default, the agent verifies the SSL certificate if you use an HTTPS connection to the APM server.
+
+Verification can be disabled by changing this setting to false.
+
+[float]
 [[config-flush-interval]]
 ==== `FlushInterval` (added[1.1])
 

--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -395,7 +395,7 @@ Use this setting in case the APM Server requires a token (e.g. APM Server in Ela
 
 [float]
 [[config-verify-server-cert]]
-==== `VerifyServerCert`
+==== `VerifyServerCert` (added[1.3])
 
 [options="header"]
 |============

--- a/src/Elastic.Apm/BackendComm/CentralConfigFetcher.cs
+++ b/src/Elastic.Apm/BackendComm/CentralConfigFetcher.cs
@@ -475,6 +475,7 @@ namespace Elastic.Apm.BackendComm
 			public int TransactionMaxSpans => _configDelta.TransactionMaxSpans ?? _wrapped.TransactionMaxSpans;
 
 			public double TransactionSampleRate => _configDelta.TransactionSampleRate ?? _wrapped.TransactionSampleRate;
+			public bool VerifyServerCert => _wrapped.VerifyServerCert;
 		}
 	}
 }

--- a/src/Elastic.Apm/Config/AbstractConfigurationReader.cs
+++ b/src/Elastic.Apm/Config/AbstractConfigurationReader.cs
@@ -117,6 +117,13 @@ namespace Elastic.Apm.Config
 			return kv.Value;
 		}
 
+		protected bool ParseVerifyServerCert(ConfigurationKeyValue kv)
+		{
+			if (kv == null || string.IsNullOrEmpty(kv.Value)) return DefaultValues.VerifyServerCert;
+			// ReSharper disable once SimplifyConditionalTernaryExpression
+			return bool.TryParse(kv.Value, out var value) ? value : DefaultValues.VerifyServerCert;
+		}
+
 		protected bool ParseCaptureHeaders(ConfigurationKeyValue kv) => ParseBoolOption(kv, DefaultValues.CaptureHeaders, "CaptureHeaders");
 
 		protected LogLevel ParseLogLevel(ConfigurationKeyValue kv)

--- a/src/Elastic.Apm/Config/AbstractConfigurationWithEnvFallbackReader.cs
+++ b/src/Elastic.Apm/Config/AbstractConfigurationWithEnvFallbackReader.cs
@@ -84,5 +84,8 @@ namespace Elastic.Apm.Config
 
 		public virtual double TransactionSampleRate =>
 			ParseTransactionSampleRate(Read(ConfigConsts.KeyNames.TransactionSampleRate, ConfigConsts.EnvVarNames.TransactionSampleRate));
+
+		public virtual bool VerifyServerCert =>
+			ParseVerifyServerCert(Read(ConfigConsts.KeyNames.VerifyServerCert, ConfigConsts.EnvVarNames.VerifyServerCert));
 	}
 }

--- a/src/Elastic.Apm/Config/ConfigConsts.cs
+++ b/src/Elastic.Apm/Config/ConfigConsts.cs
@@ -29,6 +29,7 @@ namespace Elastic.Apm.Config
 			public const int TransactionMaxSpans = 500;
 			public const double TransactionSampleRate = 1.0;
 			public const string UnknownServiceName = "unknown";
+			public const bool VerifyServerCert = true;
 
 			public static List<WildcardMatcher> DisableMetrics = new List<WildcardMatcher>();
 
@@ -82,6 +83,7 @@ namespace Elastic.Apm.Config
 			public const string StackTraceLimit = Prefix + "STACK_TRACE_LIMIT";
 			public const string TransactionMaxSpans = Prefix + "TRANSACTION_MAX_SPANS";
 			public const string TransactionSampleRate = Prefix + "TRANSACTION_SAMPLE_RATE";
+			public const string VerifyServerCert = Prefix + "VERIFY_SERVER_CERT";
 		}
 
 		public static class KeyNames
@@ -108,6 +110,7 @@ namespace Elastic.Apm.Config
 			public const string StackTraceLimit = "ElasticApm:StackTraceLimit";
 			public const string TransactionMaxSpans = "ElasticApm:TransactionMaxSpans";
 			public const string TransactionSampleRate = "ElasticApm:TransactionSampleRate";
+			public const string VerifyServerCert = "ElasticApm:VerifyServerCert";
 		}
 
 		public static class SupportedValues

--- a/src/Elastic.Apm/Config/ConfigSnapshotFromReader.cs
+++ b/src/Elastic.Apm/Config/ConfigSnapshotFromReader.cs
@@ -39,5 +39,6 @@ namespace Elastic.Apm.Config
 		public int StackTraceLimit => _content.StackTraceLimit;
 		public int TransactionMaxSpans => _content.TransactionMaxSpans;
 		public double TransactionSampleRate => _content.TransactionSampleRate;
+		public bool VerifyServerCert => _content.VerifyServerCert;
 	}
 }

--- a/src/Elastic.Apm/Config/EnvironmentConfigurationReader.cs
+++ b/src/Elastic.Apm/Config/EnvironmentConfigurationReader.cs
@@ -68,6 +68,8 @@ namespace Elastic.Apm.Config
 
 		public double TransactionSampleRate => ParseTransactionSampleRate(Read(ConfigConsts.EnvVarNames.TransactionSampleRate));
 
+		public bool VerifyServerCert => ParseVerifyServerCert(Read(ConfigConsts.EnvVarNames.VerifyServerCert));
+
 		private ConfigurationKeyValue Read(string key) =>
 			new ConfigurationKeyValue(key, ReadEnvVarValue(key), Origin);
 	}

--- a/src/Elastic.Apm/Config/IConfigurationReader.cs
+++ b/src/Elastic.Apm/Config/IConfigurationReader.cs
@@ -135,5 +135,11 @@ namespace Elastic.Apm.Config
 		int TransactionMaxSpans { get; }
 
 		double TransactionSampleRate { get; }
+
+		/// <summary>
+		/// The agent verifies the server's certificate if an HTTPS connection to the APM server is used.
+		/// Verification can be disabled by setting to <c>false</c>.
+		/// </summary>
+		bool VerifyServerCert { get; }
 	}
 }

--- a/test/Elastic.Apm.Tests/ConfigTests.cs
+++ b/test/Elastic.Apm.Tests/ConfigTests.cs
@@ -753,6 +753,8 @@ namespace Elastic.Apm.Tests
 				);
 		}
 
+
+
 		/// <summary>
 		/// Disables CPU metrics and makes sure that remaining metrics are still captured
 		/// </summary>
@@ -777,6 +779,23 @@ namespace Elastic.Apm.Tests
 				.Contain(n => n.KeyValue.Key.Equals("system.process.memory.size", StringComparison.InvariantCultureIgnoreCase));
 			firstMetrics.Samples.Should()
 				.Contain(n => n.KeyValue.Key.Equals("system.process.memory.rss.bytes", StringComparison.InvariantCultureIgnoreCase));
+		}
+
+		[Fact]
+		public void DefaultVerifyServerCertIsTrue()
+		{
+			var agent = new ApmAgent(new TestAgentComponents());
+			agent.ConfigurationReader.VerifyServerCert.Should().BeTrue();
+		}
+
+		[Theory]
+		[InlineData("false", false)]
+		[InlineData("true", true)]
+		[InlineData("nonsense value", true)]
+		public void SetVerifyServerCert(string verifyServerCert, bool expected)
+		{
+			var agent = new ApmAgent(new TestAgentComponents(config: new MockConfigSnapshot(verifyServerCert: verifyServerCert)));
+			agent.ConfigurationReader.VerifyServerCert.Should().Be(expected);
 		}
 
 		private static double MetricsIntervalTestCommon(string configValue)

--- a/test/Elastic.Apm.Tests/ConstructorTests.cs
+++ b/test/Elastic.Apm.Tests/ConstructorTests.cs
@@ -53,6 +53,7 @@ namespace Elastic.Apm.Tests
 			public double SpanFramesMinDurationInMilliseconds => ConfigConsts.DefaultValues.SpanFramesMinDurationInMilliseconds;
 			public int StackTraceLimit => ConfigConsts.DefaultValues.StackTraceLimit;
 			public double TransactionSampleRate => ConfigConsts.DefaultValues.TransactionSampleRate;
+			public bool VerifyServerCert => ConfigConsts.DefaultValues.VerifyServerCert;
 
 			public int TransactionMaxSpans => ConfigConsts.DefaultValues.TransactionMaxSpans;
 			// ReSharper restore UnassignedGetOnlyAutoProperty

--- a/test/Elastic.Apm.Tests/Mocks/MockConfigSnapshot.cs
+++ b/test/Elastic.Apm.Tests/Mocks/MockConfigSnapshot.cs
@@ -34,6 +34,7 @@ namespace Elastic.Apm.Tests.Mocks
 		private readonly string _stackTraceLimit;
 		private readonly string _transactionMaxSpans;
 		private readonly string _transactionSampleRate;
+		private readonly string _verifyServerCert;
 
 		public MockConfigSnapshot(
 			IApmLogger logger = null,
@@ -59,7 +60,8 @@ namespace Elastic.Apm.Tests.Mocks
 			string maxQueueEventCount = null,
 			string sanitizeFieldNames = null,
 			string globalLabels = null,
-			string disableMetrics = null
+			string disableMetrics = null,
+			string verifyServerCert = null
 		) : base(logger, ThisClassName)
 		{
 			_serverUrls = serverUrls;
@@ -85,6 +87,7 @@ namespace Elastic.Apm.Tests.Mocks
 			_sanitizeFieldNames = sanitizeFieldNames;
 			_globalLabels = globalLabels;
 			_disableMetrics = disableMetrics;
+			_verifyServerCert = verifyServerCert;
 		}
 
 		public string CaptureBody => ParseCaptureBody(Kv(ConfigConsts.EnvVarNames.CaptureBody, _captureBody, Origin));
@@ -131,5 +134,8 @@ namespace Elastic.Apm.Tests.Mocks
 
 		public double TransactionSampleRate =>
 			ParseTransactionSampleRate(Kv(ConfigConsts.EnvVarNames.TransactionSampleRate, _transactionSampleRate, Origin));
+
+		public bool VerifyServerCert =>
+			ParseVerifyServerCert(Kv(ConfigConsts.EnvVarNames.VerifyServerCert, _verifyServerCert, Origin));
 	}
 }


### PR DESCRIPTION
This commit adds support for server certificate verification. A configuration value can be supplied

1. through environment variables with key `"ELASTIC_APM_VERIFY_SERVER_CERT"` and a value that can be parsed to a boolean
2. through configuration with key `"ElasticApm:VerifyServerCert"` and a value than can be parsed to a boolean