### PR TITLE
Fix failing ApiTest from #740

### DIFF
--- a/src/Elastic.Apm/BackendComm/CentralConfigFetcher.cs
+++ b/src/Elastic.Apm/BackendComm/CentralConfigFetcher.cs
@@ -479,6 +479,7 @@ namespace Elastic.Apm.BackendComm
 			public bool UseElasticTraceparentHeader => _wrapped.UseElasticTraceparentHeader;
 
 			public bool VerifyServerCert => _wrapped.VerifyServerCert;
+			public IReadOnlyCollection<string> ExcludedNamespaces => _wrapped.ExcludedNamespaces;
 		}
 	}
 }

--- a/src/Elastic.Apm/BackendComm/CentralConfigFetcher.cs
+++ b/src/Elastic.Apm/BackendComm/CentralConfigFetcher.cs
@@ -480,6 +480,7 @@ namespace Elastic.Apm.BackendComm
 
 			public bool VerifyServerCert => _wrapped.VerifyServerCert;
 			public IReadOnlyCollection<string> ExcludedNamespaces => _wrapped.ExcludedNamespaces;
+			public IReadOnlyCollection<string> ApplicationNamespaces => _wrapped.ApplicationNamespaces;
 		}
 	}
 }

--- a/src/Elastic.Apm/Config/AbstractConfigurationReader.cs
+++ b/src/Elastic.Apm/Config/AbstractConfigurationReader.cs
@@ -28,6 +28,9 @@ namespace Elastic.Apm.Config
 		private readonly LazyContextualInit<IReadOnlyList<string>> _cachedExcludedNamespaces =
 			new LazyContextualInit<IReadOnlyList<string>>();
 
+		private readonly LazyContextualInit<IReadOnlyList<string>> _cachedApplicationNamespaces =
+			new LazyContextualInit<IReadOnlyList<string>>();
+
 		private readonly IApmLogger _logger;
 
 		protected AbstractConfigurationReader(IApmLogger logger, string dbgDerivedClassName) =>
@@ -826,6 +829,25 @@ namespace Elastic.Apm.Config
 			{
 				_logger?.Debug()?.Log("Using default excluded namespaces: {ExcludedNamespaces}", DefaultValues.DefaultExcludedNamespaces);
 				return DefaultValues.DefaultExcludedNamespaces.ToList();
+			}
+		}
+		
+
+		protected IReadOnlyList<string> ParseApplicationNamespaces(ConfigurationKeyValue kv) =>
+			_cachedApplicationNamespaces.IfNotInited?.InitOrGet(() => ParseApplicationNamespacesImpl(kv)) ?? _cachedApplicationNamespaces.Value;
+
+		private IReadOnlyList<string> ParseApplicationNamespacesImpl(ConfigurationKeyValue kv)
+		{
+			if (kv == null || string.IsNullOrEmpty(kv.Value)) return LogAndReturnDefault().AsReadOnly();
+
+			var list = kv.Value.Split(',').ToList();
+
+			return list.Count == 0 ? LogAndReturnDefault().AsReadOnly() : list.AsReadOnly();
+
+			List<string> LogAndReturnDefault()
+			{
+				_logger?.Debug()?.Log("Using default application namespaces: {ApplicationNamespaces}", DefaultValues.DefaultApplicationNamespaces);
+				return DefaultValues.DefaultApplicationNamespaces.ToList();
 			}
 		}
 

--- a/src/Elastic.Apm/Config/AbstractConfigurationWithEnvFallbackReader.cs
+++ b/src/Elastic.Apm/Config/AbstractConfigurationWithEnvFallbackReader.cs
@@ -90,5 +90,8 @@ namespace Elastic.Apm.Config
 
 		public virtual bool VerifyServerCert =>
 			ParseVerifyServerCert(Read(ConfigConsts.KeyNames.VerifyServerCert, ConfigConsts.EnvVarNames.VerifyServerCert));
+		
+		public IReadOnlyCollection<string> ExcludedNamespaces => 
+			ParseExcludedNamespaces(Read(ConfigConsts.KeyNames.ExcludedNamespaces, ConfigConsts.EnvVarNames.ExcludedNamespaces));
 	}
 }

