### PR TITLE
Add test covering #460 - making sure capturing request body does not erase the body

### DIFF
--- a/sample/SampleAspNetCoreApp/Controllers/HomeController.cs
+++ b/sample/SampleAspNetCoreApp/Controllers/HomeController.cs
@@ -31,6 +31,7 @@ namespace SampleAspNetCoreApp.Controllers
 				throw new ArgumentException($"{captureControllerActionAsSpanQueryStringKey} query string key should have at most one value" +
 					$", instead it's values: {captureControllerActionAsSpanQueryStringValues}",
 					captureControllerActionAsSpanQueryStringKey);
+
 			// ReSharper disable once SimplifyConditionalTernaryExpression
 			return captureControllerActionAsSpanQueryStringValues.Count == 0 ? false : bool.Parse(captureControllerActionAsSpanQueryStringValues[0]);
 		}
@@ -39,25 +40,25 @@ namespace SampleAspNetCoreApp.Controllers
 		{
 			return SafeCaptureSpan<IActionResult>(GetCaptureControllerActionAsSpanFromQueryString(),
 				"Index_span_name", "Index_span_type", async () =>
-			{
-				_sampleDataContext.Database.Migrate();
-				var model = _sampleDataContext.SampleTable.Select(item => item.Name).ToList();
-
-				try
 				{
-					var httpClient = new HttpClient();
-					httpClient.DefaultRequestHeaders.Add("User-Agent", "APM-Sample-App");
-					var responseMsg = await httpClient.GetAsync("https://api.github.com/repos/elastic/apm-agent-dotnet");
-					var responseStr = await responseMsg.Content.ReadAsStringAsync();
-					ViewData["stargazers_count"] = JObject.Parse(responseStr)["stargazers_count"];
-				}
-				catch
-				{
-					Console.WriteLine("Failed HTTP GET elastic.co");
-				}
+					_sampleDataContext.Database.Migrate();
+					var model = _sampleDataContext.SampleTable.Select(item => item.Name).ToList();
 
-				return View(model);
-			});
+					try
+					{
+						var httpClient = new HttpClient();
+						httpClient.DefaultRequestHeaders.Add("User-Agent", "APM-Sample-App");
+						var responseMsg = await httpClient.GetAsync("https://api.github.com/repos/elastic/apm-agent-dotnet");
+						var responseStr = await responseMsg.Content.ReadAsStringAsync();
+						ViewData["stargazers_count"] = JObject.Parse(responseStr)["stargazers_count"];
+					}
+					catch
+					{
+						Console.WriteLine("Failed HTTP GET elastic.co");
+					}
+
+					return View(model);
+				});
 		}
 
 		/// <summary>
@@ -169,13 +170,36 @@ namespace SampleAspNetCoreApp.Controllers
 		}
 
 		[ResponseCache(Duration = 0, Location = ResponseCacheLocation.None, NoStore = true)]
-
 		public IActionResult Error() => View(new ErrorViewModel { RequestId = Activity.Current?.Id ?? HttpContext.TraceIdentifier });
-		
+
 		[HttpPost, Route("api/Home/Post")]
 		public ActionResult<string> Post() => "somevalue";
 
 		[HttpPost, Route("api/Home/PostError")]
 		public ActionResult<string> PostError() => throw new Exception("This is a post method test exception!");
+
+		/// <summary>
+		/// Test for: https://github.com/elastic/apm-agent-dotnet/issues/460
+		/// </summary>
+		/// <param name="filter">A parameter with a little bit more complex data type coming through the request body</param>
+		/// <returns>HTTP 200 if the parameter is available in the method (aka not <code>null</code>), HTTP500 otherwise </returns>
+		[HttpPost("api/Home/Send")]
+		public IActionResult Send([FromBody] BaseReportFilter<SendMessageFilter> filter)
+		{
+			return filter == null ? StatusCode(500) : Ok();
+		}
+	}
+
+	public class BaseReportFilter<T>
+	{
+		public T ReportFilter { get; set; }
+	}
+
+	public class SendMessageFilter
+	{
+		public string SenderApplicationCode { get; set; }
+		public string MediaType { get; set; }
+		public string Body { get; set; }
+		public List<string> Recipients { get; set; }
 	}
 }

--- a/sample/SampleAspNetCoreApp/Controllers/HomeController.cs
+++ b/sample/SampleAspNetCoreApp/Controllers/HomeController.cs
@@ -182,7 +182,7 @@ namespace SampleAspNetCoreApp.Controllers
 		/// Test for: https://github.com/elastic/apm-agent-dotnet/issues/460
 		/// </summary>
 		/// <param name="filter">A parameter with a little bit more complex data type coming through the request body</param>
