### PR TITLE
Implement context.destination.address/port for HTTP-call spans

### DIFF
--- a/sample/AspNetFullFrameworkSampleApp/Controllers/HomeController.cs
+++ b/sample/AspNetFullFrameworkSampleApp/Controllers/HomeController.cs
@@ -45,7 +45,8 @@ namespace AspNetFullFrameworkSampleApp.Controllers
 		internal const int DummyHttpStatusCode = 599;
 		internal const string ExceptionMessage = "For testing purposes";
 
-		internal const string ForbidHttpResponsePageRelativePath = HomePageRelativePath + "/" + nameof(ForbidHttpResponse);
+		internal const string ChildHttpSpanWithResponseForbiddenPath = HomePageRelativePath + "/" + nameof(ChildHttpSpanWithResponseForbidden);
+		internal static readonly Uri ChildHttpSpanWithResponseForbiddenUrl = new Uri("https://httpstat.us/403");
 
 		internal const string GenNSpansPageRelativePath = HomePageRelativePath + "/" + nameof(GenNSpans);
 
@@ -78,11 +79,11 @@ namespace AspNetFullFrameworkSampleApp.Controllers
 
 		private bool GetCaptureControllerActionAsSpan() => bool.Parse(GetQueryStringValue(CaptureControllerActionAsSpanQueryStringKey, "false"));
 
-		public async Task<ActionResult> ForbidHttpResponse()
+		public async Task<ActionResult> ChildHttpSpanWithResponseForbidden()
 		{
 			//see https://github.com/elastic/apm-agent-dotnet/issues/443
 			var httpClient = new HttpClient();
-			var res = await httpClient.GetAsync("https://httpstat.us/403");
+			var res = await httpClient.GetAsync(ChildHttpSpanWithResponseForbiddenUrl);
 			var retVal = new ContentResult { Content = res.IsSuccessStatusCode.ToString() };
 			return retVal;
 		}

--- a/src/Elastic.Apm/Api/Destination.cs
+++ b/src/Elastic.Apm/Api/Destination.cs
@@ -27,6 +27,12 @@ namespace Elastic.Apm.Api
 			if (!_port.HasValue) _port = src._port;
 		}
 