--- a/src/Elastic.Apm/Config/AbstractConfigurationWithEnvFallbackReader.cs
+++ b/src/Elastic.Apm/Config/AbstractConfigurationWithEnvFallbackReader.cs
@@ -93,5 +93,8 @@ namespace Elastic.Apm.Config
 		
 		public IReadOnlyCollection<string> ExcludedNamespaces => 
 			ParseExcludedNamespaces(Read(ConfigConsts.KeyNames.ExcludedNamespaces, ConfigConsts.EnvVarNames.ExcludedNamespaces));
+
+		public IReadOnlyCollection<string> ApplicationNamespaces => 
+			ParseExcludedNamespaces(Read(ConfigConsts.KeyNames.ApplicationNamespaces, ConfigConsts.EnvVarNames.ApplicationNamespaces));
 	}
 }

--- a/src/Elastic.Apm/Config/ConfigConsts.cs
+++ b/src/Elastic.Apm/Config/ConfigConsts.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using Elastic.Apm.Helpers;
 
 namespace Elastic.Apm.Config
@@ -31,6 +32,7 @@ namespace Elastic.Apm.Config
 			public const string UnknownServiceName = "unknown";
 			public const bool UseElasticTraceparentHeader = true;
 			public const bool VerifyServerCert = true;
+			public static readonly IReadOnlyCollection<string> DefaultExcludedNamespaces = new List<string>{"System.", "Microsoft.", "MS.", "FSharp.", "Newtonsoft.Json", "Serilog", "NLog", "Giraffe."}.AsReadOnly();
 
 			public static List<WildcardMatcher> DisableMetrics = new List<WildcardMatcher>();
 
@@ -86,6 +88,7 @@ namespace Elastic.Apm.Config
 			public const string TransactionSampleRate = Prefix + "TRANSACTION_SAMPLE_RATE";
 			public const string UseElasticTraceparentHeader = Prefix + "USE_ELASTIC_TRACEPARENT_HEADER";
 			public const string VerifyServerCert = Prefix + "VERIFY_SERVER_CERT";
+			public const string ExcludedNamespaces = Prefix + "EXCLUDED_NAMESPACES";
 		}
 
 		public static class KeyNames
@@ -114,6 +117,7 @@ namespace Elastic.Apm.Config
 			public const string TransactionSampleRate = "ElasticApm:TransactionSampleRate";
 			public const string UseElasticTraceparentheader = "ElasticApm:UseElasticTraceparentHeder";
 			public const string VerifyServerCert = "ElasticApm:VerifyServerCert";
+			public const string ExcludedNamespaces = "ElasticApm:ExcludedNamespaces";
 		}
 
 		public static class SupportedValues

--- a/src/Elastic.Apm/Config/ConfigConsts.cs
+++ b/src/Elastic.Apm/Config/ConfigConsts.cs
@@ -33,6 +33,7 @@ namespace Elastic.Apm.Config
 			public const bool UseElasticTraceparentHeader = true;
 			public const bool VerifyServerCert = true;
 			public static readonly IReadOnlyCollection<string> DefaultExcludedNamespaces = new List<string>{"System.", "Microsoft.", "MS.", "FSharp.", "Newtonsoft.Json", "Serilog", "NLog", "Giraffe."}.AsReadOnly();
+			public static readonly IReadOnlyCollection<string> DefaultApplicationNamespaces = new List<string>().AsReadOnly();
 
 			public static List<WildcardMatcher> DisableMetrics = new List<WildcardMatcher>();
 
@@ -89,6 +90,7 @@ namespace Elastic.Apm.Config
 			public const string UseElasticTraceparentHeader = Prefix + "USE_ELASTIC_TRACEPARENT_HEADER";
 			public const string VerifyServerCert = Prefix + "VERIFY_SERVER_CERT";
 			public const string ExcludedNamespaces = Prefix + "EXCLUDED_NAMESPACES";
+			public const string ApplicationNamespaces = Prefix + "APPLICATION_NAMESPACES";
 		}
 
 		public static class KeyNames
