### PR TITLE
use transaction id as parent id for error when span non sampled or dr…

### DIFF
--- a/src/Elastic.Apm/Model/Span.cs
+++ b/src/Elastic.Apm/Model/Span.cs
@@ -226,7 +226,7 @@ namespace Elastic.Apm.Model
 				_enclosingTransaction,
 				culprit,
 				isHandled,
-				parentId
+				parentId ?? (ShouldBeSentToApmServer ? null : _enclosingTransaction.Id)
 			);
 
 		public void CaptureSpan(string name, string type, Action<ISpan> capturedAction, string subType = null, string action = null)
@@ -263,7 +263,7 @@ namespace Elastic.Apm.Model
 				this,
 				_configurationReader,
 				_enclosingTransaction,
-				parentId
+				parentId ?? (ShouldBeSentToApmServer ? null : _enclosingTransaction.Id)
 			);
 	}
 }

--- a/test/Elastic.Apm.Tests/ApiTests/ApiTests.cs
+++ b/test/Elastic.Apm.Tests/ApiTests/ApiTests.cs
@@ -680,8 +680,8 @@ namespace Elastic.Apm.Tests.ApiTests
 				agent.Tracer.CaptureTransaction(TestTransaction, CustomTransactionTypeForTests, transaction =>
 				{
 					capturedTransaction = transaction;
-					foreach (var keyValue in expectedErrorContext.Labels)
-						transaction.Context.Labels[keyValue.Key] = keyValue.Value;
+					foreach (var (key, value) in expectedErrorContext.Labels)
+						transaction.Context.Labels[key] = value;
 					ISpan span = null;
 					if (captureOnSpan)
 					{
@@ -708,7 +708,8 @@ namespace Elastic.Apm.Tests.ApiTests
 			payloadSender.FirstError.Transaction.Type.Should().Be(CustomTransactionTypeForTests);
 			payloadSender.FirstError.TransactionId.Should().Be(capturedTransaction.Id);
 			payloadSender.FirstError.TraceId.Should().Be(capturedTransaction.TraceId);
-			payloadSender.FirstError.ParentId.Should().Be(errorCapturingExecutionSegment.Id);
+			payloadSender.FirstError.ParentId.Should()
+				.Be(errorCapturingExecutionSegment.IsSampled ? errorCapturingExecutionSegment.Id : capturedTransaction.Id);
 			payloadSender.FirstError.Context.Should().BeEquivalentTo(expectedErrorContext);
 		}
 

--- a/test/Elastic.Apm.Tests/SpanTests.cs
+++ b/test/Elastic.Apm.Tests/SpanTests.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Diagnostics;
-using Elastic.Apm.Model;
 using Elastic.Apm.Tests.Mocks;
+using FluentAssertions;
 using Xunit;
 
 namespace Elastic.Apm.Tests
@@ -12,84 +12,88 @@ namespace Elastic.Apm.Tests
 		public void CaptureError_ShouldUseTransactionIdAsParent_WhenSpanDropped()
 		{
 			// Arrange
-			var currentExecutionSegmentsContainer = new NoopCurrentExecutionSegmentsContainer();
-			var logger = new NoopLogger();
 			var payloadSender = new MockPayloadSender();
-
-			var transaction = new Transaction(logger, "transaction", "type", new Sampler(1.0), null, payloadSender, null,
-				currentExecutionSegmentsContainer);
-
-			var span = new Span("parent", "type", transaction.Id, "traceId", transaction, payloadSender, logger,
-				new MockConfigSnapshot(transactionMaxSpans: "0"), currentExecutionSegmentsContainer);
-
-			// Act
-			span.CaptureError("Error message", "culprit", new StackFrame[0]);
+			using (var agent =
+				new ApmAgent(new TestAgentComponents(config: new MockConfigSnapshot(transactionMaxSpans: "0"), payloadSender: payloadSender)))
+			{
+				agent.Tracer.CaptureTransaction("transaction", "type", transaction =>
+				{
+					transaction.CaptureSpan("parent", "type", span =>
+					{
+						// Act
+						span.CaptureError("Error message", "culprit", Array.Empty<StackFrame>());
+					});
+				});
+			}
 
 			// Assert
-			Assert.Equal(transaction.Id, payloadSender.FirstError.ParentId);
+			payloadSender.FirstError.ParentId.Should().Be(payloadSender.FirstTransaction.Id);
 		}
 
 		[Fact]
 		public void CaptureException_ShouldUseTransactionIdAsParent_WhenSpanDropped()
 		{
 			// Arrange
-			var currentExecutionSegmentsContainer = new NoopCurrentExecutionSegmentsContainer();
-			var logger = new NoopLogger();
 			var payloadSender = new MockPayloadSender();
-
-			var transaction = new Transaction(logger, "transaction", "type", new Sampler(1.0), null, payloadSender, null,
-				currentExecutionSegmentsContainer);
-
-			var span = new Span("parent", "type", transaction.Id, "traceId", transaction, payloadSender, logger,
-				new MockConfigSnapshot(transactionMaxSpans: "0"), currentExecutionSegmentsContainer);
-
-			// Act
-			span.CaptureException(new Exception(), "culprit");
+			using (var agent =
+				new ApmAgent(new TestAgentComponents(config: new MockConfigSnapshot(transactionMaxSpans: "0"), payloadSender: payloadSender)))
+			{
+				agent.Tracer.CaptureTransaction("transaction", "type", transaction =>
+				{
+					transaction.CaptureSpan("parent", "type", span =>
+					{
+						// Act
+						span.CaptureException(new Exception(), "culprit");
+					});
+				});
+			}
 
 			// Assert
-			Assert.Equal(transaction.Id, payloadSender.FirstError.ParentId);
+			payloadSender.FirstError.ParentId.Should().Be(payloadSender.FirstTransaction.Id);
 		}
 
 		[Fact]
 		public void CaptureError_ShouldUseTransactionIdAsParent_WhenSpanNonSampled()
 		{
 			// Arrange
-			var currentExecutionSegmentsContainer = new NoopCurrentExecutionSegmentsContainer();
-			var logger = new NoopLogger();
 			var payloadSender = new MockPayloadSender();
-
-			var transaction = new Transaction(logger, "transaction", "type", new Sampler(0), null, payloadSender, null,
-				currentExecutionSegmentsContainer);
-
-			var span = new Span("parent", "type", transaction.Id, "traceId", transaction, payloadSender, logger,
-				new MockConfigSnapshot(transactionMaxSpans: "10"), currentExecutionSegmentsContainer);
-
-			// Act
-			span.CaptureError("Error message", "culprit", new StackFrame[0]);
+			using (var agent =
+				new ApmAgent(new TestAgentComponents(config: new MockConfigSnapshot(transactionSampleRate: "0"), payloadSender: payloadSender)))
+			{
+				agent.Tracer.CaptureTransaction("transaction", "type", transaction =>
+				{
+					transaction.CaptureSpan("parent", "type", span =>
+					{
+						// Act
+						span.CaptureError("Error message", "culprit", Array.Empty<StackFrame>());
+					});
+				});
+			}
 
 			// Assert
-			Assert.Equal(transaction.Id, payloadSender.FirstError.ParentId);
+			payloadSender.FirstError.ParentId.Should().Be(payloadSender.FirstTransaction.Id);
 		}
 
 		[Fact]
 		public void CaptureException_ShouldUseTransactionIdAsParent_WhenSpanNonSampled()
 		{
 			// Arrange
-			var currentExecutionSegmentsContainer = new NoopCurrentExecutionSegmentsContainer();
-			var logger = new NoopLogger();
 			var payloadSender = new MockPayloadSender();
-
-			var transaction = new Transaction(logger, "transaction", "type", new Sampler(0), null, payloadSender, null,
-				currentExecutionSegmentsContainer);
-
-			var span = new Span("parent", "type", transaction.Id, "traceId", transaction, payloadSender, logger,
-				new MockConfigSnapshot(transactionMaxSpans: "10"), currentExecutionSegmentsContainer);
-
-			// Act
-			span.CaptureException(new Exception(), "culprit");
+			using (var agent =
+				new ApmAgent(new TestAgentComponents(config: new MockConfigSnapshot(transactionSampleRate: "0"), payloadSender: payloadSender)))
+			{
+				agent.Tracer.CaptureTransaction("transaction", "type", transaction =>
+				{
+					transaction.CaptureSpan("parent", "type", span =>
+					{
+						// Act
+						span.CaptureException(new Exception(), "culprit");
+					});
+				});
+			}
 
 			// Assert
-			Assert.Equal(transaction.Id, payloadSender.FirstError.ParentId);
+			payloadSender.FirstError.ParentId.Should().Be(payloadSender.FirstTransaction.Id);
 		}
 	}
 }

