### PR TITLE
Add soap action in the transaction name

### DIFF
--- a/sample/AspNetFullFrameworkSampleApp/Asmx/Health.asmx
+++ b/sample/AspNetFullFrameworkSampleApp/Asmx/Health.asmx
@@ -1,0 +1,1 @@
+﻿<%@ WebService Language="C#" CodeBehind="Health.asmx.cs" Class="AspNetFullFrameworkSampleApp.Asmx.Health" %>

--- a/sample/AspNetFullFrameworkSampleApp/Asmx/Health.asmx.cs
+++ b/sample/AspNetFullFrameworkSampleApp/Asmx/Health.asmx.cs
@@ -7,9 +7,6 @@ namespace AspNetFullFrameworkSampleApp.Asmx
 	public class Health : WebService
 	{
 		[WebMethod]
-		public string Ping()
-		{
-			return "Ok";
-		}
+		public string Ping() => "Ok";
 	}
 }

--- a/sample/AspNetFullFrameworkSampleApp/Asmx/Health.asmx.cs
+++ b/sample/AspNetFullFrameworkSampleApp/Asmx/Health.asmx.cs
@@ -1,0 +1,15 @@
+﻿using System.Web.Services;
+
+namespace AspNetFullFrameworkSampleApp.Asmx
+{
+	[WebService(Namespace = "http://tempuri.org/")]
+	[WebServiceBinding(ConformsTo = WsiProfiles.BasicProfile1_1)]
+	public class Health : WebService
+	{
+		[WebMethod]
+		public string Ping()
+		{
+			return "Ok";
+		}
+	}
+}

--- a/sample/AspNetFullFrameworkSampleApp/AspNetFullFrameworkSampleApp.csproj
+++ b/sample/AspNetFullFrameworkSampleApp/AspNetFullFrameworkSampleApp.csproj
@@ -254,6 +254,15 @@
       <Version>4.5.3</Version>
     </PackageReference>
   </ItemGroup>
+  <ItemGroup>
+    <Content Include="Asmx\Health.asmx" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Asmx\Health.asmx.cs">
+      <DependentUpon>Health.asmx</DependentUpon>
+      <SubType>Component</SubType>
+    </Compile>
+  </ItemGroup>
   <PropertyGroup Condition="'$(OS)' == 'WINDOWS_NT'">
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>

--- a/src/Elastic.Apm.AspNetFullFramework/ElasticApmModule.cs
+++ b/src/Elastic.Apm.AspNetFullFramework/ElasticApmModule.cs
@@ -106,10 +106,7 @@ namespace Elastic.Apm.AspNetFullFramework
 			var transactionName = $"{httpRequest.HttpMethod} {httpRequest.Path}";
 
 			var soapAction = httpRequest.ExtractSoapAction(_logger);
-			if (soapAction != null)
-			{
-				transactionName += $" {soapAction}";
-			}
+			if (soapAction != null) transactionName += $" {soapAction}";
 
 			var distributedTracingData = ExtractIncomingDistributedTracingData(httpRequest);
 			if (distributedTracingData != null)

--- a/src/Elastic.Apm.AspNetFullFramework/Extensions/RequestExtensions.cs
+++ b/src/Elastic.Apm.AspNetFullFramework/Extensions/RequestExtensions.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.Text;
+using System.Web;
+using Elastic.Apm.Logging;
+
+
+namespace Elastic.Apm.AspNetFullFramework.Extensions
+{
+	internal static class HttpRequestExtensions
+	{
+		private const string SoapActionHeaderName = "SOAPAction";
+
+		/// <summary>
+		/// Extracts the soap action from the header if exists only with Soap 1.1
+		/// </summary>
+		/// <param name="request">The request.</param>
+		/// <param name="logger">The logger.</param>
+		public static string ExtractSoapAction(this HttpRequest request, IApmLogger logger)
+		{
+			try
+			{
+				var soapActionWithNamespace = request.Headers.Get(SoapActionHeaderName);
+
+				if (string.IsNullOrWhiteSpace(soapActionWithNamespace)) return null;
+
+				var indexPosition = soapActionWithNamespace.LastIndexOf(@"/");
+				if (indexPosition != -1)
+				{
+					return soapActionWithNamespace.Substring(indexPosition + 1).TrimEnd('\"');
+				}
+			}
+			catch (Exception e)
+			{
+				logger.Error()?.LogException(e, "Error reading soap action header");
+			}
+
+			return null;
+		}
+	}
+}

