### PR TITLE
Fix service node name version

### DIFF
--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -150,7 +150,7 @@ NOTE: The service name must conform to this regular expression: `^[a-zA-Z0-9 _-]
 
 [float]
 [[config-service-node-name]]
-==== `ServiceNodeName` (added[1.2])
+==== `ServiceNodeName` (added[1.3])
 
 Optional name used to differentiate between nodes in a service.
 If not set, data aggregations will be done based on a container ID (where valid) or on the reported hostname (automatically discovered).


### PR DESCRIPTION
This was added after we released 1.2 - this is all ok, I was aware that this feature is not in 1.2, but overlooked the version in the docs.

@vhatsura caught this: https://github.com/elastic/apm-agent-dotnet/pull/616#discussion_r350608679 