### PR TITLE
Configuration value SpanFramesMinDuration not set

### DIFF
--- a/src/Elastic.Apm/Config/EnvironmentConfigurationReader.cs
+++ b/src/Elastic.Apm/Config/EnvironmentConfigurationReader.cs
@@ -18,7 +18,7 @@ namespace Elastic.Apm.Config
 		{
 			_spanFramesMinDurationInMilliseconds
 				= new Lazy<double>(() =>
-					ParseSpanFramesMinDurationInMilliseconds(Read(ConfigConsts.EnvVarNames.StackTraceLimit)));
+					ParseSpanFramesMinDurationInMilliseconds(Read(ConfigConsts.EnvVarNames.SpanFramesMinDuration)));
 
 			_stackTraceLimit = new Lazy<int>(() => ParseStackTraceLimit(Read(ConfigConsts.EnvVarNames.StackTraceLimit)));
 		}

--- a/test/Elastic.Apm.Tests/ConfigTests.cs
+++ b/test/Elastic.Apm.Tests/ConfigTests.cs
@@ -569,6 +569,16 @@ namespace Elastic.Apm.Tests
 		public void SetMetricsIntervalToNegativeMilliseconds()
 			=> MetricsIntervalTestCommon("-5ms").Should().Be(0);
 
+		[Fact]
+		public void SetSpanFramesMinDurationAndStackTraceLimit()
+		{
+			Environment.SetEnvironmentVariable(EnvVarNames.SpanFramesMinDuration, DefaultValues.SpanFramesMinDuration);
+			Environment.SetEnvironmentVariable(EnvVarNames.StackTraceLimit, DefaultValues.StackTraceLimit.ToString());
+			var config = new EnvironmentConfigurationReader(new NoopLogger());
+			config.SpanFramesMinDurationInMilliseconds.Should().Be(DefaultValues.SpanFramesMinDurationInMilliseconds);
+			config.StackTraceLimit.Should().Be(DefaultValues.StackTraceLimit);
+		}
+
 		/// <summary>
 		/// Make sure <see cref="DefaultValues.MetricsInterval" /> and <see cref="DefaultValues.MetricsIntervalInMilliseconds" />
 		/// are in sync


### PR DESCRIPTION

Simple case of mismatched parameters. Passing StackTraceLimit instead of SpanFramesMinDuration to parser.

Test and fix included.

![image](https://user-images.githubusercontent.com/2399984/73166760-c76a8200-40f6-11ea-9600-88788f6b99d3.png)
