### PR TITLE
move the same info from projects into props files

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,5 +3,9 @@
   <PropertyGroup>
     <LangVersion>latest</LangVersion>
     <NoWarn>NU1503</NoWarn>
+
+    <SignAssembly>true</SignAssembly>
+    <AssemblyOriginatorKeyFile>..\..\build\elasticapm.snk</AssemblyOriginatorKeyFile>
+    <DelaySign>false</DelaySign>
   </PropertyGroup>
 </Project>

--- a/ElasticApmAgent.sln
+++ b/ElasticApmAgent.sln
@@ -15,6 +15,9 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SampleAspNetCoreApp", "sample\SampleAspNetCoreApp\SampleAspNetCoreApp.csproj", "{0ADF687D-4DB7-417E-80B4-27B3FD86875E}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "test", "test", "{267A241E-571F-458F-B04C-B6C4DE79E735}"
+ProjectSection(SolutionItems) = preProject
+	test\Directory.Build.props = test\Directory.Build.props
+EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Elastic.Apm", "src\Elastic.Apm\Elastic.Apm.csproj", "{90BC9629-C8D2-4FD5-863E-EA2D5FB37341}"
 EndProject

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,5 +1,18 @@
 <Project>
+  <!-- Src Directory Build Properties -->
   <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
+  <PropertyGroup>
+    <AssemblyVersion>1.1.2</AssemblyVersion>
+    <InformationalVersion>1.1.2</InformationalVersion>
+    <FileVersion>1.1.2</FileVersion>
+    
+    <PackageVersion>1.1.2</PackageVersion>
+    <Authors>Elastic and contributors</Authors>
+    <Copyright>2019 Elasticsearch BV</Copyright>
+    <PackageLicenseUrl>https://github.com/elastic/apm-agent-dotnet/blob/master/LICENSE</PackageLicenseUrl>
+    <PackageProjectUrl>https://github.com/elastic/apm-agent-dotnet</PackageProjectUrl>
+    <PackageIconUrl>https://raw.githubusercontent.com/elastic/apm-agent-dotnet/master/build/nuget-icon.png</PackageIconUrl>
+  </PropertyGroup>
   <ItemGroup>
     <PackageReference Condition=" '$(OS)' != 'Windows_NT' " Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0-preview.2" PrivateAssets="All"/>
   </ItemGroup>

--- a/src/Elastic.Apm.AspNetCore/Elastic.Apm.AspNetCore.csproj
+++ b/src/Elastic.Apm.AspNetCore/Elastic.Apm.AspNetCore.csproj
@@ -2,21 +2,8 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <AssemblyName>Elastic.Apm.AspNetCore</AssemblyName>
-    <AssemblyVersion>1.1.2</AssemblyVersion>
-    <InformationalVersion>1.1.2</InformationalVersion>
-    <FileVersion>1.1.2</FileVersion>
     <RootNamespace>Elastic.Apm.AspNetCore</RootNamespace>
-    <SignAssembly>true</SignAssembly>
-    <AssemblyOriginatorKeyFile>..\..\build\elasticapm.snk</AssemblyOriginatorKeyFile>
-    <DelaySign>false</DelaySign>
-    <PackageVersion>1.1.2</PackageVersion>
-    <Authors>Elastic and contributors</Authors>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <PackageId>Elastic.Apm.AspNetCore</PackageId>
-    <Copyright>2019 Elasticsearch BV</Copyright>
-    <PackageLicenseUrl>https://github.com/elastic/apm-agent-dotnet/blob/master/LICENSE</PackageLicenseUrl>
-    <PackageProjectUrl>https://github.com/elastic/apm-agent-dotnet</PackageProjectUrl>
-    <PackageIconUrl>https://raw.githubusercontent.com/elastic/apm-agent-dotnet/master/build/nuget-icon.png</PackageIconUrl>
     <Description>Elastic APM for ASP.NET Core. This package contains auto instrumentation for ASP.NET Core. See: https://github.com/elastic/apm-agent-dotnet/tree/master/docs</Description>
     <PackageTags>apm, monitoring, elastic, elasticapm, analytics, aspnetcore</PackageTags>
   </PropertyGroup>

--- a/src/Elastic.Apm.AspNetFullFramework/Elastic.Apm.AspNetFullFramework.csproj
+++ b/src/Elastic.Apm.AspNetFullFramework/Elastic.Apm.AspNetFullFramework.csproj
@@ -3,23 +3,9 @@
     <TargetFramework>net461</TargetFramework>
     <AssemblyName>Elastic.Apm.AspNetFullFramework</AssemblyName>
     <RootNamespace>Elastic.Apm.AspNetFullFramework</RootNamespace>
