### PR TITLE
Add runtime metrics - GC

### DIFF
--- a/docs/metrics.asciidoc
+++ b/docs/metrics.asciidoc
@@ -100,3 +100,66 @@ platform: all
 
 The total physical memory the process has.
 --
+
+[float]
+[[metrics-runtime]]
+=== Runtime metrics
+
+
+*`clr.gc.count`*::
++
+--
+type: long
+
+Platform: all.
+
+The total number of GC collections that have occurred.
+--
+
+*`clr.gc.gen0size`*::
++
+--
+type: long
+
+format: bytes
+
+Platform: all.
+
+The size of the generation 0 heap.
+--
+
+*`clr.gc.gen1size`*::
++
+--
+type: long
+
+format: bytes
+
+Platform: all.
+
+The size of the generation 1 heap.
+--
+
+*`clr.gc.gen2size`*::
++
+--
+type: long
+
+format: bytes
+
+Platform: all.
+
+The size of the generation 2 heap.
+--
+
+*`clr.gc.gen3size`*::
++
+--
+type: long
+
+format: bytes
+
+Platform: all.
+
+The size of the generation 3 heap - also known as Large Object Heap (LOH).
+--

--- a/src/Elastic.Apm/Elastic.Apm.csproj
+++ b/src/Elastic.Apm/Elastic.Apm.csproj
@@ -13,8 +13,7 @@
     <PackageReference Include="System.Diagnostics.PerformanceCounter" Version="4.5.0" />
   </ItemGroup>
   <ItemGroup>
-    <!--TODO: lower version & maybe Full Framework only--> 
-    <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="2.0.49" />
+    <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="2.0.2" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
     <!-- TODO: Are we ok with this reference/version? -->
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="4.0.0" />

--- a/src/Elastic.Apm/Elastic.Apm.csproj
+++ b/src/Elastic.Apm/Elastic.Apm.csproj
@@ -13,6 +13,8 @@
     <PackageReference Include="System.Diagnostics.PerformanceCounter" Version="4.5.0" />
   </ItemGroup>
   <ItemGroup>
+    <!--TODO: lower version & maybe Full Framework only--> 
+    <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="2.0.49" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
     <!-- TODO: Are we ok with this reference/version? -->
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="4.0.0" />

--- a/src/Elastic.Apm/Metrics/MetricsCollector.cs
+++ b/src/Elastic.Apm/Metrics/MetricsCollector.cs
@@ -58,7 +58,7 @@ namespace Elastic.Apm.Metrics
 				new ProcessWorkingSetAndVirtualMemoryProvider(),
 				new SystemTotalCpuProvider(_logger),
 				new ProcessTotalCpuTimeProvider(_logger),
-				new GcMetricsProvider()
+				new GcMetricsProvider(_logger)
 			};
 
 			_logger.Info()?.Log("Collecting metrics in {interval} milliseconds interval", interval);

--- a/src/Elastic.Apm/Metrics/MetricsCollector.cs
+++ b/src/Elastic.Apm/Metrics/MetricsCollector.cs
@@ -57,7 +57,8 @@ namespace Elastic.Apm.Metrics
 				new FreeAndTotalMemoryProvider(),
 				new ProcessWorkingSetAndVirtualMemoryProvider(),
 				new SystemTotalCpuProvider(_logger),
-				new ProcessTotalCpuTimeProvider(_logger)
+				new ProcessTotalCpuTimeProvider(_logger),
+				new GcMetricsProvider()
 			};
 
 			_logger.Info()?.Log("Collecting metrics in {interval} milliseconds interval", interval);

--- a/src/Elastic.Apm/Metrics/MetricsProvider/GcMetricsProvider.cs
+++ b/src/Elastic.Apm/Metrics/MetricsProvider/GcMetricsProvider.cs
@@ -68,14 +68,13 @@ namespace Elastic.Apm.Metrics.MetricsProvider
 					{
 						proc.AddCallbackOnDotNetRuntimeLoad((runtime) =>
 						{
-							runtime.GCStart += (process, gc) => { };
 							runtime.GCEnd += (process, gc) =>
 							{
 								_gen0Size = (ulong)gc.HeapStats.GenerationSize0;
 								_gen1Size = (ulong)gc.HeapStats.GenerationSize1;
 								_gen2Size = (ulong)gc.HeapStats.GenerationSize2;
 								_gen3Size = (ulong)gc.HeapStats.GenerationSize3;
-								_gcCount = (uint)gc.Number;
+								_gcCount = (uint)runtime.GC.GCs.Count;
 							};
 						});
 					});

