### PR TITLE
Reuse TraceId from Activity.Current for new transactions 

### DIFF
--- a/sample/SampleAspNetCoreApp/Controllers/HomeController.cs
+++ b/sample/SampleAspNetCoreApp/Controllers/HomeController.cs
@@ -103,6 +103,8 @@ namespace SampleAspNetCoreApp.Controllers
 			return View();
 		}
 
+		public string TraceId() => Activity.Current.TraceId.ToString();
+
 		public async Task<IActionResult> DistributedTracingMiniSample()
 		{
 			var httpClient = new HttpClient();

--- a/src/Elastic.Apm.AspNetCore/ApmMiddleware.cs
+++ b/src/Elastic.Apm.AspNetCore/ApmMiddleware.cs
@@ -79,23 +79,23 @@ namespace Elastic.Apm.AspNetCore
 				Transaction transaction;
 				var transactionName = $"{context.Request.Method} {context.Request.Path}";
 
-				if (context.Request.Headers.ContainsKey(DistributedTracing.TraceContext.TraceParentHeaderNamePrefixed)
-					|| context.Request.Headers.ContainsKey(DistributedTracing.TraceContext.TraceParentHeaderName))
+				if (context.Request.Headers.ContainsKey(TraceContext.TraceParentHeaderNamePrefixed)
+					|| context.Request.Headers.ContainsKey(TraceContext.TraceParentHeaderName))
 				{
-					var headerValue = context.Request.Headers.ContainsKey(DistributedTracing.TraceContext.TraceParentHeaderName)
-						? context.Request.Headers[DistributedTracing.TraceContext.TraceParentHeaderName].ToString()
-						: context.Request.Headers[DistributedTracing.TraceContext.TraceParentHeaderNamePrefixed].ToString();
+					var headerValue = context.Request.Headers.ContainsKey(TraceContext.TraceParentHeaderName)
+						? context.Request.Headers[TraceContext.TraceParentHeaderName].ToString()
+						: context.Request.Headers[TraceContext.TraceParentHeaderNamePrefixed].ToString();
 
-					var tracingData = context.Request.Headers.ContainsKey(DistributedTracing.TraceContext.TraceStateHeaderName)
-						? DistributedTracing.TraceContext.TryExtractTracingData(headerValue, context.Request.Headers[DistributedTracing.TraceContext.TraceStateHeaderName].ToString())
-						: DistributedTracing.TraceContext.TryExtractTracingData(headerValue);
+					var tracingData = context.Request.Headers.ContainsKey(TraceContext.TraceStateHeaderName)
+						? TraceContext.TryExtractTracingData(headerValue, context.Request.Headers[TraceContext.TraceStateHeaderName].ToString())
+						: TraceContext.TryExtractTracingData(headerValue);
 
 					if (tracingData != null)
 					{
 						_logger.Debug()
 							?.Log(
 								"Incoming request with {TraceParentHeaderName} header. DistributedTracingData: {DistributedTracingData}. Continuing trace.",
-								DistributedTracing.TraceContext.TraceParentHeaderNamePrefixed, tracingData);
+								TraceContext.TraceParentHeaderNamePrefixed, tracingData);
 
 						transaction = _tracer.StartTransactionInternal(
 							transactionName,
@@ -107,7 +107,7 @@ namespace Elastic.Apm.AspNetCore
 						_logger.Debug()
 							?.Log(
 								"Incoming request with invalid {TraceParentHeaderName} header (received value: {TraceParentHeaderValue}). Starting trace with new trace id.",
-								DistributedTracing.TraceContext.TraceParentHeaderNamePrefixed, headerValue);
+								TraceContext.TraceParentHeaderNamePrefixed, headerValue);
 
 						transaction = _tracer.StartTransactionInternal(transactionName,
 							ApiConstants.TypeRequest);

--- a/src/Elastic.Apm.AspNetCore/Elastic.Apm.AspNetCore.csproj
+++ b/src/Elastic.Apm.AspNetCore/Elastic.Apm.AspNetCore.csproj
@@ -5,7 +5,7 @@
     <PackageId>Elastic.Apm.AspNetCore</PackageId>
     <Description>Elastic APM for ASP.NET Core. This package contains auto instrumentation for ASP.NET Core. See: https://github.com/elastic/apm-agent-dotnet/tree/master/docs</Description>
     <PackageTags>apm, monitoring, elastic, elasticapm, analytics, aspnetcore</PackageTags>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Elastic.Apm\Elastic.Apm.csproj" />

--- a/src/Elastic.Apm/Elastic.Apm.csproj
+++ b/src/Elastic.Apm/Elastic.Apm.csproj
@@ -11,15 +11,11 @@
   </PropertyGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="System.Diagnostics.PerformanceCounter" Version="4.5.0" />
-    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="4.0.0" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'net461'">
-    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="4.4.0" />  
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="4.6.0" />
     <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="2.0.2" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
-    <!-- TODO: Are we ok with this reference/version? -->
     <PackageReference Include="System.Threading.Tasks.Dataflow" Version="4.9.0" />
   </ItemGroup>
 </Project>

--- a/test/Elastic.Apm.AspNetCore.Tests/TraceIdWithActivityTests.cs
+++ b/test/Elastic.Apm.AspNetCore.Tests/TraceIdWithActivityTests.cs
@@ -10,6 +10,7 @@ using SampleAspNetCoreApp;
 
 namespace Elastic.Apm.AspNetCore.Tests
 {
+	[Collection("DiagnosticListenerTest")]
 	public class TraceIdWithActivityTests: IClassFixture<WebApplicationFactory<Startup>>, IDisposable
 	{
 		private readonly ApmAgent _agent;

--- a/test/Elastic.Apm.AspNetCore.Tests/TraceIdWithActivityTests.cs
+++ b/test/Elastic.Apm.AspNetCore.Tests/TraceIdWithActivityTests.cs
@@ -1,0 +1,50 @@
+using System;
+using System.Diagnostics;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Elastic.Apm.Tests.Mocks;
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Xunit;
+using SampleAspNetCoreApp;
+
+namespace Elastic.Apm.AspNetCore.Tests
+{
+	public class TraceIdWithActivityTests: IClassFixture<WebApplicationFactory<Startup>>, IDisposable
+	{
+		private readonly ApmAgent _agent;
+		private readonly WebApplicationFactory<Startup> _factory;
+		private readonly MockPayloadSender _payloadSender = new MockPayloadSender();
+		private HttpClient _client;
+
+		public TraceIdWithActivityTests(WebApplicationFactory<Startup> factory)
+		{
+			_factory = factory;
+
+			_agent = new ApmAgent(new TestAgentComponents(payloadSender: _payloadSender,
+				// _agent needs to share CurrentExecutionSegmentsContainer with Agent.Instance
+				// because the sample application used by the tests (SampleAspNetCoreApp) uses Agent.Instance.Tracer.CurrentTransaction/CurrentSpan
+				currentExecutionSegmentsContainer: Agent.Instance.TracerInternal.CurrentExecutionSegmentsContainer));
+			ApmMiddlewareExtension.UpdateServiceInformation(_agent.Service);
+			_client = Helper.GetClient(_agent, _factory);
+		}
+
+		public void Dispose()
+		{
+			_agent?.Dispose();
+			_factory?.Dispose();
+		}
+
+		/// <summary>
+		/// Makes sure that for the HTTP request in ASP.NET Core the generated transaction has the same trace id as Activity.Current.TraceId
+		/// </summary>
+		[Fact]
+		public async Task ActivityFromAspNetCoreAndTransactionWithSameTraceId()
+		{
+			Activity.DefaultIdFormat = ActivityIdFormat.W3C;
+			var res = await _client.GetAsync("Home/TraceId");
+			var activityId = await res.Content.ReadAsStringAsync();
+			_payloadSender.FirstTransaction.TraceId.Should().Be(activityId);
+		}
+	}
+}

--- a/test/Elastic.Apm.Tests/ActivityIntegrationTests.cs
+++ b/test/Elastic.Apm.Tests/ActivityIntegrationTests.cs
@@ -1,0 +1,55 @@
+using System.Diagnostics;
+using System.Threading;
+using Elastic.Apm.Tests.Mocks;
+using FluentAssertions;
+using Xunit;
+
+namespace Elastic.Apm.Tests
+{
+	public class ActivityIntegrationTests
+	{
+		/// <summary>
+		/// Makes sure that in case there is an active activity, the agent reuses its TraceId when it starts a new transaction.
+		/// The prerequisite is that the IdFormat is W3C
+		/// </summary>
+		[Fact]
+		public void ElasticTransactionReusesTraceIdFromCurrentActivity()
+		{
+			Activity.DefaultIdFormat = ActivityIdFormat.W3C;
+
+			var activity = new Activity("UnitTestActivity");
+			activity.Start();
+
+			Activity.Current.TraceId.Should().Be(activity.TraceId);
+
+			var payloadSender = new MockPayloadSender();
+			using (var agent = new ApmAgent(new TestAgentComponents(payloadSender: payloadSender)))
+				agent.Tracer.CaptureTransaction("TestTransaction", "Test", () => Thread.Sleep(10));
+
+			payloadSender.FirstTransaction.TraceId.Should().Be(activity.TraceId.ToString());
+
+			activity.Stop();
+		}
+
+		/// <summary>
+		/// Makes sure that even if an activity is active, the agent will ignore it and not try to reuse the traceId if the IdFormat of the
+		/// activity is NOT w3c.
+		/// </summary>
+		[Fact]
+		public void HierarchicalIdFormatNotUsedByApmTransaction()
+		{
+			Activity.DefaultIdFormat = ActivityIdFormat.Hierarchical;
+
+			var activity = new Activity("UnitTestActivity");
+			activity.Start();
+
+			var payloadSender = new MockPayloadSender();
+			using (var agent = new ApmAgent(new TestAgentComponents(payloadSender: payloadSender)))
+				agent.Tracer.CaptureTransaction("TestTransaction", "Test", () => Thread.Sleep(10));
+
+			payloadSender.FirstTransaction.TraceId.Should().NotBe(activity.TraceId.ToString());
+
+			activity.Stop();
+		}
+	}
+}


### PR DESCRIPTION
Addressing #691. 

[`System.Diagnostics.Activity`](https://docs.microsoft.com/en-us/dotnet/api/system.diagnostics.activity?view=netcore-3.1) implements W3C TraceContext. Once an activity is started, it generates an id, and if it uses `ActivityIdFormat.W3C` it also generates a `TraceId`.

Even better ASP.NET Core itself also creates an Activity for incoming calls which means it creates a TraceId. Prior to this PR we ignored the generated TraceId and the Elastic APM Agent created its own TraceId - or used the one passed in the `traceparent` header.

Now instead of generating TraceId for every transaction the agent will just use `Activity.Current.TraceId` if it exists and it's in `ActivityIdFormat.W3C`.

## Why we do this? 
`Activity` starts getting promoted a lot by Microsoft. E.g. the default ASP.NET Core template generates a controller method like this:

```
public IActionResult Error()
{
	return View(new ErrorViewModel {RequestId = Activity.Current?.Id ?? HttpContext.TraceIdentifier});
}
```

So for the error page, the current activity id is printed.

With this PR, once users print the `Activity.Current.TraceId` into a log or add it to an error page, it'll match the `TraceId` that the Elastic APM Agent uses - furthermore this also means that this `TraceId` is the same across:
- `Activity`
- Elastic APM Traces
- Logs once the APM Log correlation is enabled

## Limitations

`Activity` is not new and originally they used a hierarchical format - this can be checked with `Activity.IdFormat` - [docs](https://docs.microsoft.com/en-us/dotnet/api/system.diagnostics.activityidformat?view=netcore-3.1).

Hierarchical id can't be reused for TraceId, since it is not compatible with W3C TraceContext (it uses invalid characters (not hex), etc.). Unfortunately it's still the default. Therefore: This feature only works if user sets `Activity.DefaultIdFormat = ActivityIdFormat.W3C;` or the service is called with `traceparent` header in ASP.NET Core 3+ (in this case `Activity` autodetects and uses W3C format unless forced with `Activity.DefaultIdFormat` to not do so).

## What this PR does not do

This does not mean we capture `Activity` instances or map it to a transaction or span - that is out of scope here. This is about making sure the traceid is the same across `Activity` and our transactions/spans. Potential follow-up: https://github.com/elastic/apm-agent-dotnet/issues/303 