### PR TITLE
Fix failing master

### DIFF
--- a/.ci/linux/release.sh
+++ b/.ci/linux/release.sh
@@ -5,9 +5,8 @@
 #
 set -euxo pipefail
 
-# Remove sample projects
+# Remove sample projects - and other we don't want to pack
 dotnet sln remove test/Elastic.Apm.PerfTests/Elastic.Apm.PerfTests.csproj
-dotnet sln remove src/Elastic.Apm.AspNetFullFramework/Elastic.Apm.AspNetFullFramework.csproj
 dotnet sln remove test/Elastic.Apm.AspNetFullFramework.Tests/Elastic.Apm.AspNetFullFramework.Tests.csproj
-
+dotnet sln remove sample/AspNetFullFrameworkSampleApp/AspNetFullFrameworkSampleApp.csproj
 dotnet pack -c Release

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -308,7 +308,6 @@ pipeline {
             when {
               beforeAgent true
               anyOf {
-                branch 'master'
                 expression { return params.Run_As_Master_Branch }
               }
             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -308,6 +308,7 @@ pipeline {
             when {
               beforeAgent true
               anyOf {
+                branch 'master'
                 expression { return params.Run_As_Master_Branch }
               }
             }


### PR DESCRIPTION
Currently `master` fails during the `Release to AppVeyor` stage. 

Logs:
```
[2019-10-16T17:46:01.383Z] + .ci/linux/release.sh
//..more logs
[2019-10-16T17:46:12.412Z] /var/lib/jenkins/workspace/tnet_apm-agent-dotnet-mbp_master/apm-agent-dotnet/sample/AspNetFullFrameworkSampleApp/AspNetFullFrameworkSampleApp.csproj : error MSB4057: The target "pack" does not exist in the project.
```

`AspNetFullFrameworkSampleApp.csproj` is a project which we can't `dotnet pack` plus it's a sample project (so not an agent project) that we don't want to publish anyway. So I excluded it.

Tested in 2f41af9 - that was green, so I assume `master` with this stage of the PR will be also green.