### PR TITLE
Fix AspNetFullFrameworkSampleApp logging

### DIFF
--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -40,7 +40,7 @@ in the `IConfiguration or Web.config key` column of the corresponding option's d
 NOTE: By simply calling `app.UseElasticApm()` without the overload, the agent will read configurations only from environment variables.
 
 [float]
-[[configuration-on-asp-net-core-sample-config]]
+[[sample-config]]
 ==== Sample configuration file
 
 Below is a sample `appsettings.json` configuration file for a typical ASP.NET Core application. There are two important takeaways:
@@ -101,7 +101,7 @@ You can find the key of each configuration option
 in the `IConfiguration or Web.config key` column of the corresponding option's description.
 
 [float]
-[[configuration-on-asp-net-sample-config]]
+[[asp-net-sample-config]]
 ==== Sample configuration file
 
 Below is a sample `Web.config` configuration file for a ASP.NET application.

--- a/docs/setup.asciidoc
+++ b/docs/setup.asciidoc
@@ -9,8 +9,13 @@ In order to avoid adding unnecessary dependencies in applications that aren’t 
 * https://www.nuget.org/packages/Elastic.Apm[Elastic.Apm]: This is the core of the agent, which we didn’t name “Core”, because someone already took that name :) This package also contains the <<public-api>> and it is a .NET Standard 2.0 package. We also ship every tracing component that traces classes that are part of .NET Standard 2.0 in this package, which includes the monitoring part for HttpClient. Every other Elastic APM package references this package.
 * https://www.nuget.org/packages/Elastic.Apm.AspNetCore[Elastic.Apm.AspNetCore]: This package contains ASP.NET Core monitoring related code. The main difference between this package and the `Elastic.Apm.NetCoreAll` package is that this package does not reference the `Elastic.Apm.EntityFrameworkCore` package, so if you have an ASP.NET Core application that does not use EF Core and you want to avoid adding additional unused references, you should use this package.
 * https://www.nuget.org/packages/Elastic.Apm.EntityFrameworkCore[Elastic.Apm.EntityFrameworkCore]: This package contains EF Core monitoring related code.
+* https://www.nuget.org/packages/Elastic.Apm.AspNetFullFramework[Elastic.Apm.AspNetFullFramework]: This package contains ASP.NET (Full .NET Framework) monitoring related code.
 
 You simply add the agent to your .NET application by referencing one of these packages.
+
+[float]
+[[setup-asp-net-core]]
+=== ASP.NET Core
 
 For ASP.NET Core, once you referenced the `Elastic.Apm.NetCoreAll` package, you can enable auto instrumentation by calling `UseAllElasticApm()` extension method:
 
@@ -32,3 +37,24 @@ With this you enable every agent component including ASP.NET Core tracing, monit
 In case you only reference the `Elastic.Apm.AspNetCore` package, you won't find the `UseAllElasticApm`. Instead you need to use the `UseElasticApm()` method from the `Elastic.Apm.AspNetCore` namespace. This method turns on ASP.NET Core tracing, and gives you the opportunity to manually turn on other components. By default it will only trace ASP.NET Core requests - No HTTP request tracing, database call tracing or any other tracing component will be turned on.
 
 In case you only want to use the <<public-api>>, you don't need to do any initialization, you can simply start using the API and the agent will send the data to the APM Server.
+
+
+[float]
+[[setup-asp-net]]
+=== ASP.NET
+
+For ASP.NET (Full .NET Framework), once you referenced the `Elastic.Apm.AspNetFullFramework` package,
+you can enable auto instrumentation by including `ElasticApmModule` IIS Module in application's `web.config`: 
+[source,xml]
+----
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+    <system.webServer>
+        <modules>
+            <add name="ElasticApmModule" type="Elastic.Apm.AspNetFullFramework.ElasticApmModule" />
+        </modules>
+    </system.webServer>
+</configuration>
+----
+
+You can also configure the agent using `web.config` as described at <<configuration-on-asp-net>>.

--- a/docs/setup.asciidoc
+++ b/docs/setup.asciidoc
@@ -57,4 +57,21 @@ you can enable auto instrumentation by including `ElasticApmModule` IIS Module i
 </configuration>
 ----
 
