### PR TITLE
LoggerTests - tests that Tracer.CurrentTransaction does not log

### DIFF
--- a/test/Elastic.Apm.Tests/LoggerTests.cs
+++ b/test/Elastic.Apm.Tests/LoggerTests.cs
@@ -296,8 +296,7 @@ namespace Elastic.Apm.Tests
 		/// <summary>
 		/// Makes sure that getting the current transaction does not log anything.
 		/// Reason for this is that <code>Tracer.CurrentTransaction</code> is used in log correlation and within log correlation
-		/// the
-		/// agent should not log. See: https://github.com/elastic/ecs-dotnet/issues/58#issuecomment-595864256
+		/// the agent should not log. See: https://github.com/elastic/ecs-dotnet/issues/58#issuecomment-595864256
 		/// </summary>
 		[Fact]
 		public void GetCurrentTransactionNoLogging()

--- a/test/Elastic.Apm.Tests/LoggerTests.cs
+++ b/test/Elastic.Apm.Tests/LoggerTests.cs
@@ -293,6 +293,27 @@ namespace Elastic.Apm.Tests
 					"placeholders with missing values:");
 		}
 
+		/// <summary>
+		/// Makes sure that getting the current transaction does not log anything.
+		/// Reason for this is that <code>Tracer.CurrentTransaction</code> is used in log correlation and within log correlation
+		/// the
+		/// agent should not log. See: https://github.com/elastic/ecs-dotnet/issues/58#issuecomment-595864256
+		/// </summary>
+		[Fact]
+		public void GetCurrentTransactionNoLogging()
+		{
+			var testLogger = new TestLogger(LogLevel.Trace);
+			using var agent = new ApmAgent(new TestAgentComponents(testLogger));
+			agent.Tracer.CaptureTransaction("TestTransaction", "Test", () =>
+			{
+				var numberOfLinesPreCurrentTransaction = testLogger.Lines.Count;
+				// ReSharper disable once AccessToDisposedClosure
+				var currentTransaction = agent.Tracer.CurrentTransaction;
+				currentTransaction.Should().NotBeNull();
+				testLogger.Lines.Count.Should().Be(numberOfLinesPreCurrentTransaction);
+			});
+		}
+
 		private static TestLogger LogWithLevel(LogLevel logLevel)
 		{
 			var logger = new TestLogger(logLevel);


### PR DESCRIPTION
Tests #753.

Make sure Tracer.CurrentTransaction does not log