@@ -118,6 +120,7 @@ namespace Elastic.Apm.Config
 			public const string UseElasticTraceparentheader = "ElasticApm:UseElasticTraceparentHeder";
 			public const string VerifyServerCert = "ElasticApm:VerifyServerCert";
 			public const string ExcludedNamespaces = "ElasticApm:ExcludedNamespaces";
+			public const string ApplicationNamespaces = "ElasticApm:ApplicationNamespaces";
 		}
 
 		public static class SupportedValues

--- a/src/Elastic.Apm/Config/ConfigSnapshotFromReader.cs
+++ b/src/Elastic.Apm/Config/ConfigSnapshotFromReader.cs
@@ -41,5 +41,6 @@ namespace Elastic.Apm.Config
 		public double TransactionSampleRate => _content.TransactionSampleRate;
 		public bool UseElasticTraceparentHeader => _content.UseElasticTraceparentHeader;
 		public bool VerifyServerCert => _content.VerifyServerCert;
+		public IReadOnlyCollection<string> ExcludedNamespaces => _content.ExcludedNamespaces;
 	}
 }

--- a/src/Elastic.Apm/Config/ConfigSnapshotFromReader.cs
+++ b/src/Elastic.Apm/Config/ConfigSnapshotFromReader.cs
@@ -42,5 +42,6 @@ namespace Elastic.Apm.Config
 		public bool UseElasticTraceparentHeader => _content.UseElasticTraceparentHeader;
 		public bool VerifyServerCert => _content.VerifyServerCert;
 		public IReadOnlyCollection<string> ExcludedNamespaces => _content.ExcludedNamespaces;
+		public IReadOnlyCollection<string> ApplicationNamespaces => _content.ApplicationNamespaces;
 	}
 }

--- a/src/Elastic.Apm/Config/EnvironmentConfigurationReader.cs
+++ b/src/Elastic.Apm/Config/EnvironmentConfigurationReader.cs
@@ -72,8 +72,9 @@ namespace Elastic.Apm.Config
 
 		public bool VerifyServerCert => ParseVerifyServerCert(Read(ConfigConsts.EnvVarNames.VerifyServerCert));
 		
-		public IReadOnlyCollection<string> ExcludedNamespaces => 
-			ParseExcludedNamespaces(Read(ConfigConsts.EnvVarNames.ExcludedNamespaces));
+		public IReadOnlyCollection<string> ExcludedNamespaces => ParseExcludedNamespaces(Read(ConfigConsts.EnvVarNames.ExcludedNamespaces));
+
+		public IReadOnlyCollection<string> ApplicationNamespaces => ParseApplicationNamespaces(Read(ConfigConsts.EnvVarNames.ApplicationNamespaces));
 
 		private ConfigurationKeyValue Read(string key) =>
 			new ConfigurationKeyValue(key, ReadEnvVarValue(key), Origin);

--- a/src/Elastic.Apm/Config/EnvironmentConfigurationReader.cs
+++ b/src/Elastic.Apm/Config/EnvironmentConfigurationReader.cs
@@ -71,6 +71,9 @@ namespace Elastic.Apm.Config
 		public bool UseElasticTraceparentHeader => ParseUseElasticTraceparentHeader(Read(ConfigConsts.EnvVarNames.UseElasticTraceparentHeader));
 
 		public bool VerifyServerCert => ParseVerifyServerCert(Read(ConfigConsts.EnvVarNames.VerifyServerCert));
+		
+		public IReadOnlyCollection<string> ExcludedNamespaces => 
+			ParseExcludedNamespaces(Read(ConfigConsts.EnvVarNames.ExcludedNamespaces));
 
 		private ConfigurationKeyValue Read(string key) =>
 			new ConfigurationKeyValue(key, ReadEnvVarValue(key), Origin);

--- a/src/Elastic.Apm/Config/IConfigurationReader.cs
+++ b/src/Elastic.Apm/Config/IConfigurationReader.cs
@@ -148,5 +148,7 @@ namespace Elastic.Apm.Config
 		/// Verification can be disabled by setting to <c>false</c>.
 		/// </summary>
 		bool VerifyServerCert { get; }
+
+		IReadOnlyCollection<string> ExcludedNamespaces { get; }
 	}
 }

