### PR TITLE
Add filters API

### DIFF
--- a/sample/ApiSamples/Program.cs
+++ b/sample/ApiSamples/Program.cs
@@ -224,25 +224,25 @@ namespace ApiSamples
 		{
 			Agent.AddFilter((ITransaction transaction) => {
 				transaction.Name = "NewTransactionName";
-				return true;
+				return transaction;
 			});
 
 			Agent.AddFilter((ITransaction transaction) =>
 			{
 				transaction.Type = "NewSpanName";
-				return true;
+				return transaction;
 			});
 
 			Agent.AddFilter((ISpan span) =>
 			{
 				span.Name = "NewSpanName";
-				return true;
+				return span;
 			});
 
 			Agent.AddFilter((IError error) =>
 			{
 				Console.WriteLine($"Error id printed in a filter: {error.Id}");
-				return true;
+				return error;
 			});
 		}
 	}

--- a/sample/ApiSamples/Program.cs
+++ b/sample/ApiSamples/Program.cs
@@ -167,7 +167,7 @@ namespace ApiSamples
 				Thread.Sleep(1100);
 
 				WriteLineToConsole("Waiting for callee process to exit...");
-				calleeProcess.WaitForExit();
+				calleeProcess?.WaitForExit();
 				WriteLineToConsole("Callee process exited");
 			}
 			finally
@@ -215,5 +215,35 @@ namespace ApiSamples
 			});
 		}
 		// ReSharper restore ArrangeMethodOrOperatorBody
+
+		/// <summary>
+		/// Registers some sample filters.
+		/// </summary>
+		// ReSharper disable once UnusedMember.Local
+		private static void FilterSample()
+		{
+			Agent.AddFilter((ITransaction transaction) => {
+				transaction.Name = "NewTransactionName";
+				return true;
+			});
+
+			Agent.AddFilter((ITransaction transaction) =>
+			{
+				transaction.Type = "NewSpanName";
+				return true;
+			});
+
+			Agent.AddFilter((ISpan span) =>
+			{
+				span.Name = "NewSpanName";
+				return true;
+			});
+
+			Agent.AddFilter((IError error) =>
+			{
+				Console.WriteLine($"Error id printed in a filter: {error.Id}");
+				return true;
+			});
+		}
 	}
 }

--- a/src/Elastic.Apm/Agent.cs
+++ b/src/Elastic.Apm/Agent.cs
@@ -131,8 +131,8 @@ namespace Elastic.Apm
 		/// you can also control if the <see cref="ITransaction" /> should be sent to the server or not.
 		/// If the
 		/// <param name="filter"></param>
-		/// returns <code>false</code> the <see cref="ITransaction" /> will be dropped and won't be sent to the APM Server -
-		/// otherwise it'll be sent.
+		/// returns a non-null <see cref="ITransaction"/> instance then it will sent to the APM Server -
+		/// if it returns <code>null</code>, the event will be dropped and won't be sent to the APM server.
 		/// </summary>
 		/// <param name="filter">The filter that can process the <see cref="ITransaction"/> and decide if it should be sent to APM Server or not.</param>
 		/// <returns><code>true</code> if the filter was added successfully, <code>false</code> otherwise. In case the method returns <code>false</code> the filter won't be called.</returns>
@@ -148,8 +148,8 @@ namespace Elastic.Apm
 		/// you can also control if the <see cref="ISpan" /> should be sent to the server or not.
 		/// If the
 		/// <param name="filter"></param>
-		/// returns <code>false</code> the <see cref="ISpan" /> will be dropped and won't be sent to the APM Server -
-		/// otherwise it'll be sent.
+		/// returns a non-null <see cref="ISpan"/> instance then it will sent to the APM Server -
+		/// if it returns <code>null</code>, the event will be dropped and won't be sent to the APM server.
 		/// </summary>
 		/// <param name="filter">The filter that can process the <see cref="ISpan"/> and decide if it should be sent to APM Server or not.</param>
 		/// <returns><code>true</code> if the filter was added successfully, <code>false</code> otherwise. In case the method returns <code>false</code> the filter won't be called.</returns>
@@ -165,8 +165,8 @@ namespace Elastic.Apm
 		/// you can also control if the <see cref="IError" /> should be sent to the server or not.
 		/// If the
 		/// <param name="filter"></param>
