### PR TITLE
Use real traceparent header and handle tracestate

### DIFF
--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -598,6 +598,28 @@ the agent will capture request and response headers, including cookies.
 
 NOTE: Setting this to `false` reduces memory allocations, network bandwidth and disk space used by Elasticsearch.
 
+[float]
+[[config-use-elastic-apm-traceparent-header]]
+==== `UseElasticTraceparentHeader` (added[1.3.0])
+
+[options="header"]
+|============
+| Environment variable name                    | IConfiguration or Web.config key
+| `ELASTIC_APM_USE_ELASTIC_TRACEPARENT_HEADER` | `ElasticApm:UseElasticTraceparentHeder`
+|============
+
+[options="header"]
+|============
+| Default                 | Type
+| `true`                  | Boolean
+|============
+
+
+To enable {apm-overview-ref-v}/distributed-tracing.html[distributed tracing], the agent adds trace context headers to outgoing HTTP requests made with the `HttpClient` type. These headers (`traceparent` and `tracestate`) are defined in the https://www.w3.org/TR/trace-context-1/[W3C Trace Context] specification.
+
+When this setting is `true`, the agent will also add the header `elasticapm-traceparent` for backwards compatibility with older versions of Elastic APM agents. Versions prior to `1.3.0` only read the `elasticapm-traceparent` header.
+
+
 [[config-stacktrace]]
 === Stacktrace configuration options
 [float]

--- a/src/Elastic.Apm.AspNetCore/ApmMiddleware.cs
+++ b/src/Elastic.Apm.AspNetCore/ApmMiddleware.cs
@@ -79,34 +79,35 @@ namespace Elastic.Apm.AspNetCore
 				Transaction transaction;
 				var transactionName = $"{context.Request.Method} {context.Request.Path}";
 
-				if (context.Request.Headers.ContainsKey(TraceParent.TraceParentHeaderNamePrefixed)
-					|| context.Request.Headers.ContainsKey(TraceParent.TraceParentHeaderName))
+				if (context.Request.Headers.ContainsKey(DistributedTracing.TraceContext.TraceParentHeaderNamePrefixed)
+					|| context.Request.Headers.ContainsKey(DistributedTracing.TraceContext.TraceParentHeaderName))
 				{
-					var headerValue = context.Request.Headers.ContainsKey(TraceParent.TraceParentHeaderName)
-						? context.Request.Headers[TraceParent.TraceParentHeaderName].ToString()
-						: context.Request.Headers[TraceParent.TraceParentHeaderNamePrefixed].ToString();
+					var headerValue = context.Request.Headers.ContainsKey(DistributedTracing.TraceContext.TraceParentHeaderName)
+						? context.Request.Headers[DistributedTracing.TraceContext.TraceParentHeaderName].ToString()
+						: context.Request.Headers[DistributedTracing.TraceContext.TraceParentHeaderNamePrefixed].ToString();
 
+					var tracingData = context.Request.Headers.ContainsKey(DistributedTracing.TraceContext.TraceStateHeaderName)
+						? DistributedTracing.TraceContext.TryExtractTracingData(headerValue, context.Request.Headers[DistributedTracing.TraceContext.TraceStateHeaderName].ToString())
+						: DistributedTracing.TraceContext.TryExtractTracingData(headerValue);
 
-					var distributedTracingData = TraceParent.TryExtractTraceparent(headerValue);
-
-					if (distributedTracingData != null)
+					if (tracingData != null)
 					{
 						_logger.Debug()
 							?.Log(
 								"Incoming request with {TraceParentHeaderName} header. DistributedTracingData: {DistributedTracingData}. Continuing trace.",
-								TraceParent.TraceParentHeaderNamePrefixed, distributedTracingData);
+								DistributedTracing.TraceContext.TraceParentHeaderNamePrefixed, tracingData);
 
 						transaction = _tracer.StartTransactionInternal(
 							transactionName,
 							ApiConstants.TypeRequest,
-							distributedTracingData);
+							tracingData);
 					}
 					else
 					{
 						_logger.Debug()
 							?.Log(
 								"Incoming request with invalid {TraceParentHeaderName} header (received value: {TraceParentHeaderValue}). Starting trace with new trace id.",
-								TraceParent.TraceParentHeaderNamePrefixed, headerValue);
+								DistributedTracing.TraceContext.TraceParentHeaderNamePrefixed, headerValue);
 
 						transaction = _tracer.StartTransactionInternal(transactionName,
 							ApiConstants.TypeRequest);

--- a/src/Elastic.Apm.AspNetFullFramework/ElasticApmModule.cs
+++ b/src/Elastic.Apm.AspNetFullFramework/ElasticApmModule.cs
@@ -108,7 +108,7 @@ namespace Elastic.Apm.AspNetFullFramework
 				_logger.Debug()
 					?.Log(
 						"Incoming request with {TraceParentHeaderName} header. DistributedTracingData: {DistributedTracingData} - continuing trace",
-						TraceParent.TraceParentHeaderName, distributedTracingData);
+						TraceParent.TraceParentHeaderNamePrefixed, distributedTracingData);
 
 				_currentTransaction = Agent.Instance.Tracer.StartTransaction($"{httpRequest.HttpMethod} {httpRequest.Path}", ApiConstants.TypeRequest,
 					distributedTracingData);
@@ -129,10 +129,15 @@ namespace Elastic.Apm.AspNetFullFramework
 			// ReSharper disable once InvertIf
 			if (headerValue == null)
 			{
-				_logger.Debug()
-					?.Log("Incoming request doesn't have {TraceParentHeaderName} header - " +
-						"it means request doesn't have incoming distributed tracing data", TraceParent.TraceParentHeaderName);
-				return null;
+				headerValue = httpRequest.Headers.Get(TraceParent.TraceParentHeaderNamePrefixed);
+
+				if (headerValue == null)
+				{
+					_logger.Debug()
+						?.Log("Incoming request doesn't have {TraceParentHeaderName} header - " +
+							"it means request doesn't have incoming distributed tracing data", TraceParent.TraceParentHeaderNamePrefixed);
+					return null;
+				}
 			}
 			return TraceParent.TryExtractTraceparent(headerValue);
 		}

