### PR TITLE
ci(jenkins): enable test reporting for all the test stages

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -101,17 +101,13 @@ pipeline {
                       dir("${BASE_DIR}"){
                         dotnet(){
                           sh label: 'Test & coverage', script: '.ci/linux/test.sh'
-                          sh label: 'Convert Test Results to junit format', script: '.ci/linux/convert.sh'
                         }
                       }
                     }
                   }
                   post {
                     always {
-                      sh label: 'debugging', script: 'find . -name *.pdb'
-                      junit(allowEmptyResults: true,
-                        keepLongStdio: true,
-                        testResults: "${BASE_DIR}/**/junit-*.xml,${BASE_DIR}/target/**/TEST-*.xml")
+                      reportTests()
                       codecov(repo: env.REPO, basedir: "${BASE_DIR}", secret: "${CODECOV_SECRET}")
                     }
                     unsuccessful {
@@ -178,16 +174,12 @@ pipeline {
                           bat label: 'Prepare solution', script: '.ci/windows/prepare-test.bat'
                           bat label: 'Build', script: '.ci/windows/msbuild.bat'
                           bat label: 'Test & coverage', script: '.ci/windows/testnet461.bat'
-                          powershell label: 'Convert Test Results to junit format', script: '.ci\\windows\\convert.ps1'
                         }
                       }
                     }
                     post {
                       always {
-                        archiveArtifacts(allowEmptyArchive: true, artifacts: "${BASE_DIR}/target/diag.log,${BASE_DIR}/target/TestResults.xml")
-                        junit(allowEmptyResults: true,
-                          keepLongStdio: true,
-                          testResults: "${BASE_DIR}/**/junit-*.xml,${BASE_DIR}/target/**/TEST-*.xml")
+                        reportTests()
                       }
                       unsuccessful {
                         archiveArtifacts(allowEmptyArchive: true,
@@ -204,17 +196,15 @@ pipeline {
                         cleanDir("${WORKSPACE}/${BASE_DIR}")
                         unstash 'source'
                         dir("${BASE_DIR}"){
+                          powershell label: 'Install test tools', script: '.ci\\windows\\test-tools.ps1'
                           bat label: 'Build', script: '.ci/windows/msbuild.bat'
                           bat label: 'Test IIS', script: '.ci/windows/test-iis.bat'
-                          powershell label: 'Convert Test Results to junit format', script: '.ci\\windows\\convert.ps1'
                         }
                       }
                     }
                     post {
                       always {
-                        junit(allowEmptyResults: true,
-                          keepLongStdio: true,
-                          testResults: "${BASE_DIR}/**/junit-*.xml,${BASE_DIR}/target/**/TEST-*.xml")
+                        reportTests()
                       }
                     }
                   }
@@ -267,7 +257,6 @@ pipeline {
                         powershell label: 'Install tools', script: "${BASE_DIR}\\.ci\\windows\\tools.ps1"
                       }
                     }
-
                   }
                   /**
                   Build the project from code..
@@ -305,20 +294,15 @@ pipeline {
                             bat label: 'Build', script: '.ci/windows/dotnet.bat'
                           }
                           bat label: 'Test & coverage', script: '.ci/windows/test.bat'
-                          powershell label: 'Convert Test Results to junit format', script: '.ci\\windows\\convert.ps1'
                         }
                       }
                     }
                     post {
                       always {
-                        archiveArtifacts(allowEmptyArchive: true, artifacts: "${BASE_DIR}/target/diag.log,${BASE_DIR}/target/TestResults.xml")
-                        junit(allowEmptyResults: true,
-                          keepLongStdio: true,
-                          testResults: "${BASE_DIR}/**/junit-*.xml,${BASE_DIR}/target/**/TEST-*.xml")
+                        reportTests()
                       }
                       unsuccessful {
-                        archiveArtifacts(allowEmptyArchive: true,
-                          artifacts: "${MSBUILDDEBUGPATH}/**/MSBuild_*.failure.txt")
+                        archiveArtifacts(allowEmptyArchive: true, artifacts: "${MSBUILDDEBUGPATH}/**/MSBuild_*.failure.txt")
                       }
                     }
                   }
@@ -478,5 +462,19 @@ def release(secret){
         sh(label: 'Deploy', script: ".ci/linux/deploy.sh ${REPO_API_KEY} ${REPO_API_URL}")
       }
     }
+  }
+}
+
+def reportTests() {
+  dir("${BASE_DIR}"){
+    if(isUnix()) {
+      dotnet(){
+        sh label: 'Convert Test Results to junit format', script: '.ci/linux/convert.sh', returnStatus: true
+      }
+    } else {
+      powershell label: 'Convert Test Results to junit format', script: '.ci\\windows\\convert.ps1', returnStatus: true
+    }
+    archiveArtifacts(allowEmptyArchive: true, artifacts: 'target/diag.log,test/**/TestResults*.xml,test/**/junit-*.xml')
+    junit(allowEmptyResults: true, keepLongStdio: true, testResults: 'test/**/junit-*.xml')
   }
 }


### PR DESCRIPTION
This is a subset of https://github.com/elastic/apm-agent-dotnet/pull/752 

I raised a new PR to decouple what changes are required to be done for enabling the test reporting for all the stages versus the ones that will care of fixing some warning/errors that are already happening in some scripts in the CI.