--- a/src/Elastic.Apm/Metrics/MetricsProvider/GcMetricsProvider.cs
+++ b/src/Elastic.Apm/Metrics/MetricsProvider/GcMetricsProvider.cs
@@ -1,0 +1,67 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.Tracing;
+using Elastic.Apm.Api;
+
+namespace Elastic.Apm.Metrics.MetricsProvider
+{
+	internal class GcMetricsProvider : IMetricsProvider //TODO: Make disposable
+	{
+		private SimpleEventListener _eventListener;
+		public GcMetricsProvider() => _eventListener = new SimpleEventListener();
+
+		public int ConsecutiveNumberOfFailedReads { get; set; }
+		public string DbgName => "GcMetricsProvider";
+
+		public IEnumerable<MetricSample> GetSamples()
+		{
+			var a = 0;
+			return new List<MetricSample>();
+		}
+	}
+
+	internal class SimpleEventListener : EventListener
+	{
+		private ulong _countTotalEvents = 0;
+		private static int keyword = 1; //TODO
+
+		private long _timeGcStart = 0;
+		private EventSource _eventSourceDotNet;
+
+		public SimpleEventListener() =>
+			Console.WriteLine("SimpleEventListener ctor");
+
+		// Called whenever an EventSource is created.
+		protected override void OnEventSourceCreated(EventSource eventSource)
+		{
+			Console.WriteLine(eventSource.Name);
+			if (!eventSource.Name.Equals("Microsoft-Windows-DotNETRuntime")) return;
+
+			EnableEvents(eventSource, EventLevel.Informational, (EventKeywords)keyword);
+			_eventSourceDotNet = eventSource;
+		}
+		// Called whenever an event is written.
+		protected override void OnEventWritten(EventWrittenEventArgs eventData)
+		{
+			Console.WriteLine("OnEventWritten :" + eventData.EventName);
+			// Write the contents of the event to the console.
+			if (eventData.EventName.Contains("GCStart"))
+			{
+
+				//_timeGcStart = eventData.TimeStamp.Ticks;
+			}
+			else if (eventData.EventName.Contains("GCEnd"))
+			{
+				//long timeGCEnd = eventData.TimeStamp.Ticks;
+			//	long gcIndex = long.Parse(eventData.Payload[0].ToString());
+				// Console.WriteLine("GC#{0} took {1:f3}ms",
+				// 	gcIndex, (double) (timeGCEnd - _timeGcStart)/10.0/1000.0);
+				//
+				// if (gcIndex >= 5)
+				// 	DisableEvents(_eventSourceDotNet);
+			}
+
+			_countTotalEvents++;
+		}
+	}
+}

--- a/src/Elastic.Apm/Metrics/MetricsProvider/GcMetricsProvider.cs
+++ b/src/Elastic.Apm/Metrics/MetricsProvider/GcMetricsProvider.cs
@@ -204,8 +204,6 @@ namespace Elastic.Apm.Metrics.MetricsProvider
 
 			public override void Dispose()
 			{
-				base.Dispose();
-
 				try
 				{
 					if (_eventSourceDotNet != null)
@@ -213,7 +211,6 @@ namespace Elastic.Apm.Metrics.MetricsProvider
 						_logger.Trace()?.Log("disposing {classname}", nameof(GcEventListener));
 						DisableEvents(_eventSourceDotNet);
 						_eventSourceDotNet = null;
-
 						// calling _eventSourceDotNet.Dispose makes it impossible to re-enable the eventsource, so if we call _eventSourceDotNet.Dispose()
 						// all tests will fail after Dispose()
 					}

--- a/src/Elastic.Apm/Metrics/MetricsProvider/GcMetricsProvider.cs
+++ b/src/Elastic.Apm/Metrics/MetricsProvider/GcMetricsProvider.cs
@@ -21,14 +21,20 @@ namespace Elastic.Apm.Metrics.MetricsProvider
 		public int ConsecutiveNumberOfFailedReads { get; set; }
 		public string DbgName => "GcMetricsProvider";
 
-		public IEnumerable<MetricSample> GetSamples() => new List<MetricSample>
+		public IEnumerable<MetricSample> GetSamples()
 		{
-			new MetricSample(GcCountName, _eventListener.GcCount),
-			new MetricSample(GcGen0SizeName, _eventListener.Gen0Size),
-			new MetricSample(GcGen1SizeName, _eventListener.Gen1Size),
-			new MetricSample(GcGen2SizeName, _eventListener.Gen2Size),
-			new MetricSample(GcGen3SizeName, _eventListener.Gen3Size)
-		};
+			if (_eventListener.GcCount != 0 || _eventListener.Gen0Size != 0 || _eventListener.Gen2Size != 0 || _eventListener.Gen3Size != 0)
+				return null;
+
+			return new List<MetricSample>
+			{
+				new MetricSample(GcCountName, _eventListener.GcCount),
+				new MetricSample(GcGen0SizeName, _eventListener.Gen0Size),
+				new MetricSample(GcGen1SizeName, _eventListener.Gen1Size),
+				new MetricSample(GcGen2SizeName, _eventListener.Gen2Size),
+				new MetricSample(GcGen3SizeName, _eventListener.Gen3Size)
+			};
+		}
 
 		public void Dispose() => _eventListener?.Dispose();
 