--- a/src/Elastic.Apm.AspNetFullFramework/ElasticApmModule.cs
+++ b/src/Elastic.Apm.AspNetFullFramework/ElasticApmModule.cs
@@ -108,7 +108,7 @@ namespace Elastic.Apm.AspNetFullFramework
 				_logger.Debug()
 					?.Log(
 						"Incoming request with {TraceParentHeaderName} header. DistributedTracingData: {DistributedTracingData} - continuing trace",
-						TraceParent.TraceParentHeaderNamePrefixed, distributedTracingData);
+						DistributedTracing.TraceContext.TraceParentHeaderNamePrefixed, distributedTracingData);
 
 				_currentTransaction = Agent.Instance.Tracer.StartTransaction($"{httpRequest.HttpMethod} {httpRequest.Path}", ApiConstants.TypeRequest,
 					distributedTracingData);
@@ -123,23 +123,33 @@ namespace Elastic.Apm.AspNetFullFramework
 			if (_currentTransaction.IsSampled) FillSampledTransactionContextRequest(httpRequest, _currentTransaction);
 		}
 
+		/// <summary>
+		/// Extracts the traceparent and the tracestate headers from the <see cref="httpRequest"/>
+		/// </summary>
+		/// <param name="httpRequest"></param>
+		/// <returns>Null if traceparent is not set, otherwise the filled DistributedTracingData instance</returns>
 		private DistributedTracingData ExtractIncomingDistributedTracingData(HttpRequest httpRequest)
 		{
-			var headerValue = httpRequest.Headers.Get(TraceParent.TraceParentHeaderName);
+			var traceParentHeaderValue = httpRequest.Headers.Get(DistributedTracing.TraceContext.TraceParentHeaderName);
 			// ReSharper disable once InvertIf
-			if (headerValue == null)
+			if (traceParentHeaderValue == null)
 			{
-				headerValue = httpRequest.Headers.Get(TraceParent.TraceParentHeaderNamePrefixed);
+				traceParentHeaderValue = httpRequest.Headers.Get(DistributedTracing.TraceContext.TraceParentHeaderNamePrefixed);
 
-				if (headerValue == null)
+				if (traceParentHeaderValue == null)
 				{
 					_logger.Debug()
 						?.Log("Incoming request doesn't have {TraceParentHeaderName} header - " +
-							"it means request doesn't have incoming distributed tracing data", TraceParent.TraceParentHeaderNamePrefixed);
+							"it means request doesn't have incoming distributed tracing data", DistributedTracing.TraceContext.TraceParentHeaderNamePrefixed);
 					return null;
 				}
 			}
-			return TraceParent.TryExtractTraceparent(headerValue);
+
+			var traceStateHeaderValue = httpRequest.Headers.Get(DistributedTracing.TraceContext.TraceStateHeaderName);
+
+			return traceStateHeaderValue != null
+				? DistributedTracing.TraceContext.TryExtractTracingData(traceParentHeaderValue, httpRequest.Headers.Get(traceStateHeaderValue))
+				: DistributedTracing.TraceContext.TryExtractTracingData(traceParentHeaderValue);
 		}
 
 		private static void FillSampledTransactionContextRequest(HttpRequest httpRequest, ITransaction transaction)
@@ -188,7 +198,7 @@ namespace Elastic.Apm.AspNetFullFramework
 				case "HTTP/2.0":
 					return "2.0";
 				default:
-					return protocolString.Replace("HTTP/", string.Empty);
+					return protocolString?.Replace("HTTP/", string.Empty);
 			}
 		}
 
@@ -335,10 +345,12 @@ namespace Elastic.Apm.AspNetFullFramework
 			}
 			catch (Agent.InstanceAlreadyCreatedException ex)
 			{
-				Agent.Instance.Logger.Scoped(dbgInstanceName).Error()?.LogException(ex, "The Elastic APM agent was already initialized before call to"
-					+ $" {nameof(ElasticApmModule)}.{nameof(Init)} - {nameof(ElasticApmModule)} will use existing instance"
-					+ " even though it might lead to unexpected behavior"
-					+ " (for example agent using incorrect configuration source such as environment variables instead of Web.config).");
+				Agent.Instance.Logger.Scoped(dbgInstanceName)
+					.Error()
+					?.LogException(ex, "The Elastic APM agent was already initialized before call to"
+						+ $" {nameof(ElasticApmModule)}.{nameof(Init)} - {nameof(ElasticApmModule)} will use existing instance"
+						+ " even though it might lead to unexpected behavior"
+						+ " (for example agent using incorrect configuration source such as environment variables instead of Web.config).");
 
 				agentComponents.Dispose();
 			}

--- a/src/Elastic.Apm/Api/DistributedTracingData.cs
+++ b/src/Elastic.Apm/Api/DistributedTracingData.cs
@@ -38,8 +38,6 @@ namespace Elastic.Apm.Api
 		/// </returns>
 		public string SerializeToString() => TraceContext.BuildTraceparent(this);
 
-		internal string SerializeTraceStateToString() => TraceContext.BuildTraceState(this);
-
 		/// <summary>
 		/// Deserializes an instance from a string.
 		/// This method should be used at the callee side and the deserialized instance can be passed to
@@ -52,9 +50,6 @@ namespace Elastic.Apm.Api
 		/// .
 		/// </returns>
 		public static DistributedTracingData TryDeserializeFromString(string serialized) => TraceContext.TryExtractTracingData(serialized);