+		/// <summary>
+		/// The goal is to allow public API user to prohibit automatic deduction of any of  `context.destination` properties.
+		/// To achieve that we need a way to distinguish between `null` as the initial value
+		/// (meaning public API user is okay with us automatically deducing it) and `null` explicitly set via public API
+		/// (meaning the user doesn't want us to automatically deduce it).
+		/// </summary>
 		private readonly struct Optional<T>
 		{
 			internal readonly bool HasValue;

--- a/src/Elastic.Apm/Api/Destination.cs
+++ b/src/Elastic.Apm/Api/Destination.cs
@@ -1,0 +1,43 @@
+using Elastic.Apm.Report.Serialization;
+using Newtonsoft.Json;
+
+namespace Elastic.Apm.Api
+{
+	public class Destination
+	{
+		private Optional<string> _address;
+		private Optional<int?> _port;
+
+		[JsonConverter(typeof(TrimmedStringJsonConverter))]
+		public string Address
+		{
+			get => _address?.Value;
+			set
+			{
+				if (_address == null) _address = new Optional<string>();
+				_address.Value = value;
+			}
+		}
+
+		public int? Port
+		{
+			get => _port?.Value;
+			set
+			{
+				if (_port == null) _port = new Optional<int?>();
+				_port.Value = value;
+			}
+		}
+
+		internal void CopyMissingPropertiesFrom(Destination src)
+		{
+			if (_address == null) _address = src._address;
+			if (_port == null) _port = src._port;
+		}
+
+		private class Optional<T>
+		{
+			internal T Value;
+		}
+	}
+}

--- a/src/Elastic.Apm/Api/Destination.cs
+++ b/src/Elastic.Apm/Api/Destination.cs
@@ -3,11 +3,22 @@ using Newtonsoft.Json;
 
 namespace Elastic.Apm.Api
 {
+	/// <summary>
+	/// Public API to set properties that are stored under <c>span.destination</c> in
+	/// <a href="https://www.elastic.co/guide/en/apm/get-started/current/transaction-spans.html">the APM data model</a>.
+	/// </summary>
 	public class Destination
 	{
 		private Optional<string> _address;
 		private Optional<int?> _port;
 
+		/// <summary>
+		/// Either an IP (v4 or v6) or a host/domain name.
+		/// See <a href="https://github.com/elastic/apm/issues/115#issuecomment-555814374">this issue</a> for more information.
+		/// If this property is not set via this public API it will be deduced from other parts of <see cref="SpanContext"/>
+		/// (for example <see cref="SpanContext.Http"/> or <see cref="SpanContext.Db"/>).
+		/// Explicitly setting this property to <c>null</c> will prohibit this automatic deduction.
+		/// </summary>
 		[JsonConverter(typeof(TrimmedStringJsonConverter))]
 		public string Address
 		{
@@ -15,6 +26,13 @@ namespace Elastic.Apm.Api
 			set => _address = new Optional<string>(value);
 		}
 
+		/// <summary>
+		/// Port number - it should not be omitted even if it's the default port number for the corresponding protocol.
+		/// See <a href="https://github.com/elastic/apm/issues/115#issuecomment-555814374">this issue</a> for more information.
+		/// If this property is not set via this public API it will be deduced from other parts of <see cref="SpanContext"/>
+		/// (for example <see cref="SpanContext.Http"/> or <see cref="SpanContext.Db"/>).
+		/// Explicitly setting this property to <c>null</c> will prohibit this automatic deduction.
+		/// </summary>
 		public int? Port
 		{
 			get => _port.Value;

--- a/src/Elastic.Apm/Api/Destination.cs
+++ b/src/Elastic.Apm/Api/Destination.cs
@@ -11,33 +11,32 @@ namespace Elastic.Apm.Api
 		[JsonConverter(typeof(TrimmedStringJsonConverter))]
 		public string Address
 		{
-			get => _address?.Value;
-			set
-			{
-				if (_address == null) _address = new Optional<string>();
-				_address.Value = value;
-			}
+			get => _address.Value;
+			set => _address = new Optional<string>(value);
 		}
 
 		public int? Port
 		{
-			get => _port?.Value;
-			set
-			{
-				if (_port == null) _port = new Optional<int?>();
-				_port.Value = value;
-			}
+			get => _port.Value;
+			set => _port = new Optional<int?>(value);
 		}
 
 		internal void CopyMissingPropertiesFrom(Destination src)
 		{
-			if (_address == null) _address = src._address;
-			if (_port == null) _port = src._port;
+			if (!_address.HasValue) _address = src._address;
+			if (!_port.HasValue) _port = src._port;
 		}
 
-		private class Optional<T>
+		private readonly struct Optional<T>
 		{
-			internal T Value;
+			internal readonly bool HasValue;
+			internal readonly T Value;
+
+			internal Optional(T value)
+			{
+				Value = value;
+				HasValue = true;
+			}
 		}
 	}
 }

--- a/src/Elastic.Apm/Api/SpanContext.cs
+++ b/src/Elastic.Apm/Api/SpanContext.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using Elastic.Apm.Helpers;
 using Elastic.Apm.Report.Serialization;
 using Newtonsoft.Json;
 
@@ -8,7 +9,9 @@ namespace Elastic.Apm.Api
 	public class SpanContext
 	{
 		private readonly Lazy<Dictionary<string, string>> _labels = new Lazy<Dictionary<string, string>>();
+
 		public Database Db { get; set; }
+		public Destination Destination { get; set; }
 		public Http Http { get; set; }
 
 		/// <summary>
@@ -24,5 +27,13 @@ namespace Elastic.Apm.Api
 		/// <a href="https://www.newtonsoft.com/json/help/html/ConditionalProperties.htm">the relevant Json.NET Documentation</a>
 		/// </summary>
 		public bool ShouldSerializeLabels() => _labels.IsValueCreated && Labels.Count > 0;
+
+		public override string ToString() => new ToStringBuilder(nameof(SpanContext))
+		{
+			{ nameof(Db), Db },
+			{ nameof(Http), Http },
+			{ nameof(Labels), _labels },
+			{ nameof(Destination), Destination }
+		}.ToString();
 	}
 }

--- a/src/Elastic.Apm/DiagnosticListeners/HttpDiagnosticListenerImplBase.cs
+++ b/src/Elastic.Apm/DiagnosticListeners/HttpDiagnosticListenerImplBase.cs
@@ -125,10 +125,11 @@ namespace Elastic.Apm.DiagnosticListeners
 				return;
 			}
 
