### PR TITLE
ci(jenkins): Release to NuGet when tagged release

### DIFF
--- a/ElasticApmAgent.sln
+++ b/ElasticApmAgent.sln
@@ -43,6 +43,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "files", "files", "{B406113B
 		CONTRIBUTING.md = CONTRIBUTING.md
 		LICENSE = LICENSE
 		README.md = README.md
+		RELEASING.md = RELEASING.md
 		global.json = global.json
 		Directory.Build.props = Directory.Build.props
 	EndProjectSection

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -363,7 +363,7 @@ pipeline {
               beforeInput true
               beforeAgent true
               // Tagged release events ONLY
-              tag pattern: '\\d+\\.\\d+\\.\\d+(-alpha|-beta|-rc)?', comparator: 'REGEXP'
+              tag pattern: '\\d+\\.\\d+\\.\\d+(-(alpha|beta|rc)\\d*)?', comparator: 'REGEXP'
             }
             stages {
               stage('Notify') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -401,12 +401,9 @@ pipeline {
           stage('Integration Tests') {
             agent none
             when {
-              beforeAgent true
-              allOf {
-                anyOf {
-                  environment name: 'GIT_BUILD_CAUSE', value: 'pr'
-                  expression { return !params.Run_As_Master_Branch }
-                }
+              anyOf {
+                changeRequest()
+                expression { return !params.Run_As_Master_Branch }
               }
             }
             steps {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -341,12 +341,10 @@ pipeline {
               }
             }
             steps {
-              withGithubNotify(context: 'Release AppVeyor', tab: 'artifacts') {
-                deleteDir()
-                unstash 'source'
-                dir("${BASE_DIR}"){
-                  release('secret/apm-team/ci/elastic-observability-appveyor')
-                }
+              deleteDir()
+              unstash 'source'
+              dir("${BASE_DIR}"){
+                release('secret/apm-team/ci/elastic-observability-appveyor')
               }
             }
             post{

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -356,6 +356,20 @@ pipeline {
               }
             }
           }
+          stage('Release to NuGet') {
+            options { skipDefaultCheckout() }
+            when {
+              // Tagged release events ONLY
+              tag pattern: '\\d+\\.\\d+\\.\\d+', comparator: 'REGEXP'
+            }
+            steps {
+              deleteDir()
+              unstash 'source'
+              dir("${BASE_DIR}") {
+                release('secret/apm-team/ci/elastic-observability-nuget')
+              }
+            }
+          }
           stage('AfterRelease') {
             options {
               skipDefaultCheckout()

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -358,7 +358,7 @@ pipeline {
             options { skipDefaultCheckout() }
             when {
               // Tagged release events ONLY
-              tag pattern: '\\d+\\.\\d+\\.\\d+', comparator: 'REGEXP'
+              tag pattern: '\\d+\\.\\d+\\.\\d+(-alpha|-beta|-rc)?', comparator: 'REGEXP'
             }
             steps {
               deleteDir()

--- a/README.md
+++ b/README.md
@@ -35,6 +35,10 @@ Please note that we reserve GitHub tickets for confirmed bugs and enhancement re
 
 See the [contributing documentation](CONTRIBUTING.md)
 
+## Releasing
+
+See the [releasing documentation](RELEASING.md)
+
 ## Repository structure
 
 These are the main folders within the repository:

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -44,7 +44,7 @@ After the new changelog and version have been merged to master, the only thing r
  git push upstream <major>.<minor>.<bug>(-<suffix>)?
  ```
 
-The above commands will push the GitHub tag and will trigger the corresponding [Build pipeline](Jenkinsfile) which will run all the required stages to satisfy the release is in a good shape, then it will ask for approval to release to the NuGet repo.
+The above commands will push the GitHub tag and will trigger the corresponding [CI Build pipeline](Jenkinsfile) which will run all the required stages to satisfy the release is in a good shape, then at the very end of the pipeline there will be an input approval waiting for an UI interaction to release to the NuGet repo. This particular input approval step will notify by email, to the owners of this repo, regarding the expected action to be done for doing the release.
 
 This release process is a tagged release event based with an input approval.
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,60 @@
+# Releasing a new version
+
+This guide aims to provide guidance on how to release new versions of the `apm-agent-dotnet` binary as well as updating all the necessary parts to make it successful.
+
+## Prerequisites
+
+Releasing a new version of the binary implies that there have been changes in the source code which are meant to be released for wider consumption. Before releasing a new version there's some prerequisites that have to be checked.
+
+### Make sure the version is updated
+
+Since the source has changed, we need to update the current committed version to a higher version so that the release is published.
+
+The version is currently defined in the [Directory.Build.props](./src/Directory.Build.props) in the [SEMVER](https://semver.org) format: `MAJOR.MINOR.BUG`
+
+Say we want to perform a minor version release (i.e. no breaking changes and only new features and bug fixes are being included); in which case we'll update the _MINOR_ part of the version.
+
+For instance, the bump from version 1.1.2 to 1.2 can be found in this https://github.com/elastic/apm-agent-dotnet/pull/624
+
+### Generating a changelog for the new version
+
+Once the version is updated, we can then generate the changelog, you can see the current changelog in [`CHANGELOG.asciidoc`](CHANGELOG.asciidod). The idea is to fill all the applicable sections so that users can consume an orderly changelog.
+
+After a changelog has been manually curated, a new pull request can be opened with the changelog and version update changes.
+
+For instance, the changelog that was created for the 1.2 release can be found in this https://github.com/elastic/apm-agent-dotnet/pull/640
+
+## Executing the release
+
+After the new changelog and version have been merged to master, the only thing remaining is to run the below commands:
+
+
+ ```bash
+ ## let's assume the origin is your forked repo and upstream the one where the releases are coming from.
+ git checkout master
+
+ ## let's ensure we do use the latest commit, although this requirement could be not neccessary if it's required
+ ## to use another git commit rather than the HEAD at that time.
+ git reset --hard upstream/master
+
+ ## <major>, <minor>, <bug> and <suffix> should be replaced accordingly. <suffix> is an optional one.
+ git tag <major>.<minor>.<bug>(-<suffix>)?
+
+ ## Push commit to the usptream repo.
+ git push upstream <major>.<minor>.<bug>(-<suffix>)?
+ ```
+
+The above commands will push the GitHub tag and will trigger the corresponding [Build pipeline](Jenkinsfile) which will run all the required stages to satisfy the release is in a good shape, then it will ask for approval to release to the NuGet repo.
+
+This release process is a tagged release event based with an input approval.
+
+## Executing the release script locally
+
+If required then it's possible to run the release script locally, for such, the credentials are needed to push to the NuGet repo.
+
+```bash
+.ci/linux/release.sh
+.ci/linux/deploy.sh <API_KEY> <SERVER_URL>
+```
+
+_NOTE_ The above scripts are just wrapper for the `dotnet` command.


### PR DESCRIPTION
## What does this PR do?

1. Enable the release automation to NuGet only when a tagged released is created with the format `[0-9].[0-9].[0-9](-alpha[0-9]*|-beta[0-9]*|-rc[0-9]*)?`.

1. The tagged release is created by the owner of the repo and pushed to the upstream, then the automation will happen afterward.

1. Tidy up some unnecessary notifications to GH as it does only work for PRs and simplify the when condition for the ITs.

1. Send an email when the release to NuGet is ready to be pushed since it's required an input approval.

1. Add RELEASING.md docs.

## Why is it important?

Automate the release process that was already created sometime ago.

## Related issues

Closes #619
Related to #172

## Questions
- [x] Should it be a fully automated process or a one-button release process? 
Just agreed to use a one-button release process.
- [x] If one button-release process then an email with the link to the input approval could help. See https://github.com/elastic/apm-agent-python/pull/609 as an example.

## Test Cases
Let's use my forked repo and leave the tag in place for future references. For such, let's skip all the stages but the release and change the deploy to be DRY based :)

#### Regex work as expected with the format `0.0.1`, `1.2.0-rc`, `1.2.0-alpha123` and `1.2.0-bad`

How did I prepare the test environment?
1. Created an MBP locally similar to https://github.com/elastic/apm-agent-dotnet/blob/master/.ci/jobs/apm-agent-dotnet-mbp.yml
1. `git checkout test/release-nuget` is the one with the changes of this particular PR but with the `when` condition to skip all the stages that are not related to the release to NuGet.
1. `git tag 0.0.1` and `git push origin 0.0.1` (the same for 1.2.0-rc and 1.2.0-bad)


<details><summary>Expand to view the whole tags status</summary>
<p>

Expected behavior:
- Stable builds for the unmatched patterns
- Aborted builds for the matched patterns, since their input approval was aborted

![image](https://user-images.githubusercontent.com/2871786/72886195-4596e500-3d01-11ea-820b-39a58fb0593e.png)

</p>
</details>

<details><summary>Expand to view 0.0.1 release</summary>
<p>

Expected behavior: 
* Input approval.
* Email notification.
* If approved then a release to NuGet will happen

![image](https://user-images.githubusercontent.com/2871786/72800341-0acc7880-3c3f-11ea-8bd2-819e1737fb2d.png)

![image](https://user-images.githubusercontent.com/2871786/72801038-9692d480-3c40-11ea-97aa-91ae65b17c17.png)

![image](https://user-images.githubusercontent.com/2871786/72801062-a7434a80-3c40-11ea-9c8f-ab9f2aa4d5b4.png)

![image](https://user-images.githubusercontent.com/2871786/72801421-5ed85c80-3c41-11ea-8948-acfc1aa51566.png)

![image](https://user-images.githubusercontent.com/2871786/72800928-57648380-3c40-11ea-9327-debdc34a922a.png)

Tag -> https://github.com/v1v/apm-agent-dotnet/tree/0.0.1
</p>
</details>

<details><summary>Expand to view 1.2.0-bad release</summary>
<p>

Expected behavior: 
* No release.

![image](https://user-images.githubusercontent.com/2871786/72800761-018fdb80-3c40-11ea-80ab-82af71c79ca2.png)

Tag -> https://github.com/v1v/apm-agent-dotnet/tree/1.2.0-bad
</p>
</details>

<details><summary>Expand to view 1.2.0-rc release</summary>
<p>

Expected behavior: 
* Input approval.
* Email notification.
* If approved then a release to NuGet will happen

![image](https://user-images.githubusercontent.com/2871786/72801155-d1950800-3c40-11ea-8f3b-636b1481f929.png)

Tag -> https://github.com/v1v/apm-agent-dotnet/tree/1.2.0-rc
</p>
</details>


#### Email notification when a tag released is ready to be pushed.

I'm afraid I do need to create a PR to test this particular scenario, as my local Jenkins instance has not got any email system in place.

How did I test the email notification?
1. https://github.com/elastic/apm-agent-dotnet/pull/699

<details><summary>Expand to view email release input approval notification</summary>
<p>

Expected behavior: 
* Input approval.
* Email notification.

![image](https://user-images.githubusercontent.com/2871786/72802259-479a6e80-3c43-11ea-8808-feec2b0fb045.png)

![image](https://user-images.githubusercontent.com/2871786/72802286-584ae480-3c43-11ea-86c9-93aa90a0101d.png)

</p>
</details>

