### PR TITLE
BodyStringSanitizerConverter - handling json and other strings without `&` and `=`

### DIFF
--- a/src/Elastic.Apm/Report/Serialization/BodyStringSanitizerConverter.cs
+++ b/src/Elastic.Apm/Report/Serialization/BodyStringSanitizerConverter.cs
@@ -62,23 +62,29 @@ namespace Elastic.Apm.Report.Serialization
 			if (!bodyValue.Contains("=") && !bodyValue.Contains("&"))
 				return false;
 
+			var numberOfEqual = 0;
+			var numberOfAnds = 0;
+
 			var i = 0;
 			foreach (var c in bodyValue)
 			{
 				if (c == '=')
 				{
+					numberOfEqual++;
 					i++;
 					if (i > 1)
 						return false;
 				}
 				if (c == '&')
 				{
+					numberOfAnds++;
 					i--;
 					if (i < 0)
 						return false;
 				}
 			}
-			return true;
+
+			return numberOfAnds != 0 || numberOfEqual != 0;
 		}
 
 		public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer) =>

--- a/src/Elastic.Apm/Report/Serialization/BodyStringSanitizerConverter.cs
+++ b/src/Elastic.Apm/Report/Serialization/BodyStringSanitizerConverter.cs
@@ -32,8 +32,8 @@ namespace Elastic.Apm.Report.Serialization
 					foreach (var formValue in formValues)
 					{
 						var formsValueSplit = formValue.Split('=');
-						if (formsValueSplit.Length != 2 || string.IsNullOrWhiteSpace(formsValueSplit[0])
-							|| string.IsNullOrWhiteSpace(formsValueSplit[1]))
+						if (formsValueSplit.Length != 2 || string.IsNullOrEmpty(formsValueSplit[0])
+							|| string.IsNullOrEmpty(formsValueSplit[1]))
 						{
 							//in this case it's not in the expected format, so we won't (and can't) sanitize, we just write it and move on
 							writer.WriteValue(strValue);

--- a/src/Elastic.Apm/Report/Serialization/BodyStringSanitizerConverter.cs
+++ b/src/Elastic.Apm/Report/Serialization/BodyStringSanitizerConverter.cs
@@ -7,9 +7,9 @@ using Newtonsoft.Json;
 namespace Elastic.Apm.Report.Serialization
 {
 	/// <summary>
-	/// Sanitizes request body based on the config passed to the constructor, in case it's in  `Key1=Value1& Key2=Value2` format.
+	/// Sanitizes request body based on the config passed to the constructor, in case it's in `Key1=Value1& Key2=Value2` format.
 	/// Ideally this would inherit from <code> JsonConverter{string} </code>.
-	/// Until  https://github.com/elastic/apm-agent-dotnet/issues/555 is not done, we roll with a generic JsonConverter.
+	/// Until https://github.com/elastic/apm-agent-dotnet/issues/555 is not done, we roll with a generic JsonConverter.
 	/// </summary>
 	internal class BodyStringSanitizerConverter : JsonConverter
 	{
@@ -22,12 +22,12 @@ namespace Elastic.Apm.Report.Serialization
 		{
 			if (value is string strValue)
 			{
-				var formValues = strValue.Split('&');
-
 				if (!FormatCheck(strValue))
 					writer.WriteValue(strValue);
 				else
 				{
+					var formValues = strValue.Split('&');
+
 					var sb = new StringBuilder();
 					foreach (var formValue in formValues)
 					{
@@ -59,6 +59,9 @@ namespace Elastic.Apm.Report.Serialization
 		/// <returns></returns>
 		private static bool FormatCheck(string bodyValue)
 		{
+			if (!bodyValue.Contains("=") && !bodyValue.Contains("&"))
+				return false;
+
 			var i = 0;
 			foreach (var c in bodyValue)
 			{

--- a/src/Elastic.Apm/Report/Serialization/BodyStringSanitizerConverter.cs
+++ b/src/Elastic.Apm/Report/Serialization/BodyStringSanitizerConverter.cs
@@ -3,7 +3,6 @@ using System.Text;
 using Elastic.Apm.Config;
 using Elastic.Apm.Helpers;
 using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
 
 namespace Elastic.Apm.Report.Serialization
 {
@@ -33,7 +32,8 @@ namespace Elastic.Apm.Report.Serialization
 					foreach (var formValue in formValues)
 					{
 						var formsValueSplit = formValue.Split('=');
-						if (formsValueSplit.Length != 2 || string.IsNullOrWhiteSpace(formsValueSplit[0]) || string.IsNullOrWhiteSpace(formsValueSplit[1]) )
+						if (formsValueSplit.Length != 2 || string.IsNullOrWhiteSpace(formsValueSplit[0])
+							|| string.IsNullOrWhiteSpace(formsValueSplit[1]))
 						{
 							//in this case it's not in the expected format, so we won't (and can't) sanitize, we just write it and move on
 							writer.WriteValue(strValue);

--- a/src/Elastic.Apm/Report/Serialization/BodyStringSanitizerConverter.cs
+++ b/src/Elastic.Apm/Report/Serialization/BodyStringSanitizerConverter.cs
@@ -3,6 +3,7 @@ using System.Text;
 using Elastic.Apm.Config;
 using Elastic.Apm.Helpers;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 
 namespace Elastic.Apm.Report.Serialization
 {
@@ -32,8 +33,12 @@ namespace Elastic.Apm.Report.Serialization
 					foreach (var formValue in formValues)
 					{
 						var formsValueSplit = formValue.Split('=');
-						if (formsValueSplit.Length != 2)
-							continue;
+						if (formsValueSplit.Length != 2 || string.IsNullOrWhiteSpace(formsValueSplit[0]) || string.IsNullOrWhiteSpace(formsValueSplit[1]) )
+						{
+							//in this case it's not in the expected format, so we won't (and can't) sanitize, we just write it and move on
+							writer.WriteValue(strValue);
+							return;
+						}
 
 						if (sb.Length != 0) sb.Append("&");
 

--- a/test/Elastic.Apm.Tests/SerializationTests.cs
+++ b/test/Elastic.Apm.Tests/SerializationTests.cs
@@ -338,8 +338,8 @@ namespace Elastic.Apm.Tests
 			json = SerializePayloadItem(context);
 			json.Should().Be("{\"tags\":{\"a_b\":\"labelValue1\",\"a_b_c\":\"labelValue2\"}}");
 		}
-    
-    /// <summary>
+
+		/// <summary>
 		/// Makes sure that keys in custom are de dotted.
 		/// </summary>
 		[Fact]
@@ -376,6 +376,20 @@ namespace Elastic.Apm.Tests
 			context.Custom["a\"b_c"] = "customValue2";
 			json = SerializePayloadItem(context);
 			json.Should().Be("{\"custom\":{\"a_b\":\"customValue1\",\"a_b_c\":\"customValue2\"}}");
+		}
+
+		/// <summary>
+		/// Makes sure that the request bodies that contain json are not changed by serialization.
+		/// It basically tests <see cref="BodyStringSanitizerConverter"/>.
+		/// </summary>
+		[Fact]
+		public void RequestBodyWithJson()
+		{
+			var context = new Context();
+			context.Request = new Request("GET", new Url()) { Body = "{\"foo\": \"bar\"}" };
+
+			var json = SerializePayloadItem(context);
+			json.Should().Be("{\"request\":{\"body\":\"{\\\"foo\\\": \\\"bar\\\"}\",\"method\":\"GET\",\"url\":{}}}");
 		}
 
 		private static string SerializePayloadItem(object item) =>

--- a/test/Elastic.Apm.Tests/SerializationTests.cs
+++ b/test/Elastic.Apm.Tests/SerializationTests.cs
@@ -392,6 +392,27 @@ namespace Elastic.Apm.Tests
 			json.Should().Be("{\"request\":{\"body\":\"{\\\"foo\\\": \\\"bar\\\"}\",\"method\":\"GET\",\"url\":{}}}");
 		}
 
+		[Fact]
+		public void RequestBodyWithSingleValue()
+		{
+			var context = new Context();
+			context.Request = new Request("GET", new Url()) { Body = "password=foo" };
+
+			var json = SerializePayloadItem(context);
+			json.Should().Be("{\"request\":{\"body\":\"password=[REDACTED]\",\"method\":\"GET\",\"url\":{}}}");
+		}
+
+		[Fact]
+		public void RequestBodyWithTwoValue()
+		{
+			var context = new Context();
+			context.Request = new Request("GET", new Url()) { Body = "password=foo&pwd=bar" };
+
+			var json = SerializePayloadItem(context);
+			json.Should().Be("{\"request\":{\"body\":\"password=[REDACTED]&pwd=[REDACTED]\",\"method\":\"GET\",\"url\":{}}}");
+		}
+
+
 		private static string SerializePayloadItem(object item) =>
 			new PayloadItemSerializer(new MockConfigSnapshot()).SerializeObject(item);
 


### PR DESCRIPTION
Noticed this during testing. 

In `BodyStringSanitizerConverter.cs` we look rebuild the `key=value` format and look for keys contained in `SanitizeFieldNames`. 

If we can't rebuilt the `key=value` format we just capture the body as it is. 

In the `FormatCheck` method we did not handle the case when there is no `&` or `=` in the body, therefore we serialized things like "foo" or a json string like "{"foo" : "bar"}" as empty string. 