--- a/test/Elastic.Apm.Tests/SpanTests.cs
+++ b/test/Elastic.Apm.Tests/SpanTests.cs
@@ -1,0 +1,95 @@
+using System;
+using System.Diagnostics;
+using Elastic.Apm.Model;
+using Elastic.Apm.Tests.Mocks;
+using Xunit;
+
+namespace Elastic.Apm.Tests
+{
+	public class SpanTests
+	{
+		[Fact]
+		public void CaptureError_ShouldUseTransactionIdAsParent_WhenSpanDropped()
+		{
+			// Arrange
+			var currentExecutionSegmentsContainer = new NoopCurrentExecutionSegmentsContainer();
+			var logger = new NoopLogger();
+			var payloadSender = new MockPayloadSender();
+
+			var transaction = new Transaction(logger, "transaction", "type", new Sampler(1.0), null, payloadSender, null,
+				currentExecutionSegmentsContainer);
+
+			var span = new Span("parent", "type", transaction.Id, "traceId", transaction, payloadSender, logger,
+				new MockConfigSnapshot(transactionMaxSpans: "0"), currentExecutionSegmentsContainer);
+
+			// Act
+			span.CaptureError("Error message", "culprit", new StackFrame[0]);
+
+			// Assert
+			Assert.Equal(transaction.Id, payloadSender.FirstError.ParentId);
+		}
+
+		[Fact]
+		public void CaptureException_ShouldUseTransactionIdAsParent_WhenSpanDropped()
+		{
+			// Arrange
+			var currentExecutionSegmentsContainer = new NoopCurrentExecutionSegmentsContainer();
+			var logger = new NoopLogger();
+			var payloadSender = new MockPayloadSender();
+
+			var transaction = new Transaction(logger, "transaction", "type", new Sampler(1.0), null, payloadSender, null,
+				currentExecutionSegmentsContainer);
+
+			var span = new Span("parent", "type", transaction.Id, "traceId", transaction, payloadSender, logger,
+				new MockConfigSnapshot(transactionMaxSpans: "0"), currentExecutionSegmentsContainer);
+
+			// Act
+			span.CaptureException(new Exception(), "culprit");
+
+			// Assert
+			Assert.Equal(transaction.Id, payloadSender.FirstError.ParentId);
+		}
+
+		[Fact]
+		public void CaptureError_ShouldUseTransactionIdAsParent_WhenSpanNonSampled()
+		{
+			// Arrange
+			var currentExecutionSegmentsContainer = new NoopCurrentExecutionSegmentsContainer();
+			var logger = new NoopLogger();
+			var payloadSender = new MockPayloadSender();
+
+			var transaction = new Transaction(logger, "transaction", "type", new Sampler(0), null, payloadSender, null,
+				currentExecutionSegmentsContainer);
+
+			var span = new Span("parent", "type", transaction.Id, "traceId", transaction, payloadSender, logger,
+				new MockConfigSnapshot(transactionMaxSpans: "10"), currentExecutionSegmentsContainer);
+
+			// Act
+			span.CaptureError("Error message", "culprit", new StackFrame[0]);
+
+			// Assert
+			Assert.Equal(transaction.Id, payloadSender.FirstError.ParentId);
+		}
+
+		[Fact]
+		public void CaptureException_ShouldUseTransactionIdAsParent_WhenSpanNonSampled()
+		{
+			// Arrange
+			var currentExecutionSegmentsContainer = new NoopCurrentExecutionSegmentsContainer();
+			var logger = new NoopLogger();
+			var payloadSender = new MockPayloadSender();
+
+			var transaction = new Transaction(logger, "transaction", "type", new Sampler(0), null, payloadSender, null,
+				currentExecutionSegmentsContainer);
+
+			var span = new Span("parent", "type", transaction.Id, "traceId", transaction, payloadSender, logger,
+				new MockConfigSnapshot(transactionMaxSpans: "10"), currentExecutionSegmentsContainer);
+
+			// Act
+			span.CaptureException(new Exception(), "culprit");
+
+			// Assert
+			Assert.Equal(transaction.Id, payloadSender.FirstError.ParentId);
+		}
+	}
+}


### PR DESCRIPTION
…opped

closes #477 