### PR TITLE
ci(jenkins): fix the exclude in the deploy

### DIFF
--- a/.ci/linux/deploy.sh
+++ b/.ci/linux/deploy.sh
@@ -4,7 +4,7 @@
 #
 set -euo pipefail
 
-for nupkg in $(find . -type f -not -path '.nuget' -name '*.nupkg')
+for nupkg in $(find . -type f -not -path './.nuget/*' -name '*.nupkg')
 do
 	echo "dotnet nuget push ${nupkg}"
 	dotnet nuget push ${nupkg} -k ${1} -s ${2}


### PR DESCRIPTION
I'm afraid I did not test the script so, it does require a full match pattern:

```bash

$ find . -type f -name '*.nupkg'
./.nuget/Elastic.Apm.EntityFrameworkCore.0.0.2-alpha.nupkg
./src/Elastic.Apm.All/bin/Release/Elastic.Apm.All.0.0.2-alpha.nupkg

$ find . -type f -not -path './.nuget/*' -name '*.nupkg'
./src/Elastic.Apm.All/bin/Release/Elastic.Apm.All.0.0.2-alpha.nupkg
```