### PR TITLE
Add ITransaction.EnsureParentId() method - RUM correlation with dynamic HTML pages

### DIFF
--- a/docs/public-api.asciidoc
+++ b/docs/public-api.asciidoc
@@ -305,6 +305,33 @@ NOTE: Return value of <<convenient-capture-span>> method overloads that accept T
 NOTE: Code samples above use `Elastic.Apm.Agent.Tracer.CurrentTransaction`. In production code you should make sure the `CurrentTransaction` is not `null`.
 
 [float]
+[[api-transaction-ensure-parent-id]]
+==== `EnsureParentId`
+
+If the transaction does not have a ParentId yet, calling this method generates a new ID, sets it as the ParentId of this transaction, and returns it as a `string`.
+
+This enables the correlation of the spans the JavaScript Real User Monitoring (RUM) agent creates for the initial page load with the transaction of the backend service.
+
+If your service generates the HTML page dynamically, initializing the JavaScript RUM agent with the value of this method allows analyzing the time spent in the browser vs in the backend services.
+
+To enable the JavaScript RUM agent in ASP.NET Core, initialize the RUM agent with the .NET agent’s current transaction:
+
+[source,JavaScript]
+----
+<script>
+	elasticApm.init({
+		serviceName: 'MyService',
+		serverUrl: 'http://localhost:8200',
+		pageLoadTraceId: '@Elastic.Apm.Agent.Tracer.CurrentTransaction?.TraceId',
+		pageLoadSpanId: '@Elastic.Apm.Agent.Tracer.CurrentTransaction?.EnsureParentId()',
+		pageLoadSampled: @Json.Serialize(Elastic.Apm.Agent.Tracer?.CurrentTransaction.IsSampled)
+		})
+</script>
+----
+
+See the  {apm-rum-ref}[JavaScript RUM agent documentation] for more information.
+
+[float]
 [[api-transaction-custom]]
 ==== `Dictionary<string,string> Custom`
 

--- a/src/Elastic.Apm/Api/ITransaction.cs
+++ b/src/Elastic.Apm/Api/ITransaction.cs
@@ -16,7 +16,7 @@ namespace Elastic.Apm.Api
 		/// not searchable or aggregatable in Elasticsearch, and you cannot build dashboards on top of the data. However,
 		/// non-indexed information is useful for other reasons, like providing contextual information to help you quickly debug
 		/// performance issues or errors.
-		/// Unlike <see cref="IExecutionSegment.Labels"/> the data in this property is not trimmed.
+		/// Unlike <see cref="IExecutionSegment.Labels" /> the data in this property is not trimmed.
 		/// </summary>
 		Dictionary<string, string> Custom { get; }
 
@@ -32,5 +32,19 @@ namespace Elastic.Apm.Api
 		/// Example: 'request'
 		/// </summary>
 		string Type { get; set; }
+
+		/// <summary>
+		/// If the transaction does not have a ParentId yet, calling this method generates a new ID, sets it as the ParentId of
+		/// this transaction,
+		/// and returns it as a <see cref="string" />. If there is already a ParentId, the method just returns the existing
+		/// ParentId.
+		/// This enables the correlation of the spans the JavaScript Real User Monitoring (RUM) agent
+		/// creates for the initial page load with the transaction of the backend service.
+		/// </summary>
+		/// <returns>
+		/// The generated <see cref="IExecutionSegment.ParentId" /> that was applied to the current transaction, or the
+		/// existing one.
+		/// </returns>
+		string EnsureParentId();
 	}
 }

--- a/src/Elastic.Apm/Model/Transaction.cs
+++ b/src/Elastic.Apm/Model/Transaction.cs
@@ -202,6 +202,17 @@ namespace Elastic.Apm.Model
 		[JsonConverter(typeof(TrimmedStringJsonConverter))]
 		public string Type { get; set; }
 
