### PR TITLE
Add IsMetricAlreadyCaptured to IMetricsProvider

### DIFF
--- a/src/Elastic.Apm/Metrics/IMetricsProvider.cs
+++ b/src/Elastic.Apm/Metrics/IMetricsProvider.cs
@@ -29,5 +29,16 @@ namespace Elastic.Apm.Metrics
 		/// </summary>
 		/// <returns>The key and the value of the metric(s)</returns>
 		IEnumerable<MetricSample> GetSamples();
+
+		/// <summary>
+		/// Indicates if metrics were already collected - or there was an attempt to collect them.
+		/// Until this property is false, metrics from the implementor won't be collected.
+		/// This property exists to cover cases when the metric collection happens in the background
+		/// (e.g. collecting GC metrics through EventListener) and values are not captured directly in
+		/// the <see cref="GetSamples"/> method.
+		/// If metrics are captured on the fly in <see cref="GetSamples"/> just set this to <code>true</code>
+		/// during initialization.
+		/// </summary>
+		bool IsMetricAlreadyCaptured { get; }
 	}
 }

--- a/src/Elastic.Apm/Metrics/MetricsCollector.cs
+++ b/src/Elastic.Apm/Metrics/MetricsCollector.cs
@@ -118,7 +118,7 @@ namespace Elastic.Apm.Metrics
 			}
 		}
 