-    <AssemblyVersion>1.1.2</AssemblyVersion>
-    <InformationalVersion>1.1.2</InformationalVersion>
-    <FileVersion>1.1.2</FileVersion>
-    <SignAssembly>true</SignAssembly>
-    <AssemblyOriginatorKeyFile>..\..\build\elasticapm.snk</AssemblyOriginatorKeyFile>
-    <DelaySign>false</DelaySign>
-    <PackageVersion>1.1.2</PackageVersion>
-    
     <PackageId>Elastic.Apm.AspNetFullFramework</PackageId>
-    <Copyright>2019 Elasticsearch BV</Copyright>
-    <PackageLicenseUrl>https://github.com/elastic/apm-agent-dotnet/blob/master/LICENSE</PackageLicenseUrl>
-    <PackageProjectUrl>https://github.com/elastic/apm-agent-dotnet</PackageProjectUrl>
-    <PackageIconUrl>https://raw.githubusercontent.com/elastic/apm-agent-dotnet/master/build/nuget-icon.png</PackageIconUrl>
     <Description>Elastic APM for ASP.NET Full Framework. This package contains auto instrumentation for ASP.NET Full Framework. See: https://github.com/elastic/apm-agent-dotnet/tree/master/docs</Description>
     <PackageTags>apm, monitoring, elastic, elasticapm, analytics, aspnet</PackageTags>
-    <Authors>Elastic and contributors</Authors>
-    
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/src/Elastic.Apm.EntityFramework6/Elastic.Apm.EntityFramework6.csproj
+++ b/src/Elastic.Apm.EntityFramework6/Elastic.Apm.EntityFramework6.csproj
@@ -3,20 +3,7 @@
     <TargetFramework>net461</TargetFramework>
     <RootNamespace>Elastic.Apm.EntityFramework6</RootNamespace>
     <AssemblyName>Elastic.Apm.EntityFramework6</AssemblyName>
-    <AssemblyVersion>1.1.2</AssemblyVersion>
-    <InformationalVersion>1.1.2</InformationalVersion>
-    <FileVersion>1.1.2</FileVersion>
-    <SignAssembly>true</SignAssembly>
-    <AssemblyOriginatorKeyFile>..\..\build\elasticapm.snk</AssemblyOriginatorKeyFile>
-    <DelaySign>false</DelaySign>
-    <PackageVersion>1.1.2</PackageVersion>
-    <Authors>Elastic and contributors</Authors>
-    <TargetFrameworks>net461</TargetFrameworks>
     <PackageId>Elastic.Apm.EntityFramework6</PackageId>
-    <Copyright>2019 Elasticsearch BV</Copyright>
-    <PackageLicenseUrl>https://github.com/elastic/apm-agent-dotnet/blob/master/LICENSE</PackageLicenseUrl>
-    <PackageProjectUrl>https://github.com/elastic/apm-agent-dotnet</PackageProjectUrl>
-    <PackageIconUrl>https://raw.githubusercontent.com/elastic/apm-agent-dotnet/master/build/nuget-icon.png</PackageIconUrl>
     <Description>Elastic APM for Entity Framework 6. This package contains auto instrumentation for Entity Framework 6. See: https://github.com/elastic/apm-agent-dotnet/tree/master/docs</Description>
     <PackageTags>apm, monitoring, elastic, elasticapm, analytics, entiryframework6, ef6</PackageTags>
   </PropertyGroup>

--- a/src/Elastic.Apm.EntityFrameworkCore/Elastic.Apm.EntityFrameworkCore.csproj
+++ b/src/Elastic.Apm.EntityFrameworkCore/Elastic.Apm.EntityFrameworkCore.csproj
@@ -3,20 +3,7 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <RootNamespace>Elastic.Apm.EntityFrameworkCore</RootNamespace>
     <AssemblyName>Elastic.Apm.EntityFrameworkCore</AssemblyName>
