### PR TITLE
Update CHANGELOG.asciidoc

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -21,7 +21,7 @@ endif::[]
 [[release-notes-1.x]]
 === .NET Agent version 1.x
 
-[[release-notes-1.3.0]]
+[[release-notes-1.3.1]]
 ==== 1.3.1
 
 [float]


### PR DESCRIPTION
Copy paste error previously causing 

```
21:35:25 INFO:build_docs:asciidoctor: WARNING: ../CHANGELOG.asciidoc: line 34: id assigned to section already in use: release-notes-1.3.0
```