### PR TITLE
ci(jenkins): force the reinstall

### DIFF
--- a/.ci/windows/msbuild-tools.ps1
+++ b/.ci/windows/msbuild-tools.ps1
@@ -3,6 +3,6 @@
 #
 
 # Install visualstudio2019buildtools
-& choco install visualstudio2019buildtools -m -y --no-progress -r --version=16.4.0.0
-& choco install visualstudio2019enterprise -m -y --no-progress -r --version=16.4.0.0 --package-parameters "--includeRecommended --includeOptional"
-& choco install visualstudio2019-workload-netweb -m -y --no-progress -r --version=1.0.0
+& choco install visualstudio2019buildtools -m -y --no-progress --force -r --version=16.4.0.0
+& choco install visualstudio2019enterprise -m -y --no-progress --force -r --version=16.4.0.0 --package-parameters "--includeRecommended --includeOptional"
+& choco install visualstudio2019-workload-netweb -m -y --no-progress --force -r --version=1.0.0


### PR DESCRIPTION
This will help to avoid any CI environmental issues with the VS2019 by forcing the installation during the build. 