-		/// <returns>HTTP 200 if the parameter is available in the method (aka not <code>null</code>), HTTP500 otherwise </returns>
+		/// <returns>HTTP200 if the parameter is available in the method (aka not <code>null</code>), HTTP500 otherwise </returns>
 		[HttpPost("api/Home/Send")]
 		public IActionResult Send([FromBody] BaseReportFilter<SendMessageFilter> filter)
 		{

--- a/test/Elastic.Apm.AspNetCore.Tests/BodyCapturingTests.cs
+++ b/test/Elastic.Apm.AspNetCore.Tests/BodyCapturingTests.cs
@@ -27,6 +27,7 @@ namespace Elastic.Apm.AspNetCore.Tests
 	/// This test uses <see cref="Program.CreateWebHostBuilder"/> to host the sample application on purpose - that was the key
 	/// to reproduce the problem in an automated test.
 	/// </summary>
+	[Collection("DiagnosticListenerTest")] //To avoid tests from DiagnosticListenerTests running in parallel with this we add them to 1 collection.
 	public class BodyCapturingTests : IAsyncLifetime
 	{
 		private readonly CancellationTokenSource _cancellationTokenSource = new CancellationTokenSource();

--- a/test/Elastic.Apm.AspNetCore.Tests/BodyCapturingTests.cs
+++ b/test/Elastic.Apm.AspNetCore.Tests/BodyCapturingTests.cs
@@ -1,0 +1,105 @@
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Reflection;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Elastic.Apm.Config;
+using Elastic.Apm.Tests.Mocks;
+using FluentAssertions;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.DependencyInjection;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
+using SampleAspNetCoreApp;
+using SampleAspNetCoreApp.Controllers;
+using Xunit;
+
+namespace Elastic.Apm.AspNetCore.Tests
+{
+	/// <summary>
+	/// Tests the capture body feature of ASP.NET Core
+	/// During investigation of https://github.com/elastic/apm-agent-dotnet/issues/460
+	/// it turned out that tests that host the sample application with <see cref="IClassFixture{WebApplicationFactory}" />
+	/// don't reproduce the problem reported in #460.
+	/// This test uses <see cref="Program.CreateWebHostBuilder"/> to host the sample application on purpose - that was the key
+	/// to reproduce the problem in an automated test.
+	/// </summary>
+	public class BodyCapturingTests : IAsyncLifetime
+	{
+		private readonly CancellationTokenSource _cancellationTokenSource = new CancellationTokenSource();
+		private readonly MockPayloadSender _payloadSender1 = new MockPayloadSender();
+		private ApmAgent _agent;
+		private Task _taskForSampleApp;
+
+		/// <summary>
+		/// Calls <see cref="HomeController.Send(BaseReportFilter{SendMessageFilter})" />.
+		/// That method returns HTTP 500 in case the request body is null in the method, otherwise HTT 200.
+		/// Tests against https://github.com/elastic/apm-agent-dotnet/issues/460
+		/// </summary>
+		/// <returns></returns>
+		[Fact]
+		public async Task ComplexDataSendCaptureBody()
+		{
+			// build test data, which we send to the sample app
+			var data = new BaseReportFilter<SendMessageFilter>();
+			data.ReportFilter = new SendMessageFilter();
+			data.ReportFilter.Body = "message body";
+			data.ReportFilter.SenderApplicationCode = "26";
+			data.ReportFilter.MediaType = "TokenBasedSms";
+			data.ReportFilter.Recipients = new List<string> { "abc123" };
+
+			var body = JsonConvert.SerializeObject(data,
+				new JsonSerializerSettings { ContractResolver = new CamelCasePropertyNamesContractResolver() });
+
+			// send data to the sample app
+			var httpClient = new HttpClient();
+			httpClient.BaseAddress = new Uri("http://localhost:5903");
+			var result = await httpClient.PostAsync("api/Home/Send", new StringContent(body, Encoding.UTF8, "application/json"));
+
+			// make sure the sample app received the data
+			result.StatusCode.Should().Be(200);
+
+			// and make sure the data is captured by the agent
+			_payloadSender1.FirstTransaction.Should().NotBeNull();
+			_payloadSender1.FirstTransaction.Context.Request.Body.Should().Be(body);
+		}
+
+		public Task InitializeAsync()
+		{
+			_agent = new ApmAgent(new TestAgentComponents(payloadSender: _payloadSender1,
+				config: new MockConfigSnapshot(new NoopLogger(), captureBody: ConfigConsts.SupportedValues.CaptureBodyAll)));
+
+			_taskForSampleApp = Program.CreateWebHostBuilder(null)
+				.ConfigureServices(services =>
+					{
+						Startup.ConfigureServicesExceptMvc(services);
+
+						services.AddMvc()
+							.AddApplicationPart(Assembly.Load(new AssemblyName(nameof(SampleAspNetCoreApp))))
+							.SetCompatibilityVersion(CompatibilityVersion.Version_2_1);
+					}
+				)
+				.Configure(app =>
+				{
+					app.UseElasticApm(_agent, new TestLogger());
+						Startup.ConfigureAllExceptAgent(app);
+				})
+				.UseUrls("http://localhost:5903")
+				.Build()
+				.RunAsync(_cancellationTokenSource.Token);
+
+			return Task.CompletedTask;
+		}
+
+		public async Task DisposeAsync()
+		{
+			_cancellationTokenSource.Cancel();
+			await _taskForSampleApp;
+
+			_agent?.Dispose();
+		}
+	}
+}

--- a/test/Elastic.Apm.AspNetCore.Tests/Helper.cs
+++ b/test/Elastic.Apm.AspNetCore.Tests/Helper.cs
@@ -27,8 +27,6 @@ namespace Elastic.Apm.AspNetCore.Tests
 
 						app.UseDeveloperExceptionPage();
 
-						app.UseHsts();
-
 						app.UseHttpsRedirection();
 						app.UseStaticFiles();
 						app.UseCookiePolicy();


### PR DESCRIPTION
In #460 we had a bug which was that once the agent captures the request body, the body itself was not visible anymore in the MVC action method. This is fixed in https://github.com/elastic/apm-agent-dotnet/pull/539. 

This PR adds a test that reproduces and tests that scenario.

~The new test will fail until https://github.com/elastic/apm-agent-dotnet/pull/539 is not merged (atm. build is in-progress, I wait for it to finish, then I'll merge).~ Update: #539 is merged to `master`, I rebased this PR, all test should be green.