+		public string EnsureParentId()
+		{
+			if (!string.IsNullOrEmpty(ParentId))
+				return ParentId;
+
+			var idBytes = new byte[8];
+			ParentId = RandomGenerator.GenerateRandomBytesAsString(idBytes);
+			_logger?.Debug()?.Log("Setting ParentId to transaction, {transaction}", this);
+			return ParentId;
+		}
+
 		/// <summary>
 		/// Method to conditionally serialize <see cref="Context" /> because context should be serialized only when the transaction
 		/// is sampled.

--- a/test/Elastic.Apm.Tests/ApiTests/ApiTests.cs
+++ b/test/Elastic.Apm.Tests/ApiTests/ApiTests.cs
@@ -7,9 +7,11 @@ using System.Threading.Tasks;
 using Elastic.Apm.Api;
 using Elastic.Apm.Helpers;
 using Elastic.Apm.Logging;
+using Elastic.Apm.Tests.HelpersTests;
 using Elastic.Apm.Tests.Mocks;
 using FluentAssertions;
 using Xunit;
+
 // ReSharper disable AccessToDisposedClosure
 
 namespace Elastic.Apm.Tests.ApiTests
@@ -756,22 +758,22 @@ namespace Elastic.Apm.Tests.ApiTests
 				{
 					tx.CaptureSpan("manually set destination address", "test_span_type", span =>
 					{
-						span.Context.Destination = new Destination{ Address = manualAddress };
+						span.Context.Destination = new Destination { Address = manualAddress };
 						span.Context.Http = new Http { Method = "PUT", Url = url.ToString() };
 					});
 					tx.CaptureSpan("manually set destination port", "test_span_type", span =>
 					{
-						span.Context.Destination = new Destination{ Port = manualPort };
+						span.Context.Destination = new Destination { Port = manualPort };
 						span.Context.Http = new Http { Method = "PUT", Url = url.ToString() };
 					});
 					tx.CaptureSpan("manually set destination address to null", "test_span_type", span =>
 					{
-						span.Context.Destination = new Destination{ Address = null };
+						span.Context.Destination = new Destination { Address = null };
 						span.Context.Http = new Http { Method = "PUT", Url = url.ToString() };
 					});
 					tx.CaptureSpan("manually set destination port to null", "test_span_type", span =>
 					{
-						span.Context.Destination = new Destination{ Port = null };
+						span.Context.Destination = new Destination { Port = null };
 						span.Context.Http = new Http { Method = "PUT", Url = url.ToString() };
 					});
 				});
@@ -801,10 +803,8 @@ namespace Elastic.Apm.Tests.ApiTests
 
 			using (var agent = new ApmAgent(new TestAgentComponents(payloadSender: payloadSender)))
 			{
-				agent.Tracer.CaptureTransaction("test TX name", "test TX type", tx =>
-				{
-					tx.CaptureSpan("test span name", "test_span_subtype", () => {});
-				});
+				agent.Tracer.CaptureTransaction("test TX name", "test TX type",
+					tx => { tx.CaptureSpan("test span name", "test_span_subtype", () => { }); });
 			}
 
 			payloadSender.Spans.Single().Context.Destination.Should().BeNull();