+By default the agent creates transactions for all HTTP requests including for the ones for static content
+(.html pages, images, etc.). If you would like to create transactions only for HTTP requests only for dynamic content
+such as `.aspx` pages you can add `managedHandler` `preCondition`
+(https://docs.microsoft.com/en-us/iis/configuration/system.webserver/modules/add[official documentation])
+as in the following example:
+[source,xml]
+----
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+    <system.webServer>
+        <modules>
+            <add name="ElasticApmModule" type="Elastic.Apm.AspNetFullFramework.ElasticApmModule" preCondition="managedHandler" />
+        </modules>
+    </system.webServer>
+</configuration>
+----
+
 You can also configure the agent using `web.config` as described at <<configuration-on-asp-net>>.

--- a/docs/setup.asciidoc
+++ b/docs/setup.asciidoc
@@ -43,8 +43,8 @@ In case you only want to use the <<public-api>>, you don't need to do any initia
 [[setup-asp-net]]
 === ASP.NET
 
-For ASP.NET (Full .NET Framework), once you referenced the `Elastic.Apm.AspNetFullFramework` package,
-you can enable auto instrumentation by including `ElasticApmModule` IIS Module in application's `web.config`: 
+For ASP.NET (Full .NET Framework), once you've referenced the `Elastic.Apm.AspNetFullFramework` package,
+you can enable auto instrumentation by including the `ElasticApmModule` IIS Module in your application's `web.config`: 
 [source,xml]
 ----
 <?xml version="1.0" encoding="utf-8"?>
@@ -57,11 +57,11 @@ you can enable auto instrumentation by including `ElasticApmModule` IIS Module i
 </configuration>
 ----
 
-By default the agent creates transactions for all HTTP requests including for the ones for static content
-(.html pages, images, etc.). If you would like to create transactions only for HTTP requests only for dynamic content
-such as `.aspx` pages you can add `managedHandler` `preCondition`
+By default the agent creates transactions for all HTTP requests, including the ones for static content:
+.html pages, images, etc. If you would like to create transactions only for HTTP requests with dynamic content,
+such as `.aspx` pages, you can add `managedHandler` `preCondition`
 (https://docs.microsoft.com/en-us/iis/configuration/system.webserver/modules/add[official documentation])
-as in the following example:
+as shown in the following example:
 [source,xml]
 ----
 <?xml version="1.0" encoding="utf-8"?>

--- a/docs/supported-technologies.asciidoc
+++ b/docs/supported-technologies.asciidoc
@@ -48,7 +48,7 @@ We support automatic instrumentation for the following web frameworks.
 |1.0
 
 |ASP.NET (.NET Framework) on IIS
-|3.5 and higher (IIS 7.0 and higher)
+|4.6.1 or newer (IIS 7.0 or newer)
 |1.1
 
 |===

--- a/docs/supported-technologies.asciidoc
+++ b/docs/supported-technologies.asciidoc
@@ -47,6 +47,10 @@ We support automatic instrumentation for the following web frameworks.
 |2.x
 |1.0
 
+|ASP.NET (.NET Framework) on IIS
+|3.5 and higher (IIS 7.0 and higher)
+|1.1
+
 |===
 
 
@@ -80,5 +84,9 @@ The spans are named after the schema `<method> <host>`, for example `GET elastic
 |System.Net.Http.HttpClient on .NET Core
 |
 |1.0
+
+|System.Net.Http.HttpClient on .NET Framework
+|
+|1.1
 
 |===

--- a/sample/AspNetFullFrameworkSampleApp/App_Start/LoggingConfig.cs
+++ b/sample/AspNetFullFrameworkSampleApp/App_Start/LoggingConfig.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Text;
 using Elastic.Apm.AspNetFullFramework;
@@ -59,8 +60,10 @@ namespace AspNetFullFrameworkSampleApp
 			Logger.Debug(nameof(SetupLogging) + " completed. Path to log file: {SampleAppLogFilePath}", logFileEnvVarValue);
 		}
 
-		private sealed class PrefixingTraceTarget: TargetWithLayout
+		private sealed class PrefixingTraceTarget : TargetWithLayout
 		{
+			// The order in endOfLines is important because we need to check longer sequences first
+			private static readonly string[] EndOfLineCharSequences = { "\r\n", "\n", "\r" };
 			private readonly string _prefix;
 
 			internal PrefixingTraceTarget(string prefix = "")
@@ -71,12 +74,9 @@ namespace AspNetFullFrameworkSampleApp
 
 			protected override void Write(LogEventInfo logEvent)
 			{
-				var message = this.RenderLogEvent(this.Layout, logEvent);
-				System.Diagnostics.Trace.WriteLine(PrefixEveryLine(message, _prefix));
+				var message = RenderLogEvent(Layout, logEvent);
+				Trace.WriteLine(PrefixEveryLine(message, _prefix));
 			}
-
-			// The order in endOfLines is important because we need to check longer sequences first
-			private static readonly string[] EndOfLineCharSequences = { "\r\n", "\n", "\r" };
 
 			private static string PrefixEveryLine(string input, string prefix = "")
 			{

--- a/sample/AspNetFullFrameworkSampleApp/App_Start/LoggingConfig.cs
+++ b/sample/AspNetFullFrameworkSampleApp/App_Start/LoggingConfig.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Text;
 using Elastic.Apm.AspNetFullFramework;
 using NLog;
 using NLog.Common;
@@ -32,7 +33,7 @@ namespace AspNetFullFrameworkSampleApp
 
 			var logTargets = new List<TargetWithLayout>
 			{
-				new TraceTarget(),
+				new PrefixingTraceTarget($"Elastic APM .NET {nameof(AspNetFullFrameworkSampleApp)}> "),
 				LogMemoryTarget,
 				new ConsoleTarget()
 			};
@@ -56,6 +57,61 @@ namespace AspNetFullFrameworkSampleApp
 			AgentDependencies.Logger = new ApmLoggerToNLog();
 
 			Logger.Debug(nameof(SetupLogging) + " completed. Path to log file: {SampleAppLogFilePath}", logFileEnvVarValue);
+		}
+
+		private sealed class PrefixingTraceTarget: TargetWithLayout
+		{
+			private readonly string _prefix;
+
+			internal PrefixingTraceTarget(string prefix = "")
+			{
+				_prefix = prefix;
+				OptimizeBufferReuse = true;
+			}
+
+			protected override void Write(LogEventInfo logEvent)
+			{
+				var message = this.RenderLogEvent(this.Layout, logEvent);
+				System.Diagnostics.Trace.WriteLine(PrefixEveryLine(message, _prefix));
+			}
+
+			// The order in endOfLines is important because we need to check longer sequences first
+			private static readonly string[] EndOfLineCharSequences = { "\r\n", "\n", "\r" };
+
+			private static string PrefixEveryLine(string input, string prefix = "")
+			{
+				// We treat empty input as a special case because StringReader doesn't return it as an empty line
+				if (input.Length == 0) return prefix;
+
+				var resultBuilder = new StringBuilder(input.Length);
+				using (var stringReader = new StringReader(input))
+				{
+					var isFirstLine = true;
+					string line;
+					while ((line = stringReader.ReadLine()) != null)
+					{
+						if (isFirstLine)
+							isFirstLine = false;
+						else
+							resultBuilder.AppendLine();
+						resultBuilder.Append(prefix);
+						resultBuilder.Append(line);
+					}
+				}
+
+				// Since lines returned by StringReader exclude newline characters it's possible that the last line had newline at the end
+				// but we didn't append it
+
+				foreach (var endOfLineSeq in EndOfLineCharSequences)
+				{
+					if (!input.EndsWith(endOfLineSeq)) continue;
+
+					resultBuilder.Append(endOfLineSeq);
+					break;
+				}
+
+				return resultBuilder.ToString();
+			}
 		}
 	}
 }


### PR DESCRIPTION
**Note:** this PR is built on top of #507 and it should be reviewed only after #507 is merged.

1. Before this change `AspNetFullFrameworkSampleApp` redirected agent's logging to NLog only if `ELASTIC_APM_ASP_NET_FULL_FRAMEWORK_SAMPLE_APP_LOG_FILE` environment variable was set (it's set by `Elastic.Apm.AspNetFullFramework.Tests`). It is useful to have `AspNetFullFrameworkSampleApp` log to the rest of target other than file (Trace, etc.) even when `ELASTIC_APM_ASP_NET_FULL_FRAMEWORK_SAMPLE_APP_LOG_FILE` is not set. For example when `AspNetFullFrameworkSampleApp` is started manually from IDE and not automatically by `Elastic.Apm.AspNetFullFramework.Tests`.
2. Add `Elastic APM .NET AspNetFullFrameworkSampleApp>` prefix to `TraceTarget` output (goes to `System.Diagnostics.Trace`) so it's easier to filter `AspNetFullFrameworkSampleApp` log even the log statements producing multiple lines (exception stack traces, etc.)
