### PR TITLE
Make IsConfigured thread safe

### DIFF
--- a/src/Elastic.Apm/Agent.cs
+++ b/src/Elastic.Apm/Agent.cs
@@ -96,12 +96,13 @@ namespace Elastic.Apm
 	{
 		private static readonly Lazy<ApmAgent> LazyApmAgent = new Lazy<ApmAgent>(() => new ApmAgent(_components));
 		private static AgentComponents _components;
+		private static volatile bool _isConfigured;
 
 		public static IConfigurationReader Config => Instance.ConfigurationReader;
 
 		internal static ApmAgent Instance => LazyApmAgent.Value;
 
-		public static bool IsConfigured { get; private set; }
+		public static bool IsConfigured => _isConfigured;
 
 		/// <summary>
 		/// The entry point for manual instrumentation. The <see cref="Tracer" /> property returns the tracer,
@@ -129,7 +130,7 @@ namespace Elastic.Apm
 				throw new InstanceAlreadyCreatedException("The singleton APM agent has already been instantiated and can no longer be configured.");
 
 			_components = agentComponents;
-			IsConfigured = true;
+			_isConfigured = true;
 		}
 
 		internal class InstanceAlreadyCreatedException : Exception


### PR DESCRIPTION
In #609 `Agent.IsInstanceCreated` was replaced `Agent.IsConfigured` introducing a regression - `IsInstanceCreated` was thread safe (in the sense that code checking if `IsInstanceCreated` is `true` before accessing `Agent.Instance` was guaranteed to see `Agent.Instance` constructed with  `AgentComponents` passed to `Agent.Setup()`) while [newly introduced `IsConfigured = true;` in `Agent.Setup()`](https://github.com/elastic/apm-agent-dotnet/pull/609/files#diff-2165dddf8d0c70f9a5985092338383bdR132) doesn't have memory release fence after it so .NET CLR memory model allows various optimization phases (compiler, JITer, CPU pre-fetching/caching, etc.) to effectively swap the order of `_components = agentComponents;` and `IsConfigured = true;` thus potentially causing situation where other thread see `Agent.IsConfigured` as `true` then calls `Agent.Instance` and creates agent singleton based on `_components` still being `null`.

Making `IsConfigured` baking field `volatile` introduces memory release fence after `_isConfigured = true;` (and, which just as important, memory acquire fence for reads from `IsConfigured`) thus disallowing optimizations to change the order of `_components = agentComponents;` and `_isConfigured = true;` from the point of view of other threads (i.e., threads other than the one that actually executed `Agent.Setup()`.