-			var span = (Span)ExecutionSegmentCommon.GetCurrentExecutionSegment(_agent).StartSpan(
-				$"{RequestGetMethod(request)} {requestUrl.Host}",
-				ApiConstants.TypeExternal,
-				ApiConstants.SubtypeHttp);
+			var span = (Span)ExecutionSegmentCommon.GetCurrentExecutionSegment(_agent)
+				.StartSpan(
+					$"{RequestGetMethod(request)} {requestUrl.Host}",
+					ApiConstants.TypeExternal,
+					ApiConstants.SubtypeHttp);
 
 			if (!ProcessingRequests.TryAdd(request, span))
 			{
@@ -143,11 +144,10 @@ namespace Elastic.Apm.DiagnosticListeners
 				// but here we want the string to be in W3C 'traceparent' header format.
 				RequestHeadersAdd(request, TraceParent.TraceParentHeaderName, TraceParent.BuildTraceparent(span.OutgoingDistributedTracingData));
 
-			if (span.ShouldBeSentToApmServer)
-      {
-        span.Context.Http = new Http { Method = RequestGetMethod(request) };
-        span.Context.Http.SetUrl(requestUrl);
-      }
+			if (!span.ShouldBeSentToApmServer) return;
+
+			span.Context.Http = new Http { Method = RequestGetMethod(request) };
+			span.Context.Http.SetUrl(requestUrl);
 		}
 
 		private void ProcessStopEvent(object eventValue, TRequest request, Uri requestUrl)