-    <AssemblyVersion>1.1.2</AssemblyVersion>
-    <InformationalVersion>1.1.2</InformationalVersion>
-    <FileVersion>1.1.2</FileVersion>
-    <SignAssembly>true</SignAssembly>
-    <AssemblyOriginatorKeyFile>..\..\build\elasticapm.snk</AssemblyOriginatorKeyFile>
-    <DelaySign>false</DelaySign>
-    <PackageVersion>1.1.2</PackageVersion>
-    <Authors>Elastic and contributors</Authors>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <PackageId>Elastic.Apm.EntityFrameworkCore</PackageId>
-    <Copyright>2019 Elasticsearch BV</Copyright>
-    <PackageLicenseUrl>https://github.com/elastic/apm-agent-dotnet/blob/master/LICENSE</PackageLicenseUrl>
-    <PackageProjectUrl>https://github.com/elastic/apm-agent-dotnet</PackageProjectUrl>
-    <PackageIconUrl>https://raw.githubusercontent.com/elastic/apm-agent-dotnet/master/build/nuget-icon.png</PackageIconUrl>
     <Description>Elastic APM for Entity Framework Core. This package contains auto instrumentation for Entity Framework Core. See: https://github.com/elastic/apm-agent-dotnet/tree/master/docs</Description>
     <PackageTags>apm, monitoring, elastic, elasticapm, analytics, entiryframeworkcore, efcore</PackageTags>
   </PropertyGroup>

--- a/src/Elastic.Apm.NetCoreAll/Elastic.Apm.NetCoreAll.csproj
+++ b/src/Elastic.Apm.NetCoreAll/Elastic.Apm.NetCoreAll.csproj
@@ -2,26 +2,13 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <RootNamespace>Elastic.Apm.NetCoreAll</RootNamespace>
-    <AssemblyVersion>1.1.2</AssemblyVersion>
-    <InformationalVersion>1.1.2</InformationalVersion>
-    <FileVersion>1.1.2</FileVersion>
-    <SignAssembly>true</SignAssembly>
-    <AssemblyOriginatorKeyFile>..\..\build\elasticapm.snk</AssemblyOriginatorKeyFile>
-    <DelaySign>false</DelaySign>
-    <PackageVersion>1.1.2</PackageVersion>
-    <Authors>Elastic and contributors</Authors>    
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <PackageId>Elastic.Apm.NetCoreAll</PackageId>
-    <Copyright>2019 Elasticsearch BV</Copyright>
-    <PackageLicenseUrl>https://github.com/elastic/apm-agent-dotnet/blob/master/LICENSE</PackageLicenseUrl>
-    <PackageProjectUrl>https://github.com/elastic/apm-agent-dotnet</PackageProjectUrl>
-    <PackageIconUrl>https://raw.githubusercontent.com/elastic/apm-agent-dotnet/master/build/nuget-icon.png</PackageIconUrl>
     <Description>Elastic APM .NET agent. This is a convenient package that automatically pulls in ASP.NET Core, and Entity Framework Core auto instrumentation with the Elastic APM .NET Agent. If your application uses the Microsoft.AspNetCore.All package the easiest way to reference the Elastic APM project is to use this package. If you only need specific functionalities (e.g. EF Core monitoring, or ASP.NET Core without EF Core monitoring, etc) you can reference specific Elastic.Apm packages. See: https://github.com/elastic/apm-agent-dotnet/tree/master/docs</Description>
     <PackageTags>apm, monitoring, elastic, elasticapm, analytics, aspnetcore, entiryframeworkcore, efcore</PackageTags>
   </PropertyGroup>
   <ItemGroup>
-    <ProjectReference Include="..\Elastic.Apm.AspNetCore\Elastic.Apm.AspNetCore.csproj" />
-    <ProjectReference Include="..\Elastic.Apm.EntityFrameworkCore\Elastic.Apm.EntityFrameworkCore.csproj" />
-    <ProjectReference Include="..\Elastic.Apm\Elastic.Apm.csproj" />
+    <ProjectReference Include="..\Elastic.Apm.AspNetCore\Elastic.Apm.AspNetCore.csproj"/>
+    <ProjectReference Include="..\Elastic.Apm.EntityFrameworkCore\Elastic.Apm.EntityFrameworkCore.csproj"/>
+    <ProjectReference Include="..\Elastic.Apm\Elastic.Apm.csproj"/>
   </ItemGroup>
 </Project>

--- a/src/Elastic.Apm/Elastic.Apm.csproj
+++ b/src/Elastic.Apm/Elastic.Apm.csproj
@@ -5,22 +5,9 @@
   <PropertyGroup>
     <RootNamespace>Elastic.Apm</RootNamespace>
     <AssemblyName>Elastic.Apm</AssemblyName>
-    <AssemblyVersion>1.1.2</AssemblyVersion>
-    <InformationalVersion>1.1.2</InformationalVersion>
-    <FileVersion>1.1.2</FileVersion>
-    <SignAssembly>true</SignAssembly>
-    <AssemblyOriginatorKeyFile>..\..\build\elasticapm.snk</AssemblyOriginatorKeyFile>
-    <DelaySign>false</DelaySign>
-    <PackageVersion>1.1.2</PackageVersion>
-    <Authors>Elastic and contributors</Authors>
     <PackageId>Elastic.Apm</PackageId>
