### PR TITLE
Logger exceptions

### DIFF
--- a/src/Elastic.Apm/Logging/LogValuesFormatter.cs
+++ b/src/Elastic.Apm/Logging/LogValuesFormatter.cs
@@ -1,7 +1,3 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0.
-
-using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
@@ -16,13 +12,20 @@ namespace Elastic.Apm.Logging
 	/// </summary>
 	internal class LogValuesFormatter
 	{
-		private readonly string _scope;
 		private const string NullValue = "(null)";
 		private static readonly object[] EmptyArray = new object[0];
 		private static readonly char[] FormatDelimiters = { ',', ':' };
 		private readonly string _format;
+		private readonly bool _isArgumentNumberMismatch;
 
-		public LogValuesFormatter(string format, string scope = null)
+		/// <summary>
+		/// Holds the list of placeholders that do not have corresponding values in the structured log.
+		/// </summary>
+		private readonly List<string> _mismatchedValueNames = new List<string>();
+
+		private readonly string _scope;
+
+		public LogValuesFormatter(string format, int expectedArgs, string scope = null)
 		{
 			_scope = scope;
 			OriginalFormat = format;
@@ -46,19 +49,41 @@ namespace Elastic.Apm.Logging
 					// Format item syntax : { index[,alignment][ :formatString] }.
 					var formatDelimiterIndex = FindIndexOfAny(format, FormatDelimiters, openBraceIndex, closeBraceIndex);
 
-					sb.Append(format, scanIndex, openBraceIndex - scanIndex + 1);
-					sb.Append((ValueNames.Count).ToString(CultureInfo.InvariantCulture));
-					ValueNames.Add(format.Substring(openBraceIndex + 1, formatDelimiterIndex - openBraceIndex - 1));
-					sb.Append(format, formatDelimiterIndex, closeBraceIndex - formatDelimiterIndex + 1);
+					if (ValueNames.Count < expectedArgs)
+					{
+						sb.Append(format, scanIndex, openBraceIndex - scanIndex + 1);
+						sb.Append(ValueNames.Count.ToString(CultureInfo.InvariantCulture));
+						ValueNames.Add(format.Substring(openBraceIndex + 1, formatDelimiterIndex - openBraceIndex - 1));
+						sb.Append(format, formatDelimiterIndex, closeBraceIndex - formatDelimiterIndex + 1);
+					}
+					else
+					{
+						_isArgumentNumberMismatch = true;
+						_mismatchedValueNames.Add(format.Substring(openBraceIndex + 1, formatDelimiterIndex - openBraceIndex - 1));
+					}
 
 					scanIndex = closeBraceIndex + 1;
 				}
 			}
 
+			if (_isArgumentNumberMismatch)
+			{
+				sb.AppendLine();
+				sb.AppendLine(
+					$"Invalid structured log line: number of arguments is not matching the number of placeholders, placeholders with missing values: {string.Join(", ", _mismatchedValueNames.ToArray())}");
+			}
+
+			if (ValueNames.Count != expectedArgs)
+			{
+				sb.AppendLine();
+				sb.AppendLine(
+					$"Invalid structured log line: number of placeholders in the log message does not match the number of parameters, message until the 1. parameter: {OriginalFormat.Split('{')[0]}");
+			}
+
 			_format = sb.ToString();
 		}
 
-		public string OriginalFormat { get; private set; }
+		public string OriginalFormat { get; }
 		public List<string> ValueNames { get; } = new List<string>();
 
 		private static int FindBraceIndex(string format, char brace, int startIndex, int endIndex)
@@ -126,6 +151,7 @@ namespace Elastic.Apm.Logging
 
 			return string.Format(CultureInfo.InvariantCulture, _format, values);
 		}
+
 		private string Format(string scope, object[] values)
 		{
 			values = values ?? EmptyArray;
@@ -133,7 +159,7 @@ namespace Elastic.Apm.Logging
 			args[0] = scope;
 
 			for (var i = 0; i < values.Length; i++)
-				args[i+1] = FormatArgument(values[i]);
+				args[i + 1] = FormatArgument(values[i]);
 
 			return string.Format(CultureInfo.InvariantCulture, _format, args);
 		}
@@ -155,14 +181,17 @@ namespace Elastic.Apm.Logging
 		public LogValues GetState(object[] values)
 		{
 			values = values ?? EmptyArray;
-			var offset = (_scope == null ? 1 : 2);
+			var offset = _scope == null ? 1 : 2;
 			var args = new KeyValuePair<string, object>[values.Length + offset];
 			args[0] = new KeyValuePair<string, object>("{OriginalFormat}", OriginalFormat);
 			if (_scope != null)
 				args[1] = new KeyValuePair<string, object>("{Scope}", _scope);
 
-			for (int i = 0, j = (_scope != null ? 1 : 0); j < ValueNames.Count; i++, j++)
-				args[offset + i] = new KeyValuePair<string, object>(ValueNames[j], values[i]);
+			for (int i = 0, j = _scope != null ? 1 : 0; j < ValueNames.Count; i++, j++)
+			{
+				if (values.Length < i)
+					args[offset + i] = new KeyValuePair<string, object>(ValueNames[j], values[i]);
+			}
 
 			return new LogValues(args);
 		}