--- a/src/Elastic.Apm/Config/IConfigurationReader.cs
+++ b/src/Elastic.Apm/Config/IConfigurationReader.cs
@@ -149,6 +149,16 @@ namespace Elastic.Apm.Config
 		/// </summary>
 		bool VerifyServerCert { get; }
 
+		/// <summary>
+		/// A list of namespaces to exclude when reading an exception's StackTrace to determine the culprit.
+		/// Namespaces are checked with string.StartsWith() so "System." matches all System namespaces
+		/// </summary>
 		IReadOnlyCollection<string> ExcludedNamespaces { get; }
+
+		/// <summary>
+		/// When defined, all namespaces not starting with one of the values of this collection are ignored when determining Exception culprit.
+		/// This suppresses any configuration of <see cref="ExcludedNamespaces"/>
+		/// </summary>
+		IReadOnlyCollection<string> ApplicationNamespaces { get; }
 	}
 }

--- a/src/Elastic.Apm/Model/ExecutionSegmentCommon.cs
+++ b/src/Elastic.Apm/Model/ExecutionSegmentCommon.cs
@@ -186,9 +186,9 @@ namespace Elastic.Apm.Model
 			return DefaultCulprit;
 		}
 
-		private static bool IsInApp(string fullyQualifiedTypeName , IReadOnlyCollection<string> excludedModules)
+		private static bool IsInApp(string fullyQualifiedTypeName, IReadOnlyCollection<string> excludedModules)
 		{
-			if (string.IsNullOrEmpty(fullyQualifiedTypeName )) return false;
+			if (string.IsNullOrEmpty(fullyQualifiedTypeName)) return false;
 
 			foreach (var exclude in excludedModules)
 				if (fullyQualifiedTypeName.StartsWith(exclude, StringComparison.Ordinal)) return false;

--- a/test/Elastic.Apm.Tests/ApiTests/ApiTests.cs
+++ b/test/Elastic.Apm.Tests/ApiTests/ApiTests.cs
@@ -398,7 +398,7 @@ namespace Elastic.Apm.Tests.ApiTests
 			payloadSender.FirstError.Exception.Message.Should().Be(exceptionMessage);
 			payloadSender.FirstError.Exception.Message.Should().Be(exceptionMessage);
 
-			payloadSender.FirstError.Culprit.Should().Be(!string.IsNullOrEmpty(culprit) ? culprit : "PublicAPI-CaptureException");
+			payloadSender.FirstError.Culprit.Should().Be(!string.IsNullOrEmpty(culprit) ? culprit : "Elastic.Apm.Tests.ApiTests.ApiTests");
 		}
 
 		/// <summary>

--- a/test/Elastic.Apm.Tests/BasicAgentTests.cs
+++ b/test/Elastic.Apm.Tests/BasicAgentTests.cs
@@ -94,6 +94,27 @@ namespace Elastic.Apm.Tests
 			StringToByteArray(payloadSender.FirstError.TransactionId).Should().HaveCount(8);
 		}
 
