### PR TITLE
Add official package list to readme.md with download links

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Official NuGet packages can be referenced from [NuGet.org](https://www.nuget.org
 
 ## Documentation
 
-Docs are located [here](https://www.elastic.co/guide/en/apm/agent/dotnet/current/index.html). That page is generated from the content of the [docs](docs) folder.
+Docs are located [here](https://www.elastic.co/guide/en/apm/agent/dotnet/). That page is generated from the content of the [docs](docs) folder.
 
 ## Getting Help
 
@@ -40,7 +40,7 @@ These are the main folders within the repository:
     * `Elastic.Apm`: The core project targeting .NET Standard 2.0. It contains the [Agent API](/docs/public-api.asciidoc), the infrastructure to report data to the APM Server, the logging infrastructure, and auto-instrumentation for things that are part of .NET Standard 2.0.
     * `Elastic.Apm.AspNetCore`: Auto-instrumentation for ASP.NET Core.
     * `Elastic.Apm.EntityFrameworkCore`: Auto-instrumentation for EntityFramework Core.
-    * `Elastic.Apm.NetCoreAll`: A convenient project that references all other .NET Core related projects from the `src` folder. It contains an ASP.NET Core middleware extension that enables the agent and every other component with a single line of code. In a typical ASP.NET Core application (e.g. apps referencing [Microsoft.AspNetCore.All](https://www.nuget.org/packages/Microsoft.AspNetCore.All)) that uses EF Core the `Elastic.Apm.NetCoreAll` can be referenced.
+    * `Elastic.Apm.NetCoreAll`: A convenience project that references all other .NET Core related projects from the `src` folder. It contains an ASP.NET Core middleware extension that enables the agent and every other component with a single line of code. In a typical ASP.NET Core application (e.g. apps referencing [Microsoft.AspNetCore.All](https://www.nuget.org/packages/Microsoft.AspNetCore.All)) that uses EF Core the `Elastic.Apm.NetCoreAll` can be referenced.
     * `Elastic.Apm.AspNetFullFramework`: Auto-instrumentation for ASP.NET (classic).
 * test: This folder contains test projects. Typically each project from the `src` folder has a corresponding test project.
     * `Elastic.Apm.Tests`: Tests the `Elastic.Apm` project.

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ These are the main folders within the repository:
     * `Elastic.Apm`: The core project targeting .NET Standard 2.0. It contains the [Agent API](/docs/public-api.asciidoc), the infrastructure to report data to the APM Server, the logging infrastructure, and auto-instrumentation for things that are part of .NET Standard 2.0.
     * `Elastic.Apm.AspNetCore`: Auto-instrumentation for ASP.NET Core.
     * `Elastic.Apm.EntityFrameworkCore`: Auto-instrumentation for EntityFramework Core.
-    * `Elastic.Apm.NetCoreAll`: A convenience project that references all other .NET Core related projects from the `src` folder. It contains an ASP.NET Core middleware extension that enables the agent and every other component with a single line of code. In a typical ASP.NET Core application (e.g. apps referencing [Microsoft.AspNetCore.All](https://www.nuget.org/packages/Microsoft.AspNetCore.All)) that uses EF Core the `Elastic.Apm.NetCoreAll` can be referenced.
+    * `Elastic.Apm.NetCoreAll`: A convenient project that references all other .NET Core related projects from the `src` folder. It contains an ASP.NET Core middleware extension that enables the agent and every other component with a single line of code. In a typical ASP.NET Core application (e.g. apps referencing [Microsoft.AspNetCore.All](https://www.nuget.org/packages/Microsoft.AspNetCore.All)) that uses EF Core the `Elastic.Apm.NetCoreAll` can be referenced.
     * `Elastic.Apm.AspNetFullFramework`: Auto-instrumentation for ASP.NET (classic).
 * test: This folder contains test projects. Typically each project from the `src` folder has a corresponding test project.
     * `Elastic.Apm.Tests`: Tests the `Elastic.Apm` project.

--- a/README.md
+++ b/README.md
@@ -6,9 +6,20 @@
 Please fill out this survey to help us prioritizing framework support:
 [https://goo.gl/forms/FHHbhptcDx8eDNx92](https://goo.gl/forms/FHHbhptcDx8eDNx92)
 
+# Installation
+
+Official NuGet packages can be referenced from [NuGet.org](https://www.nuget.org).
+
+| Package Name            | Purpose          | Download         |
+| ----------------------- | ---------------- | -----------------|
+| `Elastic.Apm`           |  The core of the Agent, Public Agent API, Auto instrumentation for libraries that are part of .NET Standard 2.0  | [![NuGet Release][ElasticApm-image]][ElasticApm-nuget-url]  |
+| `Elastic.Apm.AspNetCore` | ASP.NET Core auto instrumentation | [![NuGet Release][ElasticApmAspNetCore-image]][ElasticApmAspNetCore-nuget-url] |
+| `Elastic.Apm.EntityFrameworkCore` | Entity Framework Core auto instrumentation | [![NuGet Release][Elastic.Apm.EntityFrameworkCore-image]][Elastic.Apm.EntityFrameworkCore-nuget-url] |
+| `Elastic.Apm.NetCoreAll` | References every .NET Core related elastic APM package. It can be used to simply turn on the agent with a single line and activate all auto instrumentation. | [![NuGet Release][Elastic.Apm.NetCoreAll-image]][Elastic.Apm.NetCoreAll-nuget-url] |
+
 ## Documentation
 
-Docs are located [here](docs).
+Docs are located [here](https://www.elastic.co/guide/en/apm/agent/dotnet/current/index.html). That page is generated from the content of the [docs](docs) folder.
 
 ## Getting Help
 
@@ -29,7 +40,8 @@ These are the main folders within the repository:
     * `Elastic.Apm`: The core project targeting .NET Standard 2.0. It contains the [Agent API](/docs/public-api.asciidoc), the infrastructure to report data to the APM Server, the logging infrastructure, and auto-instrumentation for things that are part of .NET Standard 2.0.
     * `Elastic.Apm.AspNetCore`: Auto-instrumentation for ASP.NET Core.
     * `Elastic.Apm.EntityFrameworkCore`: Auto-instrumentation for EntityFramework Core.
-    * `Elastic.Apm.NetCoreAll`: A convenient project that references all other projects from the `src` folder. It contains an ASP.NET Core middleware extension that enables the agent and every other component with a single line of code. In a typical ASP.NET Core application (e.g. apps referencing [Microsoft.AspNetCore.All](https://www.nuget.org/packages/Microsoft.AspNetCore.All)) that uses EF Core the `Elastic.Apm.All` can be referenced.
+    * `Elastic.Apm.NetCoreAll`: A convenient project that references all other .NET Core related projects from the `src` folder. It contains an ASP.NET Core middleware extension that enables the agent and every other component with a single line of code. In a typical ASP.NET Core application (e.g. apps referencing [Microsoft.AspNetCore.All](https://www.nuget.org/packages/Microsoft.AspNetCore.All)) that uses EF Core the `Elastic.Apm.NetCoreAll` can be referenced.
+    * `Elastic.Apm.AspNetFullFramework`: Auto-instrumentation for ASP.NET (classic).
 * test: This folder contains test projects. Typically each project from the `src` folder has a corresponding test project.
     * `Elastic.Apm.Tests`: Tests the `Elastic.Apm` project.
     * `Elastic.Apm.AspNetCore.Tests`: Tests the `Elastic.Apm.AspNetCore` project.
@@ -42,3 +54,19 @@ These are the main folders within the repository:
 
 ## License
 Elastic APM .Net Agent is licensed under Apache License, Version 2.0.
+
+[ElasticApm-nuget-url]:https://www.nuget.org/packages/Elastic.Apm/
+[ElasticApm-image]:
+https://img.shields.io/nuget/v/Elastic.Apm.svg
+
+[ElasticApmAspNetCore-nuget-url]:https://www.nuget.org/packages/Elastic.Apm.AspNetCore/
+[ElasticApmAspNetCore-image]:
+https://img.shields.io/nuget/v/Elastic.Apm.AspNetCore.svg
+
+[Elastic.Apm.EntityFrameworkCore-nuget-url]:https://www.nuget.org/packages/Elastic.Apm.EntityFrameworkCore/
+[Elastic.Apm.EntityFrameworkCore-image]:
+https://img.shields.io/nuget/v/Elastic.Apm.EntityFrameworkCore.svg
+
+[Elastic.Apm.NetCoreAll-nuget-url]:https://www.nuget.org/packages/Elastic.Apm.NetCoreAll/
+[Elastic.Apm.NetCoreAll-image]:
+https://img.shields.io/nuget/v/Elastic.Apm.NetCoreAll.svg

--- a/src/Elastic.Apm.AspNetFullFramework/README.md
+++ b/src/Elastic.Apm.AspNetFullFramework/README.md
@@ -1,0 +1,5 @@
+# Elastic.Apm.AspNetFullFramework
+
+_NOTE: this project is work in progress and it's not yet officially released. Feel free to build it from source and experiment with it, but do not use it in production._
+
+This project contains an IIS module that automatically starts and stops transactions for incoming HTTP requests. The goal is to provide auto instrumentation for ASP.NET (classic) applications.


### PR DESCRIPTION
Sometimes I see that people are confused about what we released and what we haven't. After looking at the repo, I think we could make some improvements to avoid this.

- Added a list of official packages with download links
- Added a readme to the `AspNetFullFramework` package - I try to make sure it's clear it's not yet released (e.g. I think [here](https://discuss.elastic.co/t/recommended-setup-for-rest-service-monitoring/196875) it wasn't clear)
- Some other minor things