### PR TITLE
[Docs] Change TransactionMaxSpans version

### DIFF
--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -219,7 +219,7 @@ It also expects that a period (`.`) is used to separate the integer and the frac
 
 [float]
 [[config-transaction-max-spans]]
-==== `TransactionMaxSpans` (performance) (added[1.2])
+==== `TransactionMaxSpans` (performance) (added[1.1.1])
 
 Limits the amount of spans that are recorded per transaction.
 This is helpful in cases where a transaction creates a very high amount of spans,


### PR DESCRIPTION
As mentioned [here](https://github.com/elastic/apm-agent-dotnet/pull/472#issuecomment-537962865) this feature went out earlier than expected.  cc @vhatsura. 

Once this is merged we can also merge `master` into `1.x` and with that the docs will be in sync with the latest release. 