### PR TITLE
Remove logging in CurrentExecutionSegmentsContainer

### DIFF
--- a/src/Elastic.Apm/AgentComponents.cs
+++ b/src/Elastic.Apm/AgentComponents.cs
@@ -44,7 +44,7 @@ namespace Elastic.Apm
 			CentralConfigFetcher = centralConfigFetcher ?? new CentralConfigFetcher(Logger, ConfigStore, Service);
 
 			TracerInternal = new Tracer(Logger, Service, PayloadSender, ConfigStore,
-				currentExecutionSegmentsContainer ?? new CurrentExecutionSegmentsContainer(Logger));
+				currentExecutionSegmentsContainer ?? new CurrentExecutionSegmentsContainer());
 		}
 
 		internal ICentralConfigFetcher CentralConfigFetcher { get; }

--- a/src/Elastic.Apm/CurrentExecutionSegmentsContainer.cs
+++ b/src/Elastic.Apm/CurrentExecutionSegmentsContainer.cs
@@ -1,20 +1,12 @@
 using System.Threading;
-using Elastic.Apm.Helpers;
-using Elastic.Apm.Logging;
 using Elastic.Apm.Model;
 
 namespace Elastic.Apm
 {
 	internal sealed class CurrentExecutionSegmentsContainer : ICurrentExecutionSegmentsContainer
 	{
-		private readonly ContextLocalHolder<Span> _currentSpan;
-		private readonly ContextLocalHolder<Transaction> _currentTransaction;
-
-		internal CurrentExecutionSegmentsContainer(IApmLogger logger)
-		{
-			_currentTransaction = new ContextLocalHolder<Transaction>(logger, "transaction");
-			_currentSpan = new ContextLocalHolder<Span>(logger, "span");
-		}
+		private readonly AsyncLocal<Span> _currentSpan = new AsyncLocal<Span>();
+		private readonly AsyncLocal<Transaction> _currentTransaction = new AsyncLocal<Transaction>();
 
 		public Span CurrentSpan
 		{
@@ -26,21 +18,6 @@ namespace Elastic.Apm
 		{
 			get => _currentTransaction.Value;
 			set => _currentTransaction.Value = value;
-		}
-
-		private sealed class ContextLocalHolder<T>
-		{
-			private readonly IApmLogger _logger;
-			private readonly AsyncLocal<T> _value = new AsyncLocal<T>();
-
-			internal ContextLocalHolder(IApmLogger logger, string loggerNameSuffix) =>
-				_logger = logger.Scoped($"{nameof(CurrentExecutionSegmentsContainer)}.{loggerNameSuffix}");
-
-			internal T Value
-			{
-				get => _value.Value;
-				set => _value.Value = value;
-			}
 		}
 	}
 }

--- a/src/Elastic.Apm/CurrentExecutionSegmentsContainer.cs
+++ b/src/Elastic.Apm/CurrentExecutionSegmentsContainer.cs
@@ -38,23 +38,8 @@ namespace Elastic.Apm
 
 			internal T Value
 			{
-				get
-				{
-					_logger.Trace()
-						?.Log("Getting value..." +
-							" Current thread: {ThreadDesc}. Current value: {ExecutionSegment}."
-							, DbgUtils.CurrentThreadDesc, _value.Value);
-					return _value.Value;
-				}
-
-				set
-				{
-					_logger.Trace()
-						?.Log("Setting value..." +
-							" Current thread: {ThreadDesc}. Current value: {ExecutionSegment}. New value: {ExecutionSegment}."
-							, DbgUtils.CurrentThreadDesc, _value.Value, value);
-					_value.Value = value;
-				}
+				get => _value.Value;
+				set => _value.Value = value;
 			}
 		}
 	}

--- a/test/Elastic.Apm.AspNetCore.Tests/SanitizeFieldNamesTests.cs
+++ b/test/Elastic.Apm.AspNetCore.Tests/SanitizeFieldNamesTests.cs
@@ -37,7 +37,7 @@ namespace Elastic.Apm.AspNetCore.Tests
 			var agentComponents = new TestAgentComponents(
 				_logger,
 				configSnapshot, _capturedPayload,
-				new CurrentExecutionSegmentsContainer(_logger));
+				new CurrentExecutionSegmentsContainer());
 
 			_agent = new ApmAgent(agentComponents);
 			_client = Helper.GetClient(_agent, _factory);


### PR DESCRIPTION
Solves https://github.com/elastic/ecs-dotnet/issues/58. 

This property is used in lots of cases - also in the serilog enricher. In that case creating a new log line within an enricher calls the enricher itself, which leads to stackoverflow.

Alternative solution would be to introduce a property that does not log.

2 options I see here:
- Add an internal property that does not log and can be called from the serilog enricher: The less good thing here is that we aimed to only use public things in the serilog enricher, since that is something that should be doable in any other logging framework - also by users without using anything internal.
- Add a public property that does not log: I feel for a verbose log that is an overkill.

Also considered adding a method - something like `SuspendLogging()`, but that again feel an overkill and makes things more complicated.

Overall I feel the simplest is to just not log there.