### PR TITLE
update Microsoft.NETFramework.ReferenceAssemblies to stable version

### DIFF
--- a/sample/Directory.Build.props
+++ b/sample/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
   <ItemGroup>
-    <PackageReference Condition=" '$(OS)' != 'Windows_NT'" Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0-preview.2" PrivateAssets="All"/>
+    <PackageReference Condition=" '$(OS)' != 'Windows_NT'" Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All"/>
   </ItemGroup>
 </Project>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -14,6 +14,6 @@
     <PackageIconUrl>https://raw.githubusercontent.com/elastic/apm-agent-dotnet/master/build/nuget-icon.png</PackageIconUrl>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Condition=" '$(OS)' != 'Windows_NT' " Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0-preview.2" PrivateAssets="All"/>
+    <PackageReference Condition=" '$(OS)' != 'Windows_NT' " Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All"/>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
The stable version of `Microsoft.NETFramework.ReferenceAssemblies` package [was released 5 days ago](https://www.nuget.org/packages/Microsoft.NETFramework.ReferenceAssemblies/1.0.0).


/cc @gregkalapos, @Mpdreamz 