### PR TITLE
Update .editorconfig #532

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -38,78 +38,78 @@ dotnet_sort_system_directives_first = true
 # TODO can we force _ for private fields?
 # TODO elevate severity after code cleanup to warning minimum
 # TODO use language latest
-dotnet_style_qualification_for_field = false:warning
-dotnet_style_qualification_for_property = false:warning
-dotnet_style_qualification_for_method = false:warning
-dotnet_style_qualification_for_event = false:warning
+dotnet_style_qualification_for_field = false:error
+dotnet_style_qualification_for_property = false:error
+dotnet_style_qualification_for_method = false:error
+dotnet_style_qualification_for_event = false:error
 
 # Use language keywords instead of framework type names for type references
-dotnet_style_predefined_type_for_locals_parameters_members = true:warning
-dotnet_style_predefined_type_for_member_access = true:warning
+dotnet_style_predefined_type_for_locals_parameters_members = true:error
+dotnet_style_predefined_type_for_member_access = true:error
 
 # Suggest more modern language features when available
-dotnet_style_object_initializer = true:warning
-dotnet_style_collection_initializer = true:warning
-dotnet_style_explicit_tuple_names = true:warning
-dotnet_style_prefer_inferred_anonymous_type_member_names = true:warning
-dotnet_style_prefer_inferred_tuple_names = true:warning
-dotnet_style_coalesce_expression = true:warning
-dotnet_style_null_propagation = true:warning
+dotnet_style_object_initializer = true:error
+dotnet_style_collection_initializer = true:error
+dotnet_style_explicit_tuple_names = true:error
+dotnet_style_prefer_inferred_anonymous_type_member_names = true:error
+dotnet_style_prefer_inferred_tuple_names = true:error
+dotnet_style_coalesce_expression = true:error
+dotnet_style_null_propagation = true:error
 
-dotnet_style_require_accessibility_modifiers = for_non_interface_members:warning
-dotnet_style_readonly_field = true:warning
+dotnet_style_require_accessibility_modifiers = for_non_interface_members:error
+dotnet_style_readonly_field = true:error
 
 # CSharp code style settings:
 [*.cs]
 # Prefer "var" everywhere
-csharp_style_var_for_built_in_types = true:warning
-csharp_style_var_when_type_is_apparent = true:warning
-csharp_style_var_elsewhere = true:warning
+csharp_style_var_for_built_in_types = true:error
+csharp_style_var_when_type_is_apparent = true:error
+csharp_style_var_elsewhere = true:error
 
-csharp_style_expression_bodied_methods = true:none
-csharp_style_expression_bodied_constructors = true:none
-csharp_style_expression_bodied_operators = true:hint
-csharp_style_expression_bodied_properties = true:hint
-csharp_style_expression_bodied_indexers = true:hint
-csharp_style_expression_bodied_accessors = true:hint
+csharp_style_expression_bodied_methods = true:error
+csharp_style_expression_bodied_constructors = true:error
+csharp_style_expression_bodied_operators = true:error
+csharp_style_expression_bodied_properties = true:error
+csharp_style_expression_bodied_indexers = true:error
+csharp_style_expression_bodied_accessors = true:error
 
 # Suggest more modern language features when available
-csharp_style_pattern_matching_over_is_with_cast_check = true:warning
-csharp_style_pattern_matching_over_as_with_null_check = true:warning
-csharp_style_inlined_variable_declaration = true:warning
-csharp_style_deconstructed_variable_declaration = true:warning
-csharp_style_pattern_local_over_anonymous_function = true:warning
-csharp_style_throw_expression = true:warning
-csharp_style_conditional_delegate_call = true:warning
+csharp_style_pattern_matching_over_is_with_cast_check = true:error
+csharp_style_pattern_matching_over_as_with_null_check = true:error
+csharp_style_inlined_variable_declaration = true:error
+csharp_style_deconstructed_variable_declaration = true:error
+csharp_style_pattern_local_over_anonymous_function = true:error
+csharp_style_throw_expression = true:error
+csharp_style_conditional_delegate_call = true:error
 
 csharp_prefer_braces = false:warning
-csharp_preferred_modifier_order = public,private,protected,internal,static,extern,new,virtual,abstract,sealed,override,readonly,unsafe,volatile,async:warning
+csharp_preferred_modifier_order = public,private,protected,internal,static,extern,new,virtual,abstract,sealed,override,readonly,unsafe,volatile,async:error
 
 # ---
 # formatting conventions https://docs.microsoft.com/en-us/visualstudio/ide/editorconfig-code-style-settings-reference#formatting-conventions
 
 # Newline settings (Allman yo!)
 csharp_new_line_before_open_brace = all
-csharp_new_line_before_else = true:warning
-csharp_new_line_before_catch = true:warning
-csharp_new_line_before_finally = true:warning
-csharp_new_line_before_members_in_object_initializers = false
+csharp_new_line_before_else = true:error
+csharp_new_line_before_catch = true:error
+csharp_new_line_before_finally = true:error
+csharp_new_line_before_members_in_object_initializers = true
 # just a suggestion do to our JSON tests that use anonymous types to 
 # represent json quite a bit (makes copy paste easier).
 csharp_new_line_before_members_in_anonymous_types = true:suggestion
-csharp_new_line_between_query_expression_clauses = true:warning
+csharp_new_line_between_query_expression_clauses = true:error
 
 # Indent
-csharp_indent_case_contents = true:warning
-csharp_indent_switch_labels = true:warning
-csharp_space_after_cast = false:warning
-csharp_space_after_keywords_in_control_flow_statements = true:warning
-csharp_space_between_method_declaration_parameter_list_parentheses = false:warning
-csharp_space_between_method_call_parameter_list_parentheses = false:warning
+csharp_indent_case_contents = true:error
+csharp_indent_switch_labels = true:error
+csharp_space_after_cast = false:error
+csharp_space_after_keywords_in_control_flow_statements = true:error
+csharp_space_between_method_declaration_parameter_list_parentheses = false:error
+csharp_space_between_method_call_parameter_list_parentheses = false:error
 
 #Wrap
-csharp_preserve_single_line_statements = false:warning
-csharp_preserve_single_line_blocks = true:warning
+csharp_preserve_single_line_statements = false:error
+csharp_preserve_single_line_blocks = true:error
 
 # Resharper
 resharper_csharp_braces_for_lock=required_for_multiline
@@ -121,9 +121,6 @@ resharper_csharp_braces_for_fixed=required_for_multiline
 resharper_csharp_braces_for_ifelse=required_for_multiline
 
 resharper_csharp_accessor_owner_body=expression_body
-
-resharper_local_function_body=expression_body
-resharper_arrange_local_function_body_highlighting=hint
 
 [Jenkinsfile]
 indent_style = space


### PR DESCRIPTION
The `.editorconfig` was changed in #497. 

That PR was about "Central Config Implementation". Let's revert the `.editorconfig` change and in case we really want to change it please do it in a separate PR. Also as agreed we should keep `.editorconfig` in sync across .NET repos at elastic - or at least make it very similar.

#532 and #535 take care of making the errors go away and from this point we have CI support to enforce the correct code style. 

Mainly noticed because of `csharp_style_expression_bodied_methods = true:error` was changed to `true:none`. That'd cause not reformatting one liners to expression bodied methods, while we already have lots of existing expression bodied methods - let's try to keep this unified and not change for now. 