@@ -171,6 +200,5 @@ namespace Elastic.Apm.Logging
 		{
 			public LogValues(IList<KeyValuePair<string, object>> list) : base(list) { }
 		}
-
 	}
 }

--- a/src/Elastic.Apm/Logging/LogValuesFormatter.cs
+++ b/src/Elastic.Apm/Logging/LogValuesFormatter.cs
@@ -70,14 +70,14 @@ namespace Elastic.Apm.Logging
 			{
 				sb.AppendLine();
 				sb.AppendLine(
-					$"Invalid structured log line: number of arguments is not matching the number of placeholders, placeholders with missing values: {string.Join(", ", _mismatchedValueNames.ToArray())}");
+					$"Above line is from an invalid structured log and may not be complete: number of arguments is not matching the number of placeholders, placeholders with missing values: {string.Join(", ", _mismatchedValueNames.ToArray())}");
 			}
 
 			if (ValueNames.Count != expectedArgs)
 			{
 				sb.AppendLine();
 				sb.AppendLine(
-					$"Invalid structured log line: number of placeholders in the log message does not match the number of parameters, message until the 1. parameter: {OriginalFormat.Split('{')[0]}");
+					$"Above line is from an invalid structured log and may not be complete: number of placeholders in the log message does not match the number of parameters.");
 			}
 
 			_format = sb.ToString();

--- a/src/Elastic.Apm/Logging/ScopedLogger.cs
+++ b/src/Elastic.Apm/Logging/ScopedLogger.cs
@@ -16,14 +16,7 @@ namespace Elastic.Apm.Logging
 		public bool IsEnabled(LogLevel level) => Logger.IsEnabled(level);
 
 		internal LogValuesFormatter GetOrAddFormatter(string message, int expectedCount)
-		{
-			var formatter = Formatters.GetOrAdd(message, s => new LogValuesFormatter($"{{{{{{Scope}}}}}} {s}", Scope));
-			if (formatter.ValueNames.Count != expectedCount)
-			{
-				//TODO log invalid structured logging? Should our LogValuesFormatter recover from this?
-			}
-			return formatter;
-		}
+			=> Formatters.GetOrAdd(message, s => new LogValuesFormatter($"{{{{{{Scope}}}}}} {s}", expectedCount, Scope));
 
 		void IApmLogger.Log<TState>(LogLevel level, TState state, Exception e, Func<TState, Exception, string> formatter) =>
 			Logger.Log(level, state, e, formatter);

--- a/src/Elastic.Apm/Logging/ScopedLogger.cs
+++ b/src/Elastic.Apm/Logging/ScopedLogger.cs
@@ -16,7 +16,7 @@ namespace Elastic.Apm.Logging
 		public bool IsEnabled(LogLevel level) => Logger.IsEnabled(level);
 
 		internal LogValuesFormatter GetOrAddFormatter(string message, int expectedCount)
-			=> Formatters.GetOrAdd(message, s => new LogValuesFormatter($"{{{{{{Scope}}}}}} {s}", expectedCount, Scope));
+			=> Formatters.GetOrAdd(message, s => new LogValuesFormatter($"{{{{{{Scope}}}}}} {s}", expectedCount + 1, Scope));
 
 		void IApmLogger.Log<TState>(LogLevel level, TState state, Exception e, Func<TState, Exception, string> formatter) =>
 			Logger.Log(level, state, e, formatter);

--- a/test/Elastic.Apm.Tests/LoggerTests.cs
+++ b/test/Elastic.Apm.Tests/LoggerTests.cs
@@ -177,7 +177,7 @@ namespace Elastic.Apm.Tests
 			testLogger.Lines[1]
 				.Should()
 				.Contain(
-					"Invalid structured log line: number of placeholders in the log message does not match the number of parameters, message until the 1. parameter: This is a test log from the test StructuredLogTemplateWithAdditionalArguments_LogError, args: ");
+					"Above line is from an invalid structured log and may not be complete: number of placeholders in the log message does not match the number of parameters.");
 			testLogger.Lines[0]
 				.Should()
 				.Contain("This is a test log from the test StructuredLogTemplateWithAdditionalArguments_LogError, args: testArgumentValue1 testArgumentValue2");
