### PR TITLE
Request body does not need old copy

### DIFF
--- a/src/Elastic.Apm.AspNetCore/Extensions/RequestExtentions.cs
+++ b/src/Elastic.Apm.AspNetCore/Extensions/RequestExtentions.cs
@@ -21,9 +21,6 @@ namespace Elastic.Apm.AspNetCore.Extensions
 
 			try
 			{
-				// Keep a reference to the body to reset it later
-				var initialBody = request.Body;
-
 				request.EnableRewind();
 				request.Body.Position = 0;
 
@@ -41,9 +38,6 @@ namespace Elastic.Apm.AspNetCore.Extensions
 					}
 					request.Body.Position = 0;
 				}
-
-				// Reset the body stream for any read operations that might be carried on at a later stage
-				request.Body = initialBody; 
 			}
 			catch (IOException ioException)
 			{


### PR DESCRIPTION
The result of a EnableRewind is a valid Request.Body

All tests passed.

https://devblogs.microsoft.com/aspnet/re-reading-asp-net-core-request-bodies-with-enablebuffering/