-
-		internal static DistributedTracingData TryDeserializeFromString(string serializedTraceParent, string serializedTraceState) =>
-			TraceContext.TryExtractTracingData(serializedTraceParent, serializedTraceState);
 
 		public override string ToString() => new ToStringBuilder(nameof(DistributedTracingData))
 		{

--- a/src/Elastic.Apm/Api/DistributedTracingData.cs
+++ b/src/Elastic.Apm/Api/DistributedTracingData.cs
@@ -12,17 +12,20 @@ namespace Elastic.Apm.Api
 	/// </summary>
 	public class DistributedTracingData
 	{
-		internal DistributedTracingData(string traceId, string parentId, bool flagRecorded)
+		internal DistributedTracingData(string traceId, string parentId, bool flagRecorded, string traceState = null)
 		{
 			TraceId = traceId;
 			ParentId = parentId;
 			FlagRecorded = flagRecorded;
+			TraceState = traceState;
 		}
 
 		internal bool FlagRecorded { get; }
-		internal string ParentId { get; }
 
+		internal bool HasTraceState => !string.IsNullOrEmpty(TraceState);
+		internal string ParentId { get; }
 		internal string TraceId { get; }
+		internal string TraceState { get; }
 
 		/// <summary>
 		/// Serializes this instance to a string.
@@ -33,7 +36,9 @@ namespace Elastic.Apm.Api
 		/// <returns>
 		/// String containing the instance in serialized form.
 		/// </returns>
-		public string SerializeToString() => TraceParent.BuildTraceparent(this);
+		public string SerializeToString() => TraceContext.BuildTraceparent(this);
+
+		internal string SerializeTraceStateToString() => TraceContext.BuildTraceState(this);
 
 		/// <summary>
 		/// Deserializes an instance from a string.
@@ -46,7 +51,10 @@ namespace Elastic.Apm.Api
 		/// <param name="serialized" />
 		/// .
 		/// </returns>
-		public static DistributedTracingData TryDeserializeFromString(string serialized) => TraceParent.TryExtractTraceparent(serialized);
+		public static DistributedTracingData TryDeserializeFromString(string serialized) => TraceContext.TryExtractTracingData(serialized);
+
+		internal static DistributedTracingData TryDeserializeFromString(string serializedTraceParent, string serializedTraceState) =>
+			TraceContext.TryExtractTracingData(serializedTraceParent, serializedTraceState);
 
 		public override string ToString() => new ToStringBuilder(nameof(DistributedTracingData))
 		{

--- a/src/Elastic.Apm/BackendComm/CentralConfigFetcher.cs
+++ b/src/Elastic.Apm/BackendComm/CentralConfigFetcher.cs
@@ -331,7 +331,7 @@ namespace Elastic.Apm.BackendComm
 
 			internal static readonly string[] SupportedOptions =
 			{
-				CaptureBodyKey, CaptureBodyContentTypesKey, TransactionMaxSpansKey, TransactionSampleRateKey,
+				CaptureBodyKey, CaptureBodyContentTypesKey, TransactionMaxSpansKey, TransactionSampleRateKey
 			};
 
 			[JsonProperty(CaptureBodyKey)]
@@ -475,6 +475,7 @@ namespace Elastic.Apm.BackendComm
 			public int TransactionMaxSpans => _configDelta.TransactionMaxSpans ?? _wrapped.TransactionMaxSpans;
 
 			public double TransactionSampleRate => _configDelta.TransactionSampleRate ?? _wrapped.TransactionSampleRate;
+			public bool UseElasticTraceparentHeader => _wrapped.UseElasticTraceparentHeader;
 		}
 	}
 }

--- a/src/Elastic.Apm/Config/AbstractConfigurationReader.cs
+++ b/src/Elastic.Apm/Config/AbstractConfigurationReader.cs
@@ -33,6 +33,9 @@ namespace Elastic.Apm.Config
 		protected static ConfigurationKeyValue Kv(string key, string value, string origin) =>
 			new ConfigurationKeyValue(key, value, origin);
 
+		protected bool ParseUseElasticTraceparentHeader(ConfigurationKeyValue kv) =>
+			ParseBoolOption(kv, DefaultValues.UseElasticTraceparentHeader, "UseElasticTraceparentHeader");
+
 		protected internal static bool TryParseLogLevel(string value, out LogLevel level)
 		{
 			level = default;

--- a/src/Elastic.Apm/Config/AbstractConfigurationWithEnvFallbackReader.cs
+++ b/src/Elastic.Apm/Config/AbstractConfigurationWithEnvFallbackReader.cs
@@ -84,5 +84,8 @@ namespace Elastic.Apm.Config
 
 		public virtual double TransactionSampleRate =>
 			ParseTransactionSampleRate(Read(ConfigConsts.KeyNames.TransactionSampleRate, ConfigConsts.EnvVarNames.TransactionSampleRate));
+
+		public bool UseElasticTraceparentHeader => ParseUseElasticTraceparentHeader(Read(ConfigConsts.KeyNames.UseElasticTraceparentheader,
+			ConfigConsts.EnvVarNames.UseElasticTraceparentHeader));
 	}
 }

--- a/src/Elastic.Apm/Config/ConfigConsts.cs
+++ b/src/Elastic.Apm/Config/ConfigConsts.cs
@@ -29,6 +29,7 @@ namespace Elastic.Apm.Config
 			public const int TransactionMaxSpans = 500;
 			public const double TransactionSampleRate = 1.0;
 			public const string UnknownServiceName = "unknown";
+			public const bool UseElasticTraceparentHeader = true;
 
 			public static List<WildcardMatcher> DisableMetrics = new List<WildcardMatcher>();
 
@@ -82,6 +83,7 @@ namespace Elastic.Apm.Config
 			public const string StackTraceLimit = Prefix + "STACK_TRACE_LIMIT";
 			public const string TransactionMaxSpans = Prefix + "TRANSACTION_MAX_SPANS";
 			public const string TransactionSampleRate = Prefix + "TRANSACTION_SAMPLE_RATE";
+			public const string UseElasticTraceparentHeader = Prefix + "USE_ELASTIC_TRACEPARENT_HEADER";
 		}
 
 		public static class KeyNames
