### PR TITLE
add net461 target for Elastic.Apm.Tests project

### DIFF
--- a/test/Elastic.Apm.Tests/Elastic.Apm.Tests.csproj
+++ b/test/Elastic.Apm.Tests/Elastic.Apm.Tests.csproj
@@ -1,6 +1,6 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;netcoreapp2.2;netcoreapp3.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp2.2;netcoreapp3.0;netcoreapp3.1</TargetFrameworks>
     <RootNamespace>Elastic.Apm.Tests</RootNamespace>
     <AssemblyName>Elastic.Apm.Tests</AssemblyName>
   </PropertyGroup>

--- a/test/Elastic.Apm.Tests/Extensions/TaskExtensions.cs
+++ b/test/Elastic.Apm.Tests/Extensions/TaskExtensions.cs
@@ -1,0 +1,15 @@
+using System.Threading.Tasks;
+
+
+namespace Elastic.Apm.Tests.Extensions
+{
+	internal static class TaskExtensions
+	{
+		public static bool IsCompletedSuccessfully(this Task task) =>
+#if NET461
+			task.Status == TaskStatus.RanToCompletion && !task.IsFaulted && !task.IsCanceled;
+#else
+			task.IsCompletedSuccessfully;
+#endif
+	}
+}

--- a/test/Elastic.Apm.Tests/HelpersTests/AgentTimerTests.cs
+++ b/test/Elastic.Apm.Tests/HelpersTests/AgentTimerTests.cs
@@ -5,6 +5,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Elastic.Apm.Helpers;
 using Elastic.Apm.Logging;
+using Elastic.Apm.Tests.Extensions;
 using Elastic.Apm.Tests.Mocks;
 using Elastic.Apm.Tests.TestHelpers;
 using FluentAssertions;
@@ -319,13 +320,13 @@ namespace Elastic.Apm.Tests.HelpersTests
 
 			public void VerifyTryAwaitCompletedSuccessfully(Task tryAwaitOrTimeoutTask, Task delayTask)
 			{
-				tryAwaitOrTimeoutTask.IsCompletedSuccessfully.Should().BeTrue();
+				tryAwaitOrTimeoutTask.IsCompletedSuccessfully().Should().BeTrue();
 
 				UnpackTryAwaitOrTimeoutTaskResult(tryAwaitOrTimeoutTask, out var hasTaskToAwaitCompleted, out var taskToAwaitResult);
 				hasTaskToAwaitCompleted.Should().BeTrue();
 				taskToAwaitResult.Should().Be(_resultValue);
 
-				_taskToAwaitTcs.Task.IsCompletedSuccessfully.Should().BeTrue();
+				_taskToAwaitTcs.Task.IsCompletedSuccessfully().Should().BeTrue();
 				_taskToAwaitTcs.Task.Result.Should().Be(_resultValue);
 
 				VerifyFinalAgentTimerState(delayTask);
@@ -333,11 +334,11 @@ namespace Elastic.Apm.Tests.HelpersTests
 
 			public void VerifyAwaitCompletedSuccessfully(Task awaitOrTimeoutTask, Task delayTask)
 			{
-				awaitOrTimeoutTask.IsCompletedSuccessfully.Should().BeTrue();
+				awaitOrTimeoutTask.IsCompletedSuccessfully().Should().BeTrue();
 
 				if (!_isVoid) ((Task<TResult>)awaitOrTimeoutTask).Result.Should().Be(_resultValue);
 
-				_taskToAwaitTcs.Task.IsCompletedSuccessfully.Should().BeTrue();
+				_taskToAwaitTcs.Task.IsCompletedSuccessfully().Should().BeTrue();
 				_taskToAwaitTcs.Task.Result.Should().Be(_resultValue);
 
 				VerifyFinalAgentTimerState(delayTask);
@@ -345,7 +346,7 @@ namespace Elastic.Apm.Tests.HelpersTests
 
 			public void VerifyTryAwaitTimeout(Task tryAwaitOrTimeoutTask, Task delayTask)
 			{
-				tryAwaitOrTimeoutTask.IsCompletedSuccessfully.Should().BeTrue();
+				tryAwaitOrTimeoutTask.IsCompletedSuccessfully().Should().BeTrue();
 
 				UnpackTryAwaitOrTimeoutTaskResult(tryAwaitOrTimeoutTask, out var hasTaskToAwaitCompleted, out var taskToAwaitResult);
 				hasTaskToAwaitCompleted.Should().BeFalse();
@@ -429,7 +430,7 @@ namespace Elastic.Apm.Tests.HelpersTests
 				if (wasDelayCancelled)
 					delayTask.IsCanceled.Should().BeTrue();
 				else
-					delayTask.IsCompletedSuccessfully.Should().BeTrue();
+					delayTask.IsCompletedSuccessfully().Should().BeTrue();
 			}
 		}
 	}

--- a/test/Elastic.Apm.Tests/HelpersTests/TimeUtilsTests.cs
+++ b/test/Elastic.Apm.Tests/HelpersTests/TimeUtilsTests.cs
@@ -23,9 +23,10 @@ namespace Elastic.Apm.Tests.HelpersTests
 			{ 5 * 24 * 60 * 60 * 1_000_000L, new DateTime(1970, 1, 6, 0, 0, 0, DateTimeKind.Utc) }
 		};
 
+#if !NET461
 		[Fact]
 		public void TimeUtilsUnixEpochDateTimeEqualsDateTimeUnixEpoch() => TimeUtils.UnixEpochDateTime.Should().Be(DateTime.UnixEpoch);
-
+#endif
 		[Theory]
 		[InlineData(0)]
 		[InlineData(1.0)]

--- a/test/Elastic.Apm.Tests/Mocks/TestLogger.cs
+++ b/test/Elastic.Apm.Tests/Mocks/TestLogger.cs
@@ -17,6 +17,6 @@ namespace Elastic.Apm.Tests.Mocks
 		public TestLogger(LogLevel level, StringWriter writer) : base(level, writer, writer) => _writer = writer;
 
 		public IReadOnlyList<string> Lines =>
-			_writer.GetStringBuilder().ToString().Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries).ToList();
+			_writer.GetStringBuilder().ToString().Split(new[] { Environment.NewLine }, StringSplitOptions.RemoveEmptyEntries).ToList();
 	}
 }


### PR DESCRIPTION
During work under #700, I need to have the ability to run tests under the net461 target framework.

Changes are very simple:
1. Add net461 target for `Elastic.Apm.Tests`
2. Add `IsCompletedSuccessfully()` extensions method for `Task` due to `IsCompletedSuccessfully` property is missed in net461
3. Fix other small method calls

So, I understand that infrastructure needs to be adjusted in such case and very appreciative to hear feedback on how it can be done in a more efficient way without a lot of changes in CI infrastructure.

A little bit of information, why we need to target a net461 framework. The `SqlClient` spread execution events through different approaches in .Net Framework and .Net Core: [`EventSource` in .Net Framework](https://github.com/dotnet/SqlClient/blob/master/src/Microsoft.Data.SqlClient/netfx/src/Microsoft/Data/SqlEventSource.cs) and [`DiagnosticSource` in .Net Core](https://github.com/dotnet/SqlClient/blob/master/src/Microsoft.Data.SqlClient/netcore/src/Microsoft/Data/SqlClient/SqlClientDiagnosticListenerExtensions.cs). As we have different behaviour for different frameworks (`HttpClientDiagnosticListener` also has different implementations) it would be nice cover this by tests at appropriate platform.

/cc, @gregkalapos 