### PR TITLE
Fix building log state - NullReferenceException with Serilog

### DIFF
--- a/src/Elastic.Apm/Logging/LogValuesFormatter.cs
+++ b/src/Elastic.Apm/Logging/LogValuesFormatter.cs
@@ -183,11 +183,11 @@ namespace Elastic.Apm.Logging
 			var args = new KeyValuePair<string, object>[values.Length + offset];
 			args[0] = new KeyValuePair<string, object>("{OriginalFormat}", OriginalFormat);
 			if (_scope != null)
-				args[1] = new KeyValuePair<string, object>("{Scope}", _scope);
+				args[1] = new KeyValuePair<string, object>("Scope", _scope);
 
 			for (int i = 0, j = _scope != null ? 1 : 0; j < ValueNames.Count; i++, j++)
 			{
-				if (values.Length < i)
+				if (values.Length > i)
 					args[offset + i] = new KeyValuePair<string, object>(ValueNames[j], values[i]);
 			}
 

--- a/test/Elastic.Apm.Tests/LogValuesFormatterTests.cs
+++ b/test/Elastic.Apm.Tests/LogValuesFormatterTests.cs
@@ -1,0 +1,69 @@
+using Elastic.Apm.Logging;
+using FluentAssertions;
+using Xunit;
+
+namespace Elastic.Apm.Tests
+{
+	/// <summary>
+	/// Makes sure that <see cref="LogValuesFormatter"/> builds correct logstate
+	/// </summary>
+	public class LogValuesFormatterTests
+	{
+		[Fact]
+		public void SimpleStateTest()
+		{
+			object[] parameters = { "123" };
+			var logValuesFormatter = new LogValuesFormatter("MyLog {template}", parameters);
+			var state = logValuesFormatter.GetState(parameters);
+
+			state.Count.Should().Be(2);
+
+			state[0].Key.Should().Be("{OriginalFormat}");
+			state[0].Value.Should().Be("MyLog {template}");
+
+			state[1].Key.Should().Be("template");
+			state[1].Value.Should().Be("123");
+		}
+
+		[Fact]
+		public void MultipleParametersTest()
+		{
+			object[] parameters = { "123", "456" };
+			var logValuesFormatter = new LogValuesFormatter("MyLog {template1}, {template2}", parameters);
+			var state = logValuesFormatter.GetState(parameters);
+
+			state.Count.Should().Be(3);
+
+			state[0].Key.Should().Be("{OriginalFormat}");
+			state[0].Value.Should().Be("MyLog {template1}, {template2}");
+
+			state[1].Key.Should().Be("template1");
+			state[1].Value.Should().Be("123");
+
+			state[2].Key.Should().Be("template2");
+			state[2].Value.Should().Be("456");
+		}
+
+		[Fact]
+		public void ScopedMultipleParametersTest()
+		{
+			object[] parameters = { "123", "456" };
+			var logValuesFormatter = new LogValuesFormatter("{Scope} MyLog {template1}, {template2}", parameters, nameof(LogValuesFormatterTests));
+			var state = logValuesFormatter.GetState(parameters);
+
+			state.Count.Should().Be(4);
+
+			state[0].Key.Should().Be("{OriginalFormat}");
+			state[0].Value.Should().Be("{Scope} MyLog {template1}, {template2}");
+
+			state[1].Key.Should().Be("Scope");
+			state[1].Value.Should().Be(nameof(LogValuesFormatterTests));
+
+			state[2].Key.Should().Be("template1");
+			state[2].Value.Should().Be("123");
+
+			state[3].Key.Should().Be("template2");
+			state[3].Value.Should().Be("456");
+		}
+	}
+}


### PR DESCRIPTION
Solves #544

As it seems when we parse the log state ourselves, everything is ok, but what we built in `LogValuesFormatter.GetState()` was not correct and this became a problem when we passed that state object to Serilog.

- The parameters were missing due to `<`, `>` mismatch. That caused items with `null` causing `NullReferenceException`s. 
- By adding `{` `}` to the scope, Serilog was unable to resolve the scope causing lines like this (so instead of the real scope `{{Scope}}` got printed):

```
{{Scope}} The agent was started without a service name. The service name will be automatically discovered.
```