@@ -108,6 +110,7 @@ namespace Elastic.Apm.Config
 			public const string StackTraceLimit = "ElasticApm:StackTraceLimit";
 			public const string TransactionMaxSpans = "ElasticApm:TransactionMaxSpans";
 			public const string TransactionSampleRate = "ElasticApm:TransactionSampleRate";
+			public const string UseElasticTraceparentheader = "ElasticApm:UseElasticTraceparentHeder";
 		}
 
 		public static class SupportedValues

--- a/src/Elastic.Apm/Config/ConfigSnapshotFromReader.cs
+++ b/src/Elastic.Apm/Config/ConfigSnapshotFromReader.cs
@@ -39,5 +39,6 @@ namespace Elastic.Apm.Config
 		public int StackTraceLimit => _content.StackTraceLimit;
 		public int TransactionMaxSpans => _content.TransactionMaxSpans;
 		public double TransactionSampleRate => _content.TransactionSampleRate;
+		public bool UseElasticTraceparentHeader => _content.UseElasticTraceparentHeader;
 	}
 }

--- a/src/Elastic.Apm/Config/EnvironmentConfigurationReader.cs
+++ b/src/Elastic.Apm/Config/EnvironmentConfigurationReader.cs
@@ -68,6 +68,8 @@ namespace Elastic.Apm.Config
 
 		public double TransactionSampleRate => ParseTransactionSampleRate(Read(ConfigConsts.EnvVarNames.TransactionSampleRate));
 
+		public bool UseElasticTraceparentHeader => ParseUseElasticTraceparentHeader(Read(ConfigConsts.EnvVarNames.UseElasticTraceparentHeader));
+
 		private ConfigurationKeyValue Read(string key) =>
 			new ConfigurationKeyValue(key, ReadEnvVarValue(key), Origin);
 	}

--- a/src/Elastic.Apm/Config/IConfigurationReader.cs
+++ b/src/Elastic.Apm/Config/IConfigurationReader.cs
@@ -135,5 +135,12 @@ namespace Elastic.Apm.Config
 		int TransactionMaxSpans { get; }
 
 		double TransactionSampleRate { get; }
+
+		/// <summary>
+		/// If true, for all outgoing HTTP requests the agent stores the traceparent in a header prefixed with elastic-apm
+		/// (elastic-apm-traceparent)
+		/// otherwise it'll use the official header name from w3c, which is "traceparewnt".
+		/// </summary>
+		bool UseElasticTraceparentHeader { get; }
 	}
 }

--- a/src/Elastic.Apm/DiagnosticListeners/HttpDiagnosticListenerCoreImpl.cs
+++ b/src/Elastic.Apm/DiagnosticListeners/HttpDiagnosticListenerCoreImpl.cs
@@ -18,7 +18,8 @@ namespace Elastic.Apm.DiagnosticListeners
 
 		protected override string RequestGetMethod(HttpRequestMessage request) => request.Method.Method;
 
-		protected override bool RequestHeadersContain(HttpRequestMessage request, string headerName) => request.Headers.Contains(headerName);
+		protected override bool RequestHeadersContain(HttpRequestMessage request, string headerName)
+			=> request.Headers.Contains(headerName);
 
 		protected override void RequestHeadersAdd(HttpRequestMessage request, string headerName, string headerValue) =>
 			request.Headers.Add(headerName, headerValue);

--- a/src/Elastic.Apm/DiagnosticListeners/HttpDiagnosticListenerImplBase.cs
+++ b/src/Elastic.Apm/DiagnosticListeners/HttpDiagnosticListenerImplBase.cs
@@ -144,6 +144,18 @@ namespace Elastic.Apm.DiagnosticListeners
 				// but here we want the string to be in W3C 'traceparent' header format.
 				RequestHeadersAdd(request, TraceParent.TraceParentHeaderName, TraceParent.BuildTraceparent(span.OutgoingDistributedTracingData));
 
+			if (transaction is Transaction t)
+			{
+				if (t.ConfigSnapshot.UseElasticTraceparentHeader)
+				{
+					if (!RequestHeadersContain(request, TraceParent.TraceParentHeaderNamePrefixed))
+					{
+						RequestHeadersAdd(request, TraceParent.TraceParentHeaderNamePrefixed,
+							TraceParent.BuildTraceparent(span.OutgoingDistributedTracingData));
+					}
+				}
+			}
+
 			if (!span.ShouldBeSentToApmServer) return;
 
 			span.Context.Http = new Http { Method = RequestGetMethod(request) };

--- a/src/Elastic.Apm/DiagnosticListeners/HttpDiagnosticListenerImplBase.cs
+++ b/src/Elastic.Apm/DiagnosticListeners/HttpDiagnosticListenerImplBase.cs
@@ -138,23 +138,26 @@ namespace Elastic.Apm.DiagnosticListeners
 				return;
 			}
 
-			if (!RequestHeadersContain(request, TraceParent.TraceParentHeaderName))
+			if (!RequestHeadersContain(request, DistributedTracing.TraceContext.TraceParentHeaderName))
 				// We call TraceParent.BuildTraceparent explicitly instead of DistributedTracingData.SerializeToString because
 				// in the future we might change DistributedTracingData.SerializeToString to use some other internal format
 				// but here we want the string to be in W3C 'traceparent' header format.
-				RequestHeadersAdd(request, TraceParent.TraceParentHeaderName, TraceParent.BuildTraceparent(span.OutgoingDistributedTracingData));
+				RequestHeadersAdd(request, DistributedTracing.TraceContext.TraceParentHeaderName, DistributedTracing.TraceContext.BuildTraceparent(span.OutgoingDistributedTracingData));
 
 			if (transaction is Transaction t)
 			{
 				if (t.ConfigSnapshot.UseElasticTraceparentHeader)
 				{
-					if (!RequestHeadersContain(request, TraceParent.TraceParentHeaderNamePrefixed))
+					if (!RequestHeadersContain(request, DistributedTracing.TraceContext.TraceParentHeaderNamePrefixed))
 					{
-						RequestHeadersAdd(request, TraceParent.TraceParentHeaderNamePrefixed,
-							TraceParent.BuildTraceparent(span.OutgoingDistributedTracingData));
+						RequestHeadersAdd(request, DistributedTracing.TraceContext.TraceParentHeaderNamePrefixed,
+							DistributedTracing.TraceContext.BuildTraceparent(span.OutgoingDistributedTracingData));
 					}
 				}
 			}
