### PR TITLE
Update supported-technologies.asciidoc

### DIFF
--- a/docs/supported-technologies.asciidoc
+++ b/docs/supported-technologies.asciidoc
@@ -43,7 +43,7 @@ We support automatic instrumentation for the following web frameworks.
 |Framework |Supported versions |Supported since agent's version
 
 |ASP.NET Core
-|2.x
+|2.1 and later
 |1.0
 
 |ASP.NET (.NET Framework) on IIS


### PR DESCRIPTION
We don't support ASP.NET Core 2.0 anymore due to #608  (more details in the issue description) - Microsoft already dropped support a long time ago. 

Updated the docs accordingly, so from the current release we support ASP.NET Core 2.1 and later 