### PR TITLE
Fix system CPU test

### DIFF
--- a/test/Elastic.Apm.Tests/MetricsTests.cs
+++ b/test/Elastic.Apm.Tests/MetricsTests.cs
@@ -46,8 +46,8 @@ namespace Elastic.Apm.Tests
 			var retVal = systemTotalCpuProvider.GetSamples();
 			var metricSamples = retVal as MetricSample[] ?? retVal.ToArray();
 
-			metricSamples.First().KeyValue.Value.Should().BeGreaterThan(0);
-			metricSamples.First().KeyValue.Value.Should().BeLessThan(1);
+			metricSamples.First().KeyValue.Value.Should().BeGreaterOrEqualTo(0);
+			metricSamples.First().KeyValue.Value.Should().BeLessOrEqualTo(1);
 		}
 
 		[Fact]


### PR DESCRIPTION
I saw this test failing with:

```
Error
Expected metricSamples.First().KeyValue.Value to be less than 1.0, but found 1.0.
```

1.0 would mean 100% CPU usage, which is not unlikely, especially on a CI machine. Therefore adapting it to also accept 0% and 100% CPU usage. 