### PR TITLE
Tests on full framework

### DIFF
--- a/.ci/windows/testnet461.bat
+++ b/.ci/windows/testnet461.bat
@@ -2,4 +2,4 @@
 :: This script runs the tests and stored them in an xml file defined in the
 :: LogFilePath property
 ::
-dotnet test -f net461 -v n -r target -d target\diag.log --no-build --logger:"xunit;LogFilePath=TestResults.xml" /p:CollectCoverage=true /p:CoverletOutputFormat=cobertura /p:CoverletOutput=target\Coverage\ /p:Exclude=\"[Elastic.Apm.Tests]*,[SampleAspNetCoreApp*]*,[xunit*]*\" /p:Threshold=0 /p:ThresholdType=branch /p:ThresholdStat=total
+dotnet test -f net461 -v n -r target -d target\diag.log --no-build --logger:"xunit;LogFilePath=TestResults.xml" /p:CollectCoverage=true /p:CoverletOutputFormat=cobertura /p:CoverletOutput=target\Coverage\ /p:Exclude=\"[Elastic.Apm.Tests]*,[xunit*]*\" /p:Threshold=0 /p:ThresholdType=branch /p:ThresholdStat=total

--- a/.ci/windows/testnet461.bat
+++ b/.ci/windows/testnet461.bat
@@ -2,4 +2,4 @@
 :: This script runs the tests and stored them in an xml file defined in the
 :: LogFilePath property
 ::
-dotnet test -f net461 -v n -r target -d target\diag.log --no-build --logger:"xunit;LogFilePath=TestResults.xml" /p:CollectCoverage=true /p:CoverletOutputFormat=cobertura /p:CoverletOutput=target\Coverage\ /p:Exclude=\"[Elastic.Apm.Tests]*,[SampleAspNetCoreApp*]*,[xunit*]*\" /p:Threshold=0 /p:ThresholdType=branch /p:ThresholdStat=total
+dotnet test test\Elastic.Apm.Tests -f net461 -v n -r target -d target\diag.log --no-build --logger:"xunit;LogFilePath=TestResults.xml" /p:CollectCoverage=true /p:CoverletOutputFormat=cobertura /p:CoverletOutput=target\Coverage\ /p:Exclude=\"[Elastic.Apm.Tests]*,[SampleAspNetCoreApp*]*,[xunit*]*\" /p:Threshold=0 /p:ThresholdType=branch /p:ThresholdStat=total

--- a/.ci/windows/testnet461.bat
+++ b/.ci/windows/testnet461.bat
@@ -1,0 +1,5 @@
+::
+:: This script runs the tests and stored them in an xml file defined in the
+:: LogFilePath property
+::
+dotnet test -f net461 -v n -r target -d target\diag.log --no-build --logger:"xunit;LogFilePath=TestResults.xml" /p:CollectCoverage=true /p:CoverletOutputFormat=cobertura /p:CoverletOutput=target\Coverage\ /p:Exclude=\"[Elastic.Apm.Tests]*,[SampleAspNetCoreApp*]*,[xunit*]*\" /p:Threshold=0 /p:ThresholdType=branch /p:ThresholdStat=total

--- a/.ci/windows/testnet461.bat
+++ b/.ci/windows/testnet461.bat
@@ -2,4 +2,4 @@
 :: This script runs the tests and stored them in an xml file defined in the
 :: LogFilePath property
 ::
-dotnet test -f net461 -v n -r target -d target\diag.log --no-build --logger:"xunit;LogFilePath=TestResults.xml" /p:CollectCoverage=true /p:CoverletOutputFormat=cobertura /p:CoverletOutput=target\Coverage\ /p:Exclude=\"[Elastic.Apm.Tests]*,[xunit*]*\" /p:Threshold=0 /p:ThresholdType=branch /p:ThresholdStat=total
+dotnet test -f net461 -v n -r target -d target\diag.log --no-build --logger:"xunit;LogFilePath=TestResults.xml" /p:CollectCoverage=true /p:CoverletOutputFormat=cobertura /p:CoverletOutput=target\Coverage\ /p:Exclude=\"[Elastic.Apm.Tests]*,[SampleAspNetCoreApp*]*,[xunit*]*\" /p:Threshold=0 /p:ThresholdType=branch /p:ThresholdStat=total

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -177,7 +177,7 @@ pipeline {
                           powershell label: 'Install test tools', script: '.ci\\windows\\test-tools.ps1'
                           bat label: 'Prepare solution', script: '.ci/windows/prepare-test.bat'
                           bat label: 'Build', script: '.ci/windows/msbuild.bat'
-                          bat label: 'Test & coverage', script: '.ci/windows/test.bat'
+                          bat label: 'Test & coverage', script: '.ci/windows/testnet461.bat'
                           powershell label: 'Convert Test Results to junit format', script: '.ci\\windows\\convert.ps1'
                         }
                       }