+
+			if (!RequestHeadersContain(request, DistributedTracing.TraceContext.TraceStateHeaderName) && transaction.OutgoingDistributedTracingData.HasTraceState)
+				RequestHeadersAdd(request, DistributedTracing.TraceContext.TraceStateHeaderName, DistributedTracing.TraceContext.BuildTraceState(transaction.OutgoingDistributedTracingData));
 
 			if (!span.ShouldBeSentToApmServer) return;
 

--- a/src/Elastic.Apm/DiagnosticListeners/HttpDiagnosticListenerImplBase.cs
+++ b/src/Elastic.Apm/DiagnosticListeners/HttpDiagnosticListenerImplBase.cs
@@ -138,26 +138,29 @@ namespace Elastic.Apm.DiagnosticListeners
 				return;
 			}
 
-			if (!RequestHeadersContain(request, DistributedTracing.TraceContext.TraceParentHeaderName))
+			if (!RequestHeadersContain(request, TraceContext.TraceParentHeaderName))
 				// We call TraceParent.BuildTraceparent explicitly instead of DistributedTracingData.SerializeToString because
 				// in the future we might change DistributedTracingData.SerializeToString to use some other internal format
 				// but here we want the string to be in W3C 'traceparent' header format.
-				RequestHeadersAdd(request, DistributedTracing.TraceContext.TraceParentHeaderName, DistributedTracing.TraceContext.BuildTraceparent(span.OutgoingDistributedTracingData));
+				RequestHeadersAdd(request, TraceContext.TraceParentHeaderName, TraceContext.BuildTraceparent(span.OutgoingDistributedTracingData));
 
 			if (transaction is Transaction t)
 			{
 				if (t.ConfigSnapshot.UseElasticTraceparentHeader)
 				{
-					if (!RequestHeadersContain(request, DistributedTracing.TraceContext.TraceParentHeaderNamePrefixed))
+					if (!RequestHeadersContain(request, TraceContext.TraceParentHeaderNamePrefixed))
 					{
-						RequestHeadersAdd(request, DistributedTracing.TraceContext.TraceParentHeaderNamePrefixed,
-							DistributedTracing.TraceContext.BuildTraceparent(span.OutgoingDistributedTracingData));
+						RequestHeadersAdd(request, TraceContext.TraceParentHeaderNamePrefixed,
+							TraceContext.BuildTraceparent(span.OutgoingDistributedTracingData));
 					}
 				}
 			}
 
-			if (!RequestHeadersContain(request, DistributedTracing.TraceContext.TraceStateHeaderName) && transaction.OutgoingDistributedTracingData.HasTraceState)
-				RequestHeadersAdd(request, DistributedTracing.TraceContext.TraceStateHeaderName, DistributedTracing.TraceContext.BuildTraceState(transaction.OutgoingDistributedTracingData));
+			if (!RequestHeadersContain(request, TraceContext.TraceStateHeaderName) && transaction.OutgoingDistributedTracingData.HasTraceState)
+			{
+				RequestHeadersAdd(request, TraceContext.TraceStateHeaderName,
+					TraceContext.BuildTraceState(transaction.OutgoingDistributedTracingData));
+			}
 
 			if (!span.ShouldBeSentToApmServer) return;
 

--- a/src/Elastic.Apm/DistributedTracing/TraceContext.cs
+++ b/src/Elastic.Apm/DistributedTracing/TraceContext.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
+using System.Text;
 using Elastic.Apm.Api;
 
 namespace Elastic.Apm.DistributedTracing
@@ -7,7 +9,6 @@ namespace Elastic.Apm.DistributedTracing
 	/// <summary>
 	/// This is an implementation of the
 	/// "https://www.w3.org/TR/trace-context/#traceparent-field" w3c 'Trace Context'.
-	///
 	/// traceparent header:
 	/// traceparent: 00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01
 	/// (_________)  () (______________________________) (______________) ()
@@ -36,6 +37,8 @@ namespace Elastic.Apm.DistributedTracing
 		/// <returns>The parsed data if parsing was successful, null otherwise.</returns>
 		internal static DistributedTracingData TryExtractTracingData(string traceParentValue, string traceStateValue = null)
 		{
+			Console.WriteLine("TraceState: " + traceStateValue);
+
 			var bestAttempt = false;
 
 			if (string.IsNullOrWhiteSpace(traceParentValue)) return null;
@@ -118,8 +121,108 @@ namespace Elastic.Apm.DistributedTracing
 			}
 
 			return traceStateValue != null
-				? new DistributedTracingData(traceId, parentId, (traceFlags & FlagRecorded) == FlagRecorded, traceStateValue)
+				? new DistributedTracingData(traceId, parentId, (traceFlags & FlagRecorded) == FlagRecorded, ValidateTracestate(traceStateValue))
 				: new DistributedTracingData(traceId, parentId, (traceFlags & FlagRecorded) == FlagRecorded);
