### PR TITLE
Fixing CI publish step

### DIFF
--- a/.ci/linux/deploy.sh
+++ b/.ci/linux/deploy.sh
@@ -4,9 +4,17 @@
 #
 set -euo pipefail
 
-for nupkg in Elastic.Apm Elastic.Apm.AspNetCore Elastic.Apm.EntityFrameworkCore Elastic.Apm.NetCoreAll Elastic.Apm.EntityFramework6 Elastic.Apm.AspNetFullFramework
+declare -a projectsToPublish=("Elastic.Apm" "Elastic.Apm.AspNetCore" "Elastic.Apm.EntityFrameworkCore" "Elastic.Apm.NetCoreAll" "Elastic.Apm.EntityFramework6" "Elastic.Apm.AspNetFullFramework")
+
+for project in  "${projectsToPublish[@]}"
 do
-	nupkg+=".nupkg"
-	echo "dotnet nuget push ${nupkg}"
-	dotnet nuget push ${nupkg} -k ${1} -s ${2}
+	for nupkg in $(find . -type f -not -path './.nuget/*' -name '*.nupkg')
+	do
+		pattern=".*${project}[0-9|.]*.nupkg"
+		if [[ $nupkg =~ $pattern ]]
+		then
+			echo "dotnet nuget push ${nupkg}"
+			dotnet nuget push ${nupkg} -k ${1} -s ${2}
+		fi
+	done
 done


### PR DESCRIPTION
Fixing #772.

Let me start this by stating that I'm not a bash script automation expert... 👼 

The idea is to run through a predefined array of strings that contains all packages we want to push and find all .nupkg files which we match to the strings in the array - if it matches, we push it.

Question: how do we test this? This won't run on the PR branch - that's why #769 was merged and only saw it failing on master. I'd say if we are ok with this, let's just merge and see on `master`.