-		/// returns <code>false</code> the <see cref="IError" /> will be dropped and won't be sent to the APM Server -
-		/// otherwise it'll be sent.
+		/// returns a non-null <see cref="IError"/> instance then it will sent to the APM Server -
+		/// if it returns <code>null</code>, the event will be dropped and won't be sent to the APM server.
 		/// </summary>
 		/// <param name="filter">The filter that can process the <see cref="IError"/> and decide if it should be sent to APM Server or not.</param>
 		/// <returns><code>true</code> if the filter was added successfully, <code>false</code> otherwise. In case the method returns <code>false</code> the filter won't be called.</returns>

--- a/src/Elastic.Apm/Agent.cs
+++ b/src/Elastic.Apm/Agent.cs
@@ -107,21 +107,6 @@ namespace Elastic.Apm
 		private static AgentComponents _components;
 		private static volatile bool _isConfigured;
 
-		public static bool AddFilter(Func<ITransaction, bool> filter) => CheckAndAddFilter(p => p.TransactionFilters.Add(filter));
-
-		public static bool AddFilter(Func<ISpan, bool> filter) => CheckAndAddFilter(p => p.SpanFilters.Add(filter));
-
-		public static bool AddFilter(Func<IError, bool> filter)  => CheckAndAddFilter(p => p.ErrorFilters.Add(filter));
-
-		private static bool CheckAndAddFilter(Action<PayloadSenderV2> action)
-		{
-			// This check it TBD
-			// if (!IsConfigured) return false;
-			if (!(Instance.PayloadSender is PayloadSenderV2 payloadSenderV2)) return false;
-
-			action(payloadSenderV2);
-			return true;
-		}
 
 		public static IConfigurationReader Config => Instance.ConfigurationReader;
 
@@ -135,6 +120,67 @@ namespace Elastic.Apm
 		/// a transaction.
 		/// </summary>
 		public static ITracer Tracer => Instance.Tracer;
+
+		/// <summary>
+		/// Adds a filter which gets called before each transaction gets sent to APM Server.
+		/// In the
+		/// <param name="filter"></param>
+		/// have access to the <see cref="ITransaction" /> instance which gets sent to  APM Server
+		/// and you can modify it. With the return value of the
+		/// <param name="filter"></param>
+		/// you can also control if the <see cref="ITransaction" /> should be sent to the server or not.
+		/// If the
+		/// <param name="filter"></param>
+		/// returns <code>false</code> the <see cref="ITransaction" /> will be dropped and won't be sent to the APM Server -
+		/// otherwise it'll be sent.
+		/// </summary>
+		/// <param name="filter">The filter that can process the <see cref="ITransaction"/> and decide if it should be sent to APM Server or not.</param>
+		/// <returns><code>true</code> if the filter was added successfully, <code>false</code> otherwise. In case the method returns <code>false</code> the filter won't be called.</returns>
+		public static bool AddFilter(Func<ITransaction, bool> filter) => CheckAndAddFilter(p => p.TransactionFilters.Add(filter));
+
+		/// <summary>
+		/// Adds a filter which gets called before each span gets sent to APM Server.
+		/// In the
+		/// <param name="filter"></param>
+		/// have access to the <see cref="ISpan" /> instance which gets sent to  APM Server
+		/// and you can modify it. With the return value of the
+		/// <param name="filter"></param>
+		/// you can also control if the <see cref="ISpan" /> should be sent to the server or not.
+		/// If the
+		/// <param name="filter"></param>
+		/// returns <code>false</code> the <see cref="ISpan" /> will be dropped and won't be sent to the APM Server -
+		/// otherwise it'll be sent.
+		/// </summary>
+		/// <param name="filter">The filter that can process the <see cref="ISpan"/> and decide if it should be sent to APM Server or not.</param>
+		/// <returns><code>true</code> if the filter was added successfully, <code>false</code> otherwise. In case the method returns <code>false</code> the filter won't be called.</returns>
+		public static bool AddFilter(Func<ISpan, bool> filter) => CheckAndAddFilter(p => p.SpanFilters.Add(filter));
+
+		/// <summary>
+		/// Adds a filter which gets called before each error gets sent to APM Server.
+		/// In the
+		/// <param name="filter"></param>
+		/// have access to the <see cref="IError" /> instance which gets sent to  APM Server
+		/// and you can modify it. With the return value of the
+		/// <param name="filter"></param>
+		/// you can also control if the <see cref="IError" /> should be sent to the server or not.
+		/// If the
+		/// <param name="filter"></param>
+		/// returns <code>false</code> the <see cref="IError" /> will be dropped and won't be sent to the APM Server -
+		/// otherwise it'll be sent.
+		/// </summary>
+		/// <param name="filter">The filter that can process the <see cref="IError"/> and decide if it should be sent to APM Server or not.</param>
+		/// <returns><code>true</code> if the filter was added successfully, <code>false</code> otherwise. In case the method returns <code>false</code> the filter won't be called.</returns>
+		public static bool AddFilter(Func<IError, bool> filter) => CheckAndAddFilter(p => p.ErrorFilters.Add(filter));
+
+		private static bool CheckAndAddFilter(Action<PayloadSenderV2> action)
+		{
+			// This check it TBD
+			// if (!IsConfigured) return false;
+			if (!(Instance.PayloadSender is PayloadSenderV2 payloadSenderV2)) return false;
+
+			action(payloadSenderV2);
+			return true;
+		}
 
 		/// <summary>
 		/// Sets up multiple <see cref="IDiagnosticsSubscriber" />s to start listening to one or more

