### PR TITLE
Reduce memory allocations for payload formatter

### DIFF
--- a/src/Elastic.Apm/Helpers/ObjectPool.cs
+++ b/src/Elastic.Apm/Helpers/ObjectPool.cs
@@ -1,0 +1,60 @@
+using System;
+using System.Threading;
+
+namespace Elastic.Apm.Helpers
+{
+	internal class ObjectPool<T> where T : class
+	{
+		private readonly T[] _objects;
+		private readonly Action<T> _returnAction;
+
+		private int _index = -1;
+
+		internal ObjectPool(int amount, Func<T> valueFactory, Action<T> returnAction)
+		{
+			if (amount <= 0) throw new ArgumentOutOfRangeException(nameof(amount));
+			if (valueFactory == null) throw new ArgumentNullException(nameof(valueFactory));
+			if (returnAction == null) throw new ArgumentNullException(nameof(returnAction));
+
+			_objects = new T[amount];
+			for (var i = 0; i < amount; i++) _objects[i] = valueFactory();
+
+			_returnAction = returnAction;
+		}
+
+		public ObjectHolder Get()
+		{
+			int index;
+			T @object;
+
+			do
+				index = Interlocked.Increment(ref _index) % _objects.Length;
+			while ((@object = Interlocked.Exchange(ref _objects[index], null)) == null);
+
+			return new ObjectHolder(this, @object, index);
+		}
+
+		private void ReturnToPool(T @object, int index)
+		{
+			_returnAction(@object);
+			_objects[index] = @object;
+		}
+
+		internal struct ObjectHolder : IDisposable
+		{
+			internal T Object { get; }
+
+			private readonly ObjectPool<T> _pool;
+			private readonly int _index;
+
+			public ObjectHolder(ObjectPool<T> pool, T @object, int index)
+			{
+				_pool = pool;
+				Object = @object;
+				_index = index;
+			}
+
+			public void Dispose() => _pool.ReturnToPool(Object, _index);
+		}
+	}
+}

--- a/src/Elastic.Apm/Helpers/StringWriterPool.cs
+++ b/src/Elastic.Apm/Helpers/StringWriterPool.cs
@@ -1,0 +1,18 @@
+using System.IO;
+using System.Text;
+
+namespace Elastic.Apm.Helpers
+{
+	internal class StringWriterPool : ObjectPool<StringWriter>
+	{
+		internal StringWriterPool(int amount, int initialCharactersAmount, int charactersLimit)
+			: base(amount,
+				() => new StringWriter(new StringBuilder(initialCharactersAmount)),
+				writer =>
+				{
+					var builder = writer.GetStringBuilder();
+					builder.Length = 0;
+					if (builder.Capacity > charactersLimit) builder.Capacity = charactersLimit;
+				}) { }
+	}
+}