-		internal void CollectAllMetricsImpl()
+		private void CollectAllMetricsImpl()
 		{
 			_logger.Trace()?.Log("CollectAllMetrics started");
 
@@ -157,6 +157,14 @@ namespace Elastic.Apm.Metrics
 			{
 				if (metricsProvider.ConsecutiveNumberOfFailedReads == MaxTryWithoutSuccess)
 					continue;
+
+				if (!metricsProvider.IsMetricAlreadyCaptured)
+				{
+					_logger.Trace()
+						?.Log("Skipping {MetricsProviderName} - {propertyName} indicated false", metricsProvider.DbgName,
+							nameof(IMetricsProvider.IsMetricAlreadyCaptured));
+					continue;
+				}
 
 				try
 				{

--- a/src/Elastic.Apm/Metrics/MetricsProvider/FreeAndTotalMemoryProvider.cs
+++ b/src/Elastic.Apm/Metrics/MetricsProvider/FreeAndTotalMemoryProvider.cs
@@ -20,10 +20,12 @@ namespace Elastic.Apm.Metrics.MetricsProvider
 		private readonly bool _collectTotalMemory;
 
 		public FreeAndTotalMemoryProvider(bool collectFreeMemory, bool collectTotalMemory) =>
-			(_collectFreeMemory, _collectTotalMemory) = (collectFreeMemory, collectTotalMemory);
+			(_collectFreeMemory, _collectTotalMemory, IsMetricAlreadyCaptured) = (collectFreeMemory, collectTotalMemory, true);
 
 		public int ConsecutiveNumberOfFailedReads { get; set; }
 		public string DbgName => "total and free memory";
+
+		public bool IsMetricAlreadyCaptured { get; }
 
 		public IEnumerable<MetricSample> GetSamples()
 		{

--- a/src/Elastic.Apm/Metrics/MetricsProvider/ProcessTotalCpuTimeProvider.cs
+++ b/src/Elastic.Apm/Metrics/MetricsProvider/ProcessTotalCpuTimeProvider.cs
@@ -15,6 +15,8 @@ namespace Elastic.Apm.Metrics.MetricsProvider
 		{
 			IApmLogger loggerInCtor = logger.Scoped(nameof(ProcessTotalCpuTimeProvider));
 
+			IsMetricAlreadyCaptured = true;
+
 			try
 			{
 				_lastTimeWindowStart = DateTime.UtcNow;
@@ -79,5 +81,7 @@ namespace Elastic.Apm.Metrics.MetricsProvider
 			_lastCurrentProcessCpuTime = cpuUsage;
 			return new List<MetricSample> { new MetricSample(ProcessCpuTotalPct, cpuUsageTotal) };
 		}
+
+		public bool IsMetricAlreadyCaptured { get; }
 	}
 }

--- a/src/Elastic.Apm/Metrics/MetricsProvider/ProcessWorkingSetAndVirtualMemoryProvider.cs
+++ b/src/Elastic.Apm/Metrics/MetricsProvider/ProcessWorkingSetAndVirtualMemoryProvider.cs
@@ -13,10 +13,13 @@ namespace Elastic.Apm.Metrics.MetricsProvider
 		private readonly bool _collectProcessWorkingSetMemory;
 
 		public ProcessWorkingSetAndVirtualMemoryProvider(bool collectProcessVirtualMemory, bool collectProcessWorkingSetMemory) =>
-			(_collectProcessVirtualMemory, _collectProcessWorkingSetMemory) = (collectProcessVirtualMemory, collectProcessWorkingSetMemory);
+			(_collectProcessVirtualMemory, _collectProcessWorkingSetMemory, IsMetricAlreadyCaptured) =
+			(collectProcessVirtualMemory, collectProcessWorkingSetMemory, true);
 
 		public int ConsecutiveNumberOfFailedReads { get; set; }
 		public string DbgName => "process's working set and virtual memory size";
+
+		public bool IsMetricAlreadyCaptured { get; }
 
 		public IEnumerable<MetricSample> GetSamples()
 		{

--- a/src/Elastic.Apm/Metrics/MetricsProvider/SystemTotalCpuProvider.cs
+++ b/src/Elastic.Apm/Metrics/MetricsProvider/SystemTotalCpuProvider.cs
@@ -124,6 +124,8 @@ namespace Elastic.Apm.Metrics.MetricsProvider
 			return null;
 		}
 
+		public bool IsMetricAlreadyCaptured => true;
+
 		public void Dispose()
 		{
 			_procStatStreamReader?.Dispose();

--- a/test/Elastic.Apm.Tests/MetricsTests.cs
+++ b/test/Elastic.Apm.Tests/MetricsTests.cs
@@ -234,6 +234,8 @@ namespace Elastic.Apm.Tests
 				// ReSharper disable once RedundantAssignment
 				var containsValue = false;
 
+#if !NETCOREAPP2_1
+				//EventSource Microsoft-Windows-DotNETRuntime is only 2.2+, no gc metrics on 2.1
 				//repeat the allocation multiple times and make sure at least 1 GetSamples() call returns value
 				for (var j = 0; j < 100; j++)
 				{
@@ -259,8 +261,7 @@ namespace Elastic.Apm.Tests
 					if (containsValue)
 						break;
 				}
-#if !NETCOREAPP2_1
-				//EventSource Microsoft-Windows-DotNETRuntime is only 2.2+, no gc metrics on 2.1
+
 				containsValue.Should().BeTrue();
 				gcMetricsProvider.IsMetricAlreadyCaptured.Should().BeTrue();
 #endif

--- a/test/Elastic.Apm.Tests/MetricsTests.cs
+++ b/test/Elastic.Apm.Tests/MetricsTests.cs
@@ -254,7 +254,7 @@ namespace Elastic.Apm.Tests
 
 					var samples = gcMetricsProvider.GetSamples();
 
-					containsValue = samples?.Count() != 0;
+					containsValue = samples != null && samples.Count() != 0;
 
 					if (containsValue)
 						break;

--- a/test/Elastic.Apm.Tests/MetricsTests.cs
+++ b/test/Elastic.Apm.Tests/MetricsTests.cs
@@ -173,7 +173,11 @@ namespace Elastic.Apm.Tests
 
 			using var metricsCollector = new MetricsCollector(logger, mockPayloadSender, new MockConfigSnapshot(logger, "Information"));
 			var metricsProviderMock = new Mock<IMetricsProvider>();
-			metricsProviderMock.Setup(x => x.GetSamples())
+
+			metricsProviderMock.Setup(x => x.IsMetricAlreadyCaptured).Returns(true);
+
+			metricsProviderMock
+				.Setup(x => x.GetSamples())
 				.Returns(() => samples);
 			metricsProviderMock.SetupProperty(x => x.ConsecutiveNumberOfFailedReads);
 
@@ -200,6 +204,9 @@ namespace Elastic.Apm.Tests
 			using var metricsCollector = new MetricsCollector(logger, mockPayloadSender, new MockConfigSnapshot(logger, "Information"));
 
 			var metricsProviderMock = new Mock<IMetricsProvider>();
+
+			metricsProviderMock.Setup(x => x.IsMetricAlreadyCaptured).Returns(true);
+
 			metricsProviderMock.Setup(x => x.GetSamples())
 				.Returns(() => new List<MetricSample> { new MetricSample("key1", double.NaN), new MetricSample("key2", 0.95) });
 			metricsProviderMock.SetupProperty(x => x.ConsecutiveNumberOfFailedReads);
@@ -221,6 +228,10 @@ namespace Elastic.Apm.Tests
 		{
 			using (var gcMetricsProvider = new GcMetricsProvider(_logger))
 			{
+				gcMetricsProvider.IsMetricAlreadyCaptured.Should().BeFalse();
+
+				// ReSharper disable once TooWideLocalVariableScope
+				// ReSharper disable once RedundantAssignment
 				var containsValue = false;
 
 				//repeat the allocation multiple times and make sure at least 1 GetSamples() call returns value
@@ -251,6 +262,7 @@ namespace Elastic.Apm.Tests
 #if !NETCOREAPP2_1
 				//EventSource Microsoft-Windows-DotNETRuntime is only 2.2+, no gc metrics on 2.1
 				containsValue.Should().BeTrue();
+				gcMetricsProvider.IsMetricAlreadyCaptured.Should().BeTrue();
 #endif
 			}
 		}
@@ -268,6 +280,8 @@ namespace Elastic.Apm.Tests
 				NumberOfGetValueCalls++;
 				throw new Exception(ExceptionMessage);
 			}
+
+			public bool IsMetricAlreadyCaptured => true;
 		}
 
 		internal class TestSystemTotalCpuProvider : SystemTotalCpuProvider

--- a/test/Elastic.Apm.Tests/MetricsTests.cs
+++ b/test/Elastic.Apm.Tests/MetricsTests.cs
@@ -252,6 +252,8 @@ namespace Elastic.Apm.Tests
 						var _ = new int[100];
 					}
 
+					GC.Collect();
+
 					Thread.Sleep(1000);
 
 					var samples = gcMetricsProvider.GetSamples();


### PR DESCRIPTION
Solves #729

Prior to GC metrics, all metrics were captured "on the fly", meaning the agent periodically collected metrics (let's say every 30 seconds) and metrics providers were queried for data when the agent wanted to collect the data.

But this does not work in all cases. For collecting GC metrics we subscribe to EventSource (or ETW on Full Framework + Windows) and the GC triggers a method when a GC happens and that is our chance to collect data. GC is just 1 example, I expect similar situations later with other metrics.

It can happen that no GC is triggered for let's say 5 minutes - in this case each time the agent tries to collect data before the 1. GC, it won't see any data.

The `MetricsCollector` wrongly disabled collecting metrics in such cases - so GC metrics were disabled forever for the given process.

Therefore a `bool` property `IsMetricAlreadyCaptured` is added to `IMetricsProvider`. Until this property does not return true, `MetricsCollector` won't try to get data from a metrics provider and won't disable it either - it just skips it.  The new `IsMetricAlreadyCaptured` should be set to `true` when the `IMetricsProvider` tried to query data or was triggered by e.g. ETW or EventSource the 1. time.