### PR TITLE
Document the `params IDiagnosticsSubscriber[] subscribers` parameter.

### DIFF
--- a/docs/setup.asciidoc
+++ b/docs/setup.asciidoc
@@ -64,6 +64,17 @@ With this you enable every agent component including ASP.NET Core tracing, monit
 
 In case you only reference the `Elastic.Apm.AspNetCore` package, you won't find the `UseAllElasticApm`. Instead you need to use the `UseElasticApm()` method from the `Elastic.Apm.AspNetCore` namespace. This method turns on ASP.NET Core tracing, and gives you the opportunity to manually turn on other components. By default it will only trace ASP.NET Core requests - No HTTP request tracing, database call tracing or any other tracing component will be turned on.
 
+In case you would like to turn on specific tracing components you can pass those to the `UseElasticApm` method.
+
+For example:
+
+[source,csharp]
+----
+app.UseElasticApm(Configuration,
+	new HttpDiagnosticsSubscriber(),  /* Enable tracing of outgoing HTTP requests */,
+	new EfCoreDiagnosticsSubscriber() /* Enable tracing of database calls through EF Core*/)
+----
+
 In case you only want to use the <<public-api>>, you don't need to do any initialization, you can simply start using the API and the agent will send the data to the APM Server.
 
 

--- a/docs/setup.asciidoc
+++ b/docs/setup.asciidoc
@@ -72,7 +72,7 @@ For example:
 ----
 app.UseElasticApm(Configuration,
 	new HttpDiagnosticsSubscriber(),  /* Enable tracing of outgoing HTTP requests */
-	new EfCoreDiagnosticsSubscriber()) /* Enable tracing of database calls through EF Core*/
+	new EfCoreDiagnosticsSubscriber()); /* Enable tracing of database calls through EF Core*/
 ----
 
 In case you only want to use the <<public-api>>, you don't need to do any initialization, you can simply start using the API and the agent will send the data to the APM Server.

--- a/docs/setup.asciidoc
+++ b/docs/setup.asciidoc
@@ -72,7 +72,7 @@ For example:
 ----
 app.UseElasticApm(Configuration,
 	new HttpDiagnosticsSubscriber(),  /* Enable tracing of outgoing HTTP requests */
-	new EfCoreDiagnosticsSubscriber() /* Enable tracing of database calls through EF Core*/)
+	new EfCoreDiagnosticsSubscriber()) /* Enable tracing of database calls through EF Core*/
 ----
 
 In case you only want to use the <<public-api>>, you don't need to do any initialization, you can simply start using the API and the agent will send the data to the APM Server.

--- a/docs/setup.asciidoc
+++ b/docs/setup.asciidoc
@@ -71,7 +71,7 @@ For example:
 [source,csharp]
 ----
 app.UseElasticApm(Configuration,
-	new HttpDiagnosticsSubscriber(),  /* Enable tracing of outgoing HTTP requests */,
+	new HttpDiagnosticsSubscriber(),  /* Enable tracing of outgoing HTTP requests */
 	new EfCoreDiagnosticsSubscriber() /* Enable tracing of database calls through EF Core*/)
 ----
 


### PR DESCRIPTION
Addressing #680. 

Short description on how you can manually turn on tracing components.