### PR TITLE
Handling servicePoint.ConnectionLeaseTimeout exceptions - #164

### DIFF
--- a/src/Elastic.Apm/Report/PayloadSenderV2.cs
+++ b/src/Elastic.Apm/Report/PayloadSenderV2.cs
@@ -14,6 +14,7 @@ using System.Threading.Tasks.Dataflow;
 using Elastic.Apm.Api;
 using Elastic.Apm.Config;
 using Elastic.Apm.Logging;
+using Elastic.Apm.Metrics;
 using Elastic.Apm.Model;
 using Elastic.Apm.Report.Serialization;
 
@@ -27,20 +28,18 @@ namespace Elastic.Apm.Report
 	{
 		private static readonly int DnsTimeout = (int)TimeSpan.FromMinutes(1).TotalMilliseconds;
 
+		internal readonly Api.System System;
+
 		private readonly BatchBlock<object> _eventQueue =
 			new BatchBlock<object>(20);
 
 		private readonly HttpClient _httpClient;
 		private readonly IApmLogger _logger;
-
-		internal readonly Api.System System;
-
-		private CancellationTokenSource _batchBlockReceiveAsyncCts;
+		private readonly Metadata _metadata;
 
 		private readonly PayloadItemSerializer _payloadItemSerializer = new PayloadItemSerializer();
 
 		private readonly SingleThreadTaskScheduler _singleThreadTaskScheduler = new SingleThreadTaskScheduler(CancellationToken.None);
-		private readonly Metadata _metadata;
 
 		public PayloadSenderV2(IApmLogger logger, IConfigurationReader configurationReader, Service service, Api.System system,
 			HttpMessageHandler handler = null
@@ -60,9 +59,10 @@ namespace Elastic.Apm.Report
 			}
 			catch (Exception e)
 			{
-				_logger.Error()
+				_logger.Warning()
 					?.LogException(e,
-						"Failed setting servicePoint.ConnectionLeaseTimeout - default ConnectionLeaseTimeout from HttpClient will be used");
+						"Failed setting servicePoint.ConnectionLeaseTimeout - default ConnectionLeaseTimeout from HttpClient will be used. "
+						+ "Unless you notice connection issues between the APM Server and the agent, no action needed.");
 			}
 
 			servicePoint.ConnectionLimit = 20;
@@ -99,6 +99,8 @@ namespace Elastic.Apm.Report
 			// https://github.com/dotnet/corefx/blob/e64cac6dcacf996f98f0b3f75fb7ad0c12f588f7/src/System.Net.Http/src/System/Net/Http/HttpRuleParser.cs#L41
 			string AdaptUserAgentValue(string value) => Regex.Replace(value, "[ /()<>@,:;={}?\\[\\]\"\\\\]", "_");
 		}
+
+		private CancellationTokenSource _batchBlockReceiveAsyncCts;
 
 		public void QueueTransaction(ITransaction transaction)
 		{
@@ -171,7 +173,7 @@ namespace Elastic.Apm.Report
 						case Error _:
 							ndjson.AppendLine("{\"error\": " + serialized + "}");
 							break;
-						case Metrics.MetricSet _:
+						case MetricSet _:
 							ndjson.AppendLine("{\"metricset\": " + serialized + "}");
 							break;
 					}

--- a/test/Elastic.Apm.DockerTests/BasicDockerTests.cs
+++ b/test/Elastic.Apm.DockerTests/BasicDockerTests.cs
@@ -16,9 +16,9 @@ namespace Elastic.Apm.DockerTests
 			{
 				var payloadSender = (agent.PayloadSender as PayloadSenderV2);
 				payloadSender.Should().NotBeNull();
-				payloadSender?._system.Should().NotBeNull();
-				payloadSender?._system.Container.Should().NotBeNull();
-				payloadSender?._system.Container.Id.Should().NotBeNullOrWhiteSpace();
+				payloadSender?.System.Should().NotBeNull();
+				payloadSender?.System.Container.Should().NotBeNull();
+				payloadSender?.System.Container.Id.Should().NotBeNullOrWhiteSpace();
 			}
 		}
 	}


### PR DESCRIPTION
Ran into this again while making the `Elastic.Apm.Tests` also run on Full Framework. Solves #164. 

Added a try-catch to: `servicePoint.ConnectionLeaseTimeout = DnsTimeout` that caused `NotImplementedException` on Mono.

More info about it: https://github.com/dotnet/standard/issues/642

Based on [this comment](https://github.com/dotnet/standard/issues/642#issuecomment-431409137) .NET Core has a no-op implementation, therefore on .NET Core this line did not have any effect anyway - same applies to newer Mono versions.

I think there is nothing more to do than simply log this and move on, with the default the agent will still work.