### PR TITLE
Add ITransactionObserver

### DIFF
--- a/src/Elastic.Apm/Agent.cs
+++ b/src/Elastic.Apm/Agent.cs
@@ -98,6 +98,39 @@ namespace Elastic.Apm
 		private static AgentComponents _components;
 		private static volatile bool _isConfigured;
 
+		/// <summary>
+		/// Adds an <see cref="ITransactionObserver"/> instance to the agent, which gets called each time the currently active transaction changes.
+		/// You can only add <see cref="ITransactionObserver"/>s when the agent is already configured - which you can check
+		/// with the <see cref="IsConfigured"/> property.
+		/// </summary>
+		/// <param name="transactionObserver">The instance that will be informed when the active transaction changes</param>
+		/// <returns><code>true</code> if the <param name="transactionObserver"></param> was successfully added, <code>false</code> otherwise.</returns>
+		internal static bool RegisterTransactionObserver(ITransactionObserver transactionObserver)
+		{
+			if (!_isConfigured)
+				return false;
+
+			if (!(Instance.TracerInternal.CurrentExecutionSegmentsContainer is CurrentExecutionSegmentsContainer currentExecutionSegmentsContainer))
+				return false;
+
+			currentExecutionSegmentsContainer.TransactionObservers.Add(transactionObserver);
+			return true;
+		}
+
+		/// <summary>
+		/// Clears all <see cref="ITransactionObserver"/> instances that are currently registered for the agent.
+		/// </summary>
+		internal static void ClearTransactionObservers()
+		{
+			if (!_isConfigured)
+				return;
+
+			if (!(Instance.TracerInternal.CurrentExecutionSegmentsContainer is CurrentExecutionSegmentsContainer currentExecutionSegmentsContainer))
+				return;
+
+			currentExecutionSegmentsContainer.TransactionObservers.Clear();
+		}
+
 		public static IConfigurationReader Config => Instance.ConfigurationReader;
 
 		internal static ApmAgent Instance => LazyApmAgent.Value;

--- a/src/Elastic.Apm/ITransactionObserver.cs
+++ b/src/Elastic.Apm/ITransactionObserver.cs
@@ -1,0 +1,12 @@
+using Elastic.Apm.Api;
+
+namespace Elastic.Apm
+{
+	/// <summary>
+	/// An interface which is used by the <see cref="Agent"/> to notify external components that the currently active transaction changed.
+	/// </summary>
+	internal interface ITransactionObserver
+	{
+		void ActiveTransactionChanged(ITransaction currentTransaction);
+	}
+}

--- a/test/Elastic.Apm.Tests/StaticTests.cs
+++ b/test/Elastic.Apm.Tests/StaticTests.cs
@@ -1,3 +1,6 @@
+using Elastic.Apm.Api;
+using Elastic.Apm.Tests.Mocks;
+using Elastic.Apm.Tests.TestHelpers;
 using FluentAssertions;
 using Xunit;
 
@@ -8,12 +11,14 @@ namespace Elastic.Apm.Tests
 	/// All other tests should have their own <see cref="ApmAgent"/> instance and not rely on anything static.
 	/// Tests accessing the static <see cref="Agent"/> instance cannot run in parallel with tests that also access the static instance.
 	/// </summary>
+	[TestCaseOrderer("Elastic.Apm.Tests.TestHelpers.PriorityOrderer", "Elastic.Apm.Tests")]
 	public class StaticAgentTests
 	{
 		/// <summary>
 		/// Makes sure Agent.IsConfigured only returns true after Setup is called.
 		/// </summary>
-		[Fact]
+		//[Fact]
+		[Fact, TestPriority(0)]
 		public void IsConfigured()
 		{
 			Agent.IsConfigured.Should().BeFalse();
@@ -21,5 +26,57 @@ namespace Elastic.Apm.Tests
 			Agent.Setup(new AgentComponents());
 			Agent.IsConfigured.Should().BeTrue();
 		}
+
+		/// <summary>
+		/// Registers multiple transaction observers and counts the call that their receive.
+		/// </summary>
+		[Fact, TestPriority(1)]
+		public void TransactionObserverTest()
+		{
+			Agent.Setup(new TestAgentComponents());
+			var transactionObserver = new FakeObserver();
+
+			//register 1 observer
+			var isRegistered = Agent.RegisterTransactionObserver(transactionObserver);
+			isRegistered.Should().BeTrue();
+
+			Agent.Tracer.CaptureTransaction("Test", "Test", () =>
+				transactionObserver.NumberOfActiveTransactionChangedCalled.Should().Be(1));
+
+			transactionObserver.NumberOfActiveTransactionChangedCalled.Should().Be(2);
+
+			//register another observer
+			var secondTransactionObserver = new FakeObserver();
+			var isSecondRegistered = Agent.RegisterTransactionObserver(secondTransactionObserver);
+			isSecondRegistered.Should().BeTrue();
+
+			Agent.Tracer.CaptureTransaction("Test", "Test", () =>
+			{
+				transactionObserver.NumberOfActiveTransactionChangedCalled.Should().Be(3);
+				secondTransactionObserver.NumberOfActiveTransactionChangedCalled.Should().Be(1);
+			});
+
+			transactionObserver.NumberOfActiveTransactionChangedCalled.Should().Be(4);
+			secondTransactionObserver.NumberOfActiveTransactionChangedCalled.Should().Be(2);
+
+			//clear all observers - none of them will be triggered
+			Agent.ClearTransactionObservers();
+
+			Agent.Tracer.CaptureTransaction("Test", "Test", () =>
+			{
+				transactionObserver.NumberOfActiveTransactionChangedCalled.Should().Be(4);
+				secondTransactionObserver.NumberOfActiveTransactionChangedCalled.Should().Be(2);
+			});
+
+			transactionObserver.NumberOfActiveTransactionChangedCalled.Should().Be(4);
+			secondTransactionObserver.NumberOfActiveTransactionChangedCalled.Should().Be(2);
+		}
+	}
+
+	internal class FakeObserver : ITransactionObserver
+	{
+		public int NumberOfActiveTransactionChangedCalled { get; private set; }
+
+		public void ActiveTransactionChanged(ITransaction currentTransaction) => NumberOfActiveTransactionChangedCalled++;
 	}
 }