+		}
+
+		/// <summary>
+		/// Validates the tracestate value
+		/// </summary>
+		/// <param name="traceState">The value to validate</param>
+		/// <returns>The <see cref="traceState" /> if the value is a valid trace state, <code>null</code> otherwise</returns>
+		private static string ValidateTracestate(string traceState)
+		{
+			if (string.IsNullOrEmpty(traceState))
+				return null;
+
+			var listMembers = traceState.Split(',');
+			var set = new HashSet<string>();
+
+			if (!listMembers.Any() || listMembers.Length > 32) return null;
+
+			var sb = new StringBuilder();
+
+			foreach (var listMember in listMembers)
+			{
+				var item = listMember.Split('=');
+				if (item.Count() != 2)
+					continue;
+
+				if (set.Contains(item[0]))
+					return null;
+
+				if (item[0].Length > 256)
+					return null;
+
+				if (item[0].Contains('@'))
+				{
+					var vendorFormatKey = item[0].Split('@');
+					if (vendorFormatKey.Count() != 2)
+						return null;
+
+					if (vendorFormatKey[0].Length == 0 || string.IsNullOrEmpty(vendorFormatKey[0]) || vendorFormatKey[0].Length > 241)
+						return null;
+					if (vendorFormatKey[1].Length == 0 || string.IsNullOrEmpty(vendorFormatKey[1]) || vendorFormatKey[1].Length > 14)
+						return null;
+
+					if (!ValidateKey(vendorFormatKey[0]) || !ValidateKey(vendorFormatKey[1])) return null;
+				}
+				else
+				{
+					if (!ValidateKey(item[0]))
+						return null;
+				}
+
+				if (!ValidateValue(item[1]))
+					return null;
+
+				if (sb.Length != 0)
+					sb.Append(',');
+				sb.Append(listMember);
+
+				set.Add(item[0]);
+			}
+
+			return sb.Length != traceState.Length ? sb.ToString() : traceState;
+
+			static bool ValidateValue(string str)
+			{
+				if (string.IsNullOrEmpty(str))
+					return false;
+
+				// ReSharper disable once LoopCanBeConvertedToQuery
+				for (var i = 0; i < str.Length; i++)
+				{
+					var c = str[i];
+					var isOk = c >= 0x20 && c <= 0x7E || c == '\t' && c != ',' && c != '='
+						//OWS rule: if we hit a ' ', then it must be next to a '\t'
+						|| c == ' ' && (i > 0 && str[i - 1] == '\t' || i < str.Length - 2 && str[i + 1] == '\t');
+
+					if (!isOk)
+						return false;
+				}
+
+				return true;
+			}
+
+			static bool ValidateKey(string str)
+			{
+				// ReSharper disable once LoopCanBeConvertedToQuery
+				for (var i = 0; i < str.Length; i++)
+				{
+					var c = str[i];
+					var isOk = c >= '0' && c <= '9' ||
+						c >= 'a' && c <= 'z'
+						|| c == '_' || c == '-' || c == '*' || c == '/' || c == '\t'
+						//OWS rule: if we hit a ' ', then it must be next to a '\t'
+						|| c == ' ' && (i > 0 && str[i - 1] == '\t' || i < str.Length - 2 && str[i + 1] == '\t');
+
+					if (!isOk)
+						return false;
+				}
+
+				return true;
+			}
 		}
 
 		internal static bool IsHex(IEnumerable<char> chars)

--- a/src/Elastic.Apm/DistributedTracing/TraceParent.cs
+++ b/src/Elastic.Apm/DistributedTracing/TraceParent.cs
@@ -20,7 +20,8 @@ namespace Elastic.Apm.DistributedTracing
 		private const int OptionsLength = 2;
 		private const int SpanIdLength = 16;
 		private const int TraceIdLength = 32;
-		internal const string TraceParentHeaderName = "elastic-apm-traceparent";
+		internal const string TraceParentHeaderName = "traceparent";
+		internal const string TraceParentHeaderNamePrefixed = "elastic-apm-traceparent";
 		private const int VersionAndTraceIdAndSpanIdLength = 53;
 		private const int VersionAndTraceIdLength = 36;
 		private const int VersionPrefixIdLength = 3;

--- a/src/Elastic.Apm/Metrics/MetricsCollector.cs
+++ b/src/Elastic.Apm/Metrics/MetricsCollector.cs
@@ -84,8 +84,10 @@ namespace Elastic.Apm.Metrics
 			var collectGen3Size = !WildcardMatcher.IsAnyMatch(configurationReader.DisableMetrics,
 				GcMetricsProvider.GcGen3SizeName);
 			if (collectGcCount || collectGen0Size || collectGen1Size || collectGen2Size || collectGen3Size)
+			{
 				MetricsProviders.Add(new GcMetricsProvider(_logger, collectGcCount, collectGen0Size, collectGen1Size, collectGen2Size,
 					collectGen3Size));
+			}
 
 			_logger.Info()?.Log("Collecting metrics in {interval} milliseconds interval", interval);
 			_timer = new Timer(interval);

--- a/test/Elastic.Apm.PerfTests/Program.cs
+++ b/test/Elastic.Apm.PerfTests/Program.cs
@@ -160,7 +160,7 @@ namespace Elastic.Apm.PerfTests
 		{
 			const string traceParent = "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01";
 
-			var res = TraceParent.TryExtractTraceparent(traceParent);
+			var res = DistributedTracing.TraceContext.TryExtractTracingData(traceParent);
 			Debug.WriteLine($"{res}");
 		}
 	}

--- a/test/Elastic.Apm.Tests.MockApmServer/AssertValidExtensions.cs
+++ b/test/Elastic.Apm.Tests.MockApmServer/AssertValidExtensions.cs
@@ -193,7 +193,7 @@ namespace Elastic.Apm.Tests.MockApmServer
 			var because =
 				$"String should be {numHexChars} hex digits ({sizeInBits}-bits) but the actual value is `{thisObj}' (length: {thisObj.Length})";
 			thisObj.Length.Should().Be(numHexChars, because); // 2 hex chars per byte
-			TraceParent.IsHex(thisObj).Should().BeTrue(because);
+			DistributedTracing.TraceContext.IsHex(thisObj).Should().BeTrue(because);
 		}
 
 		internal static void NonEmptyAssertValid(this string thisObj, int maxLength = 1024)

--- a/test/Elastic.Apm.Tests.MockApmServer/MetricsAssertValid.cs
+++ b/test/Elastic.Apm.Tests.MockApmServer/MetricsAssertValid.cs
@@ -23,6 +23,10 @@ namespace Elastic.Apm.Tests.MockApmServer
 
 			foreach (var metricSample in metricSet.Samples)
 			{
+				//GC metrics are only captured when at least 1 GC happens during the test - so we don't assert on those.
+				if (metricSample.Key.Contains("clr.gc", StringComparison.CurrentCultureIgnoreCase))
+					continue;
+
 				MetricMetadataPerType.Should().ContainKey(metricSample.Key);
 				MetricMetadataPerType[metricSample.Key].VerifyAction(metricSample.Value.Value);
 			}