+		[Fact]
+		public void GetCulpritTest()
+		{
+			var payloadSender = new MockPayloadSender();
+			using (var agent = new ApmAgent(new TestAgentComponents(payloadSender: payloadSender)))
+			{
+				try
+				{
+					// Throw the exception to generate a stacktrace
+					throw new Exception("TestMst");
+				}
+				catch(Exception e)
+				{
+					agent.Tracer.CaptureTransaction("TestTransaction", "TestTransactionType",
+						t => { t.CaptureException(e); });
+				}
+			}
+
+			payloadSender.FirstError.Culprit.Should().Be("Elastic.Apm.Tests.BasicAgentTests");
+		}
+
 		private static IEnumerable<byte> StringToByteArray(string hex)
 		{
 			var numberChars = hex.Length;

--- a/test/Elastic.Apm.Tests/ConstructorTests.cs
+++ b/test/Elastic.Apm.Tests/ConstructorTests.cs
@@ -58,6 +58,7 @@ namespace Elastic.Apm.Tests
 
 			public bool VerifyServerCert => ConfigConsts.DefaultValues.VerifyServerCert;
 			public IReadOnlyCollection<string> ExcludedNamespaces => ConfigConsts.DefaultValues.DefaultExcludedNamespaces;
+			public IReadOnlyCollection<string> ApplicationNamespaces => ConfigConsts.DefaultValues.DefaultApplicationNamespaces;
 
 			public bool UseElasticTraceparentHeader => ConfigConsts.DefaultValues.UseElasticTraceparentHeader;
 

--- a/test/Elastic.Apm.Tests/ConstructorTests.cs
+++ b/test/Elastic.Apm.Tests/ConstructorTests.cs
@@ -57,6 +57,7 @@ namespace Elastic.Apm.Tests
 			public double TransactionSampleRate => ConfigConsts.DefaultValues.TransactionSampleRate;
 
 			public bool VerifyServerCert => ConfigConsts.DefaultValues.VerifyServerCert;
+			public IReadOnlyCollection<string> ExcludedNamespaces => ConfigConsts.DefaultValues.DefaultExcludedNamespaces;
 
 			public bool UseElasticTraceparentHeader => ConfigConsts.DefaultValues.UseElasticTraceparentHeader;
 

--- a/test/Elastic.Apm.Tests/Mocks/MockConfigSnapshot.cs
+++ b/test/Elastic.Apm.Tests/Mocks/MockConfigSnapshot.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using Elastic.Apm.Config;
 using Elastic.Apm.Helpers;
 using Elastic.Apm.Logging;
@@ -36,9 +37,9 @@ namespace Elastic.Apm.Tests.Mocks
 		private readonly string _transactionSampleRate;
 		private readonly string _useElasticTraceparentHeader;
 		private readonly string _verifyServerCert;
+		private readonly string _applicationNamespaces;
 
-		public MockConfigSnapshot(
-			IApmLogger logger = null,
+		public MockConfigSnapshot(IApmLogger logger = null,
 			string logLevel = null,
 			string serverUrls = null,
 			string serviceName = null,
@@ -63,7 +64,8 @@ namespace Elastic.Apm.Tests.Mocks
 			string globalLabels = null,
 			string disableMetrics = null,
 			string verifyServerCert = null,
-			string useElasticTraceparentHeader = null
+			string useElasticTraceparentHeader = null,
+			string applicationNamespaces = null
 		) : base(logger, ThisClassName)
 		{
 			_serverUrls = serverUrls;
@@ -91,6 +93,7 @@ namespace Elastic.Apm.Tests.Mocks
 			_disableMetrics = disableMetrics;
 			_verifyServerCert = verifyServerCert;
 			_useElasticTraceparentHeader = useElasticTraceparentHeader;
+			_applicationNamespaces = applicationNamespaces;
 		}
 
 		public string CaptureBody => ParseCaptureBody(Kv(ConfigConsts.EnvVarNames.CaptureBody, _captureBody, Origin));
@@ -145,5 +148,6 @@ namespace Elastic.Apm.Tests.Mocks
 			ParseVerifyServerCert(Kv(ConfigConsts.EnvVarNames.VerifyServerCert, _verifyServerCert, Origin));
 		
 		public IReadOnlyCollection<string> ExcludedNamespaces => ConfigConsts.DefaultValues.DefaultExcludedNamespaces;
+		public IReadOnlyCollection<string> ApplicationNamespaces => ParseApplicationNamespaces(new ConfigurationKeyValue(ConfigConsts.EnvVarNames.ApplicationNamespaces, _applicationNamespaces, Origin));
 	}
 }

--- a/test/Elastic.Apm.Tests/Mocks/MockConfigSnapshot.cs
+++ b/test/Elastic.Apm.Tests/Mocks/MockConfigSnapshot.cs
@@ -143,5 +143,7 @@ namespace Elastic.Apm.Tests.Mocks
 
 		public bool VerifyServerCert =>
 			ParseVerifyServerCert(Kv(ConfigConsts.EnvVarNames.VerifyServerCert, _verifyServerCert, Origin));
+		
+		public IReadOnlyCollection<string> ExcludedNamespaces => ConfigConsts.DefaultValues.DefaultExcludedNamespaces;
 	}
 }


### PR DESCRIPTION
Since culprit capturing was changed in #740 we need to adapt this test.