--- a/src/Elastic.Apm/Metrics/MetricsProvider/GcMetricsProvider.cs
+++ b/src/Elastic.Apm/Metrics/MetricsProvider/GcMetricsProvider.cs
@@ -5,67 +5,100 @@ using Elastic.Apm.Api;
 
 namespace Elastic.Apm.Metrics.MetricsProvider
 {
-	internal class GcMetricsProvider : IMetricsProvider //TODO: Make disposable
+	/// <summary>
+	/// A metrics provider that collects GC metrics through EventSource
+	/// </summary>
+	internal class GcMetricsProvider : IMetricsProvider, IDisposable
 	{
-		private const string GcCount = "clr.gc.count";
-		private readonly SimpleEventListener _eventListener;
+		private const string GcCountName = "clr.gc.count";
+		private const string GcGen0SizeName = "clr.gc.gen0size";
+		private const string GcGen1SizeName = "clr.gc.gen1size";
+		private const string GcGen2SizeName = "clr.gc.gen2size";
+		private const string GcGen3SizeName = "clr.gc.gen3size";
 
-		private static readonly object Lock = new object();
-
-		public GcMetricsProvider() => _eventListener = new SimpleEventListener();
+		private readonly GcEventListener _eventListener = new GcEventListener();
 
 		public int ConsecutiveNumberOfFailedReads { get; set; }
 		public string DbgName => "GcMetricsProvider";
 
-		public IEnumerable<MetricSample> GetSamples()
+		public IEnumerable<MetricSample> GetSamples() => new List<MetricSample>
 		{
-			if (_eventListener.Samples == null)
-				return null;
+			new MetricSample(GcCountName, _eventListener.GcCount),
+			new MetricSample(GcGen0SizeName, _eventListener.Gen0Size),
+			new MetricSample(GcGen1SizeName, _eventListener.Gen1Size),
+			new MetricSample(GcGen2SizeName, _eventListener.Gen2Size),
+			new MetricSample(GcGen3SizeName, _eventListener.Gen3Size)
+		};
 
-			var retVal = new MetricSample[_eventListener.Samples.Count];
-			lock (Lock)
-			{
-				_eventListener.Samples.CopyTo(retVal, 0);
-				_eventListener.Samples.Clear();
-			}
+		public void Dispose() => _eventListener?.Dispose();
 
-			return retVal;
-		}
-
-		private class SimpleEventListener : EventListener
+		/// <summary>
+		/// An event listener that collects the GC stats
+		/// </summary>
+		private class GcEventListener : EventListener
 		{
-			private static readonly int keyword = 1; //TODO
+			private static readonly int keywordGC = 1; //TODO
 
-			internal List<MetricSample> Samples = new List<MetricSample>();
+			private EventSource _eventSourceDotNet;
 
-			public SimpleEventListener() =>
-				Console.WriteLine("SimpleEventListener ctor");
+			internal uint GcCount;
+			internal ulong Gen0Size;
+			internal ulong Gen1Size;
+			internal ulong Gen2Size;
+			internal ulong Gen3Size;
 
 			protected override void OnEventSourceCreated(EventSource eventSource)
 			{
-				Console.WriteLine(eventSource.Name);
 				if (!eventSource.Name.Equals("Microsoft-Windows-DotNETRuntime")) return;
 
-				EnableEvents(eventSource, EventLevel.Informational, (EventKeywords)keyword);
+				EnableEvents(eventSource, EventLevel.Informational, (EventKeywords)keywordGC);
+				_eventSourceDotNet = eventSource;
 			}
 
 			protected override void OnEventWritten(EventWrittenEventArgs eventData)
 			{
-				Console.WriteLine("OnEventWritten :" + eventData.EventName);
-
-				if (eventData.EventName.Contains("GCStart")) { } //TODO: remove
-
-				else if (eventData.EventName.Contains("GCEnd"))
+				// Collect heap sizes
+				if (eventData.EventName.Contains("GCHeapStats_V1"))
 				{
-					var indexOfCount = eventData.PayloadNames.IndexOf("Count");
+					SetValue("GenerationSize0", ref Gen0Size);
+					SetValue("GenerationSize1", ref Gen1Size);
+					SetValue("GenerationSize2", ref Gen2Size);
+					SetValue("GenerationSize3", ref Gen3Size);
+				}
+
+				// Collect GC count
+				if (eventData.EventName.Contains("GCEnd"))
+				{
+					var indexOfCount = IndexOf("Count");
 					if (indexOfCount < 0) return;
 
 					var gcCount = eventData.Payload[indexOfCount];
 
 					if (!(gcCount is uint gcCountInt)) return;
 
-					lock (Lock) Samples.Add(new MetricSample(GcCount, gcCountInt));
+					GcCount = gcCountInt;
 				}
+
+				void SetValue(string name, ref ulong value)
+				{
+					var gen0SizeIndex = IndexOf(name);
+					if (gen0SizeIndex < 0) return;
+
+					var gen0Size = eventData.Payload[gen0SizeIndex];
+					if (gen0Size is ulong gen0SizeLong)
+						value = gen0SizeLong;
+				}
+
+				int IndexOf(string name)
+				{
+					return eventData.PayloadNames.IndexOf(name);
+				}
+			}
+
+			public override void Dispose()
+			{
+				DisableEvents(_eventSourceDotNet);
+				base.Dispose();
 			}
 		}
 	}