--- a/src/Elastic.Apm/Agent.cs
+++ b/src/Elastic.Apm/Agent.cs
@@ -136,7 +136,7 @@ namespace Elastic.Apm
 		/// </summary>
 		/// <param name="filter">The filter that can process the <see cref="ITransaction"/> and decide if it should be sent to APM Server or not.</param>
 		/// <returns><code>true</code> if the filter was added successfully, <code>false</code> otherwise. In case the method returns <code>false</code> the filter won't be called.</returns>
-		public static bool AddFilter(Func<ITransaction, bool> filter) => CheckAndAddFilter(p => p.TransactionFilters.Add(filter));
+		public static bool AddFilter(Func<ITransaction, ITransaction> filter) => CheckAndAddFilter(p => p.TransactionFilters.Add(filter));
 
 		/// <summary>
 		/// Adds a filter which gets called before each span gets sent to APM Server.
@@ -153,7 +153,7 @@ namespace Elastic.Apm
 		/// </summary>
 		/// <param name="filter">The filter that can process the <see cref="ISpan"/> and decide if it should be sent to APM Server or not.</param>
 		/// <returns><code>true</code> if the filter was added successfully, <code>false</code> otherwise. In case the method returns <code>false</code> the filter won't be called.</returns>
-		public static bool AddFilter(Func<ISpan, bool> filter) => CheckAndAddFilter(p => p.SpanFilters.Add(filter));
+		public static bool AddFilter(Func<ISpan, ISpan> filter) => CheckAndAddFilter(p => p.SpanFilters.Add(filter));
 
 		/// <summary>
 		/// Adds a filter which gets called before each error gets sent to APM Server.
@@ -170,7 +170,7 @@ namespace Elastic.Apm
 		/// </summary>
 		/// <param name="filter">The filter that can process the <see cref="IError"/> and decide if it should be sent to APM Server or not.</param>
 		/// <returns><code>true</code> if the filter was added successfully, <code>false</code> otherwise. In case the method returns <code>false</code> the filter won't be called.</returns>