--- a/src/Elastic.Apm/Helpers/UrlUtils.cs
+++ b/src/Elastic.Apm/Helpers/UrlUtils.cs
@@ -9,9 +9,11 @@ namespace Elastic.Apm.Helpers
 
 		internal static bool TryExtractDestinationInfo(Uri url, out string host, out int? port, IApmLogger logger)
 		{
+			// We cannot extract
 			if (!url.IsAbsoluteUri || url.HostNameType == UriHostNameType.Basic || url.HostNameType == UriHostNameType.Unknown)
 			{
-				logger.Scoped($"{ThisClassName}.{DbgUtils.CurrentMethodName()}").Debug()?.Log("Cannot extract destination info."
+				logger.Scoped($"{ThisClassName}.{DbgUtils.CurrentMethodName()}").Debug()?.Log(
+					"Cannot extract destination info (URL is not absolute or doesn't point to an external resource)."
 					+ " url: IsAbsoluteUri: {IsAbsoluteUri}, HostNameType: {HostNameType}."
 					, url.IsAbsoluteUri, url.HostNameType);
 				host = null;

--- a/src/Elastic.Apm/Helpers/UrlUtils.cs
+++ b/src/Elastic.Apm/Helpers/UrlUtils.cs
@@ -1,13 +1,19 @@
 using System;
+using Elastic.Apm.Logging;
 
 namespace Elastic.Apm.Helpers
 {
 	internal static class UrlUtils
 	{
-		internal static bool TryExtractDestinationInfo(Uri url, out string host, out int? port)
+		private const string ThisClassName = nameof(UrlUtils);
+
+		internal static bool TryExtractDestinationInfo(Uri url, out string host, out int? port, IApmLogger logger)
 		{
 			if (!url.IsAbsoluteUri || url.HostNameType == UriHostNameType.Basic || url.HostNameType == UriHostNameType.Unknown)
 			{
+				logger.Scoped($"{ThisClassName}.{DbgUtils.CurrentMethodName()}").Debug()?.Log("Cannot extract destination info."
+					+ " url: IsAbsoluteUri: {IsAbsoluteUri}, HostNameType: {HostNameType}."
+					, url.IsAbsoluteUri, url.HostNameType);
 				host = null;
 				port = null;
 				return false;

--- a/src/Elastic.Apm/Helpers/UrlUtils.cs
+++ b/src/Elastic.Apm/Helpers/UrlUtils.cs
@@ -1,0 +1,24 @@
+using System;
+
+namespace Elastic.Apm.Helpers
+{
+	internal static class UrlUtils
+	{
+		internal static bool TryExtractDestinationInfo(Uri url, out string host, out int? port)
+		{
+			if (!url.IsAbsoluteUri || url.HostNameType == UriHostNameType.Basic || url.HostNameType == UriHostNameType.Unknown)
+			{
+				host = null;
+				port = null;
+				return false;
+			}
+
+			host = url.Host;
+			if (url.HostNameType == UriHostNameType.IPv6 && host.Length > 2 && host[0] == '[' && host[host.Length - 1] == ']')
+				host = host.Substring(1, host.Length - 2);
+
+			port = url.Port == -1 ? (int?)null : url.Port;
+			return true;
+		}
+	}
+}

--- a/src/Elastic.Apm/Model/Span.cs
+++ b/src/Elastic.Apm/Model/Span.cs
@@ -293,7 +293,7 @@ namespace Elastic.Apm.Model
 			}
 		}
 
-		internal Destination DeduceHttpDestination()
+		private Destination DeduceHttpDestination()
 		{
 			try
 			{

--- a/test/Elastic.Apm.AspNetFullFramework.Tests/ErrorsTests.cs
+++ b/test/Elastic.Apm.AspNetFullFramework.Tests/ErrorsTests.cs
@@ -55,16 +55,20 @@ namespace Elastic.Apm.AspNetFullFramework.Tests
 		[AspNetFullFrameworkFact]
 		public async Task HttpCallWithResponseForbidden()
 		{
-			var forbidResponsePageData = SampleAppUrlPaths.ForbidHttpResponsePageDescriptionPage;
-			await SendGetRequestToSampleAppAndVerifyResponse(forbidResponsePageData.RelativeUrlPath, forbidResponsePageData.StatusCode);
+			var pageData = SampleAppUrlPaths.ChildHttpSpanWithResponseForbiddenPage;
+			await SendGetRequestToSampleAppAndVerifyResponse(pageData.RelativeUrlPath, pageData.StatusCode);
 
 			await WaitAndCustomVerifyReceivedData(receivedData =>
 			{
-				VerifyReceivedDataSharedConstraints(forbidResponsePageData, receivedData);
+				VerifyReceivedDataSharedConstraints(pageData, receivedData);
 
 				receivedData.Spans.First().Should().NotBeNull();
 				receivedData.Spans.First().Context.Http.Should().NotBeNull();
 				receivedData.Spans.First().Context.Http.StatusCode.Should().Be(403);
+				receivedData.Spans.First().Context.Http.Method.Should().Be("GET");
+				receivedData.Spans.First().Context.Http.Url.Should().Be(HomeController.ChildHttpSpanWithResponseForbiddenUrl.ToString());
+				receivedData.Spans.First().Context.Destination.Address.Should().Be(HomeController.ChildHttpSpanWithResponseForbiddenUrl.Host);
+				receivedData.Spans.First().Context.Destination.Port.Should().Be(HomeController.ChildHttpSpanWithResponseForbiddenUrl.Port);
 			});
 		}
 

--- a/test/Elastic.Apm.AspNetFullFramework.Tests/TestsBase.cs
+++ b/test/Elastic.Apm.AspNetFullFramework.Tests/TestsBase.cs
@@ -140,8 +140,8 @@ namespace Elastic.Apm.AspNetFullFramework.Tests
 				new SampleAppUrlPathData(HomeController.CustomChildSpanThrowsPageRelativePath, 500, spansCount: 2, errorsCount: 3);
 
 
-			internal static readonly SampleAppUrlPathData ForbidHttpResponsePageDescriptionPage =
-				new SampleAppUrlPathData(HomeController.ForbidHttpResponsePageRelativePath, 200, spansCount: 1, errorsCount: 1);
+			internal static readonly SampleAppUrlPathData ChildHttpSpanWithResponseForbiddenPage =
+				new SampleAppUrlPathData(HomeController.ChildHttpSpanWithResponseForbiddenPath, 200, spansCount: 1, errorsCount: 1);
 
 			internal static readonly SampleAppUrlPathData GetDotNetRuntimeDescriptionPage =
 				new SampleAppUrlPathData(HomeController.GetDotNetRuntimeDescriptionPageRelativePath, 200);

--- a/test/Elastic.Apm.Tests.MockApmServer/AssertValidExtensions.cs
+++ b/test/Elastic.Apm.Tests.MockApmServer/AssertValidExtensions.cs
@@ -246,6 +246,15 @@ namespace Elastic.Apm.Tests.MockApmServer
 			thisObj.Url.Should().NotBeNullOrEmpty();
 		}
 
+		internal static void AssertValid(this Destination thisObj)
+		{
+			thisObj.Should().NotBeNull();
+
+			thisObj.Address.Should().NotBeNullOrEmpty();
+			thisObj.Address.AssertValid();
+			thisObj.Port?.Should().BeGreaterOrEqualTo(0);
+		}
+
 		internal static void AssertValid(this List<CapturedStackFrame> thisObj)
 		{
 			thisObj.Should().NotBeNull();

--- a/test/Elastic.Apm.Tests.MockApmServer/SpanContextDto.cs
+++ b/test/Elastic.Apm.Tests.MockApmServer/SpanContextDto.cs
@@ -14,6 +14,8 @@ namespace Elastic.Apm.Tests.MockApmServer
 	{
 		public Database Db { get; set; }
 
+		public Destination Destination { get; set; }
+
 		public Http Http { get; set; }
 
 		[JsonProperty("tags")]
@@ -21,7 +23,7 @@ namespace Elastic.Apm.Tests.MockApmServer
 
 		public override string ToString() => new ToStringBuilder(nameof(SpanContextDto))
 		{
-			{ nameof(Db), Db }, { nameof(Http), Http }, { nameof(Labels), Labels }
+			{ nameof(Db), Db }, { nameof(Http), Http }, { nameof(Labels), Labels }, { nameof(Destination), Destination }
 		}.ToString();
 
 		public void AssertValid()
@@ -29,6 +31,7 @@ namespace Elastic.Apm.Tests.MockApmServer
 			Db?.AssertValid();
 			Http?.AssertValid();
 			Labels?.LabelsAssertValid();
+			Destination?.AssertValid();
 		}
 	}
 }

--- a/test/Elastic.Apm.Tests/ApiTests/ConvenientApiSpanTests.cs
+++ b/test/Elastic.Apm.Tests/ApiTests/ConvenientApiSpanTests.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using Elastic.Apm.Api;
 using Elastic.Apm.Model;
 using Elastic.Apm.Tests.Extensions;
+using Elastic.Apm.Tests.HelpersTests;
 using Elastic.Apm.Tests.Mocks;
 using FluentAssertions;
 using Xunit;
@@ -722,6 +723,8 @@ namespace Elastic.Apm.Tests.ApiTests
 			payloadSender.Spans[0].Context.Http.Url.Should().Be("http://mysite.com");
 			payloadSender.Spans[0].Context.Http.Method.Should().Be("GET");
 			payloadSender.Spans[0].Context.Http.StatusCode.Should().Be(200);
+			payloadSender.Spans[0].Context.Destination.Address.Should().Be("mysite.com");
+			payloadSender.Spans[0].Context.Destination.Port.Should().Be(UrlUtilsTests.DefaultHttpPort);
 
 			payloadSender.Spans[1].Name.Should().Be("SampleSpan2");
 			payloadSender.Spans[1].Context.Db.Statement.Should().Be("Select * from MyTable");

--- a/test/Elastic.Apm.Tests/HelpersTests/UrlUtilsTests.cs
+++ b/test/Elastic.Apm.Tests/HelpersTests/UrlUtilsTests.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Linq;
 using Elastic.Apm.Helpers;
 using Elastic.Apm.Logging;
 using Elastic.Apm.Tests.Mocks;
@@ -32,8 +31,10 @@ namespace Elastic.Apm.Tests.HelpersTests
 		[InlineData("https://[fe80::200:39ff:fe36:1a2d%254]:54321/temp/example.htm", "fe80::200:39ff:fe36:1a2d", 54321)]
 		[InlineData("https://[fe80::200:39ff:fe36:1a2d%254]", "fe80::200:39ff:fe36:1a2d", DefaultHttpsPort)]
 		// Non-ASCII characters in host name
+		// ReSharper disable StringLiteralTypo
 		[InlineData("http://München", "münchen", DefaultHttpPort)]
 		[InlineData("http://Хост", "Хост", DefaultHttpPort)] // Host in Russian
+		// ReSharper restore StringLiteralTypo
 		public void TryExtractDestinationInfo_valid_input(string inputUrl, string expectedHost, int? expectedPort)
 		{
 			UrlUtils.TryExtractDestinationInfo(new Uri(inputUrl), out var actualHost, out var actualPort, new NoopLogger()).Should().BeTrue();
@@ -46,7 +47,7 @@ namespace Elastic.Apm.Tests.HelpersTests
 		public void TryExtractDestinationInfo_invalid_input(string inputUrl)
 		{
 			var mockLogger = new TestLogger(LogLevel.Trace);
-			UrlUtils.TryExtractDestinationInfo(new Uri(inputUrl), out var actualHost, out var actualPort, mockLogger).Should().BeFalse();
+			UrlUtils.TryExtractDestinationInfo(new Uri(inputUrl), out _, out _, mockLogger).Should().BeFalse();
 			mockLogger.Lines.Should().Contain(line => line.Contains(nameof(UrlUtils)) && line.Contains(nameof(UrlUtils.TryExtractDestinationInfo)));
 		}
 	}

--- a/test/Elastic.Apm.Tests/HelpersTests/UrlUtilsTests.cs
+++ b/test/Elastic.Apm.Tests/HelpersTests/UrlUtilsTests.cs
@@ -1,5 +1,7 @@
 using System;
+using System.Linq;
 using Elastic.Apm.Helpers;
+using Elastic.Apm.Tests.Mocks;
 using FluentAssertions;
 using Xunit;
 
@@ -33,7 +35,7 @@ namespace Elastic.Apm.Tests.HelpersTests
 		[InlineData("http://Хост", "Хост", DefaultHttpPort)] // Host in Russian
 		public void TryExtractDestinationInfo_valid_input(string inputUrl, string expectedHost, int? expectedPort)
 		{
-			UrlUtils.TryExtractDestinationInfo(new Uri(inputUrl), out var actualHost, out var actualPort).Should().BeTrue();
+			UrlUtils.TryExtractDestinationInfo(new Uri(inputUrl), out var actualHost, out var actualPort, new NoopLogger()).Should().BeTrue();
 			actualHost.Should().Be(expectedHost);
 			actualPort.Should().Be(expectedPort);
 		}
@@ -42,7 +44,9 @@ namespace Elastic.Apm.Tests.HelpersTests
 		[InlineData("C:\\")] // no host (Basic host name type)
 		public void TryExtractDestinationInfo_invalid_input(string inputUrl)
 		{
-			UrlUtils.TryExtractDestinationInfo(new Uri(inputUrl), out var actualHost, out var actualPort).Should().BeFalse();
+			var mockLogger = new TestLogger();
+			UrlUtils.TryExtractDestinationInfo(new Uri(inputUrl), out var actualHost, out var actualPort, mockLogger).Should().BeFalse();
+			mockLogger.Lines.Should().Contain(line => line.Contains(nameof(UrlUtils)) && line.Contains(nameof(UrlUtils.TryExtractDestinationInfo)));
 		}
 	}
 }

--- a/test/Elastic.Apm.Tests/HelpersTests/UrlUtilsTests.cs
+++ b/test/Elastic.Apm.Tests/HelpersTests/UrlUtilsTests.cs
@@ -1,0 +1,48 @@
+using System;
+using Elastic.Apm.Helpers;
+using FluentAssertions;
+using Xunit;
+
+namespace Elastic.Apm.Tests.HelpersTests
+{
+	public class UrlUtilsTests
+	{
+		public const int DefaultHttpPort = 80;
+		public const int DefaultHttpsPort = 443;
+
+		[Theory]
+		[InlineData("https://elastic.co/foo/bar", "elastic.co", DefaultHttpsPort)]
+		[InlineData("http://elastic.co/foo/bar", "elastic.co", DefaultHttpPort)]
+		// unknown scheme and thus no default port
+		[InlineData("dummyscheme://elastic.co/foo/bar", "elastic.co", null)]
+		[InlineData("dummyscheme://elastic.co:1234/foo/bar", "elastic.co", 1234)]
+		[InlineData("dummyscheme://elastic.co", "elastic.co", null)]
+		[InlineData("dummyscheme://elastic.co:1234", "elastic.co", 1234)]
+		// IPv4
+		[InlineData("http://1.2.3.4:56789", "1.2.3.4", 56789)]
+		// IPv6
+		[InlineData("http://[::1]:8080/", "::1", 8080)]
+		[InlineData("http://[2012:b86a:f950::b86a:f950]:8080/", "2012:b86a:f950::b86a:f950", 8080)]
+		[InlineData("http://[2012:b86a:f950::b86a:f950]", "2012:b86a:f950::b86a:f950", DefaultHttpPort)]
+		// IPv6 with zone indices
+		// https://en.wikipedia.org/wiki/IPv6_address#Use_of_zone_indices_in_URIs
+		[InlineData("https://[fe80::200:39ff:fe36:1a2d%254]:54321/temp/example.htm", "fe80::200:39ff:fe36:1a2d", 54321)]
+		[InlineData("https://[fe80::200:39ff:fe36:1a2d%254]", "fe80::200:39ff:fe36:1a2d", DefaultHttpsPort)]
+		// Non-ASCII characters in host name
+		[InlineData("http://München", "münchen", DefaultHttpPort)]
+		[InlineData("http://Хост", "Хост", DefaultHttpPort)] // Host in Russian
+		public void TryExtractDestinationInfo_valid_input(string inputUrl, string expectedHost, int? expectedPort)
+		{
+			UrlUtils.TryExtractDestinationInfo(new Uri(inputUrl), out var actualHost, out var actualPort).Should().BeTrue();
+			actualHost.Should().Be(expectedHost);
+			actualPort.Should().Be(expectedPort);
+		}
+
+		[Theory]
+		[InlineData("C:\\")] // no host (Basic host name type)
+		public void TryExtractDestinationInfo_invalid_input(string inputUrl)
+		{
+			UrlUtils.TryExtractDestinationInfo(new Uri(inputUrl), out var actualHost, out var actualPort).Should().BeFalse();
+		}
+	}
+}

--- a/test/Elastic.Apm.Tests/HelpersTests/UrlUtilsTests.cs
+++ b/test/Elastic.Apm.Tests/HelpersTests/UrlUtilsTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Linq;
 using Elastic.Apm.Helpers;
+using Elastic.Apm.Logging;
 using Elastic.Apm.Tests.Mocks;
 using FluentAssertions;
 using Xunit;
@@ -44,7 +45,7 @@ namespace Elastic.Apm.Tests.HelpersTests
 		[InlineData("C:\\")] // no host (Basic host name type)
 		public void TryExtractDestinationInfo_invalid_input(string inputUrl)
 		{
-			var mockLogger = new TestLogger();
+			var mockLogger = new TestLogger(LogLevel.Trace);
 			UrlUtils.TryExtractDestinationInfo(new Uri(inputUrl), out var actualHost, out var actualPort, mockLogger).Should().BeFalse();
 			mockLogger.Lines.Should().Contain(line => line.Contains(nameof(UrlUtils)) && line.Contains(nameof(UrlUtils.TryExtractDestinationInfo)));
 		}

--- a/test/Elastic.Apm.Tests/HttpDiagnosticListenerTests.cs
+++ b/test/Elastic.Apm.Tests/HttpDiagnosticListenerTests.cs
@@ -487,11 +487,11 @@ namespace Elastic.Apm.Tests
 				var topSpanSent = payloadSender.Spans.Last();
 				topSpanSent.Name.Should().Be(topSpanName);
 				topSpanSent.Type.Should().Be(topSpanType);
+				// ReSharper disable AccessToDisposedClosure
 				numberOfHttpCalls.Repeat(i =>
 				{
 					var httpCallSpan = payloadSender.Spans[i];
 					httpCallSpan.Should().NotBeNull();
-					// ReSharper disable once AccessToDisposedClosure
 					httpCallSpan.Context.Http.Url.Should().Be($"{localServer.Uri}?i={i}");
 					httpCallSpan.Context.Http.StatusCode.Should().Be(200);
 					httpCallSpan.Context.Http.Method.Should().Be(HttpMethod.Get.Method);
@@ -501,6 +501,7 @@ namespace Elastic.Apm.Tests
 					topSpanSent.Duration.Value.Should().BeGreaterOrEqualTo(httpCallSpan.Duration.Value);
 					httpCallSpan.ParentId.Should().Be(topSpanSent.Id);
 				});
+				// ReSharper restore AccessToDisposedClosure
 			}
 		}
 


### PR DESCRIPTION
Implements part of #611 (context.destination.address/port for HTTP-call spans).