@@ -197,7 +197,7 @@ namespace Elastic.Apm.Tests
 			testLogger.Lines[1]
 				.Should()
 				.Contain(
-					"Invalid structured log line: number of arguments is not matching the number of placeholders, placeholders with missing values: arg2");
+					"Above line is from an invalid structured log and may not be complete: number of arguments is not matching the number of placeholders, placeholders with missing values: arg2");
 
 			testLogger.Lines[0]
 				.Should()

--- a/test/Elastic.Apm.Tests/LoggerTests.cs
+++ b/test/Elastic.Apm.Tests/LoggerTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using Elastic.Apm.Logging;
 using Elastic.Apm.Tests.Mocks;
@@ -53,7 +54,7 @@ namespace Elastic.Apm.Tests
 		}
 
 		/// <summary>
-		/// Logs a message with exception by using <see cref="LoggingExtensions.MaybeLogger.LogException"/>.
+		/// Logs a message with exception by using <see cref="LoggingExtensions.MaybeLogger.LogException" />.
 		/// Makes sure that both the message and the exception is printed.
 		/// First the Message is printed and the exception is in the last line.
 		/// </summary>
@@ -64,8 +65,9 @@ namespace Elastic.Apm.Tests
 
 			logger.Warning()
 				?.LogException(
-					new Exception("Something went wrong"), $"Failed sending events. Following events were not transferred successfully to the server:{Environment.NewLine}{{items}}",
-					string.Join($",{Environment.NewLine}", new List<string>{"Item1", "Item2", "Item3"} ));
+					new Exception("Something went wrong"),
+					$"Failed sending events. Following events were not transferred successfully to the server:{Environment.NewLine}{{items}}",
+					string.Join($",{Environment.NewLine}", new List<string> { "Item1", "Item2", "Item3" }));
 
 			logger.Lines[0]
 				.Should()
@@ -77,11 +79,130 @@ namespace Elastic.Apm.Tests
 
 			logger.Lines.Last()
 				.Should()