--- a/src/Elastic.Apm.AspNetFullFramework/Extensions/RequestExtensions.cs
+++ b/src/Elastic.Apm.AspNetFullFramework/Extensions/RequestExtensions.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Text;
 using System.Web;
 using Elastic.Apm.Logging;
 
@@ -23,11 +22,8 @@ namespace Elastic.Apm.AspNetFullFramework.Extensions
 
 				if (string.IsNullOrWhiteSpace(soapActionWithNamespace)) return null;
 
-				var indexPosition = soapActionWithNamespace.LastIndexOf(@"/");
-				if (indexPosition != -1)
-				{
-					return soapActionWithNamespace.Substring(indexPosition + 1).TrimEnd('\"');
-				}
+				var indexPosition = soapActionWithNamespace.LastIndexOf(@"/", StringComparison.InvariantCulture);
+				if (indexPosition != -1) return soapActionWithNamespace.Substring(indexPosition + 1).TrimEnd('\"');
 			}
 			catch (Exception e)
 			{

--- a/test/Elastic.Apm.AspNetFullFramework.Tests/DistributedTracingTests.cs
+++ b/test/Elastic.Apm.AspNetFullFramework.Tests/DistributedTracingTests.cs
@@ -3,6 +3,9 @@ using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text;
 using System.Threading.Tasks;
 using AspNetFullFrameworkSampleApp.Controllers;
 using Elastic.Apm.Api;
@@ -107,6 +110,43 @@ namespace Elastic.Apm.AspNetFullFramework.Tests
 				VerifyReceivedDataSharedConstraints(rootTxData, receivedData);
 
 				VerifyRootChildTransactions(receivedData, rootTxData, childTxData, out _, out _);
+			});
+		}
+
+		[AspNetFullFrameworkFact]
+		public async Task CallSoapRequest()
+		{
+			var rootTxData = SampleAppUrlPaths.CallSoapServiceProtocolV1_1;
+			var fullUrl = Consts.SampleApp.RootUrl + "/" + rootTxData.RelativeUrlPath;
+			var action = "Ping";
+
+			var httpContent = new StringContent($@"<?xml version=""1.0"" encoding=""utf-8""?>
+                <soap:Envelope xmlns:xsi=""http://www.w3.org/2001/XMLSchema-instance"" xmlns:xsd=""http://www.w3.org/2001/XMLSchema"" xmlns:soap=""http://schemas.xmlsoap.org/soap/envelope/"">
+                  <soap:Body>
+                    <{action} xmlns=""http://tempuri.org/"" />
+                  </soap:Body>
+                </soap:Envelope>", Encoding.UTF8, "text/xml");
+
+			using (var client = new HttpClient())
+			{
+				var request = new HttpRequestMessage()
+				{
+					RequestUri = new Uri(fullUrl),
+					Method = HttpMethod.Post,
+					Content = httpContent
+				};
+
+				client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("text/xml"));
+				request.Content.Headers.ContentType = new MediaTypeHeaderValue("text/xml");
+				request.Headers.Add("SOAPAction", $"http://tempuri.org/{action}");
+
+				var response = client.SendAsync(request).Result;
+			}
+
+			await WaitAndCustomVerifyReceivedData(receivedData =>
+			{
+				receivedData.Transactions.Count.Should().Be(1);
+				receivedData.Transactions.First().Name.Should().EndWith(action);
 			});
 		}
 

--- a/test/Elastic.Apm.AspNetFullFramework.Tests/TestsBase.cs
+++ b/test/Elastic.Apm.AspNetFullFramework.Tests/TestsBase.cs
@@ -155,6 +155,9 @@ namespace Elastic.Apm.AspNetFullFramework.Tests
 
 			internal static readonly SampleAppUrlPathData GenNSpansPage =
 				new SampleAppUrlPathData(HomeController.GenNSpansPageRelativePath, (int)HttpStatusCode.Created);
+
+			internal static readonly SampleAppUrlPathData CallSoapServiceProtocolV1_1 =
+				new SampleAppUrlPathData("Asmx/Health.asmx", (int)HttpStatusCode.OK);
 		}
 
 		private TimedEvent? _sampleAppClientCallTiming;


### PR DESCRIPTION
Closes #637 

Retrieve the soap action from the header request only if it's available and add it to the transaction name.

Code has been implemented to work with soap 1.1 where soap action is present in the http header.