### PR TITLE
[Docs] Update ASP.NET Core configuration instructions

### DIFF
--- a/docs/setup.asciidoc
+++ b/docs/setup.asciidoc
@@ -56,6 +56,8 @@ public class Startup
 }
 ----
 
+NOTE: Make sure the `app.UseAllElasticApm(...)` line is the first line in the `Configure` method, otherwise the agent won't be able to properly measure the timing of your requests and potentially complete requests may be missed by the agent. 
+
 With this you enable every agent component including ASP.NET Core tracing, monitoring of outgoing HTTP request, Entity Framework Core database tracing, etc.
 
 In case you only reference the `Elastic.Apm.AspNetCore` package, you won't find the `UseAllElasticApm`. Instead you need to use the `UseElasticApm()` method from the `Elastic.Apm.AspNetCore` namespace. This method turns on ASP.NET Core tracing, and gives you the opportunity to manually turn on other components. By default it will only trace ASP.NET Core requests - No HTTP request tracing, database call tracing or any other tracing component will be turned on.

--- a/docs/setup.asciidoc
+++ b/docs/setup.asciidoc
@@ -56,7 +56,7 @@ public class Startup
 }
 ----
 
-NOTE: Make sure the `app.UseAllElasticApm(...)` line is the first line in the `Configure` method, otherwise the agent won't be able to properly measure the timing of your requests and potentially complete requests may be missed by the agent. 
+The `app.UseAllElasticApm(...)` line must be the first line in the `Configure` method, otherwise the agent won't be able to properly measure the timing of your requests, and potentially complete requests may be missed by the agent. 
 
 With this you enable every agent component including ASP.NET Core tracing, monitoring of outgoing HTTP request, Entity Framework Core database tracing, etc.
 


### PR DESCRIPTION
Triggered by https://github.com/elastic/apm-agent-dotnet/issues/651.


The order in the `Configure` method when the agent is registered matters - this was not explained in the docs, so adding a note about this. 

Once we are ok with this, I'll also open a PR against `1.x`. 