--- a/src/Elastic.Apm/Report/EnhancedPayloadFormatter.cs
+++ b/src/Elastic.Apm/Report/EnhancedPayloadFormatter.cs
@@ -1,0 +1,143 @@
+using System;
+using System.Text;
+using System.Threading;
+using Elastic.Apm.Config;
+using Elastic.Apm.Logging;
+using Elastic.Apm.Metrics;
+using Elastic.Apm.Model;
+using Elastic.Apm.Report.Serialization;
+
+namespace Elastic.Apm.Report
+{
+	internal class StringBuilderPool : ObjectPool<StringBuilder>
+	{
+		internal StringBuilderPool(int amount, int initialCharactersAmount, int charactersLimit)
+			: base(amount,
+				() => new StringBuilder(initialCharactersAmount),
+				builder =>
+				{
+					builder.Length = 0;
+					if (builder.Capacity > charactersLimit) builder.Capacity = charactersLimit;
+				})
+		{
+		}
+	}
+
+	internal class ObjectPool<T> where T : class
+	{
+		private readonly T[] _objects;
+		private readonly Action<T> _returnAction;
+
+		private int _index = -1;
+
+		internal ObjectPool(int amount, Func<T> valueFactory, Action<T> returnAction)
+		{
+			if (amount <= 0) throw new ArgumentOutOfRangeException(nameof(amount));
+			if (valueFactory == null) throw new ArgumentNullException(nameof(valueFactory));
+			if (returnAction == null) throw new ArgumentNullException(nameof(returnAction));
+
+			_objects = new T[amount];
+			for (var i = 0; i < amount; i++) _objects[i] = valueFactory();
+
+			_returnAction = returnAction;
+		}
+
+		public ObjectHolder Get()
+		{
+			int index;
+			T @object;
+
+			do
+				index = Interlocked.Increment(ref _index) % _objects.Length;
+			while ((@object = Interlocked.Exchange(ref _objects[index], null)) == null);
+
+			return new ObjectHolder(this, @object, index);
+		}
+
+		private void ReturnToPool(T @object, int index)
+		{
+			_returnAction(@object);
+			_objects[index] = @object;
+		}
+
+		internal struct ObjectHolder : IDisposable
+		{
+			internal T Object { get; }
+
+			private readonly ObjectPool<T> _pool;
+			private readonly int _index;
+
+			public ObjectHolder(ObjectPool<T> pool, T @object, int index)
+			{
+				_pool = pool;
+				Object = @object;
+				_index = index;
+			}
+
+			public void Dispose() => _pool.ReturnToPool(Object, _index);
+		}
+	}
+
+	internal class EnhancedPayloadFormatter : IPayloadFormatter
+	{
+		private readonly IApmLogger _logger;
+		private readonly PayloadItemSerializer _payloadItemSerializer;
+		private readonly Metadata _metadata;
+
+		private string _cachedMetadataJsonLine;
+
+		private readonly StringBuilderPool _stringBuilderPool;
+
+		public EnhancedPayloadFormatter(IApmLogger logger, IConfigurationReader config, Metadata metadata)
+		{
+			_logger = logger.Scoped(nameof(EnhancedPayloadFormatter));
+			_payloadItemSerializer = new PayloadItemSerializer(config);
+			_metadata = metadata;
+
+			_stringBuilderPool = new StringBuilderPool(5, 1_000, 20_000);
+		}
+
+		public string FormatPayload(object[] items)
+		{
+			using (var holder = _stringBuilderPool.Get())
+			{
+				var ndjson = holder.Object;
+				if (_cachedMetadataJsonLine == null)
+					_cachedMetadataJsonLine = "{\"metadata\": " + _payloadItemSerializer.SerializeObject(_metadata) + "}";
+				ndjson.AppendLine(_cachedMetadataJsonLine);
+
+				foreach (var item in items)
+				{
+					var serialized = _payloadItemSerializer.SerializeObject(item);
+					switch (item)
+					{
+						case Transaction _:
+							ndjson.Append("{\"transaction\": ");
+							ndjson.Append(serialized);
+							ndjson.AppendLine("}");
+							break;
+						case Span _:
+							ndjson.Append("{\"span\": ");
+							ndjson.Append(serialized);
+							ndjson.AppendLine("}");
+							break;
+						case Error _:
+							ndjson.Append("{\"error\": ");
+							ndjson.Append(serialized);
+							ndjson.AppendLine("}");
+							break;
+						case MetricSet _:
+							ndjson.Append("{\"metricset\": ");
+							ndjson.Append(serialized);
+							ndjson.AppendLine("}");
+							break;
+					}
+
+					_logger?.Trace()?.Log("Serialized item to send: {ItemToSend} as {SerializedItem}", item, serialized);
+				}
+
+				return ndjson.ToString();
+			}
+		}
+	}
+}

--- a/src/Elastic.Apm/Report/IPayloadFormatter.cs
+++ b/src/Elastic.Apm/Report/IPayloadFormatter.cs
@@ -1,0 +1,7 @@
+namespace Elastic.Apm.Report
+{
+	internal interface IPayloadFormatter
+	{
+		string FormatPayload(object[] items);
+	}
+}

