### PR TITLE
[TEMP PR] Proposed changes to PR #533 (use transaction id as parent id for error when span is not set

### DIFF
--- a/src/Elastic.Apm/Model/Span.cs
+++ b/src/Elastic.Apm/Model/Span.cs
@@ -226,7 +226,7 @@ namespace Elastic.Apm.Model
 				_enclosingTransaction,
 				culprit,
 				isHandled,
-				parentId
+				parentId ?? (ShouldBeSentToApmServer ? null : _enclosingTransaction.Id)
 			);
 
 		public void CaptureSpan(string name, string type, Action<ISpan> capturedAction, string subType = null, string action = null)
@@ -263,7 +263,7 @@ namespace Elastic.Apm.Model
 				this,
 				_configurationReader,
 				_enclosingTransaction,
-				parentId
+				parentId ?? (ShouldBeSentToApmServer ? null : _enclosingTransaction.Id)
 			);
 	}
 }

--- a/test/Elastic.Apm.Tests/ApiTests/ApiTests.cs
+++ b/test/Elastic.Apm.Tests/ApiTests/ApiTests.cs
@@ -680,8 +680,8 @@ namespace Elastic.Apm.Tests.ApiTests
 				agent.Tracer.CaptureTransaction(TestTransaction, CustomTransactionTypeForTests, transaction =>
 				{
 					capturedTransaction = transaction;
-					foreach (var keyValue in expectedErrorContext.Labels)
-						transaction.Context.Labels[keyValue.Key] = keyValue.Value;
+					foreach (var (key, value) in expectedErrorContext.Labels)
+						transaction.Context.Labels[key] = value;
 					ISpan span = null;
 					if (captureOnSpan)
 					{
@@ -708,7 +708,8 @@ namespace Elastic.Apm.Tests.ApiTests
 			payloadSender.FirstError.Transaction.Type.Should().Be(CustomTransactionTypeForTests);
 			payloadSender.FirstError.TransactionId.Should().Be(capturedTransaction.Id);
 			payloadSender.FirstError.TraceId.Should().Be(capturedTransaction.TraceId);
-			payloadSender.FirstError.ParentId.Should().Be(errorCapturingExecutionSegment.Id);
+			payloadSender.FirstError.ParentId.Should()
+				.Be(errorCapturingExecutionSegment.IsSampled ? errorCapturingExecutionSegment.Id : capturedTransaction.Id);
 			payloadSender.FirstError.Context.Should().BeEquivalentTo(expectedErrorContext);
 		}
 

--- a/test/Elastic.Apm.Tests/SpanTests.cs
+++ b/test/Elastic.Apm.Tests/SpanTests.cs
@@ -1,0 +1,95 @@
+using System;
+using System.Diagnostics;
+using Elastic.Apm.Model;
+using Elastic.Apm.Tests.Mocks;
+using Xunit;
+
+namespace Elastic.Apm.Tests
+{
+	public class SpanTests
+	{
+		[Fact]
+		public void CaptureError_ShouldUseTransactionIdAsParent_WhenSpanDropped()
+		{
+			// Arrange
+			var currentExecutionSegmentsContainer = new NoopCurrentExecutionSegmentsContainer();
+			var logger = new NoopLogger();
+			var payloadSender = new MockPayloadSender();
+
+			var transaction = new Transaction(logger, "transaction", "type", new Sampler(1.0), null, payloadSender, null,
+				currentExecutionSegmentsContainer);
+
+			var span = new Span("parent", "type", transaction.Id, "traceId", transaction, payloadSender, logger,
+				new MockConfigSnapshot(transactionMaxSpans: "0"), currentExecutionSegmentsContainer);
+
+			// Act
+			span.CaptureError("Error message", "culprit", new StackFrame[0]);
+
+			// Assert
+			Assert.Equal(transaction.Id, payloadSender.FirstError.ParentId);
+		}
+
+		[Fact]
+		public void CaptureException_ShouldUseTransactionIdAsParent_WhenSpanDropped()
+		{
+			// Arrange
+			var currentExecutionSegmentsContainer = new NoopCurrentExecutionSegmentsContainer();
+			var logger = new NoopLogger();
+			var payloadSender = new MockPayloadSender();
+
+			var transaction = new Transaction(logger, "transaction", "type", new Sampler(1.0), null, payloadSender, null,
+				currentExecutionSegmentsContainer);
+
+			var span = new Span("parent", "type", transaction.Id, "traceId", transaction, payloadSender, logger,
+				new MockConfigSnapshot(transactionMaxSpans: "0"), currentExecutionSegmentsContainer);
+
+			// Act
+			span.CaptureException(new Exception(), "culprit");
+
+			// Assert
+			Assert.Equal(transaction.Id, payloadSender.FirstError.ParentId);
+		}
+
+		[Fact]
+		public void CaptureError_ShouldUseTransactionIdAsParent_WhenSpanNonSampled()
+		{
+			// Arrange
+			var currentExecutionSegmentsContainer = new NoopCurrentExecutionSegmentsContainer();
+			var logger = new NoopLogger();
+			var payloadSender = new MockPayloadSender();
+
+			var transaction = new Transaction(logger, "transaction", "type", new Sampler(0), null, payloadSender, null,
+				currentExecutionSegmentsContainer);
+
+			var span = new Span("parent", "type", transaction.Id, "traceId", transaction, payloadSender, logger,
+				new MockConfigSnapshot(transactionMaxSpans: "10"), currentExecutionSegmentsContainer);
+
+			// Act
+			span.CaptureError("Error message", "culprit", new StackFrame[0]);
+
+			// Assert
+			Assert.Equal(transaction.Id, payloadSender.FirstError.ParentId);
+		}
+
+		[Fact]
+		public void CaptureException_ShouldUseTransactionIdAsParent_WhenSpanNonSampled()
+		{
+			// Arrange
+			var currentExecutionSegmentsContainer = new NoopCurrentExecutionSegmentsContainer();
+			var logger = new NoopLogger();
+			var payloadSender = new MockPayloadSender();
+
+			var transaction = new Transaction(logger, "transaction", "type", new Sampler(0), null, payloadSender, null,
+				currentExecutionSegmentsContainer);
+
+			var span = new Span("parent", "type", transaction.Id, "traceId", transaction, payloadSender, logger,
+				new MockConfigSnapshot(transactionMaxSpans: "10"), currentExecutionSegmentsContainer);
+
+			// Act
+			span.CaptureException(new Exception(), "culprit");
+
+			// Assert
+			Assert.Equal(transaction.Id, payloadSender.FirstError.ParentId);
+		}
+	}
+}


### PR DESCRIPTION
Minimize use of agent's implementation internals in `SpanTests` and use agent's public API instead