@@ -818,18 +818,59 @@ namespace Elastic.Apm.Tests.ApiTests
 
 			using (var agent = new ApmAgent(new TestAgentComponents(mockLogger, payloadSender: payloadSender)))
 			{
-				agent.Tracer.CaptureTransaction("test TX name", "test TX type", tx =>
-				{
-					tx.CaptureSpan("test span name", "test_span_type", span =>
+				agent.Tracer.CaptureTransaction("test TX name", "test TX type",
+					tx =>
 					{
-						span.Context.Http = new Http { Method = "PUT", Url = "://" };
+						tx.CaptureSpan("test span name", "test_span_type", span => { span.Context.Http = new Http { Method = "PUT", Url = "://" }; });
 					});
-				});
 			}
 
 			payloadSender.Spans.Single().Context.Destination.Should().BeNull();
-			mockLogger.Lines.Should().Contain(line => line.Contains("destination")
-				&& line.Contains("URL"));
+			mockLogger.Lines.Should()
+				.Contain(line => line.Contains("destination")
+					&& line.Contains("URL"));
+		}
+
+		/// <summary>
+		/// Makes sure that <see cref="ITransaction.EnsureParentId" /> creates a new parent id, sets it to the transaction and
+		/// returrns it.
+		/// </summary>
+		[Fact]
+		public void EnsureParentIdWithNoParentId()
+		{
+			var mockLogger = new TestLogger(LogLevel.Trace);
+			var payloadSender = new MockPayloadSender();
+
+			using var agent = new ApmAgent(new TestAgentComponents(mockLogger, payloadSender: payloadSender));
+			agent.Tracer.CaptureTransaction("test TX name", "test TX type", tx =>
+			{
+				var newParentId = tx.EnsureParentId();
+				newParentId.Should().NotBeNullOrWhiteSpace();
+				newParentId.Should().Be(tx.ParentId);
+			});
+		}
+
+		/// <summary>
+		/// Makes sure that in case a ParentId already exists, the <see cref="ITransaction.EnsureParentId" /> returns it and does
+		/// not change the
+		/// existing ParentId.
+		/// </summary>
+		[Fact]
+		public void EnsureParentIdWithExistingParentId()
+		{
+			var mockLogger = new TestLogger(LogLevel.Trace);
+			var payloadSender = new MockPayloadSender();
+
+			using var agent = new ApmAgent(new TestAgentComponents(mockLogger, payloadSender: payloadSender));
+			agent.Tracer.CaptureTransaction("test TX name", "test TX type", tx =>
+				{
+					var newParentId = tx.EnsureParentId();
+					newParentId.Should().NotBeNullOrWhiteSpace();
+					newParentId.Should().Be(tx.ParentId);
+					newParentId.Should().Be(DistributedTracingDataHelper.ValidParentId);
+				},
+				DistributedTracingDataHelper.BuildDistributedTracingData(DistributedTracingDataHelper.ValidTraceId,
+					DistributedTracingDataHelper.ValidParentId, DistributedTracingDataHelper.ValidTraceFlags));
 		}
 
 		private class TestException : Exception

--- a/test/Elastic.Apm.Tests/ApiTests/DistributedTracingDataTests.cs
+++ b/test/Elastic.Apm.Tests/ApiTests/DistributedTracingDataTests.cs
@@ -9,6 +9,8 @@ using Elastic.Apm.Tests.Mocks;
 using FluentAssertions;
 using Xunit;
 
+using static Elastic.Apm.Tests.HelpersTests.DistributedTracingDataHelper;
+
 namespace Elastic.Apm.Tests.ApiTests
 {
 	/// <summary>
@@ -18,9 +20,6 @@ namespace Elastic.Apm.Tests.ApiTests
 	{
 		private const string TestTransaction = "TestTransaction";
 		private const string UnitTest = "UnitTest";
-		private const string ValidParentId = "5ec5de4fdae36f4c";
-		private const string ValidTraceFlags = "01";
-		private const string ValidTraceId = "005a6663c2fb9591a0e53d322df6c3e2";
 
 		/// <summary>
 		/// Passes a valid trace context to <see cref="Tracer.StartTransaction" />.
@@ -71,7 +70,7 @@ namespace Elastic.Apm.Tests.ApiTests
 			using (var agent = new ApmAgent(new TestAgentComponents(payloadSender: payloadSender1)))
 			{
 				var transaction =
-					agent.Tracer.StartTransaction(TestTransaction, UnitTest, BuildDistributedTracingData(traceId, parentId, traceFlags));
+					agent.Tracer.StartTransaction(TestTransaction, UnitTest,  BuildDistributedTracingData(traceId, parentId, traceFlags));
 				transaction.End();
 			}
 
@@ -80,31 +79,31 @@ namespace Elastic.Apm.Tests.ApiTests
 		}
 
 		/// <summary>
-		/// Tests the <see cref="Tracer.CaptureTransaction(string,string,System.Action, DistributedTracingData)" /> method with a
+		/// Tests the <see cref="Tracer.CaptureTransaction(string,string,Action, DistributedTracingData)" /> method with a
 		/// valid
 		/// DistributedTracingData parameter
 		/// </summary>
 		[Fact]
 		public void DistributedTracingDataWithSimpleAction_Valid() =>
 			AssertValidDistributedTracingData(agent => agent.Tracer.CaptureTransaction(TestTransaction,
-				UnitTest, () => { WaitHelpers.SleepMinimum(); }, BuildDistributedTracingData(ValidTraceId, ValidParentId, ValidTraceFlags)));
+				UnitTest, () => { WaitHelpers.SleepMinimum(); },  BuildDistributedTracingData(ValidTraceId, ValidParentId, ValidTraceFlags)));
 
 		[Theory]
 		[ClassData(typeof(InvalidDistributedTracingDataData))]
 		public void DistributedTracingDataWithSimpleAction_Invalid(string traceId, string parentId, string traceFlags) =>
 			AssertInvalidDistributedTracingData(agent => agent.Tracer.CaptureTransaction(TestTransaction,
-				UnitTest, () => { WaitHelpers.SleepMinimum(); }, BuildDistributedTracingData(traceId, parentId, traceFlags)), traceId);
+				UnitTest, () => { WaitHelpers.SleepMinimum(); },  BuildDistributedTracingData(traceId, parentId, traceFlags)), traceId);
 
 
 		/// <summary>
 		/// Tests the