--- a/src/Elastic.Apm/Report/PayloadFormatterV2.cs
+++ b/src/Elastic.Apm/Report/PayloadFormatterV2.cs
@@ -1,0 +1,56 @@
+using System.Text;
+using Elastic.Apm.Config;
+using Elastic.Apm.Logging;
+using Elastic.Apm.Metrics;
+using Elastic.Apm.Model;
+using Elastic.Apm.Report.Serialization;
+
+namespace Elastic.Apm.Report
+{
+	internal class PayloadFormatterV2 : IPayloadFormatter
+	{
+		private readonly IApmLogger _logger;
+		private readonly PayloadItemSerializer _payloadItemSerializer;
+		private readonly Metadata _metadata;
+
+		private string _cachedMetadataJsonLine;
+
+		public PayloadFormatterV2(IApmLogger logger, IConfigurationReader config, Metadata metadata)
+		{
+			_logger = logger.Scoped(nameof(PayloadFormatterV2));
+			_payloadItemSerializer = new PayloadItemSerializer(config);
+			_metadata = metadata;
+		}
+
+		public string FormatPayload(object[] items)
+		{
+			var ndjson = new StringBuilder();
+			if (_cachedMetadataJsonLine == null)
+				_cachedMetadataJsonLine = "{\"metadata\": " + _payloadItemSerializer.SerializeObject(_metadata) + "}";
+			ndjson.AppendLine(_cachedMetadataJsonLine);
+
+			foreach (var item in items)
+			{
+				var serialized = _payloadItemSerializer.SerializeObject(item);
+				switch (item)
+				{
+					case Transaction _:
+						ndjson.AppendLine("{\"transaction\": " + serialized + "}");
+						break;
+					case Span _:
+						ndjson.AppendLine("{\"span\": " + serialized + "}");
+						break;
+					case Error _:
+						ndjson.AppendLine("{\"error\": " + serialized + "}");
+						break;
+					case MetricSet _:
+						ndjson.AppendLine("{\"metricset\": " + serialized + "}");
+						break;
+				}
+				_logger?.Trace()?.Log("Serialized item to send: {ItemToSend} as {SerializedItem}", item, serialized);
+			}
+
+			return ndjson.ToString();
+		}
+	}
+}

