### PR TITLE
Fix IsConfigured test

### DIFF
--- a/test/Elastic.Apm.Tests/BasicAgentTests.cs
+++ b/test/Elastic.Apm.Tests/BasicAgentTests.cs
@@ -52,18 +52,6 @@ namespace Elastic.Apm.Tests
 		}
 
 		/// <summary>
-		/// Makes sure Agent.IsConfigured only returns true after Setup is called.
-		/// </summary>
-		[Fact]
-		public void IsConfigured()
-		{
-			Agent.IsConfigured.Should().BeFalse();
-
-			Agent.Setup(new AgentComponents());
-			Agent.IsConfigured.Should().BeTrue();
-		}
-
-		/// <summary>
 		/// Creates 1 span and 1 transaction.
 		/// Makes sure that the ids have the correct lengths.
 		/// </summary>

--- a/test/Elastic.Apm.Tests/ConfigTests.cs
+++ b/test/Elastic.Apm.Tests/ConfigTests.cs
@@ -303,7 +303,7 @@ namespace Elastic.Apm.Tests
 		}
 
 		[Fact]
-		public void DefaultLogLevelTest() => Agent.Config.LogLevel.Should().Be(LogLevel.Error);
+		public void DefaultLogLevelTest() => new ApmAgent(new TestAgentComponents()).ConfigurationReader.LogLevel.Should().Be(LogLevel.Error);
 
 		[Theory]
 		[InlineData("Trace", LogLevel.Trace)]

--- a/test/Elastic.Apm.Tests/StaticTests.cs
+++ b/test/Elastic.Apm.Tests/StaticTests.cs
@@ -1,0 +1,25 @@
+using FluentAssertions;
+using Xunit;
+
+namespace Elastic.Apm.Tests
+{
+	/// <summary>
+	/// These tests access the static <see cref="Agent"/> instance.
+	/// All other tests should have their own <see cref="ApmAgent"/> instance and not rely on anything static.
+	/// Tests accessing the static <see cref="Agent"/> instance can not run in parallel with tests that also access the static instance.
+	/// </summary>
+	public class StaticAgentTests
+	{
+		/// <summary>
+		/// Makes sure Agent.IsConfigured only returns true after Setup is called.
+		/// </summary>
+		[Fact]
+		public void IsConfigured()
+		{
+			Agent.IsConfigured.Should().BeFalse();
+
+			Agent.Setup(new AgentComponents());
+			Agent.IsConfigured.Should().BeTrue();
+		}
+	}
+}

--- a/test/Elastic.Apm.Tests/StaticTests.cs
+++ b/test/Elastic.Apm.Tests/StaticTests.cs
@@ -6,7 +6,7 @@ namespace Elastic.Apm.Tests
 	/// <summary>
 	/// These tests access the static <see cref="Agent"/> instance.
 	/// All other tests should have their own <see cref="ApmAgent"/> instance and not rely on anything static.
-	/// Tests accessing the static <see cref="Agent"/> instance can not run in parallel with tests that also access the static instance.
+	/// Tests accessing the static <see cref="Agent"/> instance cannot run in parallel with tests that also access the static instance.
 	/// </summary>
 	public class StaticAgentTests
 	{


### PR DESCRIPTION
The new `IsConfigured` test is failing - only in CI, only on Windows.

It uses the static `Agent`, which I think causes the problem - maybe another test runs in parallel and uses `Agent`. Update: yeah, this theory seems to be verified.

Probably a strategy like this would be ok:
- No tests should use the static agents (except tests that are in the next category), basically all our tests already do this
- Tests that must use the static agent property (I think `IsConfigured` is the first and only) must be in the same category, so they won't run in parallel - I'm doing this now by putting all these tests into the same class - those tests will run sequentially.