### PR TITLE
Update release process - only release fix set of packages 

### DIFF
--- a/.ci/linux/deploy.sh
+++ b/.ci/linux/deploy.sh
@@ -4,8 +4,9 @@
 #
 set -euo pipefail
 
-for nupkg in $(find . -type f -not -path './.nuget/*' -name '*.nupkg')
+for nupkg in Elastic.Apm Elastic.Apm.AspNetCore Elastic.Apm.EntityFrameworkCore Elastic.Apm.NetCoreAll Elastic.Apm.EntityFramework6 Elastic.Apm.AspNetFullFramework
 do
+	nupkg+=".nupkg"
 	echo "dotnet nuget push ${nupkg}"
 	dotnet nuget push ${nupkg} -k ${1} -s ${2}
 done

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -26,7 +26,7 @@ After a changelog has been manually curated, a new pull request can be opened wi
 
 For instance, the changelog that was created for the 1.2 release can be found in this https://github.com/elastic/apm-agent-dotnet/pull/640
 
-## Releasing a new pacakge
+## Releasing a new package
 
 In case you release a package the first time and you rely on the CI to push that to nuget.org, you need to make sure that the [deploy.sh](https://github.com/elastic/apm-agent-dotnet/blob/master/.ci/linux/deploy.sh) script is updated. You need to add the name of the new package into that script.
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -26,6 +26,10 @@ After a changelog has been manually curated, a new pull request can be opened wi
 
 For instance, the changelog that was created for the 1.2 release can be found in this https://github.com/elastic/apm-agent-dotnet/pull/640
 
+## Releasing a new pacakge
+
+In case you release a package the first time and you rely on the CI to push that to nuget.org, you need to make sure that the [deploy.sh](https://github.com/elastic/apm-agent-dotnet/blob/master/.ci/linux/deploy.sh) script is updated. You need to add the name of the new package into that script.
+
 ## Executing the release
 
 After the new changelog and version have been merged to master, the only thing remaining is to run the below commands:


### PR DESCRIPTION
I'd like to adapt our deploy script.

## Why? 
Currently the `deploy.sh` script iterates through all `*.nupkg` files and pushes them. The problem with this is that we can have packages there that we don't want to release yet. Currently we have the `Elastic.Apm.SqlClient` package, which is already on `master`, but we don't want to create an official release package yet (it's not ready for that) - with the current script we'd push this package and release it. I assume this situation is not special, we'll have similar packages later.

## Alternatives
I know this is not so good from the automation point of view, but given this part really pushes official packages to our users, I feel it's better to be very careful here.

Worst case that can happen with this is that we forget to update the `deploy.sh` file when we release a new package, in that case we can still push it later, or rerun the script. The other way around (pushing something we don't want) is worse I feel.