--- a/test/Elastic.Apm.Tests/ConstructorTests.cs
+++ b/test/Elastic.Apm.Tests/ConstructorTests.cs
@@ -18,7 +18,7 @@ namespace Elastic.Apm.Tests
 		public void Compose()
 		{
 			//build AgentComponents manually so we can disable metrics collection. reason: creating metrics collector pro test and disposing it makes test failing (ETW or EventSource subscribe unsubscribe in each test in parallel if all tests are running)
-			var agent = new ApmAgent(new AgentComponents(null, configurationReader: new LogConfig(LogLevel.Warning), null, metricsCollector: null,
+			var agent = new ApmAgent(new AgentComponents(null, new LogConfig(LogLevel.Warning), null, null,
 				null, null));
 			var logger = agent.Logger as ConsoleLogger;
 
@@ -30,6 +30,8 @@ namespace Elastic.Apm.Tests
 		private class LogConfig : IConfigSnapshot
 		{
 			public LogConfig(LogLevel level) => LogLevel = level;
+
+			public string DbgDescription => "LogConfig";
 
 			// ReSharper disable UnassignedGetOnlyAutoProperty
 			public string CaptureBody => ConfigConsts.DefaultValues.CaptureBody;
@@ -53,11 +55,10 @@ namespace Elastic.Apm.Tests
 			public double SpanFramesMinDurationInMilliseconds => ConfigConsts.DefaultValues.SpanFramesMinDurationInMilliseconds;
 			public int StackTraceLimit => ConfigConsts.DefaultValues.StackTraceLimit;
 			public double TransactionSampleRate => ConfigConsts.DefaultValues.TransactionSampleRate;
+			public bool UseElasticTraceparentHeader => ConfigConsts.DefaultValues.UseElasticTraceparentHeader;
 
 			public int TransactionMaxSpans => ConfigConsts.DefaultValues.TransactionMaxSpans;
 			// ReSharper restore UnassignedGetOnlyAutoProperty
-
-			public string DbgDescription => "LogConfig";
 		}
 	}
 }

--- a/test/Elastic.Apm.Tests/DistributedTracingTests.cs
+++ b/test/Elastic.Apm.Tests/DistributedTracingTests.cs
@@ -78,6 +78,6 @@ namespace Elastic.Apm.Tests
 		/// </summary>
 		[Fact]
 		public void TraceParentHeaderName() =>
-			TraceParent.TraceParentHeaderName.Should().Be("elastic-apm-traceparent");
+			TraceParent.TraceParentHeaderNamePrefixed.Should().Be("elastic-apm-traceparent");
 	}
 }

--- a/test/Elastic.Apm.Tests/DistributedTracingTests.cs
+++ b/test/Elastic.Apm.Tests/DistributedTracingTests.cs
@@ -11,7 +11,7 @@ namespace Elastic.Apm.Tests
 		{
 			const string traceParent = "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01";
 
-			var res = TraceParent.TryExtractTraceparent(traceParent);
+			var res = DistributedTracing.TraceContext.TryExtractTracingData(traceParent);
 			res.Should().NotBeNull();
 			res.TraceId.Should().Be("0af7651916cd43dd8448eb211c80319c");
 			res.ParentId.Should().Be("b7ad6b7169203331");
@@ -19,7 +19,7 @@ namespace Elastic.Apm.Tests
 
 			//try also with flag options C6
 			const string traceParent2 = "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-E7";
-			var res2 = TraceParent.TryExtractTraceparent(traceParent2);
+			var res2 = DistributedTracing.TraceContext.TryExtractTracingData(traceParent2);
 			res2.FlagRecorded.Should().BeTrue();
 		}
 
@@ -28,7 +28,7 @@ namespace Elastic.Apm.Tests
 		{
 			const string traceParent = "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-00";
 
-			var res = TraceParent.TryExtractTraceparent(traceParent);
+			var res = DistributedTracing.TraceContext.TryExtractTracingData(traceParent);
 
 			res.TraceId.Should().Be("0af7651916cd43dd8448eb211c80319c");
 			res.ParentId.Should().Be("b7ad6b7169203331");
@@ -37,7 +37,7 @@ namespace Elastic.Apm.Tests
 
 			//try also with flag options C6
 			const string traceParent2 = "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-C6";
-			var res2 = TraceParent.TryExtractTraceparent(traceParent2);
+			var res2 = DistributedTracing.TraceContext.TryExtractTracingData(traceParent2);
 			res2.FlagRecorded.Should().BeFalse();
 		}
 
@@ -47,7 +47,7 @@ namespace Elastic.Apm.Tests
 			const string traceParent = "99-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01";
 
 			//Best attempt, even if it's a future version we still try to read the traceId and parentId
-			var res = TraceParent.TryExtractTraceparent(traceParent);
+			var res = DistributedTracing.TraceContext.TryExtractTracingData(traceParent);
 			res.Should().NotBeNull();
 			res.TraceId.Should().Be("0af7651916cd43dd8448eb211c80319c");
 			res.ParentId.Should().Be("b7ad6b7169203331");
@@ -58,7 +58,7 @@ namespace Elastic.Apm.Tests
 		public void ValidateTraceParentWithInvalidLength()
 		{
 			const string traceParent = "99-af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01"; //TraceId is 1 char shorter than expected
-			var res = TraceParent.TryExtractTraceparent(traceParent);
+			var res = DistributedTracing.TraceContext.TryExtractTracingData(traceParent);
 			res.Should().BeNull();
 		}
 
@@ -68,7 +68,7 @@ namespace Elastic.Apm.Tests
 			const string
 				traceParent =
 					"00-0af7651916cd43dd8448eb211c80319ca-7ad6b7169203331-01"; //TraceId is 1 char longer than expected, and parentId is 1 char longer