-    <copyright>2019 Elasticsearch BV</copyright>
-    <PackageLicenseUrl>https://github.com/elastic/apm-agent-dotnet/blob/master/LICENSE</PackageLicenseUrl>
-    <PackageProjectUrl>https://github.com/elastic/apm-agent-dotnet</PackageProjectUrl>
-    <PackageIconUrl>https://raw.githubusercontent.com/elastic/apm-agent-dotnet/master/build/nuget-icon.png</PackageIconUrl>
     <Description>Elastic APM .NET Agent base package. This package provides core functionality for transmitting of all Elastic APM types and is a dependent package for all other Elastic APM package. Additionally this package contains the public Agent API that allows you to manually capture transactions and spans. Please install the platform specific package for the best experience. See: https://github.com/elastic/apm-agent-dotnet/tree/master/docs</Description>
     <PackageTags>apm, monitoring, elastic, elasticapm, analytics, sdk</PackageTags>
-    <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="System.Diagnostics.PerformanceCounter" Version="4.5.0" />

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -1,0 +1,9 @@
+<Project>
+  <!-- Test Directory Build Properties -->
+  <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
+  <PropertyGroup>
+    <IsPackable>false</IsPackable>
+    <!-- Always generate debug symbols this allows fluent symbols exception messages to include variable names -->
+    <DebugSymbols>True</DebugSymbols>
+  </PropertyGroup>
+</Project>

--- a/test/Elastic.Apm.AspNetCore.Tests/Elastic.Apm.AspNetCore.Tests.csproj
+++ b/test/Elastic.Apm.AspNetCore.Tests/Elastic.Apm.AspNetCore.Tests.csproj
@@ -1,13 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
     <TargetFramework>netcoreapp2.1</TargetFramework>
-    <IsPackable>false</IsPackable>
     <AssemblyName>Elastic.Apm.AspNetCore.Tests</AssemblyName>
     <RootNamespace>Elastic.Apm.AspNetCore.Tests</RootNamespace>
-    <SignAssembly>true</SignAssembly>
-    <AssemblyOriginatorKeyFile>..\..\build\elasticapm.snk</AssemblyOriginatorKeyFile>
-    <!-- Always generate debug symbols this allows fluent symbols exception messages to include variable names -->
-    <DebugSymbols>True</DebugSymbols>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="5.6.0" />

--- a/test/Elastic.Apm.AspNetFullFramework.Tests/Elastic.Apm.AspNetFullFramework.Tests.csproj
+++ b/test/Elastic.Apm.AspNetFullFramework.Tests/Elastic.Apm.AspNetFullFramework.Tests.csproj
@@ -1,13 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
     <TargetFramework>netcoreapp2.1</TargetFramework>
-    <IsPackable>false</IsPackable>
     <AssemblyName>Elastic.Apm.AspNetFullFramework.Tests</AssemblyName>
     <RootNamespace>Elastic.Apm.AspNetFullFramework.Tests</RootNamespace>
-    <SignAssembly>true</SignAssembly>
-    <AssemblyOriginatorKeyFile>..\..\build\elasticapm.snk</AssemblyOriginatorKeyFile>
-    <!-- Always generate debug symbols this allows fluent symbols exception messages to include variable names -->
-    <DebugSymbols>True</DebugSymbols>
   </PropertyGroup>
   <ItemGroup Condition="'$(OS)' == 'WINDOWS_NT'">
     <PackageReference Include="Microsoft.AspNetCore.App" />

--- a/test/Elastic.Apm.DockerTests/Elastic.Apm.DockerTests.csproj
+++ b/test/Elastic.Apm.DockerTests/Elastic.Apm.DockerTests.csproj
@@ -1,15 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 <PropertyGroup>
   <TargetFramework>netcoreapp2.1</TargetFramework>
-
-  <IsPackable>false</IsPackable>
   <RootNamespace>Elastic.Apm.DockerTests</RootNamespace>
   <AssemblyName>Elastic.Apm.DockerTests</AssemblyName>
-  <SignAssembly>true</SignAssembly>
-  <AssemblyOriginatorKeyFile>..\..\build\elasticapm.snk</AssemblyOriginatorKeyFile>
-  <DelaySign>false</DelaySign>
-  <!-- Always generate debug symbols this allows fluent symbols exception messages to include variable names -->
-  <DebugSymbols>True</DebugSymbols>
 </PropertyGroup>
 
 <ItemGroup>