--- a/src/Elastic.Apm/Api/Service.cs
+++ b/src/Elastic.Apm/Api/Service.cs
@@ -101,6 +101,8 @@ namespace Elastic.Apm.Api
 
 		internal const string DotNetFullFrameworkName = ".NET Framework";
 
+		internal const string MonoName = "Mono";
+
 		[JsonConverter(typeof(TrimmedStringJsonConverter))]
 		public string Name { get; set; }
 

--- a/test/Elastic.Apm.Tests/ApiTests/ApiTests.cs
+++ b/test/Elastic.Apm.Tests/ApiTests/ApiTests.cs
@@ -683,8 +683,8 @@ namespace Elastic.Apm.Tests.ApiTests
 				agent.Tracer.CaptureTransaction(TestTransaction, CustomTransactionTypeForTests, transaction =>
 				{
 					capturedTransaction = transaction;
-					foreach (var (key, value) in expectedErrorContext.Labels)
-						transaction.Context.Labels[key] = value;
+					foreach (var item in expectedErrorContext.Labels)
+						transaction.Context.Labels[item.Key] = item.Value;
 					ISpan span = null;
 					if (captureOnSpan)
 					{
@@ -828,8 +828,8 @@ namespace Elastic.Apm.Tests.ApiTests
 			}
 
 			payloadSender.Spans.Single().Context.Destination.Should().BeNull();
-			mockLogger.Lines.Should().Contain(line => line.Contains("destination", StringComparison.OrdinalIgnoreCase)
-				&& line.Contains("URL", StringComparison.OrdinalIgnoreCase));
+			mockLogger.Lines.Should().Contain(line => line.Contains("destination")
+				&& line.Contains("URL"));
 		}
 
 		private class TestException : Exception

--- a/test/Elastic.Apm.Tests/Elastic.Apm.Tests.csproj
+++ b/test/Elastic.Apm.Tests/Elastic.Apm.Tests.csproj
@@ -1,15 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>netcoreapp2.1;netcoreapp2.2;netcoreapp3.0;netcoreapp3.1;net461</TargetFrameworks>
-    <IsPackable>false</IsPackable>
     <RootNamespace>Elastic.Apm.Tests</RootNamespace>
     <AssemblyName>Elastic.Apm.Tests</AssemblyName>
-    <SignAssembly>true</SignAssembly>
-    <AssemblyOriginatorKeyFile>..\..\build\elasticapm.snk</AssemblyOriginatorKeyFile>
-    <DelaySign>false</DelaySign>
-    <LangVersion>latest</LangVersion>
-    <!-- Always generate debug symbols this allows fluent symbols exception messages to include variable names -->
-    <DebugSymbols>True</DebugSymbols>
   </PropertyGroup>
 
   <ItemGroup>
@@ -18,6 +11,7 @@
     <PackageReference Include="Moq" Version="4.12.0" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
   </ItemGroup>
 

--- a/test/Elastic.Apm.Tests/Elastic.Apm.Tests.csproj
+++ b/test/Elastic.Apm.Tests/Elastic.Apm.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;netcoreapp2.2;netcoreapp3.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp2.2;netcoreapp3.0;netcoreapp3.1;net461</TargetFrameworks>
     <RootNamespace>Elastic.Apm.Tests</RootNamespace>
     <AssemblyName>Elastic.Apm.Tests</AssemblyName>
   </PropertyGroup>

--- a/test/Elastic.Apm.Tests/Elastic.Apm.Tests.csproj
+++ b/test/Elastic.Apm.Tests/Elastic.Apm.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>netcoreapp2.1;netcoreapp2.2;netcoreapp3.0;netcoreapp3.1;net461</TargetFrameworks>
     <IsPackable>false</IsPackable>

--- a/test/Elastic.Apm.Tests/Elastic.Apm.Tests.csproj
+++ b/test/Elastic.Apm.Tests/Elastic.Apm.Tests.csproj
@@ -4,6 +4,12 @@
     <IsPackable>false</IsPackable>
     <RootNamespace>Elastic.Apm.Tests</RootNamespace>
     <AssemblyName>Elastic.Apm.Tests</AssemblyName>
+    <SignAssembly>true</SignAssembly>
+    <AssemblyOriginatorKeyFile>..\..\build\elasticapm.snk</AssemblyOriginatorKeyFile>
+    <DelaySign>false</DelaySign>
+    <LangVersion>latest</LangVersion>
+    <!-- Always generate debug symbols this allows fluent symbols exception messages to include variable names -->
+    <DebugSymbols>True</DebugSymbols>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Elastic.Apm.Tests/Elastic.Apm.Tests.csproj
+++ b/test/Elastic.Apm.Tests/Elastic.Apm.Tests.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>netcoreapp2.1;netcoreapp2.2;netcoreapp3.0;netcoreapp3.1;net461</TargetFrameworks>
+    <IsPackable>false</IsPackable>
     <RootNamespace>Elastic.Apm.Tests</RootNamespace>
     <AssemblyName>Elastic.Apm.Tests</AssemblyName>
   </PropertyGroup>

--- a/test/Elastic.Apm.Tests/HelpersTests/AgentTimerTests.cs
+++ b/test/Elastic.Apm.Tests/HelpersTests/AgentTimerTests.cs
@@ -319,15 +319,13 @@ namespace Elastic.Apm.Tests.HelpersTests
 
 			public void VerifyTryAwaitCompletedSuccessfully(Task tryAwaitOrTimeoutTask, Task delayTask)
 			{
-				tryAwaitOrTimeoutTask.IsCompleted.Should().BeTrue();
-				tryAwaitOrTimeoutTask.IsFaulted.Should().BeFalse();
+				tryAwaitOrTimeoutTask.IsCompletedSuccessfully().Should().BeTrue();
 
 				UnpackTryAwaitOrTimeoutTaskResult(tryAwaitOrTimeoutTask, out var hasTaskToAwaitCompleted, out var taskToAwaitResult);
 				hasTaskToAwaitCompleted.Should().BeTrue();
 				taskToAwaitResult.Should().Be(_resultValue);
 
-				_taskToAwaitTcs.Task.IsCompleted.Should().BeTrue();
-				_taskToAwaitTcs.Task.IsFaulted.Should().BeFalse();
+				_taskToAwaitTcs.Task.IsCompletedSuccessfully().Should().BeTrue();
 				_taskToAwaitTcs.Task.Result.Should().Be(_resultValue);
 
 				VerifyFinalAgentTimerState(delayTask);
@@ -335,13 +333,11 @@ namespace Elastic.Apm.Tests.HelpersTests
 
 			public void VerifyAwaitCompletedSuccessfully(Task awaitOrTimeoutTask, Task delayTask)
 			{
-				awaitOrTimeoutTask.IsCompleted.Should().BeTrue();
-				awaitOrTimeoutTask.IsFaulted.Should().BeFalse();
+				awaitOrTimeoutTask.IsCompletedSuccessfully().Should().BeTrue();
 
 				if (!_isVoid) ((Task<TResult>)awaitOrTimeoutTask).Result.Should().Be(_resultValue);
 
-				_taskToAwaitTcs.Task.IsCompleted.Should().BeTrue();
-				_taskToAwaitTcs.Task.IsFaulted.Should().BeFalse();
+				_taskToAwaitTcs.Task.IsCompletedSuccessfully().Should().BeTrue();
 				_taskToAwaitTcs.Task.Result.Should().Be(_resultValue);
 
 				VerifyFinalAgentTimerState(delayTask);
@@ -349,8 +345,7 @@ namespace Elastic.Apm.Tests.HelpersTests
 
 			public void VerifyTryAwaitTimeout(Task tryAwaitOrTimeoutTask, Task delayTask)
 			{
-				tryAwaitOrTimeoutTask.IsCompleted.Should().BeTrue();
-				tryAwaitOrTimeoutTask.IsFaulted.Should().BeFalse();
+				tryAwaitOrTimeoutTask.IsCompletedSuccessfully().Should().BeTrue();
 
 				UnpackTryAwaitOrTimeoutTaskResult(tryAwaitOrTimeoutTask, out var hasTaskToAwaitCompleted, out var taskToAwaitResult);
 				hasTaskToAwaitCompleted.Should().BeFalse();
@@ -434,10 +429,7 @@ namespace Elastic.Apm.Tests.HelpersTests
 				if (wasDelayCancelled)
 					delayTask.IsCanceled.Should().BeTrue();
 				else
-				{
-					delayTask.IsCompleted.Should().BeTrue();
-					delayTask.IsFaulted.Should().BeFalse();
-				}
+					delayTask.IsCompletedSuccessfully().Should().BeTrue();
 			}
 		}
 	}

--- a/test/Elastic.Apm.Tests/HelpersTests/AgentTimerTests.cs
+++ b/test/Elastic.Apm.Tests/HelpersTests/AgentTimerTests.cs
@@ -319,13 +319,15 @@ namespace Elastic.Apm.Tests.HelpersTests
 
 			public void VerifyTryAwaitCompletedSuccessfully(Task tryAwaitOrTimeoutTask, Task delayTask)
 			{
-				tryAwaitOrTimeoutTask.IsCompletedSuccessfully.Should().BeTrue();
+				tryAwaitOrTimeoutTask.IsCompleted.Should().BeTrue();
+				tryAwaitOrTimeoutTask.IsFaulted.Should().BeFalse();
 
 				UnpackTryAwaitOrTimeoutTaskResult(tryAwaitOrTimeoutTask, out var hasTaskToAwaitCompleted, out var taskToAwaitResult);
 				hasTaskToAwaitCompleted.Should().BeTrue();
 				taskToAwaitResult.Should().Be(_resultValue);
 
-				_taskToAwaitTcs.Task.IsCompletedSuccessfully.Should().BeTrue();
+				_taskToAwaitTcs.Task.IsCompleted.Should().BeTrue();
+				_taskToAwaitTcs.Task.IsFaulted.Should().BeFalse();
 				_taskToAwaitTcs.Task.Result.Should().Be(_resultValue);
 
 				VerifyFinalAgentTimerState(delayTask);
@@ -333,11 +335,13 @@ namespace Elastic.Apm.Tests.HelpersTests
 
 			public void VerifyAwaitCompletedSuccessfully(Task awaitOrTimeoutTask, Task delayTask)
 			{
-				awaitOrTimeoutTask.IsCompletedSuccessfully.Should().BeTrue();
+				awaitOrTimeoutTask.IsCompleted.Should().BeTrue();
+				awaitOrTimeoutTask.IsFaulted.Should().BeFalse();
 
 				if (!_isVoid) ((Task<TResult>)awaitOrTimeoutTask).Result.Should().Be(_resultValue);
 
-				_taskToAwaitTcs.Task.IsCompletedSuccessfully.Should().BeTrue();
+				_taskToAwaitTcs.Task.IsCompleted.Should().BeTrue();
+				_taskToAwaitTcs.Task.IsFaulted.Should().BeFalse();
 				_taskToAwaitTcs.Task.Result.Should().Be(_resultValue);
 
 				VerifyFinalAgentTimerState(delayTask);
@@ -345,7 +349,8 @@ namespace Elastic.Apm.Tests.HelpersTests
 
 			public void VerifyTryAwaitTimeout(Task tryAwaitOrTimeoutTask, Task delayTask)
 			{
-				tryAwaitOrTimeoutTask.IsCompletedSuccessfully.Should().BeTrue();
+				tryAwaitOrTimeoutTask.IsCompleted.Should().BeTrue();
+				tryAwaitOrTimeoutTask.IsFaulted.Should().BeFalse();
 
 				UnpackTryAwaitOrTimeoutTaskResult(tryAwaitOrTimeoutTask, out var hasTaskToAwaitCompleted, out var taskToAwaitResult);
 				hasTaskToAwaitCompleted.Should().BeFalse();
@@ -429,7 +434,10 @@ namespace Elastic.Apm.Tests.HelpersTests
 				if (wasDelayCancelled)
 					delayTask.IsCanceled.Should().BeTrue();
 				else
-					delayTask.IsCompletedSuccessfully.Should().BeTrue();
+				{
+					delayTask.IsCompleted.Should().BeTrue();
+					delayTask.IsFaulted.Should().BeFalse();
+				}
 			}
 		}
 	}

--- a/test/Elastic.Apm.Tests/HelpersTests/PlatformDetectionTests.cs
+++ b/test/Elastic.Apm.Tests/HelpersTests/PlatformDetectionTests.cs
@@ -18,11 +18,9 @@ namespace Elastic.Apm.Tests.HelpersTests
 		{
 			var mockPayloadSender = new MockPayloadSender();
 			using (var agent = new ApmAgent(new AgentComponents(payloadSender: mockPayloadSender)))
-			{
 				agent.Tracer.CaptureTransaction("TestTransaction", "Test", () => { });
-			}
 
-			switch (RuntimeInformation.FrameworkDescription )
+			switch (RuntimeInformation.FrameworkDescription)
 			{
 				case string str when str.StartsWith(PlatformDetection.MonoDescriptionPrefix, StringComparison.OrdinalIgnoreCase):
 					mockPayloadSender.FirstTransaction.Service.Runtime.Name.Should().Be(Runtime.MonoName);

--- a/test/Elastic.Apm.Tests/HelpersTests/PlatformDetectionTests.cs
+++ b/test/Elastic.Apm.Tests/HelpersTests/PlatformDetectionTests.cs
@@ -1,0 +1,39 @@
+using System;
+using System.Runtime.InteropServices;
+using Elastic.Apm.Api;
+using Elastic.Apm.Helpers;
+using Elastic.Apm.Tests.Mocks;
+using FluentAssertions;
+using Xunit;
+
+namespace Elastic.Apm.Tests.HelpersTests
+{
+	public class PlatformDetectionTests
+	{
+		/// <summary>
+		/// Makes sure that Service.Runtime.Name is set to the correct runtime name.
+		/// </summary>
+		[Fact]
+		public void RuntimeName()
+		{
+			var mockPayloadSender = new MockPayloadSender();
+			using (var agent = new ApmAgent(new AgentComponents(payloadSender: mockPayloadSender)))
+			{
+				agent.Tracer.CaptureTransaction("TestTransaction", "Test", () => { });
+			}
+
+			switch (RuntimeInformation.FrameworkDescription )
+			{
+				case string str when str.StartsWith(PlatformDetection.MonoDescriptionPrefix, StringComparison.OrdinalIgnoreCase):
+					mockPayloadSender.FirstTransaction.Service.Runtime.Name.Should().Be(Runtime.MonoName);
+					break;
+				case string str when str.StartsWith(PlatformDetection.DotNetFullFrameworkDescriptionPrefix, StringComparison.OrdinalIgnoreCase):
+					mockPayloadSender.FirstTransaction.Service.Runtime.Name.Should().Be(Runtime.DotNetFullFrameworkName);
+					break;
+				case string str when str.StartsWith(PlatformDetection.DotNetCoreDescriptionPrefix, StringComparison.OrdinalIgnoreCase):
+					mockPayloadSender.FirstTransaction.Service.Runtime.Name.Should().Be(Runtime.DotNetCoreName);
+					break;
+			}
+		}
+	}
+}

--- a/test/Elastic.Apm.Tests/HelpersTests/TimeUtilsTests.cs
+++ b/test/Elastic.Apm.Tests/HelpersTests/TimeUtilsTests.cs
@@ -23,7 +23,7 @@ namespace Elastic.Apm.Tests.HelpersTests
 			{ 5 * 24 * 60 * 60 * 1_000_000L, new DateTime(1970, 1, 6, 0, 0, 0, DateTimeKind.Utc) }
 		};
 
-#if NETCOREAPP2_1
+#if NETCOREAPP
 		[Fact]
 		public void TimeUtilsUnixEpochDateTimeEqualsDateTimeUnixEpoch() => TimeUtils.UnixEpochDateTime.Should().Be(DateTime.UnixEpoch);
 #endif

--- a/test/Elastic.Apm.Tests/HelpersTests/TimeUtilsTests.cs
+++ b/test/Elastic.Apm.Tests/HelpersTests/TimeUtilsTests.cs
@@ -23,8 +23,10 @@ namespace Elastic.Apm.Tests.HelpersTests
 			{ 5 * 24 * 60 * 60 * 1_000_000L, new DateTime(1970, 1, 6, 0, 0, 0, DateTimeKind.Utc) }
 		};
 
+#if NETCOREAPP2_1
 		[Fact]
 		public void TimeUtilsUnixEpochDateTimeEqualsDateTimeUnixEpoch() => TimeUtils.UnixEpochDateTime.Should().Be(DateTime.UnixEpoch);
+#endif
 
 		[Theory]
 		[InlineData(0)]

--- a/test/Elastic.Apm.Tests/HttpDiagnosticListenerTests.cs
+++ b/test/Elastic.Apm.Tests/HttpDiagnosticListenerTests.cs
@@ -85,7 +85,7 @@ namespace Elastic.Apm.Tests
 		/// Builds an HttpRequestMessage and calls HttpDiagnosticListener.OnNext directly with it.
 		/// Makes sure that the processingRequests dictionary captures the ongoing transaction.
 		/// </summary>
-		[Fact]
+		[NetCoreFact] //see: https://github.com/elastic/apm-agent-dotnet/issues/516
 		public void OnNextWithStart()
 		{
 			var logger = new TestLogger();
@@ -112,7 +112,7 @@ namespace Elastic.Apm.Tests
 		/// and passes them to the OnNext method.
 		/// Makes sure that a Span with an Http context is captured.
 		/// </summary>
-		[Fact]
+		[NetCoreFact] //see: https://github.com/elastic/apm-agent-dotnet/issues/516
 		public void OnNextWithStartAndStop()
 		{
 			var logger = new TestLogger();
@@ -143,7 +143,7 @@ namespace Elastic.Apm.Tests
 		/// Makes sure that the transaction is only captured once and the span is also only captured once.
 		/// Also make sure that there is an error log.
 		/// </summary>
-		[Fact]
+		[NetCoreFact] //see: https://github.com/elastic/apm-agent-dotnet/issues/516
 		public void OnNextWithStartAndStopTwice()
 		{
 			var logger = new TestLogger(LogLevel.Warning);
@@ -229,7 +229,7 @@ namespace Elastic.Apm.Tests
 		/// Sends a simple real HTTP GET message and makes sure that
 		/// HttpDiagnosticListener captures it.
 		/// </summary>
-		[Fact]
+		[NetCoreFact] //see: https://github.com/elastic/apm-agent-dotnet/issues/516
 		public async Task TestSimpleOutgoingHttpRequest()
 		{
 			var (listener, payloadSender, _) = RegisterListenerAndStartTransaction();
@@ -291,7 +291,7 @@ namespace Elastic.Apm.Tests
 		/// The test makes sure HttpDiagnosticListener captures the POST method and
 		/// the response code correctly
 		/// </summary>
-		[Fact]
+		[NetCoreFact] //see: https://github.com/elastic/apm-agent-dotnet/issues/516
 		public async Task TestNotSuccessfulOutgoingHttpPostRequest()
 		{
 			var (listener, payloadSender, _) = RegisterListenerAndStartTransaction();
@@ -317,7 +317,7 @@ namespace Elastic.Apm.Tests
 		/// Starts an HTTP call to a non existing URL and makes sure that an error is captured.
 		/// This uses an HttpClient instance directly
 		/// </summary>
-		[NetCoreFact] //TODO: add issue reference
+		[NetCoreFact] //see: https://github.com/elastic/apm-agent-dotnet/issues/516
 		public async Task CaptureErrorOnFailingHttpCall_HttpClient()
 		{
 			var (listener, payloadSender, _) = RegisterListenerAndStartTransaction();
@@ -338,7 +338,7 @@ namespace Elastic.Apm.Tests
 		/// Unlike the <see cref="CaptureErrorOnFailingHttpCall_HttpClient" /> method this does not use HttpClient, instead here we
 		/// call the OnNext method directly.
 		/// </summary>
-		[Fact]
+		[NetCoreFact] //see: https://github.com/elastic/apm-agent-dotnet/issues/516
 		public void CaptureErrorOnFailingHttpCall_DirectCall()
 		{
 			var (disposableListener, payloadSender, agent) = RegisterListenerAndStartTransaction();
@@ -366,7 +366,7 @@ namespace Elastic.Apm.Tests
 		/// <summary>
 		/// Makes sure we set the correct type and subtype for external, http spans
 		/// </summary>
-		[Fact]
+		[NetCoreFact] //see: https://github.com/elastic/apm-agent-dotnet/issues/516
 		public async Task SpanTypeAndSubtype()
 		{
 			var (listener, payloadSender, _) = RegisterListenerAndStartTransaction();
@@ -388,7 +388,7 @@ namespace Elastic.Apm.Tests
 		/// <summary>
 		/// Makes sure we generate the correct span name
 		/// </summary>
-		[Fact]
+		[NetCoreFact] //see: https://github.com/elastic/apm-agent-dotnet/issues/516
 		public async Task SpanName()
 		{
 			var (listener, payloadSender, _) = RegisterListenerAndStartTransaction();
@@ -409,7 +409,7 @@ namespace Elastic.Apm.Tests
 		/// Makes sure that the duration of an HTTP Request is captured by the agent
 		/// </summary>
 		/// <returns>The request duration.</returns>
-		[Fact]
+		[NetCoreFact] //see: https://github.com/elastic/apm-agent-dotnet/issues/516
 		public async Task HttpRequestDuration()
 		{
 			var (listener, payloadSender, _) = RegisterListenerAndStartTransaction();
@@ -437,7 +437,7 @@ namespace Elastic.Apm.Tests
 		/// <summary>
 		/// Makes sure spans have an Id
 		/// </summary>
-		[Fact]
+		[NetCoreFact] //see: https://github.com/elastic/apm-agent-dotnet/issues/516
 		public async Task HttpRequestSpanGuid()
 		{
 			var (listener, payloadSender, _) = RegisterListenerAndStartTransaction();
@@ -458,7 +458,7 @@ namespace Elastic.Apm.Tests
 			}
 		}
 
-		[Fact]
+		[NetCoreFact] //see: https://github.com/elastic/apm-agent-dotnet/issues/516
 		[SuppressMessage("ReSharper", "PossibleInvalidOperationException")]
 		public async Task HttpCallAsNestedSpan()
 		{
@@ -576,7 +576,7 @@ namespace Elastic.Apm.Tests
 		/// <summary>
 		/// Make sure HttpDiagnosticSubscriber does not report spans after its disposed
 		/// </summary>
-		[Fact]
+		[NetCoreFact] //see: https://github.com/elastic/apm-agent-dotnet/issues/516
 		public async Task SubscriptionOnlyRegistersSpansDuringItsLifeTime()
 		{
 			var payloadSender = new MockPayloadSender();
@@ -613,7 +613,7 @@ namespace Elastic.Apm.Tests
 		/// <see cref="HttpDiagnosticsSubscriber" />.
 		/// Makes sure that the outgoing web request is captured.
 		/// </summary>
-		[Fact]
+		[NetCoreFact] //see: https://github.com/elastic/apm-agent-dotnet/issues/516
 		public async Task HttpCallWithRegisteredListener()
 		{
 			var mockPayloadSender = new MockPayloadSender();

--- a/test/Elastic.Apm.Tests/HttpDiagnosticListenerTests.cs
+++ b/test/Elastic.Apm.Tests/HttpDiagnosticListenerTests.cs
@@ -317,7 +317,7 @@ namespace Elastic.Apm.Tests
 		/// Starts an HTTP call to a non existing URL and makes sure that an error is captured.
 		/// This uses an HttpClient instance directly
 		/// </summary>
-		[Fact]
+		[NetCoreFact] //TODO: add issue reference
 		public async Task CaptureErrorOnFailingHttpCall_HttpClient()
 		{
 			var (listener, payloadSender, _) = RegisterListenerAndStartTransaction();

--- a/test/Elastic.Apm.Tests/Mocks/TestLogger.cs
+++ b/test/Elastic.Apm.Tests/Mocks/TestLogger.cs
@@ -17,6 +17,6 @@ namespace Elastic.Apm.Tests.Mocks
 		public TestLogger(LogLevel level, StringWriter writer) : base(level, writer, writer) => _writer = writer;
 
 		public IReadOnlyList<string> Lines =>
-			_writer.GetStringBuilder().ToString().Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries).ToList();
+			_writer.GetStringBuilder().ToString().Split(Environment.NewLine.ToCharArray(), StringSplitOptions.RemoveEmptyEntries).ToList();
 	}
 }

--- a/test/Elastic.Apm.Tests/NetCoreFact.cs
+++ b/test/Elastic.Apm.Tests/NetCoreFact.cs
@@ -1,0 +1,18 @@
+using System.Runtime.InteropServices;
+using Elastic.Apm.Helpers;
+using Xunit;
+
+namespace Elastic.Apm.Tests
+{
+	public sealed class NetCoreFact : FactAttribute
+	{
+		public NetCoreFact()
+		{
+			if (!RuntimeInformation.FrameworkDescription.StartsWith(PlatformDetection.DotNetCoreDescriptionPrefix))
+			{
+				Skip =
+					$"{nameof(NetCoreFact)} tests only run on .NET Core - test was executed on {RuntimeInformation.FrameworkDescription} - therefore test will be skipped";
+			}
+		}
+	}
+}

--- a/test/Elastic.Apm.Tests/TestHelpers/TaskTestExtensions.cs
+++ b/test/Elastic.Apm.Tests/TestHelpers/TaskTestExtensions.cs
@@ -1,0 +1,22 @@
+using System.Threading.Tasks;
+
+namespace Elastic.Apm.Tests.TestHelpers
+{
+	internal static class TaskTestExtensions
+	{
+		/// <summary>
+		/// Task.IsCompletedSuccessfully is defined only for .NET Core 3.0 2.2 2.1 2.0 (.NET Standard 2.1 Preview)
+		/// and it's not defined for .NET Framework at all
+		/// https://docs.microsoft.com/en-us/dotnet/api/system.threading.tasks.task.iscompletedsuccessfully
+		/// So we need to implement IsCompletedSuccessfully ourselves when targeting .NET Framework.
+		/// C#, as of versions 7.2, doesn't support extension properties
+		/// so the only option is to implement IsCompletedSuccessfully as an extension method.
+		/// </summary>
+		internal static bool IsCompletedSuccessfully(this Task thisObj) =>
+#if NETFRAMEWORK
+			thisObj.IsCompleted && !(thisObj.IsFaulted || thisObj.IsCanceled);
+#else
+			thisObj.IsCompletedSuccessfully;
+#endif
+	}
+}


### PR DESCRIPTION
Solves #214.

# Summary

We have ~500 tests in `Elastic.Apm.Tests` that test the core features of the agent, but only executed those on .NET Core previously. This PR makes `Elastic.Apm.Tests` into a multi target project, so it tests both on .NET Framework and .NET Core.

I also added `mono` to the known frameworks - mainly because in case you run the Full Framework tests on macOS with Rider, Rider starts up mono and runs all the tests - with this PR that is not an issue anymore.

## HttpClient tests

See https://github.com/elastic/apm-agent-dotnet/issues/516 

## What changed for CI: 

cc @kuisathaverat @v1v  Could one of you please review this part (specifically the `jenkinsfile` and `.ci/windows/testnet461.bat`) and maybe answer my questions below? - Thx!

### Previously: 
In the stage `Windows .NET Framework` under stage `Test` we actually did not ran the `Elastic.Apm.Tests` project on .NET Framework, we ran it on .NET Core - that's because that project only targeted previously .NET Core, so the `dotnet test` command automatically executed the tests on .NET Core. 

### Now:
Now the `Elastic.Apm.Tests` project is a multi target project, it targets both .NET Core and .NET Framework. If you run it with `dotnet run` then it defaults to executing on .NET Core, with `dotnet run -f net461` it runs on .NET Framework. I created a `.ci/windows/testnet461.bat` file, it runs the `Elastic.Apm.Tests` project with `-f net461`. In the `jenkinsfiel` now I use this file on the `Windows .NET Framework` stage. With this in the `Windows .NET Framework` we really run tests only on .NET Framework, and .NET Core tests run on the `Windows .NET Core` stage.

~# Questions:~ Update: all fixed.

~On the jenkins test reporting part I see this:~

~<img width="1343" alt="image" src="https://user-images.githubusercontent.com/1091853/65777428-53b66980-e144-11e9-9235-aad58a5f71d6.png">~

~1. It says "All 39 tests". That can't be right... we have thousands of tests... Is this something we should take a look at? Why is this?~

~2. Code coverage report seems to be broken, but it broke before I started messing with the `jenkinsfile`. I don't know why, could someone please help out with that?~