### PR TITLE
GC metrics test fixes

### DIFF
--- a/src/Elastic.Apm/Metrics/MetricsCollector.cs
+++ b/src/Elastic.Apm/Metrics/MetricsCollector.cs
@@ -84,8 +84,10 @@ namespace Elastic.Apm.Metrics
 			var collectGen3Size = !WildcardMatcher.IsAnyMatch(configurationReader.DisableMetrics,
 				GcMetricsProvider.GcGen3SizeName);
 			if (collectGcCount || collectGen0Size || collectGen1Size || collectGen2Size || collectGen3Size)
+			{
 				MetricsProviders.Add(new GcMetricsProvider(_logger, collectGcCount, collectGen0Size, collectGen1Size, collectGen2Size,
 					collectGen3Size));
+			}
 
 			_logger.Info()?.Log("Collecting metrics in {interval} milliseconds interval", interval);
 			_timer = new Timer(interval);

--- a/test/Elastic.Apm.Tests.MockApmServer/MetricsAssertValid.cs
+++ b/test/Elastic.Apm.Tests.MockApmServer/MetricsAssertValid.cs
@@ -23,6 +23,10 @@ namespace Elastic.Apm.Tests.MockApmServer
 
 			foreach (var metricSample in metricSet.Samples)
 			{
+				//GC metrics are only captured when at least 1 GC happens during the test - so we don't assert on those.
+				if (metricSample.Key.Contains("clr.gc", StringComparison.CurrentCultureIgnoreCase))
+					continue;
+
 				MetricMetadataPerType.Should().ContainKey(metricSample.Key);
 				MetricMetadataPerType[metricSample.Key].VerifyAction(metricSample.Value.Value);
 			}

--- a/test/Elastic.Apm.Tests/MetricsTests.cs
+++ b/test/Elastic.Apm.Tests/MetricsTests.cs
@@ -19,29 +19,13 @@ using Xunit.Abstractions;
 
 namespace Elastic.Apm.Tests
 {
-	internal class Logger : IApmLogger
-	{
-		private readonly ITestOutputHelper _testOutputHelper;
-
-		public Logger(ITestOutputHelper testOutputHelper)
-			=> _testOutputHelper = testOutputHelper;
-
-		public bool IsEnabled(LogLevel level) => true;
-
-		public void Log<TState>(LogLevel level, TState state, Exception e, Func<TState, Exception, string> formatter)
-		{
-			var v = formatter(state, e);
-			_testOutputHelper.WriteLine(v);
-		}
-	}
-
 	public class MetricsTests : LoggingTestBase
 	{
 		private const string ThisClassName = nameof(MetricsTests);
 
 		private readonly IApmLogger _logger;
 
-		public MetricsTests(ITestOutputHelper xUnitOutputHelper) : base(xUnitOutputHelper) => _logger = new Logger((xUnitOutputHelper));
+		public MetricsTests(ITestOutputHelper xUnitOutputHelper) : base(xUnitOutputHelper) => _logger = LoggerBase.Scoped(ThisClassName);
 
 		public static IEnumerable<object[]> DisableProviderTestData
 		{
@@ -197,10 +181,7 @@ namespace Elastic.Apm.Tests
 			metricsCollector.MetricsProviders.Add(metricsProviderMock.Object);
 
 			// Act
-			foreach (var _ in Enumerable.Range(0, iterations))
-			{
-				metricsCollector.CollectAllMetrics();
-			}
+			foreach (var _ in Enumerable.Range(0, iterations)) metricsCollector.CollectAllMetrics();
 
 			// Assert
 			mockPayloadSender.Metrics.Should().BeEmpty();
@@ -264,7 +245,7 @@ namespace Elastic.Apm.Tests
 
 					containsValue = samples?.Count() != 0;
 
-					if(containsValue)
+					if (containsValue)
 						break;
 				}
 #if !NETCOREAPP2_1


### PR DESCRIPTION
Some cleanup and fixing 1 IIS test.

To the IIS test:
In `MetricsAssertValid.AssertValid` we iterate through a fixed set of metrics and only made the test pass when the metric keys sent by the agent 100% matched the fixed set of metrics. 

Problem is that with GC this is flaky - GC metrics are only captured when there is a GC, so for old metrics tests that don't care about the GC itself it should not matter if GC metrics are captured or not. 

So adapted the test accordingly - old tests don't care about gc metrics and pass regardless gc metrics are captured or not.