-		public static bool AddFilter(Func<IError, bool> filter) => CheckAndAddFilter(p => p.ErrorFilters.Add(filter));
+		public static bool AddFilter(Func<IError, IError> filter) => CheckAndAddFilter(p => p.ErrorFilters.Add(filter));
 
 		private static bool CheckAndAddFilter(Action<PayloadSenderV2> action)
 		{

--- a/src/Elastic.Apm/Agent.cs
+++ b/src/Elastic.Apm/Agent.cs
@@ -107,6 +107,22 @@ namespace Elastic.Apm
 		private static AgentComponents _components;
 		private static volatile bool _isConfigured;
 
+		public static bool AddFilter(Func<ITransaction, bool> filter) => CheckAndAddFilter(p => p.TransactionFilters.Add(filter));
+
+		public static bool AddFilter(Func<ISpan, bool> filter) => CheckAndAddFilter(p => p.SpanFilters.Add(filter));
+
+		public static bool AddFilter(Func<IError, bool> filter)  => CheckAndAddFilter(p => p.ErrorFilters.Add(filter));
+
+		private static bool CheckAndAddFilter(Action<PayloadSenderV2> action)
+		{
+			// This check it TBD
+			// if (!IsConfigured) return false;
+			if (!(Instance.PayloadSender is PayloadSenderV2 payloadSenderV2)) return false;
+
+			action(payloadSenderV2);
+			return true;
+		}
+
 		public static IConfigurationReader Config => Instance.ConfigurationReader;
 
 		internal static ApmAgent Instance => LazyApmAgent.Value;

--- a/src/Elastic.Apm/Agent.cs
+++ b/src/Elastic.Apm/Agent.cs
@@ -107,7 +107,6 @@ namespace Elastic.Apm
 		private static AgentComponents _components;
 		private static volatile bool _isConfigured;
 
-
 		public static IConfigurationReader Config => Instance.ConfigurationReader;
 
 		internal static ApmAgent Instance => LazyApmAgent.Value;
@@ -125,13 +124,13 @@ namespace Elastic.Apm
 		/// Adds a filter which gets called before each transaction gets sent to APM Server.
 		/// In the
 		/// <param name="filter"></param>
-		/// have access to the <see cref="ITransaction" /> instance which gets sent to  APM Server
+		/// you have access to the <see cref="ITransaction" /> instance which gets sent to APM Server
 		/// and you can modify it. With the return value of the
 		/// <param name="filter"></param>
 		/// you can also control if the <see cref="ITransaction" /> should be sent to the server or not.
 		/// If the
 		/// <param name="filter"></param>
-		/// returns a non-null <see cref="ITransaction"/> instance then it will sent to the APM Server -
+		/// returns a non-null <see cref="ITransaction"/> instance then it will be sent to the APM Server -
 		/// if it returns <code>null</code>, the event will be dropped and won't be sent to the APM server.
 		/// </summary>
 		/// <param name="filter">The filter that can process the <see cref="ITransaction"/> and decide if it should be sent to APM Server or not.</param>
@@ -142,13 +141,13 @@ namespace Elastic.Apm
 		/// Adds a filter which gets called before each span gets sent to APM Server.
 		/// In the
 		/// <param name="filter"></param>
-		/// have access to the <see cref="ISpan" /> instance which gets sent to  APM Server
+		/// you have access to the <see cref="ISpan" /> instance which gets sent to APM Server
 		/// and you can modify it. With the return value of the
 		/// <param name="filter"></param>
 		/// you can also control if the <see cref="ISpan" /> should be sent to the server or not.
 		/// If the
 		/// <param name="filter"></param>
-		/// returns a non-null <see cref="ISpan"/> instance then it will sent to the APM Server -
+		/// returns a non-null <see cref="ISpan"/> instance then it will be sent to the APM Server -
 		/// if it returns <code>null</code>, the event will be dropped and won't be sent to the APM server.
 		/// </summary>
 		/// <param name="filter">The filter that can process the <see cref="ISpan"/> and decide if it should be sent to APM Server or not.</param>
@@ -159,13 +158,13 @@ namespace Elastic.Apm
 		/// Adds a filter which gets called before each error gets sent to APM Server.
 		/// In the
 		/// <param name="filter"></param>
-		/// have access to the <see cref="IError" /> instance which gets sent to  APM Server
+		/// you have access to the <see cref="IError" /> instance which gets sent to APM Server
 		/// and you can modify it. With the return value of the
 		/// <param name="filter"></param>
 		/// you can also control if the <see cref="IError" /> should be sent to the server or not.
 		/// If the
 		/// <param name="filter"></param>
-		/// returns a non-null <see cref="IError"/> instance then it will sent to the APM Server -
+		/// returns a non-null <see cref="IError"/> instance then it will be sent to the APM Server -
 		/// if it returns <code>null</code>, the event will be dropped and won't be sent to the APM server.
 		/// </summary>
 		/// <param name="filter">The filter that can process the <see cref="IError"/> and decide if it should be sent to APM Server or not.</param>
@@ -174,8 +173,6 @@ namespace Elastic.Apm
 
 		private static bool CheckAndAddFilter(Action<PayloadSenderV2> action)
 		{
-			// This check it TBD
-			// if (!IsConfigured) return false;
 			if (!(Instance.PayloadSender is PayloadSenderV2 payloadSenderV2)) return false;
 
 			action(payloadSenderV2);

--- a/src/Elastic.Apm/Report/PayloadSenderV2.cs
+++ b/src/Elastic.Apm/Report/PayloadSenderV2.cs
@@ -257,7 +257,7 @@ namespace Elastic.Apm.Report
 				void SerializeAndSend(object item, string eventType)
 				{
 					var serialized = _payloadItemSerializer.SerializeObject(item);
-					ndjson.AppendLine($"{{\"{eventType}\": " + serialized + "}}");
+					ndjson.AppendLine($"{{\"{eventType}\": " + serialized + "}");
 					_logger?.Trace()?.Log("Serialized item to send: {ItemToSend} as {SerializedItem}", item, serialized);
 				}
 			}

--- a/src/Elastic.Apm/Report/PayloadSenderV2.cs
+++ b/src/Elastic.Apm/Report/PayloadSenderV2.cs
@@ -283,10 +283,14 @@ namespace Elastic.Apm.Report
 					try
 					{
 						_logger?.Trace()?.Log("Start executing filter on transaction");
-						item = filter(item);
-						if (item != null) continue;
+						var itemAfterFilter = filter(item);
+						if (itemAfterFilter != null)
+						{
+							item = itemAfterFilter;
+							continue;
+						}
 
-						_logger?.Debug()?.Log("Filter returns false, item won't be sent, {filteredItemm}", item);
+						_logger?.Debug()?.Log("Filter returns false, item won't be sent, {filteredItem}", item);
 						return null;
 					}
 					catch (Exception e)

--- a/test/Elastic.Apm.Tests/FilterTests.cs
+++ b/test/Elastic.Apm.Tests/FilterTests.cs
@@ -41,13 +41,13 @@ namespace Elastic.Apm.Tests
 					payloadSender.TransactionFilters.Add(t =>
 					{
 						t.Name = "NewTransactionName";
-						return true;
+						return t;
 					});
 
 					payloadSender.TransactionFilters.Add(t =>
 					{
 						t.Type = "NewTransactionType";
-						return true;
+						return t;
 					});
 				},
 				agent => { agent.Tracer.CaptureTransaction("Test123", "TestTransaction", t => { Thread.Sleep(10); }); },