-				.ContainAll(new List<string>
-				{
-					"System.Exception",
-					"Something went wrong"
-				});
+				.ContainAll(new List<string> { "System.Exception", "Something went wrong" });
+		}
+
+		/// <summary>
+		/// Makes sure the logger does not throw in case of templates for structured logs with non-existing corresponding values.
+		/// This test uses scoped logger.
+		/// </summary>
+		[Fact]
+		public void StructuredLogTemplateWith1MissingArgument_ScopedLogger()
+		{
+			var consoleLogger = new ConsoleLogger(LogLevel.Trace, TextWriter.Null, TextWriter.Null);
+			var scopedLogger = consoleLogger.Scoped("MyTestScope");
+
+			const string arg1Value = "testArgumentValue";
+			scopedLogger.Warning()?.Log("This is a test log from the test StructuredLogTemplateWith1MissingArgument, args: {arg1} {arg2}", arg1Value);
+		}
+
+		/// <summary>
+		/// Makes sure the logger does not throw in case of templates for structured logs with too much arguments - in other words
+		/// with argument(s) that do not have
+		/// corresponding placeholders in the template.
+		/// This test uses scoped logger.
+		/// </summary>
+		[Fact]
+		public void StructuredLogTemplateWithAdditionalArguments()
+		{
+			var consoleLogger = new ConsoleLogger(LogLevel.Trace, TextWriter.Null, TextWriter.Null);
+
+			const string arg1Value = "testArgumentValue1";
+			const string arg2Value = "testArgumentValue2";
+			const string arg3Value = "testArgumentValue3";
+			consoleLogger.Warning()
+				?.Log("This is a test log from the test StructuredLogTemplateWith1MissingArgument, args: {arg1} {arg2}", arg1Value, arg2Value,
+					arg3Value);
+
+			const string arg4Value = "testArgumentValue4";
+			consoleLogger.Warning()
+				?.Log("This is a test log from the test StructuredLogTemplateWith1MissingArgument, args: {arg1} {arg2}", arg1Value, arg2Value,
+					arg3Value, arg4Value);
+		}
+
+		/// <summary>
+		/// Makes sure the logger does not throw in case of templates for structured logs with non-existing corresponding values.
+		/// </summary>
+		[Fact]
+		public void StructuredLogTemplateWith1MissingArgument()
+		{
+			var consoleLogger = new ConsoleLogger(LogLevel.Trace, TextWriter.Null, TextWriter.Null);
+
+			const string arg1Value = "testArgumentValue";
+			consoleLogger.Warning()
+				?.Log("This is a test log from the test StructuredLogTemplateWith1MissingArgument, args: {arg1} {arg2}", arg1Value);
+		}
+
+		/// <summary>
+		/// Makes sure the logger does not throw in case of templates for structured logs with too much arguments - in other words
+		/// with argument(s) that do not have
+		/// corresponding placeholders in the template
+		/// </summary>
+		[Fact]
+		public void StructuredLogTemplateWithAdditionalArguments_ScopedLogger()
+		{
+			var consoleLogger = new ConsoleLogger(LogLevel.Trace, TextWriter.Null, TextWriter.Null);
+			var scopedLogger = consoleLogger.Scoped("MyTestScope");
+
+			const string arg1Value = "testArgumentValue1";
+			const string arg2Value = "testArgumentValue2";
+			const string arg3Value = "testArgumentValue3";
+			scopedLogger.Warning()
+				?.Log("This is a test log from the test StructuredLogTemplateWithAdditionalArguments_ScopedLogger, args: {arg1} {arg2}", arg1Value, arg2Value,
+					arg3Value);
+
+			const string arg4Value = "testArgumentValue4";
+			scopedLogger.Warning()
+				?.Log("This is a test log from the test StructuredLogTemplateWithAdditionalArguments_ScopedLogger, args: {arg1} {arg2}", arg1Value, arg2Value,
+					arg3Value, arg4Value);
+		}
+
+		/// <summary>
+		/// Makes sure the error caused by argument mismatch is properly logged
+		/// </summary>
+		[Fact]
+		public void StructuredLogTemplateWithAdditionalArguments_LogError()
+		{
+			var testLogger = new TestLogger();
+
+			const string arg1Value = "testArgumentValue1";
+			const string arg2Value = "testArgumentValue2";
+			const string arg3Value = "testArgumentValue3";
+			const string arg4Value = "testArgumentValue4";
+			testLogger.Error()
+				?.Log("This is a test log from the test StructuredLogTemplateWithAdditionalArguments_LogError, args: {arg1} {arg2}", arg1Value,
+					arg2Value,
+					arg3Value, arg4Value);
+
+			testLogger.Lines[1]
+				.Should()
+				.Contain(
+					"Invalid structured log line: number of placeholders in the log message does not match the number of parameters, message until the 1. parameter: This is a test log from the test StructuredLogTemplateWithAdditionalArguments_LogError, args: ");
+			testLogger.Lines[0]
+				.Should()
+				.Contain("This is a test log from the test StructuredLogTemplateWithAdditionalArguments_LogError, args: testArgumentValue1 testArgumentValue2");
+		}
+
+		/// <summary>
+		/// Makes sure the error caused by argument mismatch is properly logged
+		/// </summary>
+		[Fact]
+		public void StructuredLogTemplateWith1MissingArgument_LogError()
+		{
+			var testLogger = new TestLogger(LogLevel.Trace);
+
+			const string arg1Value = "testArgumentValue";
+			testLogger.Warning()?.Log("This is a test log from the test StructuredLogTemplateWith1MissingArgument_LogError, args: {arg1} {arg2}", arg1Value);
+
+			testLogger.Lines[1]
+				.Should()
+				.Contain(
+					"Invalid structured log line: number of arguments is not matching the number of placeholders, placeholders with missing values: arg2");
+
+			testLogger.Lines[0]
+				.Should()
+				.Contain(
+					"This is a test log from the test StructuredLogTemplateWith1MissingArgument_LogError, args: testArgumentValue");
 		}
 
 		private TestLogger LogWithLevel(LogLevel logLevel)


### PR DESCRIPTION
Solves #209 

In case a structured log does not contain the expected number of parameters we make sure the logger does not throw exceptions.

Additionally this PR also adds some additional info to the log, so this won't get unnoticed.

So e.g.:
`Log("This is a log with params: {param1} {param2}", param1Value)` 


Here is how we'd log with this (the test itself is just an example)

## Sample1

Code:
```
var i = 42;
Logger?.Info()?.Log("The agent was started without a service name. The service name will be automatically discovered - args: {myArg1} {myArg2}", i);
```

Corresponding log: 
```
info: Elastic.Apm[0]
      {MicrosoftExtensionsConfig} The agent was started without a service name. The service name will be automatically discovered - args: 42
      Above line is from an invalid structured log and may not be complete: number of arguments is not matching the number of placeholders, placeholders with missing values: myArg2
```


## Sample2

Code:

```
var argVal1 = 42;
var argVal2 = 42;
Logger?.Info()?.Log("The agent was started without a service name. The service name will be automatically discovered - args: {myArg1}", argVal1, argVal2);
```

Corresponding log:

```
info: Elastic.Apm[0]
      {MicrosoftExtensionsConfig} The agent was started without a service name. The service name will be automatically discovered - args: 42
      Above line is from an invalid structured log and may not be complete: number of placeholders in the log message does not match the number of parameters.
```