### PR TITLE
Enforce code style with dotnet format 

### DIFF
--- a/.ci/linux/codestyle.sh
+++ b/.ci/linux/codestyle.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+#
+# This script installs the required tools to be used to make sure there are no code violations in the source code.
+#
+set -euxo pipefail
+
+# Install
+dotnet tool install -g dotnet-format
+
+# Check
+dotnet format --dry-run --check

--- a/.ci/linux/codestyle.sh
+++ b/.ci/linux/codestyle.sh
@@ -5,7 +5,7 @@
 set -euxo pipefail
 
 # Install
-dotnet tool install -g dotnet-format
+dotnet tool install -g dotnet-format --version 3.1.37601
 
 # Check
 dotnet format --dry-run --check

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -48,10 +48,13 @@ pipeline {
               environment {
                 MSBUILDDEBUGPATH = "${env.WORKSPACE}"
               }
+              /**
+              Make sure there are no code style violation in the repo.
+              */
               stages{
                 stage('CodeStyleCheck') {
                   steps {
-                    withGithubNotify(context: 'CodeStyle', tab: 'tests') {
+                    withGithubNotify(context: 'CodeStyle check', tab: 'tests') {
                       deleteDir()
                       unstash 'source'
                       dir("${BASE_DIR}"){

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -54,7 +54,7 @@ pipeline {
               stages{
                 stage('CodeStyleCheck') {
                   steps {
-                    withGithubNotify(context: 'CodeStyle check', tab: 'tests') {
+                    withGithubNotify(context: 'CodeStyle check') {
                       deleteDir()
                       unstash 'source'
                       dir("${BASE_DIR}"){

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -49,6 +49,17 @@ pipeline {
                 MSBUILDDEBUGPATH = "${env.WORKSPACE}"
               }
               stages{
+                stage('CodeStyleCheck') {
+                  steps {
+                    withGithubNotify(context: 'CodeStyle', tab: 'tests') {
+                      dir("${BASE_DIR}"){
+                        dotnet(){
+                          sh label: 'Install and run dotnet/format', script: '.ci/linux/codestyle.sh'
+                        }
+                      }
+                    }
+                  }
+                }
                 /**
                 Build the project from code..
                 */

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -52,6 +52,8 @@ pipeline {
                 stage('CodeStyleCheck') {
                   steps {
                     withGithubNotify(context: 'CodeStyle', tab: 'tests') {
+                      deleteDir()
+                      unstash 'source'
                       dir("${BASE_DIR}"){
                         dotnet(){
                           sh label: 'Install and run dotnet/format', script: '.ci/linux/codestyle.sh'


### PR DESCRIPTION
Addressing #510.

## What's new:
With `dotnet format --dry-run --check` we make sure all our C# code is formatted the way it should be formatted according to our `.editorconfig` file. If that is not the case then `dotnet format` returns with non-zero exit code.

I added this step only to the Linux build - I think that's enough, no need to run it on multiple OSs. Let me know if there is a better place for it.

## Next step:

~This build currently fails because we have code style violations - those are addressed in #535 (opened a separate PR, otherwise it'd be hard to review this), so that'll be merged first. #536 shows the status after #535 is merged into that branch:~ Update: code cleanup done, this PR branch should be also ok. 

<img width="831" alt="Screen Shot 2019-10-04 at 12 52 40" src="https://user-images.githubusercontent.com/1091853/66202378-ea83a880-e6a5-11e9-8f02-2b1ea8e889cb.png">