@@ -71,7 +71,7 @@ namespace Elastic.Apm.Tests
 					payloadSender.TransactionFilters.Add(t =>
 					{
 						t.Name = "NewTransactionName";
-						return true;
+						return t;
 					});
 
 					// Throw an exception
@@ -81,7 +81,7 @@ namespace Elastic.Apm.Tests
 					payloadSender.TransactionFilters.Add(t =>
 					{
 						t.Type = "NewTransactionType";
-						return true;
+						return t;
 					});
 				},
 				agent => { agent.Tracer.CaptureTransaction("Test123", "TestTransaction", t => { Thread.Sleep(10); }); },
@@ -105,7 +105,7 @@ namespace Elastic.Apm.Tests
 						payloadSender.SpanFilters.Add(span =>
 						{
 							span.Name = "NewSpanName";
-							return true;
+							return span;
 						});
 
 						// Throw an exception
@@ -115,7 +115,7 @@ namespace Elastic.Apm.Tests
 						payloadSender.SpanFilters.Add(span =>
 						{
 							span.Type = "NewSpanType";
-							return true;
+							return span;
 						});
 					},
 					agent =>
@@ -141,9 +141,9 @@ namespace Elastic.Apm.Tests
 					// Rename span name
 					payloadSender.SpanFilters.Add(span =>
 					{
-						if (span.Name == "SpanToDrop") return false;
+						if (span.Name == "SpanToDrop") return null;
 
-						return true;
+						return span;
 					});
 				},
 				agent =>

--- a/test/Elastic.Apm.Tests/FilterTests.cs
+++ b/test/Elastic.Apm.Tests/FilterTests.cs
@@ -182,10 +182,8 @@ namespace Elastic.Apm.Tests
 				}
 			});
 
