### PR TITLE
[apm-ci] retry .NET build stage when environmental issues

### DIFF
--- a/.ci/windows/dotnet.bat
+++ b/.ci/windows/dotnet.bat
@@ -3,6 +3,9 @@
 ::
 dotnet sln remove sample/AspNetFullFrameworkSampleApp/AspNetFullFrameworkSampleApp.csproj
 dotnet sln remove src/Elastic.Apm.AspNetFullFramework/Elastic.Apm.AspNetFullFramework.csproj
-dotnet sln remove test/Elastic.Apm.AspNetFullFramework.Tests/Elastic.Apm.AspNetFullFramework.Tests.csproj 
+dotnet sln remove test/Elastic.Apm.AspNetFullFramework.Tests/Elastic.Apm.AspNetFullFramework.Tests.csproj
+
+dotnet sln remove sample/SampleAspNetCoreApp/SampleAspNetCoreApp.csproj
+dotnet sln remove test/Elastic.Apm.AspNetCore.Tests/Elastic.Apm.AspNetCore.Tests.csproj
 
 dotnet build --verbosity detailed

--- a/.ci/windows/dotnet.bat
+++ b/.ci/windows/dotnet.bat
@@ -3,9 +3,6 @@
 ::
 dotnet sln remove sample/AspNetFullFrameworkSampleApp/AspNetFullFrameworkSampleApp.csproj
 dotnet sln remove src/Elastic.Apm.AspNetFullFramework/Elastic.Apm.AspNetFullFramework.csproj
-dotnet sln remove test/Elastic.Apm.AspNetFullFramework.Tests/Elastic.Apm.AspNetFullFramework.Tests.csproj
-
-dotnet sln remove sample/SampleAspNetCoreApp/SampleAspNetCoreApp.csproj
-dotnet sln remove test/Elastic.Apm.AspNetCore.Tests/Elastic.Apm.AspNetCore.Tests.csproj
+dotnet sln remove test/Elastic.Apm.AspNetFullFramework.Tests/Elastic.Apm.AspNetFullFramework.Tests.csproj 
 
 dotnet build --verbosity detailed

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -26,6 +26,7 @@ pipeline {
   }
   triggers {
     issueCommentTrigger('(?i).*(?:jenkins\\W+)?run\\W+(?:the\\W+)?tests(?:\\W+please)?.*')
+    cron('H H(1-23)/2 * * 1-5')
   }
   parameters {
     booleanParam(name: 'Run_As_Master_Branch', defaultValue: false, description: 'Allow to run any steps on a PR, some steps normally only run on master branch.')

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -253,10 +253,13 @@ pipeline {
                   stage('Build - dotnet') {
                     steps {
                       withGithubNotify(context: 'Build dotnet - Windows') {
-                        cleanDir("${WORKSPACE}/${BASE_DIR}")
-                        unstash 'source'
-                        dir("${BASE_DIR}"){
-                          bat '.ci/windows/dotnet.bat'
+                        retry(3) {
+                          sleep randomNumber(min: 5, max: 10)
+                          cleanDir("${WORKSPACE}/${BASE_DIR}")
+                          unstash 'source'
+                          dir("${BASE_DIR}"){
+                            bat '.ci/windows/dotnet.bat'
+                          }
                         }
                       }
                     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -254,7 +254,6 @@ pipeline {
                     steps {
                       withGithubNotify(context: 'Build dotnet - Windows') {
                         retry(3) {
-                          sleep randomNumber(min: 5, max: 10)
                           cleanDir("${WORKSPACE}/${BASE_DIR}")
                           unstash 'source'
                           dir("${BASE_DIR}"){

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -26,7 +26,6 @@ pipeline {
   }
   triggers {
     issueCommentTrigger('(?i).*(?:jenkins\\W+)?run\\W+(?:the\\W+)?tests(?:\\W+please)?.*')
-    cron('H H(1-23)/2 * * 1-5')
   }
   parameters {
     booleanParam(name: 'Run_As_Master_Branch', defaultValue: false, description: 'Allow to run any steps on a PR, some steps normally only run on master branch.')


### PR DESCRIPTION
Caused by https://github.com/elastic/apm-agent-dotnet/issues/593

## Description

Let's mitigate the manual actions when there is flakiness when reaching NuGet packages in the repo itself by retrying the same step up to 3 times.

This is a workaround while we can work on the root cause. Just to clarify the number of retries is a way to help so, there is not really a substantial reason for using another figure, so `3` was chosen as it was a kind of sensitive number of retries, without looping infinitely and help to detect build errors which are unrelated to the nuget package but genuine ones.

## Tasks
- Retry 