### PR TITLE
[docs] Documentation restructure

### DIFF
--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -134,7 +134,7 @@ Below is a sample `Web.config` configuration file for a ASP.NET application.
 This is used to keep all the errors and transactions of your service together
 and is the primary filter in the Elastic APM user interface.
 
-NOTE: The service name must conform to this regular expression: `^[a-zA-Z0-9_-]+$`. In less regexy terms: Your service name must only contain characters from the ASCII alphabet, numbers, dashes, underscores and spaces. Characters in service name which don't match regular expression will be replaced by `__` symbol.
+NOTE: The service name must conform to this regular expression: `^[a-zA-Z0-9 _-]+$`. In less regexy terms: Your service name must only contain characters from the ASCII alphabet, numbers, dashes, underscores and spaces. Characters in service name which don't match regular expression will be replaced by `_` symbol.
 
 [options="header"]
 |============

--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -134,7 +134,7 @@ Below is a sample `Web.config` configuration file for a ASP.NET application.
 This is used to keep all the errors and transactions of your service together
 and is the primary filter in the Elastic APM user interface.
 
-NOTE: The service name must conform to this regular expression: ^[a-zA-Z0-9 _-]+$. In less regexy terms: Your service name must only contain characters from the ASCII alphabet, numbers, dashes, underscores and spaces. Characters in service name which don't match regular expression will be replaced by `__` symbol.
+NOTE: The service name must conform to this regular expression: `^[a-zA-Z0-9_-]+$`. In less regexy terms: Your service name must only contain characters from the ASCII alphabet, numbers, dashes, underscores and spaces. Characters in service name which don't match regular expression will be replaced by `__` symbol.
 
 [options="header"]
 |============
@@ -174,11 +174,11 @@ of the deployed revision, e.g. the output of git rev-parse HEAD.
 
 The name of the environment this service is deployed in, e.g. "production" or "staging".
 
-Environments allow you to easily filter data on a global level in the APM UI.
+Environments allow you to easily filter data on a global level in the APM app.
 It's important to be consistent when naming environments across agents.
-See {kibana-ref}/filters.html#environment-selector[environment selector] in the Kibana UI for more information.
+See {apm-app-ref}/filters.html#environment-selector[environment selector] in the Kibana UI for more information.
 
-NOTE: This feature is fully supported in the APM UI in Kibana versions >= 7.2.
+NOTE: This feature is fully supported in the APM app in Kibana versions >= 7.2.
 You must use the query bar to filter for a specific environment in versions prior to 7.2.
 
 [options="header"]
@@ -248,7 +248,7 @@ The Agent will revert to the default value if the value is set below `-1`.
 [[config-central-config]]
 ==== `CentralConfig` (added[1.1])
 
-If set to `true`, the agent makes periodic requests to the APM Server to fetch the latest {kibana-ref}/agent-configuration.html[APM Agent configuration].
+If set to `true`, the agent makes periodic requests to the APM Server to fetch the latest {apm-app-ref}/agent-configuration.html[APM Agent configuration].
 
 [options="header"]
 |============

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -1,5 +1,4 @@
-:branch: current
-:server-branch: 6.5
+include::{asciidoc-dir}/../../shared/versions/stack/current.asciidoc[]
 include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 
 ifdef::env-github[]
@@ -9,11 +8,24 @@ endif::[]
 
 = APM .NET Agent Reference
 
-include::./intro.asciidoc[Introduction]
-include::./setup.asciidoc[Set Up]
-include::./supported-technologies.asciidoc[Supported Technologies]
-include::./metrics.asciidoc[Metrics]
-include::./configuration.asciidoc[Configuration]
-include::./public-api.asciidoc[Public API]
-include::./performance-tuning.asciidoc[Performance Tuning]
-include::./release-notes.asciidoc[Release notes]
+include::./intro.asciidoc[]
+
+include::./setup.asciidoc[]
+
+include::./supported-technologies.asciidoc[]
+
+include::./configuration.asciidoc[]
+
+include::./public-api.asciidoc[]
+
+include::./metrics.asciidoc[]
+
+// OpenTracing API
+
+// Log correlation
+
+include::./performance-tuning.asciidoc[]
+
+// Troubleshooting
+
+include::./release-notes.asciidoc[]