--- a/src/Elastic.Apm/Metrics/MetricsProvider/GcMetricsProvider.cs
+++ b/src/Elastic.Apm/Metrics/MetricsProvider/GcMetricsProvider.cs
@@ -184,7 +184,8 @@ namespace Elastic.Apm.Metrics.MetricsProvider
 
 			public override void Dispose()
 			{
-				DisableEvents(_eventSourceDotNet);
+				if(_eventSourceDotNet != null)
+					DisableEvents(_eventSourceDotNet);
 				base.Dispose();
 			}
 		}

--- a/src/Elastic.Apm/Metrics/MetricsProvider/GcMetricsProvider.cs
+++ b/src/Elastic.Apm/Metrics/MetricsProvider/GcMetricsProvider.cs
@@ -113,7 +113,7 @@ namespace Elastic.Apm.Metrics.MetricsProvider
 			_logger.Trace()
 				?.Log(
 					"Collected gc metrics values: gcCount: {gcCount}, gen0Size: {gen0Size},  gen1Size: {gen1Size}, gen2Size: {gen2Size}, gen1Size: {gen3Size}",
-					_gcCount, _gen0Size, _gen2Size, _gen3Size);
+					_gcCount, _gen0Size, _gen1Size, _gen2Size, _gen3Size);
 			return null;
 		}
 
@@ -194,7 +194,10 @@ namespace Elastic.Apm.Metrics.MetricsProvider
 				try
 				{
 					if (_eventSourceDotNet != null)
+					{
 						DisableEvents(_eventSourceDotNet);
+						_eventSourceDotNet.Dispose();
+					}
 					base.Dispose();
 				}
 				catch(Exception e)

--- a/test/Elastic.Apm.Tests/BackendCommTests/CentralConfigFetcherTests.cs
+++ b/test/Elastic.Apm.Tests/BackendCommTests/CentralConfigFetcherTests.cs
@@ -19,7 +19,8 @@ namespace Elastic.Apm.Tests.BackendCommTests
 		public void Dispose_stops_the_thread()
 		{
 			CentralConfigFetcher lastCentralConfigFetcher;
-			using (var agent = new ApmAgent(new AgentComponents(LoggerBase)))
+			using var agentComponents = new AgentComponents(LoggerBase);
+			using (var agent = new ApmAgent(agentComponents))
 			{
 				lastCentralConfigFetcher = (CentralConfigFetcher)agent.CentralConfigFetcher;
 				lastCentralConfigFetcher.IsRunning.Should().BeTrue();
@@ -43,9 +44,12 @@ namespace Elastic.Apm.Tests.BackendCommTests
 			var agents = new ApmAgent[numberOfAgentInstances];
 			numberOfAgentInstances.Repeat(i =>
 			{
-				agents[i] = new ApmAgent(new AgentComponents(LoggerBase));
-				((CentralConfigFetcher)agents[i].CentralConfigFetcher).IsRunning.Should().BeTrue();
-				((PayloadSenderV2)agents[i].PayloadSender).IsRunning.Should().BeTrue();
+				using var agentComponent = new AgentComponents(LoggerBase);
+				using (agents[i] = new ApmAgent(agentComponent))
+				{
+					((CentralConfigFetcher)agents[i].CentralConfigFetcher).IsRunning.Should().BeTrue();
+					((PayloadSenderV2)agents[i].PayloadSender).IsRunning.Should().BeTrue();
+				}
 			});
 
 			// Sleep a few seconds to let backend component to get to the stage where they contact APM Server

--- a/test/Elastic.Apm.Tests/ConfigTests.cs
+++ b/test/Elastic.Apm.Tests/ConfigTests.cs
@@ -357,14 +357,17 @@ namespace Elastic.Apm.Tests
 		public void DefaultServiceNameTest()
 		{
 			var payloadSender = new MockPayloadSender();
-			var agent = new ApmAgent(new AgentComponents(payloadSender: payloadSender));
-			agent.Tracer.CaptureTransaction("TestTransactionName", "TestTransactionType", t => { Thread.Sleep(2); });
+			using var agentComponents = new AgentComponents(payloadSender: payloadSender);
+			using (var agent = new ApmAgent(agentComponents))
+			{
+				agent.Tracer.CaptureTransaction("TestTransactionName", "TestTransactionType", t => { Thread.Sleep(2); });
 
-			//By default XUnit uses 'testhost' as the entry assembly, and that is what the
-			//agent reports if we don't set it to anything:
-			var serviceName = agent.Service.Name;
-			serviceName.Should().NotBeNullOrWhiteSpace();
-			serviceName.Should().NotContain(".");
+				//By default XUnit uses 'testhost' as the entry assembly, and that is what the
+				//agent reports if we don't set it to anything:
+				var serviceName = agent.Service.Name;
+				serviceName.Should().NotBeNullOrWhiteSpace();
+				serviceName.Should().NotContain(".");
+			}
 		}
 
 		/// <summary>
@@ -378,10 +381,13 @@ namespace Elastic.Apm.Tests
 			var serviceName = "MyService123";
 			Environment.SetEnvironmentVariable(EnvVarNames.ServiceName, serviceName);
 			var payloadSender = new MockPayloadSender();
-			var agent = new ApmAgent(new AgentComponents(payloadSender: payloadSender));
-			agent.Tracer.CaptureTransaction("TestTransactionName", "TestTransactionType", t => { Thread.Sleep(2); });
+			using var agentComponents = new AgentComponents(payloadSender: payloadSender);
+			using (var agent = new ApmAgent(agentComponents))
+			{
+				agent.Tracer.CaptureTransaction("TestTransactionName", "TestTransactionType", t => { Thread.Sleep(2); });
 
-			agent.Service.Name.Should().Be(serviceName);
+				agent.Service.Name.Should().Be(serviceName);
+			}
 		}
 
 		/// <summary>
@@ -396,12 +402,14 @@ namespace Elastic.Apm.Tests
 			var serviceName = "My.Service.Test";
 			Environment.SetEnvironmentVariable(EnvVarNames.ServiceName, serviceName);
 			var payloadSender = new MockPayloadSender();
-			var agent = new ApmAgent(new AgentComponents(payloadSender: payloadSender));
-			agent.Tracer.CaptureTransaction("TestTransactionName", "TestTransactionType", t => { Thread.Sleep(2); });
+			using var agentComponents = new AgentComponents(payloadSender: payloadSender);
+			using (var agent = new ApmAgent(agentComponents))
+			{
+				agent.Tracer.CaptureTransaction("TestTransactionName", "TestTransactionType", t => { Thread.Sleep(2); });
 
-
-			agent.Service.Name.Should().Be(serviceName.Replace('.', '_'));
-			agent.Service.Name.Should().NotContain(".");
+				agent.Service.Name.Should().Be(serviceName.Replace('.', '_'));
+				agent.Service.Name.Should().NotContain(".");
+			}
 		}
 
 		/// <summary>