-		/// <see cref="Tracer.CaptureTransaction(string,string,System.Action{ITransaction}, DistributedTracingData)" /> method
+		/// <see cref="Tracer.CaptureTransaction(string,string,Action{ITransaction}, DistributedTracingData)" /> method
 		/// with valid DistributedTracingData parameter.
 		/// </summary>
 		[Fact]
 		public void DistributedTracingDataWitSimpleActionWithParameter_Valid() =>
 			AssertValidDistributedTracingData(agent => agent.Tracer.CaptureTransaction(TestTransaction,
-				UnitTest, t => { WaitHelpers.SleepMinimum(); }, BuildDistributedTracingData(ValidTraceId, ValidParentId, ValidTraceFlags)));
+				UnitTest, t => { WaitHelpers.SleepMinimum(); },  BuildDistributedTracingData(ValidTraceId, ValidParentId, ValidTraceFlags)));
 
 		[Theory]
 		[ClassData(typeof(InvalidDistributedTracingDataData))]
@@ -118,7 +117,7 @@ namespace Elastic.Apm.Tests.ApiTests
 
 		/// <summary>
 		/// Tests the
-		/// <see cref="Tracer.CaptureTransaction{T}(string,string,System.Func{ITransaction,T}, DistributedTracingData)" />
+		/// <see cref="Tracer.CaptureTransaction{T}(string,string,Func{ITransaction,T}, DistributedTracingData)" />
 		/// method
 		/// with valid DistributedTracingData parameter.
 		/// </summary>
@@ -144,7 +143,7 @@ namespace Elastic.Apm.Tests.ApiTests
 				}, BuildDistributedTracingData(traceId, parentId, traceFlags)), traceId);
 
 		/// <summary>
-		/// Tests the <see cref="Tracer.CaptureTransaction{T}(string,string,System.Func{T}, DistributedTracingData)" /> method
+		/// Tests the <see cref="Tracer.CaptureTransaction{T}(string,string,Func{ITransaction,T}, DistributedTracingData)" /> method
 		/// with valid DistributedTracingData parameter.
 		/// </summary>
 		[Fact]
@@ -165,7 +164,7 @@ namespace Elastic.Apm.Tests.ApiTests
 			}, BuildDistributedTracingData(traceId, parentId, traceFlags)), traceId);
 
 		/// <summary>
-		/// Tests the <see cref="Tracer.CaptureTransaction(string,string,System.Func{Task}, DistributedTracingData)" /> method
+		/// Tests the <see cref="Tracer.CaptureTransaction(string,string,Func{Task}, DistributedTracingData)" /> method
 		/// with valid DistributedTracingData parameter.
 		/// </summary>
 		[Fact]