-			var noopLogger = new NoopLogger();
-
-			var payloadSender = new PayloadSenderV2(noopLogger, mockConfig,
-				Service.GetDefaultService(mockConfig, noopLogger), new Api.System(), handler);
+			var payloadSender = new PayloadSenderV2(_logger, mockConfig,
+				Service.GetDefaultService(mockConfig, _logger), new Api.System(), handler);
 
 			registerFilters(payloadSender);
 

--- a/test/Elastic.Apm.Tests/FilterTests.cs
+++ b/test/Elastic.Apm.Tests/FilterTests.cs
@@ -15,6 +15,7 @@ using FluentAssertions;
 using Newtonsoft.Json;
 using Xunit;
 using Xunit.Abstractions;
+using Timer = System.Timers.Timer;
 
 namespace Elastic.Apm.Tests
 {
@@ -27,6 +28,7 @@ namespace Elastic.Apm.Tests
 			var adapter = new XunitOutputToLineWriterAdaptor(testOutputHelper, nameof(FilterTests));
 			_logger = new LineWriterToLoggerAdaptor(new SplittingLineWriter(adapter), LogLevel.Trace);
 		}
+
 		/// <summary>
 		/// Registers 2 transaction filters - one changes the transaction name, one changes the transaction type.
 		/// Makes sure changes are applied to the serialized transaction.
@@ -164,8 +166,8 @@ namespace Elastic.Apm.Tests
 
 			// If from some reason the handler is not executed a timer is here defined that
 			// sets the task to cancelled, so the test is guaranteed to end