--- a/src/Elastic.Apm/Report/PayloadSenderV2.cs
+++ b/src/Elastic.Apm/Report/PayloadSenderV2.cs
@@ -42,7 +42,6 @@ namespace Elastic.Apm.Report
 			: base( /* isEnabled: */ true, logger, ThisClassName, service, config, httpMessageHandler)
 		{
 			_logger = logger?.Scoped(ThisClassName + (dbgName == null ? "" : $" (dbgName: `{dbgName}')"));
-			new PayloadItemSerializer(config);
 
 			_intakeV2EventsAbsoluteUrl = BackendCommUtils.ApmServerEndpoints.BuildIntakeV2EventsAbsoluteUrl(config.ServerUrls.First());
 
@@ -51,7 +50,8 @@ namespace Elastic.Apm.Report
 			var metadata = new Metadata { Service = service, System = System };
 			foreach (var globalLabelKeyValue in config.GlobalLabels) metadata.Labels.Add(globalLabelKeyValue.Key, globalLabelKeyValue.Value);
 
-			_payloadFormatter = new PayloadFormatterV2(_logger, config, metadata);
+			//_payloadFormatter = new PayloadFormatterV2(_logger, config, metadata);
+			_payloadFormatter = new EnhancedPayloadFormatter(config, metadata);
 
 			if (config.MaxQueueEventCount < config.MaxBatchEventCount)
 			{

--- a/test/Elastic.Apm.PerfTests/PayloadFormatterBenchmarks.cs
+++ b/test/Elastic.Apm.PerfTests/PayloadFormatterBenchmarks.cs
@@ -1,0 +1,65 @@
+using System.Collections.Generic;
+using System.Net;
+using BenchmarkDotNet.Attributes;
+using Elastic.Apm.Api;
+using Elastic.Apm.Helpers;
+using Elastic.Apm.Logging;
+using Elastic.Apm.Metrics;
+using Elastic.Apm.Model;
+using Elastic.Apm.Report;
+
+namespace Elastic.Apm.PerfTests
+{
+	[MemoryDiagnoser]
+	public class PayloadFormatterBenchmarks
+	{
+		private IPayloadFormatter _oldPayloadFormatter;
+		private IPayloadFormatter _newPayloadFormatter;
+		private object[] _items;
+
+		[Params(1, 10, 100)]
+		public int CallAmount;
+
+		[GlobalSetup]
+		public void Setup()
+		{
+			var logger = new PerfTestLogger(LogLevel.Critical);
+			var apmAgent = new ApmAgent(new AgentComponents(logger));
+
+			var metadata = new Metadata
+			{
+				Service = Service.GetDefaultService(apmAgent.ConfigurationReader, logger),
+				System = new Api.System { DetectedHostName = Dns.GetHostName() }
+			};
+
+			_oldPayloadFormatter = new PayloadFormatterV2(logger, apmAgent.ConfigurationReader, metadata);
+			_newPayloadFormatter = new EnhancedPayloadFormatter(logger, apmAgent.ConfigurationReader, metadata);
+
+			var transaction = new Elastic.Apm.Model.Transaction(apmAgent, "transaction", "transaction");
+			var span = new Span("span", "type", transaction.Id, transaction.TraceId, transaction, apmAgent.PayloadSender, logger,
+				apmAgent.ConfigurationReader, apmAgent.TracerInternal.CurrentExecutionSegmentsContainer);
+			var error = new Error(new CapturedException(), transaction, span.Id, logger);
+			var metricSet = new MetricSet(TimeUtils.TimestampNow(), new List<MetricSample> { new MetricSample("key", 25.0) });
+
+			_items = new object[] { transaction, span, error, metricSet };
+		}
+
+		[Benchmark]
+		public void PayloadFormatterV2()
+		{
+			for (var i = 0; i <= CallAmount; i++)
+			{
+				_oldPayloadFormatter.FormatPayload(_items);
+			}
+		}
+
+		[Benchmark]
+		public void EnhancedPayloadFormatter()
+		{
+			for (var i = 0; i <= CallAmount; i++)
+			{
+				_newPayloadFormatter.FormatPayload(_items);
+			}
+		}
+	}
+}

--- a/test/Elastic.Apm.Tests/Report/EnhancedPayloadFormatterTests.cs
+++ b/test/Elastic.Apm.Tests/Report/EnhancedPayloadFormatterTests.cs
@@ -1,0 +1,38 @@
+using System;
+using Elastic.Apm.Report;
+using Elastic.Apm.Tests.Mocks;
+using FluentAssertions;
+using Newtonsoft.Json;
+using Xunit;
+
+namespace Elastic.Apm.Tests.Report
+{
+	public class EnhancedPayloadFormatterTests
+	{
+		private readonly EnhancedPayloadFormatter _formatter;
+		private readonly ApmAgent _agent;
+
+		public EnhancedPayloadFormatterTests()
+		{
+			var logger = new NoopLogger();
+			_formatter = new EnhancedPayloadFormatter(new MockConfigSnapshot(), new Metadata());
+			_agent = new ApmAgent(new AgentComponents(logger));
+		}
+
+		[Fact]
+		public void FormatPayload_ShouldCorrectlyFormatTransaction()
+		{
+			// Arrange
+			var transaction = new Model.Transaction(_agent, "transaction", "transaction");
+
+			// Act
+			var result = _formatter.FormatPayload(new object[] { transaction });
+
+			// Assert
+			var resultLines = result.Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries);
+
+			resultLines.Length.Should().Be(2);
+			resultLines[1].Should().Be(JsonConvert.SerializeObject(new {transaction}, _formatter.Settings));
+		}
+	}
+}


### PR DESCRIPTION
After analysis of memory consumption, I found out that `PayloadSenderV2` allocates a lot of strings. This pull request should reduce memory allocations for payload formatter.
The main idea is to write serialized payload directly to `JsonTextWriter` (wraps `StringWriter`) without intermediate string allocation. To not create `StringWriter` every time, I introduce `StringWriterPool` - a lock-free concurrent pool of string writers. 

What was done:

1. Extracted formatting logic from `PayloadSenderV2` to separate class. `PayloadFormatterV2` class has the old logic of payload formatting. `EnhancedPayloadFormatter` has a new logic for formatting.
2. Introduced `ObjectPool` which allow to pool objects. `StringWriterPool` is a pool of string writers.
3. Added payload formatter benchmark to measure memory allocations.

NOTE: All class names aren't final ;)

What will be added, in case of interest from your side:

1. Rename `EnhancedPayloadFormatter` and remove old formatter
2. Add more tests for `EnhancedPayloadFormatter`

Result of benchmark run:

```
// * Summary *

BenchmarkDotNet=v0.11.4, OS=Windows 10.0.19002
Intel Core i7-7700 CPU 3.60GHz (Kaby Lake), 1 CPU, 8 logical and 4 physical cores
.NET Core SDK=2.1.505
  [Host]     : .NET Core 2.1.9 (CoreCLR 4.6.27414.06, CoreFX 4.6.27415.01), 64bit RyuJIT
  DefaultJob : .NET Core 2.1.9 (CoreCLR 4.6.27414.06, CoreFX 4.6.27415.01), 64bit RyuJIT


|                   Method | CallAmount |        Mean |      Error |    StdDev | Gen 0/1k Op | Gen 1/1k Op | Gen 2/1k Op | Allocated Memory/Op |
|------------------------- |----------- |------------:|-----------:|----------:|------------:|------------:|------------:|--------------------:|
|       PayloadFormatterV2 |          1 |    11.73 us |  0.0492 us | 0.0460 us |      4.6539 |           - |           - |            19.11 KB |
| EnhancedPayloadFormatter |          1 |    10.23 us |  0.0704 us | 0.0658 us |      1.9379 |           - |           - |             7.98 KB |
|       PayloadFormatterV2 |         10 |   114.90 us |  0.9248 us | 0.8650 us |     42.8467 |           - |           - |           175.98 KB |
| EnhancedPayloadFormatter |         10 |   101.10 us |  0.4803 us | 0.4493 us |     18.3105 |           - |           - |            75.23 KB |
|       PayloadFormatterV2 |        100 | 1,264.98 us | 10.4757 us | 9.7990 us |    349.6094 |     64.4531 |     48.8281 |          1619.07 KB |
| EnhancedPayloadFormatter |        100 | 1,187.33 us |  6.3206 us | 5.6030 us |    199.2188 |     99.6094 |     99.6094 |           1076.5 KB |

// * Hints *
Outliers
  PayloadFormatterBenchmarks.EnhancedPayloadFormatter: Default -> 1 outlier  was  removed

// * Legends *
  CallAmount          : Value of the 'CallAmount' parameter
  Mean                : Arithmetic mean of all measurements
  Error               : Half of 99.9% confidence interval
  StdDev              : Standard deviation of all measurements
  Gen 0/1k Op         : GC Generation 0 collects per 1k Operations
  Gen 1/1k Op         : GC Generation 1 collects per 1k Operations
  Gen 2/1k Op         : GC Generation 2 collects per 1k Operations
  Allocated Memory/Op : Allocated memory per single operation (managed only, inclusive, 1KB = 1024B)
  1 us                : 1 Microsecond (0.000001 sec)
```