### PR TITLE
Increase ASP.NET FullFramework version

### DIFF
--- a/src/Elastic.Apm.AspNetFullFramework/Elastic.Apm.AspNetFullFramework.nuspec
+++ b/src/Elastic.Apm.AspNetFullFramework/Elastic.Apm.AspNetFullFramework.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>Elastic.Apm.AspNetFullFramework</id>
-    <version>1.1.2</version>
+    <version>1.1.3</version>
     <authors>Elastic and contributors</authors>
     <licenseUrl>https://github.com/elastic/apm-agent-dotnet/blob/master/LICENSE</licenseUrl>
     <projectUrl>https://github.com/elastic/apm-agent-dotnet</projectUrl>

--- a/src/Elastic.Apm.AspNetFullFramework/Properties/AssemblyInfo.cs
+++ b/src/Elastic.Apm.AspNetFullFramework/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.1.2.0")]
-[assembly: AssemblyFileVersion("1.1.2.0")]
+[assembly: AssemblyVersion("1.1.3.0")]
+[assembly: AssemblyFileVersion("1.1.3.0")]


### PR DESCRIPTION
Preparing `1.1.3` release to offer a workaround for #596. 

We only increment the version of `Elastic.Apm.AspNetFullFramework`, since the workaround is local to that project, it still depends on `Elastic.Apm` version `1.1.2`.

cc @SergeyKleyman jfyi. 