-			var timer = new System.Timers.Timer(20000);
-			timer.Elapsed += (o,args) => { taskCompletionSource.SetCanceled(); };
+			var timer = new Timer(20000);
+			timer.Elapsed += (o, args) => { taskCompletionSource.SetCanceled(); };
 			timer.Start();
 
 			var handler = RegisterHandlerAndAssert((transactions, spans, errors) =>
@@ -197,7 +199,7 @@ namespace Elastic.Apm.Tests
 			new MockHttpMessageHandler((r, c) =>
 			{
 				var content = r.Content.ReadAsStringAsync().Result;
-				var payloadStrings = content.Split('\n');
+				var payloadStrings = content.Split(Environment.NewLine.ToCharArray());
 
 				var transactions = new List<Transaction>();
 				var spans = new List<Span>();

--- a/test/Elastic.Apm.Tests/FilterTests.cs
+++ b/test/Elastic.Apm.Tests/FilterTests.cs
@@ -1,0 +1,150 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Elastic.Apm.Api;
+using Elastic.Apm.Model;
+using Elastic.Apm.Report;
+using Elastic.Apm.Tests.Mocks;
+using FluentAssertions;
+using Newtonsoft.Json;
+using Xunit;
+
+namespace Elastic.Apm.Tests
+{
+	public class FilterTests
+	{
+		[Fact]
+		public void RenameTransactionNameAndTypeIn2Filters() =>
+			RegisterFilterRunCodeAndAssert(
+				payloadSender =>
+				{
+					payloadSender.TransactionFilters.Add(t =>
+					{
+						t.Name = "NewTransactionName";
+						return true;
+					});
+
+					payloadSender.TransactionFilters.Add(t =>
+					{
+						t.Type = "NewTransactionType";
+						return true;
+					});
+				},
+				agent => { agent.Tracer.CaptureTransaction("Test123", "TestTransaction", t => { Thread.Sleep(10); }); },
+				(transactions, spans, errors) =>
+				{
+					transactions.First().Name.Should().Be("NewTransactionName");
+					transactions.First().Type.Should().Be("NewTransactionType");
+				});
+
+		[Fact]
+		public void MultipleHandlerOneOfThemThrowingOnTransactions() =>
+			RegisterFilterRunCodeAndAssert(
+				payloadSender =>
+				{
+					// Rename transaction name
+					payloadSender.TransactionFilters.Add(t =>
+					{
+						t.Name = "NewTransactionName";
+						return true;
+					});
+
+					// Throw an exception
+					payloadSender.TransactionFilters.Add(t => throw new Exception("This is a test exception"));
+
+					// Rename transaction type
+					payloadSender.TransactionFilters.Add(t =>
+					{
+						t.Type = "NewTransactionType";
+						return true;
+					});
+				},
+				agent => { agent.Tracer.CaptureTransaction("Test123", "TestTransaction", t => { Thread.Sleep(10); }); },
+				(transactions, spans, errors) =>
+				{
+					transactions.First().Name.Should().Be("NewTransactionName");
+					transactions.First().Type.Should().Be("NewTransactionType");
+				});
+
+		private void RegisterFilterRunCodeAndAssert(Action<PayloadSenderV2> registerFilters, Action<ApmAgent> executeCodeThatGeneratesData,
+			Action<List<Transaction>, List<Span>, List<Error>> assert
+		)
+		{
+			var handlerCompleted = false;
+			var mockConfig = new MockConfigSnapshot(maxBatchEventCount: "1", flushInterval: "0");
+
+			// The handler is executed in PayloadSenderV2, where all exceptions are handled - no exception bubbles up from PayloadSenderV2 (reason is that in prod if the HTTP Request fails, agent handles it and doesn't let it bubble up
+			// From this reason, failing asserts are also handled - a failing assert would not make the test fail, because the exception thrown be XUnit is caught by PayloadSenderV2
+			// So we simply store the exceptions in the variable below and assert on that after the code from the handler with the asserts were executed.
+			Exception exception = null;
+
+			var handler = RegisterHandlerAndAssert((transactions, spans, errors) =>
+			{
+				handlerCompleted = true;
+				try
+				{
+					assert(transactions, spans, errors);
+				}
+				catch (Exception e)
+				{
+					exception = e;
+					throw;
+				}
+			});
+
+			var noopLogger = new NoopLogger();
+
+			var payloadSender = new PayloadSenderV2(noopLogger, mockConfig,
+				Service.GetDefaultService(mockConfig, noopLogger), new Api.System(), handler);
+
+			registerFilters(payloadSender);
+
+			using (var agent = new ApmAgent(new TestAgentComponents(payloadSender: payloadSender))) executeCodeThatGeneratesData(agent);
+
+			exception.Should().BeNull();
+			handlerCompleted.Should().BeTrue();
+		}
+
+		private static MockHttpMessageHandler RegisterHandlerAndAssert(Action<List<Transaction>, List<Span>, List<Error>> assert) =>
+			new MockHttpMessageHandler((r, c) =>
+			{
+				var content = r.Content.ReadAsStringAsync().Result;
+				var payloadStrings = content.Split('\n');
+
+				var transactions = new List<Transaction>();
+				var spans = new List<Span>();
+				var errors = new List<Error>();
+
+				foreach (var receivedEvent in payloadStrings)
+				{
+					switch (receivedEvent)
+					{
+						case { } s when s.StartsWith("{\"transaction\":"):
+							var str = receivedEvent.Substring(16);
+							str = str.Remove(str.Length - 2);
+							var transaction = JsonConvert.DeserializeObject<Transaction>(str);
+							transactions.Add(transaction);
+							break;
+						case { } s when s.StartsWith("{\"span\":"):
+							str = receivedEvent.Substring(9);
+							str = str.Remove(str.Length - 2);
+							var span = JsonConvert.DeserializeObject<Span>(str);
+							spans.Add(span);
+							break;
+						case { } s when s.StartsWith("{\"error\":"):
+							str = receivedEvent.Substring(10);
+							str = str.Remove(str.Length - 2);
+							var error = JsonConvert.DeserializeObject<Error>(str);
+							errors.Add(error);
+							break;
+					}
+				}
+				assert(transactions, spans, errors);
+				return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK));
+			});
+	}
+}

--- a/test/Elastic.Apm.Tests/FilterTests.cs
+++ b/test/Elastic.Apm.Tests/FilterTests.cs
@@ -187,14 +187,9 @@ namespace Elastic.Apm.Tests
 
 			registerFilters(payloadSender);
 
-			using (var agent = new ApmAgent(new TestAgentComponents(payloadSender: payloadSender, logger: _logger)))
-			{
-				// Make sure the work-loop task of PayloadSenderV2 is started
-				Thread.Sleep(1000);
-				executeCodeThatGeneratesData(agent);
-			}
-
-			// hold the test run until the event is processed within PayloadSender's thread
+			using var agent = new ApmAgent(new TestAgentComponents(payloadSender: payloadSender, logger: _logger));
+			executeCodeThatGeneratesData(agent);
+			// hold the test run until the event is processed within PayloadSender's thread - also makes sure that PayloadSender is not disposed
 			var _ = taskCompletionSource.Task.Result;
 		}
 