--- a/docs/intro.asciidoc
+++ b/docs/intro.asciidoc
@@ -18,7 +18,7 @@ The agent auto-instruments <<supported-technologies,supported technologies>> and
 like HTTP requests and database queries. To do this, it uses built in capabilities of the instrumented frameworks like [Diagnostic Source](https://docs.microsoft.com/en-us/dotnet/api/system.diagnostics.diagnosticsource?view=netcore-3.0), an HTTP module for IIS, or [IDbCommandInterceptor](https://docs.microsoft.com/en-us/dotnet/api/system.data.entity.infrastructure.interception.idbcommandinterceptor?view=entity-framework-6.2.0) for Entity Framework.
 This means that for the supported technologies, there are no code changes required.
 
-The Agent automatically {CONTENT_HERE}
+The Agent automatically registers callback methods for these built in Diagnostic Source events - or in case of the IIS HTTP module as described on the <<setup,Set up the Agent page>>, the user needs to register the module. With this, the supported frameworks trigger agent code for relevant events to measures their duration and collects metadata (like DB statements), as well as HTTP related information (like the URL, parameters, and headers).
 
 These events, called Transactions and Spans, are sent to the APM Server.
 The APM Server converts them to a format suitable for Elasticsearch, and sends them to an Elasticsearch cluster.

--- a/docs/intro.asciidoc
+++ b/docs/intro.asciidoc
@@ -6,17 +6,23 @@ endif::[]
 [[intro]]
 == Introduction
 
-Welcome to the APM .NET Agent documentation.
+The Elastic APM .NET Agent automatically measures the performance of your application and tracks errors.
+It has built-in support for the most popular frameworks and routers,
+as well as a simple API which allows you to instrument any application.
 
-Elastic APM automatically measures the performance of your application and tracks errors.
-For example, it records spans for database queries and transactions for incoming HTTP requests.
-See <<supported-technologies>> to learn about which frameworks and technologies are supported by Elastic APM .NET agent.
+[float]
+[[how-it-works]]
+=== How does the Agent work?
 
-Spans are grouped in transactions - by default one for each incoming HTTP request.
-But it's possible to create custom transactions not associated with an HTTP request.
+The agent auto-instruments <<supported-technologies,supported technologies>> and records interesting events,
+like HTTP requests and database queries. To do this, it {CONTENT_HERE}
+This means that for the supported technologies, there are no code changes required.
 
-By default the agent comes with support for ASP.NET Core out-of-the-box.
-To instrument other events, you can use custom spans.
+The Agent automatically {CONTENT_HERE}
+
+These events, called Transactions and Spans, are sent to the APM Server.
+The APM Server converts them to a format suitable for Elasticsearch, and sends them to an Elasticsearch cluster.
+You can then use the APM app in Kibana to gain insight into latency issues and error culprits within your application.
 
 [float]
 [[additional-components]]

--- a/docs/intro.asciidoc
+++ b/docs/intro.asciidoc
@@ -7,19 +7,23 @@ endif::[]
 == Introduction
 
 The Elastic APM .NET Agent automatically measures the performance of your application and tracks errors.
-It has built-in support for the most popular frameworks and routers,
+It has built-in support for the most popular frameworks,
 as well as a simple API which allows you to instrument any application.
 
 [float]
 [[how-it-works]]
 === How does the Agent work?
 
-The agent auto-instruments <<supported-technologies,supported technologies>> and records interesting events,
-like HTTP requests and database queries. To do this, it uses built in capabilities of the instrumented frameworks like [Diagnostic Source](https://docs.microsoft.com/en-us/dotnet/api/system.diagnostics.diagnosticsource?view=netcore-3.0), an HTTP module for IIS, or [IDbCommandInterceptor](https://docs.microsoft.com/en-us/dotnet/api/system.data.entity.infrastructure.interception.idbcommandinterceptor?view=entity-framework-6.2.0) for Entity Framework.
-This means that for the supported technologies, there are no code changes required.
+The agent auto-instruments <<supported-technologies,supported technologies>> and records interesting events, like HTTP requests and database queries.
+To do this, it uses built-in capabilities of the instrumented frameworks like
+https://docs.microsoft.com/en-us/dotnet/api/system.diagnostics.diagnosticsource?view=netcore-3.0[Diagnostic Source],
+an HTTP module for IIS, or
+https://docs.microsoft.com/en-us/dotnet/api/system.data.entity.infrastructure.interception.idbcommandinterceptor?view=entity-framework-6.2.0[IDbCommandInterceptor] for Entity Framework.
+This means that for the supported technologies, there are no code changes required beyond enabling <<setup,auto-instrumentation>>.
 
-The Agent automatically registers callback methods for these built in Diagnostic Source events - or in case of the IIS HTTP module as described on the <<setup,Set up the Agent page>>, the user needs to register the module. With this, the supported frameworks trigger agent code for relevant events to measures their duration and collects metadata (like DB statements), as well as HTTP related information (like the URL, parameters, and headers).
-
+The Agent automatically registers callback methods for built-in Diagnostic Source events.
+The IIS HTTP module, as described in <<setup-asp-net, Set up ASP.net Core>>, will need to be registered.
+With this, the supported frameworks trigger Agent code for relevant events to measure their duration and collect metadata, like DB statements, as well as HTTP related information, like the URL, parameters, and headers.
 These events, called Transactions and Spans, are sent to the APM Server.
 The APM Server converts them to a format suitable for Elasticsearch, and sends them to an Elasticsearch cluster.
 You can then use the APM app in Kibana to gain insight into latency issues and error culprits within your application.

--- a/docs/intro.asciidoc
+++ b/docs/intro.asciidoc
@@ -22,7 +22,6 @@ https://docs.microsoft.com/en-us/dotnet/api/system.data.entity.infrastructure.in
 This means that for the supported technologies, there are no code changes required beyond enabling <<setup,auto-instrumentation>>.
 
 The Agent automatically registers callback methods for built-in Diagnostic Source events.
-The IIS HTTP module, as described in <<setup-asp-net, Set up ASP.net Core>>, will need to be registered.
 With this, the supported frameworks trigger Agent code for relevant events to measure their duration and collect metadata, like DB statements, as well as HTTP related information, like the URL, parameters, and headers.
 These events, called Transactions and Spans, are sent to the APM Server.
 The APM Server converts them to a format suitable for Elasticsearch, and sends them to an Elasticsearch cluster.

--- a/docs/intro.asciidoc
+++ b/docs/intro.asciidoc
@@ -15,7 +15,7 @@ as well as a simple API which allows you to instrument any application.
 === How does the Agent work?
 
 The agent auto-instruments <<supported-technologies,supported technologies>> and records interesting events,
-like HTTP requests and database queries. To do this, it {CONTENT_HERE}
+like HTTP requests and database queries. To do this, it uses built in capabilities of the instrumented frameworks like [Diagnostic Source](https://docs.microsoft.com/en-us/dotnet/api/system.diagnostics.diagnosticsource?view=netcore-3.0), an HTTP module for IIS, or [IDbCommandInterceptor](https://docs.microsoft.com/en-us/dotnet/api/system.data.entity.infrastructure.interception.idbcommandinterceptor?view=entity-framework-6.2.0) for Entity Framework.
 This means that for the supported technologies, there are no code changes required.
 
 The Agent automatically {CONTENT_HERE}

--- a/docs/metrics.asciidoc
+++ b/docs/metrics.asciidoc
@@ -20,7 +20,7 @@ The metrics will be stored in the `apm-*` index and have the `processor.event` p
 [[metrics-system]]
 === System metrics
 
-As of APM version 6.6, these metrics will be visualized in the APM UI.
+As of APM version 6.6, these metrics will be visualized in the APM app.
 
 For more system metrics, consider installing {metricbeat-ref}/index.html[metricbeat] on your hosts.
 

--- a/docs/performance-tuning.asciidoc
+++ b/docs/performance-tuning.asciidoc
@@ -4,7 +4,7 @@ please view this documentation at https://www.elastic.co/guide/en/apm/agent/dotn
 endif::[]
 
 [[performance-tuning]]
-== Performance Tuning
+== Performance tuning
 
 There are many options available to tune agent performance.
 Which option to adjust depends on whether you are optimizing for speed, memory usage, bandwidth or storage.
@@ -33,7 +33,7 @@ Here's an example of setting the sample rate to 20% using <<configuration-on-asp
 
 [float]
 [[performance-tuning-stack-traces]]
-=== Stack Traces
+=== Stack traces
 
 In a complex application,
 a request may produce many spans.

--- a/docs/setup.asciidoc
+++ b/docs/setup.asciidoc
@@ -1,22 +1,45 @@
 [[setup]]
-== Set up
-The agent ships as a set of NuGet packages via https://nuget.org[nuget.org].
+== Set up the Agent
+The .NET Agent ships as a set of NuGet packages via https://nuget.org[nuget.org].
+You can add the Agent to your .NET application by referencing one of these packages.
+
+[float]
+=== Packages
 
 The following packages are available:
 
-* https://www.nuget.org/packages/Elastic.Apm.NetCoreAll[Elastic.Apm.NetCoreAll]: This is a meta package that references every other Elastic APM .NET agent package. If you plan to monitor a typical ASP.NET Core application that depends on the https://www.nuget.org/packages/Microsoft.AspNetCore.All[Microsoft.AspNetCore.All] package and uses Entity Framework Core then you should reference this package. 
-In order to avoid adding unnecessary dependencies in applications that aren’t depending on the https://www.nuget.org/packages/Microsoft.AspNetCore.All[Microsoft.AspNetCore.All] package we also offer some other packages - those are all referenced by the `Elastic.Apm.NetCoreAll` package.
-* https://www.nuget.org/packages/Elastic.Apm[Elastic.Apm]: This is the core of the agent, which we didn’t name “Core”, because someone already took that name :) This package also contains the <<public-api>> and it is a .NET Standard 2.0 package. We also ship every tracing component that traces classes that are part of .NET Standard 2.0 in this package, which includes the monitoring part for HttpClient. Every other Elastic APM package references this package.
-* https://www.nuget.org/packages/Elastic.Apm.AspNetCore[Elastic.Apm.AspNetCore]: This package contains ASP.NET Core monitoring related code. The main difference between this package and the `Elastic.Apm.NetCoreAll` package is that this package does not reference the `Elastic.Apm.EntityFrameworkCore` package, so if you have an ASP.NET Core application that does not use EF Core and you want to avoid adding additional unused references, you should use this package.
-* https://www.nuget.org/packages/Elastic.Apm.EntityFrameworkCore[Elastic.Apm.EntityFrameworkCore]: This package contains EF Core monitoring related code.
-* https://www.nuget.org/packages/Elastic.Apm.AspNetFullFramework[Elastic.Apm.AspNetFullFramework]: This package contains ASP.NET (Full .NET Framework) monitoring related code.
-* https://www.nuget.org/packages/Elastic.Apm.EntityFramework6[Elastic.Apm.EntityFramework6]: This package contains an interceptor that automatically creates spans for DB operations executed by Entity Framework 6 (EF6) on behalf of the application.
+https://www.nuget.org/packages/Elastic.Apm.NetCoreAll[**Elastic.Apm.NetCoreAll**]::
 
-You simply add the agent to your .NET application by referencing one of these packages.
+This is a meta package that references every other Elastic APM .NET agent package. If you plan to monitor a typical ASP.NET Core application that depends on the https://www.nuget.org/packages/Microsoft.AspNetCore.All[Microsoft.AspNetCore.All] package and uses Entity Framework Core then you should reference this package. 
+In order to avoid adding unnecessary dependencies in applications that aren’t depending on the https://www.nuget.org/packages/Microsoft.AspNetCore.All[Microsoft.AspNetCore.All] package we also offer some other packages - those are all referenced by the `Elastic.Apm.NetCoreAll` package.
+
+https://www.nuget.org/packages/Elastic.Apm[**Elastic.Apm**]::
+
+This is the core of the agent, which we didn’t name “Core”, because someone already took that name :) This package also contains the <<public-api>> and it is a .NET Standard 2.0 package. We also ship every tracing component that traces classes that are part of .NET Standard 2.0 in this package, which includes the monitoring part for HttpClient. Every other Elastic APM package references this package.
+https://www.nuget.org/packages/Elastic.Apm.AspNetCore[**Elastic.Apm.AspNetCore**]::
+
+This package contains ASP.NET Core monitoring related code. The main difference between this package and the `Elastic.Apm.NetCoreAll` package is that this package does not reference the `Elastic.Apm.EntityFrameworkCore` package, so if you have an ASP.NET Core application that does not use EF Core and you want to avoid adding additional unused references, you should use this package.
+https://www.nuget.org/packages/Elastic.Apm.EntityFrameworkCore[**Elastic.Apm.EntityFrameworkCore**]::
+
+This package contains EF Core monitoring related code.
+https://www.nuget.org/packages/Elastic.Apm.AspNetFullFramework[**Elastic.Apm.AspNetFullFramework**]::
+
+This package contains ASP.NET (Full .NET Framework) monitoring related code.
+
+https://www.nuget.org/packages/Elastic.Apm.EntityFramework6[**Elastic.Apm.EntityFramework6**]::
+
+This package contains an interceptor that automatically creates spans for DB operations executed by Entity Framework 6 (EF6) on behalf of the application.
+
+[float]
+=== Quick start
+
+* <<setup-asp-net-core>>
+* <<setup-asp-net>>
+* <<setup-ef6>>
 
 [float]
 [[setup-asp-net-core]]
-=== ASP.NET Core
+==== ASP.NET Core
 
 For ASP.NET Core, once you referenced the `Elastic.Apm.NetCoreAll` package, you can enable auto instrumentation by calling `UseAllElasticApm()` extension method:
 
@@ -42,7 +65,7 @@ In case you only want to use the <<public-api>>, you don't need to do any initia
 
 [float]
 [[setup-asp-net]]
-=== ASP.NET
+==== ASP.NET
 
 For ASP.NET (Full .NET Framework), once you've referenced the `Elastic.Apm.AspNetFullFramework` package,
 you can enable auto instrumentation by including the `ElasticApmModule` IIS Module in your application's `web.config`: 
@@ -80,7 +103,7 @@ You can also configure the agent using `web.config` as described at <<configurat
 
 [float]
 [[setup-ef6]]
-=== Entity Framework 6
+==== Entity Framework 6
 
 You can enable auto instrumentation for Entity Framework 6 by referencing the `Elastic.Apm.EntityFramework6` package
 and including the `Ef6Interceptor` interceptor in your application's `web.config`:

--- a/docs/supported-technologies.asciidoc
+++ b/docs/supported-technologies.asciidoc
@@ -4,8 +4,7 @@ please view this documentation at https://www.elastic.co/guide/en/apm/agent/dotn
 endif::[]
 
 [[supported-technologies]]
-== Supported Technologies
-This page describes the technologies supported by the Elastic APM .NET agent.
+== Supported technologies
 
 If your favorite technology is not supported yet,
 you can vote for it by participating in our
@@ -33,7 +32,7 @@ This means .NET Core 2.0 (or newer) and .NET Framework 4.6.1 (or newer).
 
 [float]
 [[supported-web-frameworks]]
-=== Web Frameworks
+=== Web frameworks
 
 Automatic instrumentation for a web framework means
 a transaction is automatically created for each incoming request and it is named after the registered route.
@@ -56,7 +55,7 @@ We support automatic instrumentation for the following web frameworks.
 
 [float]
 [[supported-data-access-technologies]]
-=== Data Access Technologies
+=== Data access technologies
 
 We support automatic instrumentation for the following data access technologies.
 


### PR DESCRIPTION
For https://github.com/elastic/apm-agent-dotnet/issues/572. A live preview is available **[here](http://apm-agent-dotnet_574.docs-preview.app.elstc.co/guide/en/apm/agent/dotnet/master/index.html)**.
- [x] ~Top level heading and doc sync for log correlation: https://github.com/elastic/apm/issues/149~ Added in a comment for where this heading will go
- [x] Use shared version attributes: https://github.com/elastic/apm/issues/150
- [x] Add a section on how the Agent does instrumentation: https://github.com/elastic/apm/issues/146
- [x] Rename the APM UI to "APM app": https://github.com/elastic/apm-dev/issues/567
- [x] Use `apm-app-ref`: https://github.com/elastic/docs/pull/1276
- [x] Updates to the new documentation structure outlined [here](https://docs.google.com/spreadsheets/d/1P53LbNY7jFSLLJhOKw-nmDenQbrIFlY4EEFJGqT1kmY/edit#gid=0)
- [x] ~Sync Central config docs: https://github.com/elastic/apm-agent-dotnet/pull/497#discussion_r326303325~ Already done