@@ -181,7 +180,7 @@ namespace Elastic.Apm.Tests.ApiTests
 
 		/// <summary>
 		/// Tests the
-		/// <see cref="Tracer.CaptureTransaction(string,string,System.Func{ITransaction,Task}, DistributedTracingData)" />
+		/// <see cref="Tracer.CaptureTransaction(string,string,Func{ITransaction,Task}, DistributedTracingData)" />
 		/// method
 		/// with valid DistributedTracingData parameter.
 		/// </summary>
@@ -206,7 +205,7 @@ namespace Elastic.Apm.Tests.ApiTests
 
 		/// <summary>
 		/// Tests the
-		/// <see cref="Tracer.CaptureTransaction{T}(string,string,System.Func{ITransaction,Task{T}}, DistributedTracingData)" />
+		/// <see cref="Tracer.CaptureTransaction{T}(string,string,Func{ITransaction,Task{T}}, DistributedTracingData)" />
 		/// method
 		/// with valid DistributedTracingData parameter.
 		/// </summary>
@@ -232,7 +231,7 @@ namespace Elastic.Apm.Tests.ApiTests
 				}, BuildDistributedTracingData(traceId, parentId, traceFlags)), traceId);
 
 		/// <summary>
-		/// Tests the <see cref="Tracer.CaptureTransaction{T}(string,string,System.Func{Task{T}}, DistributedTracingData)" />
+		/// Tests the <see cref="Tracer.CaptureTransaction{T}(string,string,Func{Task{T}}, DistributedTracingData)" />
 		/// method
 		/// with valid DistributedTracingData parameter.
 		/// </summary>
@@ -294,13 +293,6 @@ namespace Elastic.Apm.Tests.ApiTests
 			payloadSender.FirstTransaction.TraceId.Should().NotBe(traceId);
 			payloadSender.FirstTransaction.ParentId.Should().BeNullOrWhiteSpace();
 		}