--- a/test/Elastic.Apm.Tests/FilterTests.cs
+++ b/test/Elastic.Apm.Tests/FilterTests.cs
@@ -162,6 +162,10 @@ namespace Elastic.Apm.Tests
 			// To hold up the test we use TaskCompletionSource and control its result within the PayloadSender's thread
 			var taskCompletionSource = new TaskCompletionSource<object>();
 
+			var timer = new System.Timers.Timer(20000);
+			timer.Elapsed += (o,args) => { taskCompletionSource.SetCanceled(); };
+			timer.Start();
+
 			var handler = RegisterHandlerAndAssert((transactions, spans, errors) =>
 			{
 				try

--- a/test/Elastic.Apm.Tests/FilterTests.cs
+++ b/test/Elastic.Apm.Tests/FilterTests.cs
@@ -211,19 +211,19 @@ namespace Elastic.Apm.Tests
 					{
 						case { } s when s.StartsWith("{\"transaction\":"):
 							var str = receivedEvent.Substring(16);
-							str = str.Remove(str.Length - 2);
+							str = str.Remove(str.Length - 1);
 							var transaction = JsonConvert.DeserializeObject<Transaction>(str);
 							transactions.Add(transaction);
 							break;
 						case { } s when s.StartsWith("{\"span\":"):
 							str = receivedEvent.Substring(9);
-							str = str.Remove(str.Length - 2);
+							str = str.Remove(str.Length - 1);
 							var span = JsonConvert.DeserializeObject<Span>(str);
 							spans.Add(span);
 							break;
 						case { } s when s.StartsWith("{\"error\":"):
 							str = receivedEvent.Substring(10);
-							str = str.Remove(str.Length - 2);
+							str = str.Remove(str.Length - 1);
 							var error = JsonConvert.DeserializeObject<Error>(str);
 							errors.Add(error);
 							break;


### PR DESCRIPTION
Introduce an API to register filters https://github.com/elastic/apm-agent-dotnet/issues/361

Similar to what the [Node.js agent has](https://www.elastic.co/guide/en/apm/agent/nodejs/current/agent-api.html#apm-add-filter)

## Use case

Users can register filters and these filters will be called each time before an event (transaction, span, or error) is sent to APM Server. This allows users to manipulate data before it leaves the process - e.g. sensitive user related data can be removed. Furthermore complete events could be also dropped and not be sent to the sever.

This would already help with some of the issues here in the repo: https://github.com/elastic/apm-agent-dotnet/issues/633, https://github.com/elastic/apm-agent-dotnet/issues/418, https://github.com/elastic/apm-agent-dotnet/issues/758 (partly).

## API (updated)
_Could change, this is the current idea_

`Agent.AddFilter(filter)` registers a filter - a filter can be:
- `Func<ITransaction, ITransaction>`
- `Func<ISpan, ISpan>`
- `Func<IError, IError>`

So it's a simple callback that receives either an `ITransaction`, or an `ISpan`, or an `IError` as input parameter and returns the event itself or `null`. The input parameter is always the instance that the agent captures and prepares to send to the server. These instances can be changed in the filter. If the filter returns an instance (in other words something that is not `null`), the event will be sent, if it returns `null`, the event won't be sent (it'll be dropped).

### Samples

Drop all spans for a specific database:

```
Agent.AddFilter((ISpan span) =>
{
	if (span.Context?.Db?.Instance == "VerySecretDb")
		return null;
	return span;
});
```

Hide some data:
```
Agent.AddFilter((ITransaction transaction) =>
{
	transaction.Context.Request.Url.Protocol = "[HIDDEN]";
	return transaction;
});
```

## Open issues/questions

- [x] Maybe similarly to Node.Js we could just use the input parameter as the return type - so `Func<ITransaction, ITransaction>` instead of `Func<ITransaction, bool>` (I personally would not do that for C#) - This was done, the API is updated to match other agents.
- [ ] What do we do if the change causes inconsistency in data? - some things (like Ids) are read-only on the public API, so that's not an issue, but still dropping spans could change metrics and we also deduct some data (like destination).  - One option here is to just document it and still let users do it - I personally don't think we have to "protect" users here that much. Update: asked regarding other agents, from what it seems, this is something we just need to document.