### PR TITLE
ci(jenkins): trigger opbeans release process

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -333,38 +333,17 @@ pipeline {
               }
             }
           }
-          stage('Release') {
+          stage('AfterRelease') {
             options {
               skipDefaultCheckout()
-              timeout(time: 12, unit: 'HOURS')
             }
             when {
-              beforeInput true
               anyOf {
                 tag pattern: '\\d+\\.\\d+\\.\\d+', comparator: 'REGEXP'
                 expression { return params.Run_As_Master_Branch }
               }
             }
             stages {
-              stage('Notify') {
-                steps {
-                    emailext subject: '[apm-agent-dotnet] Release ready to be pushed',
-                            to: "${NOTIFY_TO}",
-                            body: "Please go to ${env.BUILD_URL}input to approve or reject within 12 hours."
-                }
-              }
-              stage('Release to NuGet') {
-                steps {
-                  input(message: 'Should we release a new version on NuGet?', ok: 'Yes, we should.')
-                  withGithubNotify(context: 'Release NuGet', tab: 'artifacts') {
-                    deleteDir()
-                    unstash 'source'
-                    dir("${BASE_DIR}"){
-                      release('secret/apm-team/ci/elastic-observability-nuget')
-                    }
-                  }
-                }
-              }
               stage('Opbeans') {
                 environment {
                   REPO_NAME = "${OPBEANS_REPO}"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -341,7 +341,7 @@ pipeline {
             when {
               beforeInput true
               anyOf {
-                tag pattern: 'v\\d+\\.\\d+\\d+', comparator: 'REGEXP'
+                tag pattern: '\\d+\\.\\d+\\.\\d+', comparator: 'REGEXP'
                 expression { return params.Run_As_Master_Branch }
               }
             }


### PR DESCRIPTION
## What does this pull request do?

Add a final stage in the release process to bump the opbeans agent dependency. This is triggered when a tag is created and matches the pattern `[0-9]+.[0-9]+.[0-9]+`

## Why is it important?

When a new tag, aka a new release, is created then, the automation will kick the opbeans build which consists of the following tasks:
- [x] Bump dependency versions in the opbeans-dotnet
- [x] Push changes. (Implementation within the opbeans-dotnet but the call it's done within this pipeline)
- [x] Create a tag to trigger the release pipeline in the opbeans-dotnet. That particular tag will match with the same one that the one in the agent itself.

This particular pipeline will push the changes into the `master` branch for the opbeans-dotnet and tag it with the name of the tag version too. Therefore, the opbeans-dotnet pipeline will trigger two builds, the one for its master branch and the other one for the just created tag. This particular flow is implemented within the opbeans-dotnet.

## Questions
- [x] Clarify with the apm-agent-dotnet whether the `Release to AppVeyor` stage should only happen when there is commit into master and nothing when there is a tagged release.

## Follow-ups
- Implement the release process to NuGet as it's done manually yet.
