### PR TITLE
ci(jenkins): exclude the cached .nuget folder

### DIFF
--- a/.ci/linux/deploy.sh
+++ b/.ci/linux/deploy.sh
@@ -2,9 +2,10 @@
 #
 # This script deploys to nuget given the API key and URL
 #
-set -euxo pipefail
+set -euo pipefail
 
 for nupkg in $(find . -type f -not -path '.nuget' -name '*.nupkg')
 do
+	echo "dotnet nuget push ${nupkg}"
 	dotnet nuget push ${nupkg} -k ${1} -s ${2}
 done

--- a/.ci/linux/deploy.sh
+++ b/.ci/linux/deploy.sh
@@ -4,7 +4,7 @@
 #
 set -euxo pipefail
 
-for nupkg in $(find . -name '*.nupkg')
+for nupkg in $(find . -type f -not -path '.nuget' -name '*.nupkg')
 do
 	dotnet nuget push ${nupkg} -k ${1} -s ${2}
 done


### PR DESCRIPTION
## Description

Used to work until recently:
- See [build](https://apm-ci.elastic.co/blue/organizations/jenkins/apm-agent-dotnet%2Fapm-agent-dotnet-mbp/detail/master/174/pipeline/276) that was the very last build that worked 

```bash
## Push the just generated artifact 
$ dotnet nuget push ./src/Elastic.Apm.AspNetFullFramework/bin/Release/Elastic.Apm.AspNetFullFramework.1.2.0.nupkg ...

  info : Pushing Elastic.Apm.AspNetFullFramework.1.2.0.nupkg to ''**************'...
  info :   PUT **************/
  info :   Created **************/ 1462ms
  info : Your package was pushed.

## The .nuget folder was not excluded.

$ dotnet nuget push ./.nuget/packages/microsoft.extensions.configuration.fileextensions/3.1.0/microsoft.extensions.configuration.fileextensions.3.1.0.nupkg -k ******** -s ***********
  
  info : Pushing microsoft.extensions.configuration.fileextensions.3.1.0.nupkg to '***********'...
  info :   PUT ***********/
  info :   InternalServerError ***********/ 494ms
  info :   PUT ***********/
  info :   InternalServerError ***********/ 115ms
  info :   PUT ***********/
  info :   InternalServerError ***********/ 125ms
  error: Response status code does not indicate success: 500 (NuGet package cannot be read: Item has already been added. Key in dictionary: 'packageIcon.png'  Key being added: 'packageIcon.png').
```


## What does this PR do?

Avoid verbose output and exclude any artifacts which are stored in the .nuget folder, which it's just the required dependencies. In other words, let's push only the artifacts that have been generated.

## Why is it important?

Let's greenish the build again

## Related issues

Closes https://github.com/elastic/apm-agent-dotnet/issues/671

Caused by https://github.com/elastic/apm-agent-dotnet/pull/647 . I'd say, off the top of my head, this bug is related to reusing workers between stages.