@@ -413,13 +421,16 @@ namespace Elastic.Apm.Tests
 			var serviceName = "MyService123!";
 			Environment.SetEnvironmentVariable(EnvVarNames.ServiceName, serviceName);
 			var payloadSender = new MockPayloadSender();
-			var agent = new ApmAgent(new AgentComponents(payloadSender: payloadSender));
-			agent.Tracer.CaptureTransaction("TestTransactionName", "TestTransactionType", t => { Thread.Sleep(2); });
+			using var agentComponents = new AgentComponents(payloadSender: payloadSender);
+			using (var agent = new ApmAgent(agentComponents))
+			{
+				agent.Tracer.CaptureTransaction("TestTransactionName", "TestTransactionType", t => { Thread.Sleep(2); });
 
-			agent.Service.Name.Should().NotBe(serviceName);
-			agent.Service.Name.Should()
-				.MatchRegex("^[a-zA-Z0-9 _-]+$")
-				.And.Be("MyService123_");
+				agent.Service.Name.Should().NotBe(serviceName);
+				agent.Service.Name.Should()
+					.MatchRegex("^[a-zA-Z0-9 _-]+$")
+					.And.Be("MyService123_");
+			}
 		}
 
 		/// <summary>
@@ -431,11 +442,14 @@ namespace Elastic.Apm.Tests
 			var serviceName = DefaultValues.UnknownServiceName;
 			Environment.SetEnvironmentVariable(EnvVarNames.ServiceName, serviceName);
 			var payloadSender = new MockPayloadSender();
-			var agent = new ApmAgent(new AgentComponents(payloadSender: payloadSender));
-			agent.Tracer.CaptureTransaction("TestTransactionName", "TestTransactionType", t => { Thread.Sleep(2); });
+			using var agentComponents = new AgentComponents(payloadSender: payloadSender);
+			using (var agent = new ApmAgent(agentComponents))
+			{
+				agent.Tracer.CaptureTransaction("TestTransactionName", "TestTransactionType", t => { Thread.Sleep(2); });
 
-			agent.Service.Name.Should().Be(serviceName);
-			agent.Service.Name.Should().MatchRegex("^[a-zA-Z0-9 _-]+$");
+				agent.Service.Name.Should().Be(serviceName);
+				agent.Service.Name.Should().MatchRegex("^[a-zA-Z0-9 _-]+$");
+			}
 		}
 
 		/// <summary>
@@ -449,10 +463,13 @@ namespace Elastic.Apm.Tests
 			var serviceVersion = "2.1.0.5";
 			Environment.SetEnvironmentVariable(EnvVarNames.ServiceVersion, serviceVersion);
 			var payloadSender = new MockPayloadSender();
