### PR TITLE
ci(jenkins): cancel previous running builds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -33,6 +33,16 @@ pipeline {
   stages {
     stage('Initializing'){
       stages{
+        /**
+        Cancel all the previous running old builds for the current PR.
+        */
+        stage('Cancel old builds') {
+          when { changeRequest() }
+          options { skipDefaultCheckout() }
+          steps {
+            cancelPreviousRunningBuilds()
+          }
+        }
         stage('Checkout') {
           options { skipDefaultCheckout() }
           steps {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -33,19 +33,10 @@ pipeline {
   stages {
     stage('Initializing'){
       stages{
-        /**
-        Cancel all the previous running old builds for the current PR.
-        */
-        stage('Cancel old builds') {
-          when { changeRequest() }
-          options { skipDefaultCheckout() }
-          steps {
-            cancelPreviousRunningBuilds()
-          }
-        }
         stage('Checkout') {
           options { skipDefaultCheckout() }
           steps {
+            pipelineManager([ cancelPreviousRunningBuilds: [ when: 'PR' ] ])
             deleteDir()
             gitCheckout(basedir: "${BASE_DIR}", githubNotifyFirstTimeContributor: true)
             stash allowEmpty: true, name: 'source', useDefaultExcludes: false


### PR DESCRIPTION
## What it does?

Optimize and abort all the old builds which are still running in the CI then we can reduce the number of active resources, aka Jenkins workers, and being able to have a healthy build queue.

## When does it happen?

Only for PRs. As for any branches/tags we want to keep track when a particular build failed. The pipeline for the branches/tags might be slightly different in some cases, sometimes it's required to run more exhaustive tests, benchmarks or other goals.

## Issues
- It depends on the new release of the library. Waiting for [build](https://apm-ci.elastic.co/job/apm-shared/job/apm-pipeline-library-mbp/job/master/355/)
- It might not be 100% effective if there are try/catch/catchWarn/catchErr steps within downstream jobs. But that's the closest we can enable this behavior at the moment without tweaking the pipelines.