--- a/test/Elastic.Apm.EntityFrameworkCore.Tests/Elastic.Apm.EntityFrameworkCore.Tests.csproj
+++ b/test/Elastic.Apm.EntityFrameworkCore.Tests/Elastic.Apm.EntityFrameworkCore.Tests.csproj
@@ -2,15 +2,8 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.1</TargetFramework>
-    <IsPackable>false</IsPackable>
     <RootNamespace>Elastic.Apm.EntityFrameworkCore.Tests</RootNamespace>
     <AssemblyName>Elastic.Apm.EntityFrameworkCore.Tests</AssemblyName>
-
-    <SignAssembly>true</SignAssembly>
-    <AssemblyOriginatorKeyFile>..\..\build\elasticapm.snk</AssemblyOriginatorKeyFile>
-    <DelaySign>false</DelaySign>
-    <!-- Always generate debug symbols this allows fluent symbols exception messages to include variable names -->
-    <DebugSymbols>True</DebugSymbols>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Elastic.Apm.PerfTests/Elastic.Apm.PerfTests.csproj
+++ b/test/Elastic.Apm.PerfTests/Elastic.Apm.PerfTests.csproj
@@ -1,19 +1,17 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-    <PropertyGroup>
-        <OutputType>Exe</OutputType>
-        <TargetFramework>netcoreapp2.1</TargetFramework>
-      <SignAssembly>true</SignAssembly>
-      <AssemblyOriginatorKeyFile>..\..\build\elasticapm.snk</AssemblyOriginatorKeyFile>
-    </PropertyGroup>
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
+  </PropertyGroup>
 
-    <ItemGroup>
-      <PackageReference Include="BenchmarkDotNet" Version="0.11.4" />
-    </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" Version="0.11.4"/>
+  </ItemGroup>
 
-    <ItemGroup>
-      <ProjectReference Include="..\..\src\Elastic.Apm\Elastic.Apm.csproj" />
-      <ProjectReference Include="..\Elastic.Apm.Tests\Elastic.Apm.Tests.csproj" />
-    </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Elastic.Apm\Elastic.Apm.csproj"/>
+    <ProjectReference Include="..\Elastic.Apm.Tests\Elastic.Apm.Tests.csproj"/>
+  </ItemGroup>
 
 </Project>

--- a/test/Elastic.Apm.Tests.MockApmServer/Elastic.Apm.Tests.MockApmServer.csproj
+++ b/test/Elastic.Apm.Tests.MockApmServer/Elastic.Apm.Tests.MockApmServer.csproj
@@ -1,15 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
     <TargetFramework>netcoreapp2.1</TargetFramework>
-
-    <IsPackable>false</IsPackable>
     <RootNamespace>Elastic.Apm.Tests.MockApmServer</RootNamespace>
     <AssemblyName>Elastic.Apm.Tests.MockApmServer</AssemblyName>
-    <SignAssembly>true</SignAssembly>
-    <AssemblyOriginatorKeyFile>..\..\build\elasticapm.snk</AssemblyOriginatorKeyFile>
-    <DelaySign>false</DelaySign>
-    <!-- Always generate debug symbols -->
-    <DebugSymbols>True</DebugSymbols>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Elastic.Apm.Tests/Elastic.Apm.Tests.csproj
+++ b/test/Elastic.Apm.Tests/Elastic.Apm.Tests.csproj
@@ -1,16 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netcoreapp2.1</TargetFramework>
-
-    <IsPackable>false</IsPackable>
     <RootNamespace>Elastic.Apm.Tests</RootNamespace>
     <AssemblyName>Elastic.Apm.Tests</AssemblyName>
-    <SignAssembly>true</SignAssembly>
-    <AssemblyOriginatorKeyFile>..\..\build\elasticapm.snk</AssemblyOriginatorKeyFile>
-    <DelaySign>false</DelaySign>
-    <!-- Always generate debug symbols this allows fluent symbols exception messages to include variable names -->
-    <DebugSymbols>True</DebugSymbols>
-    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
When we need to create a new source or test projects, it's necessary to copy-paste a lot of information from other projects.

Besides, to release a new version [a `PackageVersion` and assembly info stuff need to be updated](https://github.com/elastic/apm-agent-dotnet/pull/528) for each project in a solution. With adding more and more projects, this kind of work became a routine that can be solved.

After merging #426, we can store package info in `Directory.Build.props`, which done in this PR.

@gregkalapos, I believe it will simplify the release process to you.

Also, I want to raise a question about `Elastic.Apm.PerfTests` project. The project isn't similar to the test project and I suggest to move it into the separate `benchmark` folder in the root of the repository. It will allow the pinning `xunit` package version for all test projects, because after adding a new test project, `xunit` version needs to be downgraded to be consistent with `xunit` version in other test projects. Besides, it will resolve the misunderstanding that the project automatically will notify about performance degradation.