-			var agent = new ApmAgent(new AgentComponents(payloadSender: payloadSender));
-			agent.Tracer.CaptureTransaction("TestTransactionName", "TestTransactionType", t => { Thread.Sleep(2); });
+			using var agentComponents = new AgentComponents(payloadSender: payloadSender);
+			using (var agent = new ApmAgent(agentComponents))
+			{
+				agent.Tracer.CaptureTransaction("TestTransactionName", "TestTransactionType", t => { Thread.Sleep(2); });
 
-			agent.Service.Version.Should().Be(serviceVersion);
+				agent.Service.Version.Should().Be(serviceVersion);
+			}
 		}
 
 		[Fact]

--- a/test/Elastic.Apm.Tests/ConfigTests.cs
+++ b/test/Elastic.Apm.Tests/ConfigTests.cs
@@ -171,7 +171,7 @@ namespace Elastic.Apm.Tests
 			var serverUrlsWithSpace = "http://myServer:1234 \r\n";
 			Environment.SetEnvironmentVariable(EnvVarNames.ServerUrls, serverUrlsWithSpace);
 			var payloadSender = new MockPayloadSender();
-			using (var agent = new ApmAgent(new AgentComponents(payloadSender: payloadSender)))
+			using (var agent = new ApmAgent(new TestAgentComponents(payloadSender: payloadSender, config: new EnvironmentConfigurationReader())))
 			{
 #if !NETCOREAPP3_0 && !NETCOREAPP3_1
 				agent.ConfigurationReader.ServerUrls.First().Should().NotBe(serverUrlsWithSpace);
@@ -357,8 +357,7 @@ namespace Elastic.Apm.Tests
 		public void DefaultServiceNameTest()
 		{
 			var payloadSender = new MockPayloadSender();
-			using var agentComponents = new AgentComponents(payloadSender: payloadSender);
-			using (var agent = new ApmAgent(agentComponents))
+			using (var agent = new ApmAgent(new TestAgentComponents(payloadSender: payloadSender)))
 			{
 				agent.Tracer.CaptureTransaction("TestTransactionName", "TestTransactionType", t => { Thread.Sleep(2); });
 
@@ -381,8 +380,7 @@ namespace Elastic.Apm.Tests
 			var serviceName = "MyService123";
 			Environment.SetEnvironmentVariable(EnvVarNames.ServiceName, serviceName);
 			var payloadSender = new MockPayloadSender();
-			using var agentComponents = new AgentComponents(payloadSender: payloadSender);
-			using (var agent = new ApmAgent(agentComponents))
+			using (var agent = new ApmAgent(new TestAgentComponents(payloadSender: payloadSender, config: new EnvironmentConfigurationReader())))
 			{
 				agent.Tracer.CaptureTransaction("TestTransactionName", "TestTransactionType", t => { Thread.Sleep(2); });
 
@@ -402,8 +400,7 @@ namespace Elastic.Apm.Tests
 			var serviceName = "My.Service.Test";
 			Environment.SetEnvironmentVariable(EnvVarNames.ServiceName, serviceName);
 			var payloadSender = new MockPayloadSender();
-			using var agentComponents = new AgentComponents(payloadSender: payloadSender);
-			using (var agent = new ApmAgent(agentComponents))
+			using (var agent = new ApmAgent(new TestAgentComponents(payloadSender: payloadSender, config: new EnvironmentConfigurationReader())))
 			{
 				agent.Tracer.CaptureTransaction("TestTransactionName", "TestTransactionType", t => { Thread.Sleep(2); });
 
@@ -421,8 +418,7 @@ namespace Elastic.Apm.Tests
 			var serviceName = "MyService123!";
 			Environment.SetEnvironmentVariable(EnvVarNames.ServiceName, serviceName);
 			var payloadSender = new MockPayloadSender();
-			using var agentComponents = new AgentComponents(payloadSender: payloadSender);
-			using (var agent = new ApmAgent(agentComponents))
+			using (var agent = new ApmAgent(new TestAgentComponents(payloadSender: payloadSender, config: new EnvironmentConfigurationReader())))
 			{
 				agent.Tracer.CaptureTransaction("TestTransactionName", "TestTransactionType", t => { Thread.Sleep(2); });
 
@@ -442,8 +438,7 @@ namespace Elastic.Apm.Tests
 			var serviceName = DefaultValues.UnknownServiceName;
 			Environment.SetEnvironmentVariable(EnvVarNames.ServiceName, serviceName);
 			var payloadSender = new MockPayloadSender();
-			using var agentComponents = new AgentComponents(payloadSender: payloadSender);
-			using (var agent = new ApmAgent(agentComponents))
+			using (var agent = new ApmAgent(new TestAgentComponents(payloadSender: payloadSender, config: new EnvironmentConfigurationReader())))
 			{
 				agent.Tracer.CaptureTransaction("TestTransactionName", "TestTransactionType", t => { Thread.Sleep(2); });
 
@@ -463,8 +458,7 @@ namespace Elastic.Apm.Tests
 			var serviceVersion = "2.1.0.5";
 			Environment.SetEnvironmentVariable(EnvVarNames.ServiceVersion, serviceVersion);
 			var payloadSender = new MockPayloadSender();
-			using var agentComponents = new AgentComponents(payloadSender: payloadSender);
-			using (var agent = new ApmAgent(agentComponents))
+			using (var agent = new ApmAgent(new TestAgentComponents(payloadSender: payloadSender, config: new EnvironmentConfigurationReader())))
 			{
 				agent.Tracer.CaptureTransaction("TestTransactionName", "TestTransactionType", t => { Thread.Sleep(2); });
 
@@ -479,7 +473,7 @@ namespace Elastic.Apm.Tests
 			var serviceNodeName = "Some service node name";
 			Environment.SetEnvironmentVariable(EnvVarNames.ServiceNodeName, serviceNodeName);
 			var payloadSender = new MockPayloadSender();
-			using (var agent = new ApmAgent(new AgentComponents(payloadSender: payloadSender)))
+			using (var agent = new ApmAgent(new TestAgentComponents(payloadSender: payloadSender, config: new EnvironmentConfigurationReader())))
 			{
 				// Act
 				agent.Tracer.CaptureTransaction("TestTransactionName", "TestTransactionType", t => { Thread.Sleep(2); });

--- a/test/Elastic.Apm.Tests/ConstructorTests.cs
+++ b/test/Elastic.Apm.Tests/ConstructorTests.cs
@@ -17,7 +17,9 @@ namespace Elastic.Apm.Tests
 		[Fact]
 		public void Compose()
 		{
-			var agent = new ApmAgent(new AgentComponents(configurationReader: new LogConfig(LogLevel.Warning)));
+			//build AgentComponents manually so we can disable metrics collection. reason: creating metrics collector pro test and disposing it makes test failing (ETW or EventSource subscribe unsubscribe in each test in parallel if all tests are running)
+			var agent = new ApmAgent(new AgentComponents(null, configurationReader: new LogConfig(LogLevel.Warning), null, metricsCollector: null,
+				null, null));
 			var logger = agent.Logger as ConsoleLogger;
 
 			logger.Should().NotBeNull();
@@ -25,7 +27,7 @@ namespace Elastic.Apm.Tests
 			logger?.IsEnabled(LogLevel.Information).Should().BeFalse();
 		}
 
-		private class LogConfig : IConfigurationReader
+		private class LogConfig : IConfigSnapshot
 		{
 			public LogConfig(LogLevel level) => LogLevel = level;
 
@@ -53,6 +55,8 @@ namespace Elastic.Apm.Tests
 
 			public int TransactionMaxSpans => ConfigConsts.DefaultValues.TransactionMaxSpans;
 			// ReSharper restore UnassignedGetOnlyAutoProperty
+
+			public string DbgDescription => "LogConfig";
 		}
 	}
 }

--- a/test/Elastic.Apm.Tests/MetricsTests.cs
+++ b/test/Elastic.Apm.Tests/MetricsTests.cs
@@ -224,6 +224,20 @@ namespace Elastic.Apm.Tests
 			metricsProviderMock.Verify(x => x.GetSamples(), Times.Exactly(iterations));
 		}
 
+		[Fact]
+		public void CollectGcMetrics()
+		{
+			var gcMetricsProvider = new GcMetricsProvider(_logger);
+
+			for (var i = 0; i < 300_000_000; i++)
+			{
+				var _ = new int[100];
+			}
+
+			var samples = gcMetricsProvider.GetSamples();
+			samples.Should().NotBeEmpty();
+		}
+
 		internal class MetricsProviderWithException : IMetricsProvider
 		{
 			public const string ExceptionMessage = "testException";

--- a/test/Elastic.Apm.Tests/MetricsTests.cs
+++ b/test/Elastic.Apm.Tests/MetricsTests.cs
@@ -246,16 +246,22 @@ namespace Elastic.Apm.Tests
 			using (var gcMetricsProvider = new GcMetricsProvider(_logger))
 			{
 				Thread.Sleep(500);
-				for (var i = 0; i < 300_000_00; i++)
+				for (var i = 0; i < 300_000; i++)
 				{
 					var _ = new int[100];
 				}
 
+				Thread.Sleep(1000);
+
+				for (var i = 0; i < 300_000; i++)
+				{
+					var _ = new int[100];
+				}
+
+				Thread.Sleep(1000);
+
 				var samples = gcMetricsProvider.GetSamples();
-
 #if !NETCOREAPP2_1
-				Thread.Sleep(500);
-
 				//EventSource Microsoft-Windows-DotNETRuntime is only 2.2+, no gc metrics on 2.1
 				samples.Should().NotBeEmpty();
 #endif

--- a/test/Elastic.Apm.Tests/MetricsTests.cs
+++ b/test/Elastic.Apm.Tests/MetricsTests.cs
@@ -240,25 +240,36 @@ namespace Elastic.Apm.Tests
 		{
 			using (var gcMetricsProvider = new GcMetricsProvider(_logger))
 			{
-				Thread.Sleep(500);
-				for (var i = 0; i < 300_000; i++)
+				var containsValue = false;
+
+				//repeat the allocation multiple times and make sure at least 1 GetSamples() call returns value
+				for (var j = 0; j < 100; j++)
 				{
-					var _ = new int[100];
+					Thread.Sleep(500);
+					for (var i = 0; i < 300_000; i++)
+					{
+						var _ = new int[100];
+					}
+
+					Thread.Sleep(1000);
+
+					for (var i = 0; i < 300_000; i++)
+					{
+						var _ = new int[100];
+					}
+
+					Thread.Sleep(1000);
+
+					var samples = gcMetricsProvider.GetSamples();
+
+					containsValue = samples.Count() != 0;
+
+					if(containsValue)
+						break;
 				}
-
-				Thread.Sleep(1000);
-
-				for (var i = 0; i < 300_000; i++)
-				{
-					var _ = new int[100];
-				}
-
-				Thread.Sleep(1000);
-
-				var samples = gcMetricsProvider.GetSamples();
 #if !NETCOREAPP2_1
 				//EventSource Microsoft-Windows-DotNETRuntime is only 2.2+, no gc metrics on 2.1
-				samples.Should().NotBeEmpty();
+				containsValue.Should().BeTrue();
 #endif
 			}
 		}

--- a/test/Elastic.Apm.Tests/MetricsTests.cs
+++ b/test/Elastic.Apm.Tests/MetricsTests.cs
@@ -262,7 +262,7 @@ namespace Elastic.Apm.Tests
 
 					var samples = gcMetricsProvider.GetSamples();
 
-					containsValue = samples.Count() != 0;
+					containsValue = samples?.Count() != 0;
 
 					if(containsValue)
 						break;

--- a/test/Elastic.Apm.Tests/MetricsTests.cs
+++ b/test/Elastic.Apm.Tests/MetricsTests.cs
@@ -245,13 +245,20 @@ namespace Elastic.Apm.Tests
 		{
 			using (var gcMetricsProvider = new GcMetricsProvider(_logger))
 			{
+				Thread.Sleep(500);
 				for (var i = 0; i < 300_000_00; i++)
 				{
 					var _ = new int[100];
 				}
 
 				var samples = gcMetricsProvider.GetSamples();
+
+#if !NETCOREAPP2_1
+				Thread.Sleep(500);
+
+				//EventSource Microsoft-Windows-DotNETRuntime is only 2.2+, no gc metrics on 2.1
 				samples.Should().NotBeEmpty();
+#endif
 			}
 		}
 

--- a/test/Elastic.Apm.Tests/StaticTests.cs
+++ b/test/Elastic.Apm.Tests/StaticTests.cs
@@ -18,7 +18,8 @@ namespace Elastic.Apm.Tests
 		{
 			Agent.IsConfigured.Should().BeFalse();
 
-			Agent.Setup(new AgentComponents());
+			using var agentComponents = new AgentComponents();
+			Agent.Setup(agentComponents);
 			Agent.IsConfigured.Should().BeTrue();
 		}
 	}

--- a/test/Elastic.Apm.Tests/StaticTests.cs
+++ b/test/Elastic.Apm.Tests/StaticTests.cs
@@ -1,3 +1,4 @@
+using Elastic.Apm.Tests.Mocks;
 using FluentAssertions;
 using Xunit;
 
@@ -18,7 +19,7 @@ namespace Elastic.Apm.Tests
 		{
 			Agent.IsConfigured.Should().BeFalse();
 
-			using var agentComponents = new AgentComponents();
+			using var agentComponents = new TestAgentComponents();
 			Agent.Setup(agentComponents);
 			Agent.IsConfigured.Should().BeTrue();
 		}


### PR DESCRIPTION
Addressing https://github.com/elastic/apm-agent-dotnet/issues/321. 


In this round, I add GC metrics. 

Currently planned:

- `clr.gc.count`
- `clr.gc.gen0size`
- `clr.gc.gen1size`
- `clr.gc.gen2size`
- `clr.gc.gen3size`

The agent collects these metrics through EventSource on .NET Core and through Microsoft.Diagnostics.Tracing.TraceEvent (ETW) on Full Framework.

Changes in tests: We had lots of test that instantiated an `AgentComponents` and that started collecting all metrics and subscribed to `EventSource`. The tests run in parallel, so we had multiple `AgentComponents` subscribing and unsubscribing to `EventSource`, which does not seem to work. To avoid this (which does not happen in prod, so no reason to test for it at the moment) I adapted all tests to either use `TestAgentComponents` which does not collect metrics, or skip metrics collection in case a real `AgentComponents` is needed.


Some Lens visualization:

Heap sizes:

<img width="1005" alt="image" src="https://user-images.githubusercontent.com/1091853/72795040-40706200-3c3d-11ea-8c12-0a3e44156800.png">

<img width="1349" alt="image" src="https://user-images.githubusercontent.com/1091853/72795078-5120d800-3c3d-11ea-9ae9-54272ad1531d.png">


GC count over time:

<img width="1322" alt="image" src="https://user-images.githubusercontent.com/1091853/72795155-6e55a680-3c3d-11ea-95b3-dbe0bc2f4596.png">