-			var res = TraceParent.TryExtractTraceparent(traceParent);
+			var res = DistributedTracing.TraceContext.TryExtractTracingData(traceParent);
 			res.Should().BeNull();
 		}
 
@@ -78,6 +78,6 @@ namespace Elastic.Apm.Tests
 		/// </summary>
 		[Fact]
 		public void TraceParentHeaderName() =>
-			TraceParent.TraceParentHeaderNamePrefixed.Should().Be("elastic-apm-traceparent");
+			DistributedTracing.TraceContext.TraceParentHeaderNamePrefixed.Should().Be("elastic-apm-traceparent");
 	}
 }

--- a/test/Elastic.Apm.Tests/MetricsTests.cs
+++ b/test/Elastic.Apm.Tests/MetricsTests.cs
@@ -19,29 +19,13 @@ using Xunit.Abstractions;
 
 namespace Elastic.Apm.Tests
 {
-	internal class Logger : IApmLogger
-	{
-		private readonly ITestOutputHelper _testOutputHelper;
-
-		public Logger(ITestOutputHelper testOutputHelper)
-			=> _testOutputHelper = testOutputHelper;
-
-		public bool IsEnabled(LogLevel level) => true;
-
-		public void Log<TState>(LogLevel level, TState state, Exception e, Func<TState, Exception, string> formatter)
-		{
-			var v = formatter(state, e);
-			_testOutputHelper.WriteLine(v);
-		}
-	}
-
 	public class MetricsTests : LoggingTestBase
 	{
 		private const string ThisClassName = nameof(MetricsTests);
 
 		private readonly IApmLogger _logger;
 
-		public MetricsTests(ITestOutputHelper xUnitOutputHelper) : base(xUnitOutputHelper) => _logger = new Logger((xUnitOutputHelper));
+		public MetricsTests(ITestOutputHelper xUnitOutputHelper) : base(xUnitOutputHelper) => _logger = LoggerBase.Scoped(ThisClassName);
 
 		public static IEnumerable<object[]> DisableProviderTestData
 		{
@@ -197,10 +181,7 @@ namespace Elastic.Apm.Tests
 			metricsCollector.MetricsProviders.Add(metricsProviderMock.Object);
 
 			// Act
-			foreach (var _ in Enumerable.Range(0, iterations))
-			{
-				metricsCollector.CollectAllMetrics();
-			}
+			foreach (var _ in Enumerable.Range(0, iterations)) metricsCollector.CollectAllMetrics();
 
 			// Assert
 			mockPayloadSender.Metrics.Should().BeEmpty();
@@ -264,7 +245,7 @@ namespace Elastic.Apm.Tests
 
 					containsValue = samples?.Count() != 0;
 
-					if(containsValue)
+					if (containsValue)
 						break;
 				}
 #if !NETCOREAPP2_1

--- a/test/Elastic.Apm.Tests/Mocks/MockConfigSnapshot.cs
+++ b/test/Elastic.Apm.Tests/Mocks/MockConfigSnapshot.cs
@@ -34,6 +34,7 @@ namespace Elastic.Apm.Tests.Mocks
 		private readonly string _stackTraceLimit;
 		private readonly string _transactionMaxSpans;
 		private readonly string _transactionSampleRate;
+		private readonly string _useElasticTraceparentHeader;
 
 		public MockConfigSnapshot(
 			IApmLogger logger = null,
@@ -59,7 +60,8 @@ namespace Elastic.Apm.Tests.Mocks
 			string maxQueueEventCount = null,
 			string sanitizeFieldNames = null,
 			string globalLabels = null,
-			string disableMetrics = null
+			string disableMetrics = null,
+			string useElasticTraceparentHeader = null
 		) : base(logger, ThisClassName)
 		{
 			_serverUrls = serverUrls;
@@ -85,6 +87,7 @@ namespace Elastic.Apm.Tests.Mocks
 			_sanitizeFieldNames = sanitizeFieldNames;
 			_globalLabels = globalLabels;
 			_disableMetrics = disableMetrics;
+			_useElasticTraceparentHeader = useElasticTraceparentHeader;
 		}
 
 		public string CaptureBody => ParseCaptureBody(Kv(ConfigConsts.EnvVarNames.CaptureBody, _captureBody, Origin));
@@ -131,5 +134,8 @@ namespace Elastic.Apm.Tests.Mocks
 
 		public double TransactionSampleRate =>
 			ParseTransactionSampleRate(Kv(ConfigConsts.EnvVarNames.TransactionSampleRate, _transactionSampleRate, Origin));
+
+		public bool UseElasticTraceparentHeader =>
+			ParseUseElasticTraceparentHeader(Kv(ConfigConsts.EnvVarNames.UseElasticTraceparentHeader, _useElasticTraceparentHeader, Origin));
 	}
 }


### PR DESCRIPTION
Solves https://github.com/elastic/apm-agent-dotnet/issues/177

### What changes
- The agent will start using the `traceparent`  header instead of `elastic-apm-traceparent`
- Adds config `UseElasticTraceparentHeader` - for backwards compatibility with this users can still add the `elastic-apm-traceparent` additionally to `traceparent`. The default is currently true (so the agent adds both) - we'll flip it at one point to default false
- The agent also validates and forwards the `tracestate` header. 

All tests from the [tracecontext test folder](https://github.com/w3c/trace-context/blob/master/test/test.py) pass.

### For manual tracing

The public API exposes the `traceparent` to the user - you can serialize it and you can also deserialize it from a string by using the `DistributedTracingData` class. For now, the tracestate won't be exposed - I feel it'd be just confusing and rarely used.

So the API of the public `DistributedTracingData` class does not change. The agent always passes the `tracestate` header if the `traceparent` is present, but if users manually instrument code across applications, currently they can only pass `traceparent`.

This can be easily changed, but I'd wait for user request to do so, otherwise we'd just complicate the API.