-
-		private static DistributedTracingData BuildDistributedTracingData(string traceId, string parentId, string traceFlags) =>
-			DistributedTracingData.TryDeserializeFromString(
-				"00-" + // version
-				(traceId == null ? "" : $"{traceId}") +
-				(parentId == null ? "" : $"-{parentId}") +
-				(traceFlags == null ? "" : $"-{traceFlags}"));
 
 		private class InvalidDistributedTracingDataData : IEnumerable<object[]>
 		{

--- a/test/Elastic.Apm.Tests/DistributedTracingTests.cs
+++ b/test/Elastic.Apm.Tests/DistributedTracingTests.cs
@@ -11,7 +11,7 @@ namespace Elastic.Apm.Tests
 		{
 			const string traceParent = "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01";
 
-			var res = DistributedTracing.TraceContext.TryExtractTracingData(traceParent);
+			var res = TraceContext.TryExtractTracingData(traceParent);
 			res.Should().NotBeNull();
 			res.TraceId.Should().Be("0af7651916cd43dd8448eb211c80319c");
 			res.ParentId.Should().Be("b7ad6b7169203331");
@@ -19,7 +19,7 @@ namespace Elastic.Apm.Tests
 
 			//try also with flag options C6
 			const string traceParent2 = "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-E7";
-			var res2 = DistributedTracing.TraceContext.TryExtractTracingData(traceParent2);
+			var res2 = TraceContext.TryExtractTracingData(traceParent2);
 			res2.FlagRecorded.Should().BeTrue();
 		}
 
@@ -28,7 +28,7 @@ namespace Elastic.Apm.Tests
 		{
 			const string traceParent = "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-00";
 
-			var res = DistributedTracing.TraceContext.TryExtractTracingData(traceParent);
+			var res = TraceContext.TryExtractTracingData(traceParent);
 
 			res.TraceId.Should().Be("0af7651916cd43dd8448eb211c80319c");
 			res.ParentId.Should().Be("b7ad6b7169203331");
@@ -37,7 +37,7 @@ namespace Elastic.Apm.Tests
 
 			//try also with flag options C6
 			const string traceParent2 = "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-C6";
-			var res2 = DistributedTracing.TraceContext.TryExtractTracingData(traceParent2);
+			var res2 = TraceContext.TryExtractTracingData(traceParent2);
 			res2.FlagRecorded.Should().BeFalse();
 		}
 
@@ -47,7 +47,7 @@ namespace Elastic.Apm.Tests
 			const string traceParent = "99-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01";
 
 			//Best attempt, even if it's a future version we still try to read the traceId and parentId
-			var res = DistributedTracing.TraceContext.TryExtractTracingData(traceParent);
+			var res = TraceContext.TryExtractTracingData(traceParent);
 			res.Should().NotBeNull();
 			res.TraceId.Should().Be("0af7651916cd43dd8448eb211c80319c");
 			res.ParentId.Should().Be("b7ad6b7169203331");
@@ -58,7 +58,7 @@ namespace Elastic.Apm.Tests
 		public void ValidateTraceParentWithInvalidLength()
 		{
 			const string traceParent = "99-af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01"; //TraceId is 1 char shorter than expected
-			var res = DistributedTracing.TraceContext.TryExtractTracingData(traceParent);
+			var res = TraceContext.TryExtractTracingData(traceParent);
 			res.Should().BeNull();
 		}
 
@@ -68,7 +68,7 @@ namespace Elastic.Apm.Tests
 			const string
 				traceParent =
 					"00-0af7651916cd43dd8448eb211c80319ca-7ad6b7169203331-01"; //TraceId is 1 char longer than expected, and parentId is 1 char longer
-			var res = DistributedTracing.TraceContext.TryExtractTracingData(traceParent);
+			var res = TraceContext.TryExtractTracingData(traceParent);
 			res.Should().BeNull();
 		}
 
@@ -78,6 +78,6 @@ namespace Elastic.Apm.Tests
 		/// </summary>
 		[Fact]
 		public void TraceParentHeaderName() =>
-			DistributedTracing.TraceContext.TraceParentHeaderNamePrefixed.Should().Be("elastic-apm-traceparent");
+			TraceContext.TraceParentHeaderNamePrefixed.Should().Be("elastic-apm-traceparent");
 	}
 }

--- a/test/Elastic.Apm.Tests/HelpersTests/DistributedTracingDataHelper.cs
+++ b/test/Elastic.Apm.Tests/HelpersTests/DistributedTracingDataHelper.cs
@@ -1,0 +1,18 @@
+using Elastic.Apm.Api;
+
+namespace Elastic.Apm.Tests.HelpersTests
+{
+	internal static class DistributedTracingDataHelper
+	{
+		internal const string ValidParentId = "5ec5de4fdae36f4c";
+		internal const string ValidTraceFlags = "01";
+		internal const string ValidTraceId = "005a6663c2fb9591a0e53d322df6c3e2";
+
+		internal static DistributedTracingData BuildDistributedTracingData(string traceId, string parentId, string traceFlags) =>
+			DistributedTracingData.TryDeserializeFromString(
+				"00-" + // version
+				(traceId == null ? "" : $"{traceId}") +
+				(parentId == null ? "" : $"-{parentId}") +
+				(traceFlags == null ? "" : $"-{traceFlags}"));
+	}
+}


### PR DESCRIPTION
Mostly triggered by the fact that in ASP.NET Core transactions from the RUM agent are not correlated to transactions created by the .NET agent on page load - found by @alex-fedotyev 

Turned out the `EnsureParentId()` was missing in the .NET Agent which is needed for this.

Also adding docs - mostly stolen from Ruby.

Page load with RUM + .NET with this PR and the setup described in the docs:
![image](https://user-images.githubusercontent.com/1091853/76910560-9fa1ca00-68ae-11ea-8107-d085fa75bdf3.png)