--- a/test/Elastic.Apm.Tests/TestHelpers/PriorityOrderer.cs
+++ b/test/Elastic.Apm.Tests/TestHelpers/PriorityOrderer.cs
@@ -1,0 +1,48 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+namespace Elastic.Apm.Tests.TestHelpers
+{
+	/// <summary>
+	/// Credit: https://github.com/xunit/samples.xunit/
+	/// </summary>
+	public class PriorityOrderer : ITestCaseOrderer
+	{
+		public IEnumerable<TTestCase> OrderTestCases<TTestCase>(IEnumerable<TTestCase> testCases) where TTestCase : ITestCase
+		{
+			var sortedMethods = new SortedDictionary<int, List<TTestCase>>();
+
+			foreach (var testCase in testCases)
+			{
+				var priority = 0;
+
+				foreach (var attr in testCase.TestMethod.Method.GetCustomAttributes((typeof(TestPriorityAttribute).AssemblyQualifiedName)))
+					priority = attr.GetNamedArgument<int>("Priority");
+
+				GetOrCreate(sortedMethods, priority).Add(testCase);
+			}
+
+			foreach (var list in sortedMethods.Keys.Select(priority => sortedMethods[priority]))
+			{
+				list.Sort((x, y) => StringComparer.OrdinalIgnoreCase.Compare(x.TestMethod.Method.Name, y.TestMethod.Method.Name));
+				foreach (var testCase in list)
+					yield return testCase;
+			}
+		}
+
+		private static TValue GetOrCreate<TKey, TValue>(IDictionary<TKey, TValue> dictionary, TKey key) where TValue : new()
+		{
+			TValue result;
+
+			if (dictionary.TryGetValue(key, out result)) return result;
+
+			result = new TValue();
+			dictionary[key] = result;
+
+			return result;
+		}
+	}
+}

--- a/test/Elastic.Apm.Tests/TestHelpers/TestPriorityAttribute.cs
+++ b/test/Elastic.Apm.Tests/TestHelpers/TestPriorityAttribute.cs
@@ -1,0 +1,15 @@
+using System;
+
+namespace Elastic.Apm.Tests.TestHelpers
+{
+	/// <summary>
+	/// Credit: https://github.com/xunit/samples.xunit/
+	/// </summary>
+	[AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
+	public class TestPriorityAttribute : Attribute
+	{
+		public TestPriorityAttribute(int priority) => Priority = priority;
+
+		public int Priority { get; private set; }
+	}
+}


### PR DESCRIPTION
This PR adds an `ITransactionObserver` interface and through this interface the agent can notify external components about the currently active transaction.

This came out from adding logcorrelation support with NLog and Log4Net. The way these loggers work is that they use a `MappedDiagnosticsLogicalContext `(in case of Log4Net - basically an async local storage) or `MappedDiagnosticsLogicalContext` (in case of NLog - same idea) for context propagation. Each time the active transaction changes, we actively need to maintain the info in the `LogicalThreadContext` or `MappedDiagnosticsLogicalContext` - so unlike Serilog, I don't see any way to use an `Enricher` (or something similar) which gets called before each logline is written. With Log4Net and NLog we need to actively maintain the `MappedDiagnosticsLogicalContext` and `MappedDiagnosticsLogicalContext`.

Given that the agent has no opinion or knowledge about the logger used by the observed app - I think these logging integrations should live outside the agent itself. As discussed today in our .NET sync, the [ecs-dotnet](https://github.com/elastic/ecs-dotnet/) repo would be a good place. So we could just have `ITransactionObserver` implementation for Log4Net and NLog (In https://github.com/elastic/apm-agent-dotnet/pull/635 you can already see those). 

I kept `ITransactionObserver` and `Agent.RegisterTransactionObserver` `internal`, I think we can just make the agent `InternalVisibleTo` the new projects where the `ITransactionObserver` implementations live. The main reason is that I try to be careful about what we expose.