### PR TITLE
Add assembly name to <add name="ElasticApmModule" type=

### DIFF
--- a/docs/setup.asciidoc
+++ b/docs/setup.asciidoc
@@ -75,7 +75,7 @@ you can enable auto instrumentation by including the `ElasticApmModule` IIS Modu
 <configuration>
     <system.webServer>
         <modules>
-            <add name="ElasticApmModule" type="Elastic.Apm.AspNetFullFramework.ElasticApmModule" />
+            <add name="ElasticApmModule" type="Elastic.Apm.AspNetFullFramework.ElasticApmModule, Elastic.Apm.AspNetFullFramework" />
         </modules>
     </system.webServer>
 </configuration>
@@ -92,7 +92,7 @@ as shown in the following example:
 <configuration>
     <system.webServer>
         <modules>
-            <add name="ElasticApmModule" type="Elastic.Apm.AspNetFullFramework.ElasticApmModule" preCondition="managedHandler" />
+            <add name="ElasticApmModule" type="Elastic.Apm.AspNetFullFramework.ElasticApmModule, Elastic.Apm.AspNetFullFramework" preCondition="managedHandler" />
         </modules>
     </system.webServer>
 </configuration>

--- a/sample/AspNetFullFrameworkSampleApp/Web.config
+++ b/sample/AspNetFullFrameworkSampleApp/Web.config
@@ -29,7 +29,7 @@
 	<system.webServer>
 		<modules>
 			<remove name="ElasticApmModule"/>
-			<add name="ElasticApmModule" type="Elastic.Apm.AspNetFullFramework.ElasticApmModule"/>
+			<add name="ElasticApmModule" type="Elastic.Apm.AspNetFullFramework.ElasticApmModule, Elastic.Apm.AspNetFullFramework"/>
 			<remove name="TelemetryCorrelationHttpModule"/>
 			<add name="TelemetryCorrelationHttpModule" type="Microsoft.AspNet.TelemetryCorrelation.TelemetryCorrelationHttpModule, Microsoft.AspNet.TelemetryCorrelation" preCondition="managedHandler"/>
 			<remove name="ApplicationInsightsWebTracking"/>


### PR DESCRIPTION
Origin: https://discuss.elastic.co/t/cannot-make-apm-client-work-on-iis/211179

TODO: Since it's about docs we need to merge this fix to 1.x as well - #649.