### PR TITLE
Fix for Tests fail because of StackOverflowException in logger code #493

### DIFF
--- a/test/Elastic.Apm.Tests/MetricsTests.cs
+++ b/test/Elastic.Apm.Tests/MetricsTests.cs
@@ -107,7 +107,17 @@ namespace Elastic.Apm.Tests
 		[Fact]
 		public async Task MetricsWithRealAgent()
 		{
-			var logger = new XunitOutputLogger(_testOutputHelper);
+			// Note: If XunitOutputLogger is used with MetricsCollector it might cause issues because
+			// MetricsCollector's Dispose is currently broken - it doesn't guarantee that MetricsCollector's behaves correctly (i.e., ignores)
+			// timer callbacks after Dispose completed.
+			// This bug in turn causes MetricsCollector to possibly use XunitOutputLogger even after the current test has exited
+			// and ITestOutputHelper on which XunitOutputLogger is based became invalid.
+			//
+			// var logger = new XunitOutputLogger(_testOutputHelper);
+			//
+			var logger = new NoopLogger();
+			//
+
 			var payloadSender = new MockPayloadSender();
 			var configReader = new TestAgentConfigurationReader(logger, metricsInterval: "1s", logLevel: "Debug");
 			using (var agent = new ApmAgent(new AgentComponents(payloadSender: payloadSender, logger: logger, configurationReader: configReader)))

--- a/test/Elastic.Apm.Tests/MetricsTests.cs
+++ b/test/Elastic.Apm.Tests/MetricsTests.cs
@@ -113,6 +113,8 @@ namespace Elastic.Apm.Tests
 			// This bug in turn causes MetricsCollector to possibly use XunitOutputLogger even after the current test has exited
 			// and ITestOutputHelper on which XunitOutputLogger is based became invalid.
 			//
+			// After https://github.com/elastic/apm-agent-dotnet/issues/494 is fixed the line below can be uncommented.
+			//
 			// var logger = new XunitOutputLogger(_testOutputHelper);
 			//
 			var logger = new NoopLogger();

--- a/test/Elastic.Apm.Tests/TestHelpers/SystemDiagnosticsTraceLineWriter.cs
+++ b/test/Elastic.Apm.Tests/TestHelpers/SystemDiagnosticsTraceLineWriter.cs
@@ -1,5 +1,4 @@
 ﻿using System.Diagnostics;
-using Elastic.Apm.Helpers;
 
 namespace Elastic.Apm.Tests.TestHelpers
 {


### PR DESCRIPTION
Fixes #493 by using System.Diagnostics.Trace instead logger
