### PR TITLE
ci(jenkins): disable stages for only docs

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -43,8 +43,8 @@ pipeline {
             stash allowEmpty: true, name: 'source', useDefaultExcludes: false
             script {
               dir("${BASE_DIR}"){
-                // Skip all the stages except docs for PR's with asciidoc changes only
-                env.ONLY_DOCS = isGitRegionMatch(patterns: [ '.*\\.asciidoc' ], comparator: 'regexp', shouldMatchAll: true)
+                // Skip all the stages except docs for PR's with asciidoc and md changes only
+                env.ONLY_DOCS = isGitRegionMatch(patterns: [ '.*\\.(asciidoc|md)' ], shouldMatchAll: true)
               }
             }
           }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -41,9 +41,19 @@ pipeline {
             deleteDir()
             gitCheckout(basedir: "${BASE_DIR}", githubNotifyFirstTimeContributor: true)
             stash allowEmpty: true, name: 'source', useDefaultExcludes: false
+            script {
+              dir("${BASE_DIR}"){
+                // Skip all the stages except docs for PR's with asciidoc changes only
+                env.ONLY_DOCS = isGitRegionMatch(patterns: [ '.*\\.asciidoc' ], comparator: 'regexp', shouldMatchAll: true)
+              }
+            }
           }
         }
         stage('Parallel'){
+          when {
+            beforeAgent true
+            expression { return env.ONLY_DOCS == "false" }
+          }
           parallel{
             stage('Linux'){
               options { skipDefaultCheckout() }


### PR DESCRIPTION
### What

- Any builds for any branch or PR that only contains changes related to the asciidoc then it will skip all the stages but the `checkout`

### Why

Docs validation happens with the `elasticsearch-ci/docs` therefore there is no need to validate anything in our end.