### PR TITLE
Competing instrumentations - Introduce ActiveInstrumentationFlags on Transaction

### DIFF
--- a/src/Elastic.Apm.AspNetCore/ApmMiddleware.cs
+++ b/src/Elastic.Apm.AspNetCore/ApmMiddleware.cs
@@ -100,7 +100,7 @@ namespace Elastic.Apm.AspNetCore
 						transaction = _tracer.StartTransactionInternal(
 							transactionName,
 							ApiConstants.TypeRequest,
-							tracingData);
+							tracingData, InstrumentationFlag.AspNetCore);
 					}
 					else
 					{
@@ -110,14 +110,14 @@ namespace Elastic.Apm.AspNetCore
 								DistributedTracing.TraceContext.TraceParentHeaderNamePrefixed, headerValue);
 
 						transaction = _tracer.StartTransactionInternal(transactionName,
-							ApiConstants.TypeRequest);
+							ApiConstants.TypeRequest, instrumentationFlag: InstrumentationFlag.AspNetCore);
 					}
 				}
 				else
 				{
 					_logger.Debug()?.Log("Incoming request. Starting Trace.");
 					transaction = _tracer.StartTransactionInternal(transactionName,
-						ApiConstants.TypeRequest);
+						ApiConstants.TypeRequest, instrumentationFlag: InstrumentationFlag.AspNetCore);
 				}
 
 				return transaction;

--- a/src/Elastic.Apm.AspNetCore/ApmMiddleware.cs
+++ b/src/Elastic.Apm.AspNetCore/ApmMiddleware.cs
@@ -8,6 +8,7 @@ using System.Threading.Tasks;
 using Elastic.Apm.Api;
 using Elastic.Apm.AspNetCore.Extensions;
 using Elastic.Apm.Config;
+using Elastic.Apm.DistributedTracing;
 using Elastic.Apm.Logging;
 using Elastic.Apm.Model;
 using Microsoft.AspNetCore.Http;
@@ -78,32 +79,32 @@ namespace Elastic.Apm.AspNetCore
 				Transaction transaction;
 				var transactionName = $"{context.Request.Method} {context.Request.Path}";
 
-				if (context.Request.Headers.ContainsKey(DistributedTracing.TraceContext.TraceParentHeaderNamePrefixed)
-					|| context.Request.Headers.ContainsKey(DistributedTracing.TraceContext.TraceParentHeaderName))
+				if (context.Request.Headers.ContainsKey(TraceContext.TraceParentHeaderNamePrefixed)
+					|| context.Request.Headers.ContainsKey(TraceContext.TraceParentHeaderName))
 				{
-					var headerValue = context.Request.Headers.ContainsKey(DistributedTracing.TraceContext.TraceParentHeaderName)
-						? context.Request.Headers[DistributedTracing.TraceContext.TraceParentHeaderName].ToString()
-						: context.Request.Headers[DistributedTracing.TraceContext.TraceParentHeaderNamePrefixed].ToString();
+					var headerValue = context.Request.Headers.ContainsKey(TraceContext.TraceParentHeaderName)
+						? context.Request.Headers[TraceContext.TraceParentHeaderName].ToString()
+						: context.Request.Headers[TraceContext.TraceParentHeaderNamePrefixed].ToString();
 
-					var tracingData = context.Request.Headers.ContainsKey(DistributedTracing.TraceContext.TraceStateHeaderName)
-						? DistributedTracing.TraceContext.TryExtractTracingData(headerValue, context.Request.Headers[DistributedTracing.TraceContext.TraceStateHeaderName].ToString())
-						: DistributedTracing.TraceContext.TryExtractTracingData(headerValue);
+					var tracingData = context.Request.Headers.ContainsKey(TraceContext.TraceStateHeaderName)
+						? TraceContext.TryExtractTracingData(headerValue, context.Request.Headers[TraceContext.TraceStateHeaderName].ToString())
+						: TraceContext.TryExtractTracingData(headerValue);
 
 					if (tracingData != null)
 					{
 						_logger.Debug()
 							?.Log(
 								"Incoming request with {TraceParentHeaderName} header. DistributedTracingData: {DistributedTracingData}. Continuing trace.",
-								DistributedTracing.TraceContext.TraceParentHeaderNamePrefixed, tracingData);
+								TraceContext.TraceParentHeaderNamePrefixed, tracingData);
 
-						transaction = _tracer.StartTransactionInternal(transactionName, ApiConstants.TypeRequest);
+						transaction = _tracer.StartTransactionInternal(transactionName, ApiConstants.TypeRequest, tracingData);
 					}
 					else
 					{
 						_logger.Debug()
 							?.Log(
 								"Incoming request with invalid {TraceParentHeaderName} header (received value: {TraceParentHeaderValue}). Starting trace with new trace id.",
-								DistributedTracing.TraceContext.TraceParentHeaderNamePrefixed, headerValue);
+								TraceContext.TraceParentHeaderNamePrefixed, headerValue);
 
 						transaction = _tracer.StartTransactionInternal(transactionName, ApiConstants.TypeRequest);
 					}

--- a/src/Elastic.Apm.AspNetCore/ApmMiddleware.cs
+++ b/src/Elastic.Apm.AspNetCore/ApmMiddleware.cs
@@ -8,7 +8,6 @@ using System.Threading.Tasks;
 using Elastic.Apm.Api;
 using Elastic.Apm.AspNetCore.Extensions;
 using Elastic.Apm.Config;
-using Elastic.Apm.DistributedTracing;
 using Elastic.Apm.Logging;
 using Elastic.Apm.Model;
 using Microsoft.AspNetCore.Http;
@@ -97,10 +96,7 @@ namespace Elastic.Apm.AspNetCore
 								"Incoming request with {TraceParentHeaderName} header. DistributedTracingData: {DistributedTracingData}. Continuing trace.",
 								DistributedTracing.TraceContext.TraceParentHeaderNamePrefixed, tracingData);
 
-						transaction = _tracer.StartTransactionInternal(
-							transactionName,
-							ApiConstants.TypeRequest,
-							tracingData, InstrumentationFlag.AspNetCore);
+						transaction = _tracer.StartTransactionInternal(transactionName, ApiConstants.TypeRequest);
 					}
 					else
 					{
@@ -109,15 +105,13 @@ namespace Elastic.Apm.AspNetCore
 								"Incoming request with invalid {TraceParentHeaderName} header (received value: {TraceParentHeaderValue}). Starting trace with new trace id.",
 								DistributedTracing.TraceContext.TraceParentHeaderNamePrefixed, headerValue);
 
-						transaction = _tracer.StartTransactionInternal(transactionName,
-							ApiConstants.TypeRequest, instrumentationFlag: InstrumentationFlag.AspNetCore);
+						transaction = _tracer.StartTransactionInternal(transactionName, ApiConstants.TypeRequest);
 					}
 				}
 				else
 				{
 					_logger.Debug()?.Log("Incoming request. Starting Trace.");
-					transaction = _tracer.StartTransactionInternal(transactionName,
-						ApiConstants.TypeRequest, instrumentationFlag: InstrumentationFlag.AspNetCore);
+					transaction = _tracer.StartTransactionInternal(transactionName, ApiConstants.TypeRequest);
 				}
 
 				return transaction;

--- a/src/Elastic.Apm.AspNetFullFramework/ElasticApmModule.cs
+++ b/src/Elastic.Apm.AspNetFullFramework/ElasticApmModule.cs
@@ -115,14 +115,14 @@ namespace Elastic.Apm.AspNetFullFramework
 						"Incoming request with {TraceParentHeaderName} header. DistributedTracingData: {DistributedTracingData} - continuing trace",
 						DistributedTracing.TraceContext.TraceParentHeaderNamePrefixed, distributedTracingData);
 
-				_currentTransaction = Agent.Instance.TracerInternal.StartTransactionInternal(transactionName, ApiConstants.TypeRequest, distributedTracingData, InstrumentationFlag.AspNetClassic);
+				_currentTransaction = Agent.Instance.TracerInternal.StartTransactionInternal(transactionName, ApiConstants.TypeRequest, distributedTracingData);
 			}
 			else
 			{
 				_logger.Debug()
 					?.Log("Incoming request doesn't have valid incoming distributed tracing data - starting trace with new trace ID");
 
-				_currentTransaction = Agent.Instance.TracerInternal.StartTransactionInternal(transactionName, ApiConstants.TypeRequest, instrumentationFlag: InstrumentationFlag.AspNetClassic);
+				_currentTransaction = Agent.Instance.TracerInternal.StartTransactionInternal(transactionName, ApiConstants.TypeRequest);
 			}
 
 			if (_currentTransaction.IsSampled) FillSampledTransactionContextRequest(httpRequest, _currentTransaction);

--- a/src/Elastic.Apm.AspNetFullFramework/ElasticApmModule.cs
+++ b/src/Elastic.Apm.AspNetFullFramework/ElasticApmModule.cs
@@ -115,14 +115,14 @@ namespace Elastic.Apm.AspNetFullFramework
 						"Incoming request with {TraceParentHeaderName} header. DistributedTracingData: {DistributedTracingData} - continuing trace",
 						DistributedTracing.TraceContext.TraceParentHeaderNamePrefixed, distributedTracingData);
 
-				_currentTransaction = Agent.Instance.TracerInternal.StartTransactionInternal(transactionName, ApiConstants.TypeRequest, distributedTracingData);
+				_currentTransaction = Agent.Instance.Tracer.StartTransaction(transactionName, ApiConstants.TypeRequest, distributedTracingData);
 			}
 			else
 			{
 				_logger.Debug()
 					?.Log("Incoming request doesn't have valid incoming distributed tracing data - starting trace with new trace ID");
 
-				_currentTransaction = Agent.Instance.TracerInternal.StartTransactionInternal(transactionName, ApiConstants.TypeRequest);
+				_currentTransaction = Agent.Instance.Tracer.StartTransaction(transactionName, ApiConstants.TypeRequest);
 			}
 
 			if (_currentTransaction.IsSampled) FillSampledTransactionContextRequest(httpRequest, _currentTransaction);

--- a/src/Elastic.Apm.AspNetFullFramework/ElasticApmModule.cs
+++ b/src/Elastic.Apm.AspNetFullFramework/ElasticApmModule.cs
@@ -6,7 +6,6 @@ using System.Web;
 using Elastic.Apm.Api;
 using Elastic.Apm.AspNetFullFramework.Extensions;
 using Elastic.Apm.DiagnosticSource;
-using Elastic.Apm.DistributedTracing;
 using Elastic.Apm.Helpers;
 using Elastic.Apm.Logging;
 using Elastic.Apm.Model;
@@ -116,14 +115,14 @@ namespace Elastic.Apm.AspNetFullFramework
 						"Incoming request with {TraceParentHeaderName} header. DistributedTracingData: {DistributedTracingData} - continuing trace",
 						DistributedTracing.TraceContext.TraceParentHeaderNamePrefixed, distributedTracingData);
 
-				_currentTransaction = Agent.Instance.Tracer.StartTransaction(transactionName, ApiConstants.TypeRequest, distributedTracingData);
+				_currentTransaction = Agent.Instance.TracerInternal.StartTransactionInternal(transactionName, ApiConstants.TypeRequest, distributedTracingData, InstrumentationFlag.AspNetClassic);
 			}
 			else
 			{
 				_logger.Debug()
 					?.Log("Incoming request doesn't have valid incoming distributed tracing data - starting trace with new trace ID");
 
-				_currentTransaction = Agent.Instance.Tracer.StartTransaction(transactionName, ApiConstants.TypeRequest);
+				_currentTransaction = Agent.Instance.TracerInternal.StartTransactionInternal(transactionName, ApiConstants.TypeRequest, instrumentationFlag: InstrumentationFlag.AspNetClassic);
 			}
 
 			if (_currentTransaction.IsSampled) FillSampledTransactionContextRequest(httpRequest, _currentTransaction);

--- a/src/Elastic.Apm.EntityFramework6/Ef6Interceptor.cs
+++ b/src/Elastic.Apm.EntityFramework6/Ef6Interceptor.cs
@@ -25,28 +25,41 @@ namespace Elastic.Apm.EntityFramework6
 		private readonly Lazy<Impl> _impl = new Lazy<Impl>(() => new Impl());
 
 		public void NonQueryExecuting(DbCommand command, DbCommandInterceptionContext<int> interceptCtx) =>
-			CreateImplIfReady()?.StartSpan(command, interceptCtx);
+			CreateImplIfReadyAndNoConflict()?.StartSpan(command, interceptCtx);
 
 		public void NonQueryExecuted(DbCommand command, DbCommandInterceptionContext<int> interceptCtx) =>
-			CreateImplIfReady()?.EndSpan(command, interceptCtx);
+			CreateImplIfReadyAndNoConflict()?.EndSpan(command, interceptCtx);
 
 		public void ReaderExecuting(DbCommand command, DbCommandInterceptionContext<DbDataReader> interceptCtx) =>
-			CreateImplIfReady()?.StartSpan(command, interceptCtx);
+			CreateImplIfReadyAndNoConflict()?.StartSpan(command, interceptCtx);
 
 		public void ReaderExecuted(DbCommand command, DbCommandInterceptionContext<DbDataReader> interceptCtx) =>
-			CreateImplIfReady()?.EndSpan(command, interceptCtx);
+			CreateImplIfReadyAndNoConflict()?.EndSpan(command, interceptCtx);
 
 		public void ScalarExecuting(DbCommand command, DbCommandInterceptionContext<object> interceptCtx) =>
-			CreateImplIfReady()?.StartSpan(command, interceptCtx);
+			CreateImplIfReadyAndNoConflict()?.StartSpan(command, interceptCtx);
 
 		public void ScalarExecuted(DbCommand command, DbCommandInterceptionContext<object> interceptCtx) =>
-			CreateImplIfReady()?.EndSpan(command, interceptCtx);
+			CreateImplIfReadyAndNoConflict()?.EndSpan(command, interceptCtx);
 
 		/// <summary>
 		/// DB spans can be created only when there's a current transaction
 		/// which in turn means agent singleton instance should already be created.
+		///
+		/// Also checks for competing instrumentation. If SqlClient already instrumented, it'll return null, so the interceptor won't create
+		/// duplicate spans
 		/// </summary>
-		private Impl CreateImplIfReady() => Agent.IsConfigured ? _impl.Value : null;
+		private Impl CreateImplIfReadyAndNoConflict()
+		{
+			// Make sure agent is configured
+			var impl = Agent.IsConfigured ? _impl.Value : null;
+			if (impl == null)
+				return null;
+
+			// Make sure DB spans were not already captured
+			if (!(Agent.Tracer.CurrentTransaction is Transaction transaction)) return impl;
+			return (transaction.ActiveInstrumentationFlags & InstrumentationFlag.SqlClient) == InstrumentationFlag.SqlClient ? null : impl;
+		}
 
 		private class Impl
 		{
@@ -114,7 +127,7 @@ namespace Elastic.Apm.EntityFramework6
 
 				LogEvent("DB operation started - starting a new span...", command, interceptCtx, dbgOriginalCaller);
 
-				var span = Agent.Instance.TracerInternal.DbSpanCommon.StartSpan(Agent.Instance, command);
+				var span = Agent.Instance.TracerInternal.DbSpanCommon.StartSpan(Agent.Instance, command, InstrumentationFlag.EfClassic);
 				interceptCtx.SetUserState(_userStateKey, span);
 			}
 

--- a/src/Elastic.Apm.EntityFramework6/Ef6Interceptor.cs
+++ b/src/Elastic.Apm.EntityFramework6/Ef6Interceptor.cs
@@ -57,8 +57,8 @@ namespace Elastic.Apm.EntityFramework6
 				return null;
 
 			// Make sure DB spans were not already captured
-			if (!(Agent.Tracer.CurrentTransaction is Transaction transaction)) return impl;
-			return (transaction.ActiveInstrumentationFlags & InstrumentationFlag.SqlClient) == InstrumentationFlag.SqlClient ? null : impl;
+			if (!(Agent.Tracer.CurrentSpan is Span span)) return impl;
+			return span.InstrumentationFlag == InstrumentationFlag.SqlClient ? null : impl;
 		}
 
 		private class Impl

--- a/src/Elastic.Apm.EntityFrameworkCore/EfCoreDiagnosticListener.cs
+++ b/src/Elastic.Apm.EntityFrameworkCore/EfCoreDiagnosticListener.cs
@@ -22,12 +22,19 @@ namespace Elastic.Apm.EntityFrameworkCore
 
 		public void OnNext(KeyValuePair<string, object> kv)
 		{
+			// check for competing instrumentation
+			if (_agent.TracerInternal.CurrentTransaction is Transaction transaction)
+			{
+				if ((transaction.ActiveInstrumentationFlags & InstrumentationFlag.SqlClient) == InstrumentationFlag.SqlClient)
+					return;
+			}
+
 			switch (kv.Key)
 			{
 				case { } k when k == RelationalEventId.CommandExecuting.Name && _agent.Tracer.CurrentTransaction != null:
 					if (kv.Value is CommandEventData commandEventData)
 					{
-						var newSpan = _agent.TracerInternal.DbSpanCommon.StartSpan(_agent, commandEventData.Command);
+						var newSpan = _agent.TracerInternal.DbSpanCommon.StartSpan(_agent, commandEventData.Command, InstrumentationFlag.EfCore);
 						_spans.TryAdd(commandEventData.CommandId, newSpan);
 					}
 					break;

--- a/src/Elastic.Apm.EntityFrameworkCore/EfCoreDiagnosticListener.cs
+++ b/src/Elastic.Apm.EntityFrameworkCore/EfCoreDiagnosticListener.cs
@@ -23,9 +23,9 @@ namespace Elastic.Apm.EntityFrameworkCore
 		public void OnNext(KeyValuePair<string, object> kv)
 		{
 			// check for competing instrumentation
-			if (_agent.TracerInternal.CurrentTransaction is Transaction transaction)
+			if (_agent.TracerInternal.CurrentSpan is Span currentSpan)
 			{
-				if ((transaction.ActiveInstrumentationFlags & InstrumentationFlag.SqlClient) == InstrumentationFlag.SqlClient)
+				if (currentSpan.InstrumentationFlag == InstrumentationFlag.SqlClient)
 					return;
 			}
 

--- a/src/Elastic.Apm.SqlClient/SqlClientDiagnosticListener.cs
+++ b/src/Elastic.Apm.SqlClient/SqlClientDiagnosticListener.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Data;
+using Elastic.Apm.Api;
 using Elastic.Apm.DiagnosticSource;
 using Elastic.Apm.Helpers;
 using Elastic.Apm.Logging;
@@ -75,7 +76,8 @@ namespace Elastic.Apm.SqlClient
 				if (propertyFetcherSet.StartCorrelationId.Fetch(payloadData) is Guid operationId
 					&& propertyFetcherSet.StartCommand.Fetch(payloadData) is IDbCommand dbCommand)
 				{
-					var span = _apmAgent.TracerInternal.DbSpanCommon.StartSpan(_apmAgent, dbCommand, InstrumentationFlag.SqlClient);
+					var span = _apmAgent.TracerInternal.DbSpanCommon.StartSpan(_apmAgent, dbCommand, InstrumentationFlag.SqlClient,
+						ApiConstants.SubtypeMssql);
 					_spans.TryAdd(operationId, span);
 				}
 			}

--- a/src/Elastic.Apm.SqlClient/SqlEventListener.cs
+++ b/src/Elastic.Apm.SqlClient/SqlEventListener.cs
@@ -43,10 +43,9 @@ namespace Elastic.Apm.SqlClient
 			if (eventData?.Payload == null) return;
 
 			// Check for competing instrumentation
-			if (_apmAgent.TracerInternal.CurrentTransaction is Transaction transaction)
+			if (_apmAgent.TracerInternal.CurrentSpan is Span span)
 			{
-				if ((transaction.ActiveInstrumentationFlags & InstrumentationFlag.EfCore) == InstrumentationFlag.EfCore
-					|| (transaction.ActiveInstrumentationFlags & InstrumentationFlag.EfClassic) == InstrumentationFlag.EfClassic)
+				if (span.InstrumentationFlag == InstrumentationFlag.EfCore || span.InstrumentationFlag == InstrumentationFlag.EfClassic)
 					return;
 			}
 

--- a/src/Elastic.Apm.SqlClient/SqlEventListener.cs
+++ b/src/Elastic.Apm.SqlClient/SqlEventListener.cs
@@ -90,7 +90,9 @@ namespace Elastic.Apm.SqlClient
 				? commandText.Replace(Environment.NewLine, "")
 				: database;
 
-			var span = (Span)ExecutionSegmentCommon.GetCurrentExecutionSegment(_apmAgent)?.StartSpan(spanName, ApiConstants.TypeDb);
+			var span = ExecutionSegmentCommon.StartSpanOnCurrentExecutionSegment(_apmAgent, spanName, ApiConstants.TypeDb, ApiConstants.SubtypeMssql,
+				InstrumentationFlag.SqlClient);
+
 			if (span == null) return;
 
 			if (_processingSpans.TryAdd(id, (span, start)))

--- a/src/Elastic.Apm/Api/Tracer.cs
+++ b/src/Elastic.Apm/Api/Tracer.cs
@@ -44,11 +44,11 @@ namespace Elastic.Apm.Api
 		public ITransaction StartTransaction(string name, string type, DistributedTracingData distributedTracingData = null) =>
 			StartTransactionInternal(name, type, distributedTracingData);
 
-		internal Transaction StartTransactionInternal(string name, string type, DistributedTracingData distributedTracingData = null)
+		internal Transaction StartTransactionInternal(string name, string type, DistributedTracingData distributedTracingData = null, InstrumentationFlag instrumentationFlag = InstrumentationFlag.None)
 		{
 			var currentConfig = _configProvider.CurrentSnapshot;
 			var retVal = new Transaction(_logger, name, type, new Sampler(currentConfig.TransactionSampleRate), distributedTracingData
-				, _sender, currentConfig, CurrentExecutionSegmentsContainer)
+				, _sender, currentConfig, CurrentExecutionSegmentsContainer, instrumentationFlag)
 			{ Service = _service };
 
 			_logger.Debug()?.Log("Starting {TransactionValue}", retVal);

--- a/src/Elastic.Apm/Api/Tracer.cs
+++ b/src/Elastic.Apm/Api/Tracer.cs
@@ -44,11 +44,11 @@ namespace Elastic.Apm.Api
 		public ITransaction StartTransaction(string name, string type, DistributedTracingData distributedTracingData = null) =>
 			StartTransactionInternal(name, type, distributedTracingData);
 
-		internal Transaction StartTransactionInternal(string name, string type, DistributedTracingData distributedTracingData = null, InstrumentationFlag instrumentationFlag = InstrumentationFlag.None)
+		internal Transaction StartTransactionInternal(string name, string type, DistributedTracingData distributedTracingData = null)
 		{
 			var currentConfig = _configProvider.CurrentSnapshot;
 			var retVal = new Transaction(_logger, name, type, new Sampler(currentConfig.TransactionSampleRate), distributedTracingData
-				, _sender, currentConfig, CurrentExecutionSegmentsContainer, instrumentationFlag)
+				, _sender, currentConfig, CurrentExecutionSegmentsContainer)
 			{ Service = _service };
 
 			_logger.Debug()?.Log("Starting {TransactionValue}", retVal);
@@ -164,7 +164,7 @@ namespace Elastic.Apm.Api
 			{
 				if (t.Exception != null)
 				{
-					if (t.Exception is AggregateException aggregateException)
+					if (t.Exception is { } aggregateException)
 					{
 						ExceptionFilter.Capture(
 							aggregateException.InnerExceptions.Count == 1

--- a/src/Elastic.Apm/DiagnosticListeners/HttpDiagnosticListenerImplBase.cs
+++ b/src/Elastic.Apm/DiagnosticListeners/HttpDiagnosticListenerImplBase.cs
@@ -125,11 +125,8 @@ namespace Elastic.Apm.DiagnosticListeners
 				return;
 			}
 
-			var span = (Span)ExecutionSegmentCommon.GetCurrentExecutionSegment(_agent)
-				.StartSpan(
-					$"{RequestGetMethod(request)} {requestUrl.Host}",
-					ApiConstants.TypeExternal,
-					ApiConstants.SubtypeHttp);
+			var span = ExecutionSegmentCommon.StartSpanOnCurrentExecutionSegment(_agent, $"{RequestGetMethod(request)} {requestUrl.Host}",
+				ApiConstants.TypeExternal, ApiConstants.SubtypeHttp, InstrumentationFlag.HttpClient);
 
 			if (!ProcessingRequests.TryAdd(request, span))
 			{
@@ -177,9 +174,11 @@ namespace Elastic.Apm.DiagnosticListeners
 				// if we don't find the request in the dictionary and current transaction is null, then this is not a big deal -
 				// it was probably not captured in Start either - so we skip with a debug log
 				if (_agent.Tracer.CurrentTransaction == null)
+				{
 					Logger.Debug()
 						?.Log("{eventName} called with no active current transaction, url: {url} - skipping event", nameof(ProcessStopEvent),
 							Http.Sanitize(requestUrl));
+				}
 				// otherwise it's strange and it deserves a warning
 				else
 				{

--- a/src/Elastic.Apm/Model/DbSpanCommon.cs
+++ b/src/Elastic.Apm/Model/DbSpanCommon.cs
@@ -20,10 +20,10 @@ namespace Elastic.Apm.Model
 
 		internal DbSpanCommon(IApmLogger logger) => _dbConnectionStringParser = new DbConnectionStringParser(logger);
 
-		internal Span StartSpan(IApmAgent agent, IDbCommand dbCommand, InstrumentationFlag instrumentationFlag)
+		internal Span StartSpan(IApmAgent agent, IDbCommand dbCommand, InstrumentationFlag instrumentationFlag, string subType = null)
 		{
 			var spanName = dbCommand.CommandText.Replace(Environment.NewLine, " ");
-			return ExecutionSegmentCommon.StartSpanOnCurrentExecutionSegment(agent, spanName, ApiConstants.TypeDb, instrumentationFlag: instrumentationFlag);
+			return ExecutionSegmentCommon.StartSpanOnCurrentExecutionSegment(agent, spanName, ApiConstants.TypeDb, subType, instrumentationFlag);
 		}
 
 		internal void EndSpan(Span span, IDbCommand dbCommand, TimeSpan? duration = null)

--- a/src/Elastic.Apm/Model/DbSpanCommon.cs
+++ b/src/Elastic.Apm/Model/DbSpanCommon.cs
@@ -20,9 +20,11 @@ namespace Elastic.Apm.Model
 
 		internal DbSpanCommon(IApmLogger logger) => _dbConnectionStringParser = new DbConnectionStringParser(logger);
 
-		internal Span StartSpan(IApmAgent agent, IDbCommand dbCommand) =>
-			(Span)ExecutionSegmentCommon.GetCurrentExecutionSegment(agent).StartSpan(dbCommand.CommandText.Replace(Environment.NewLine, " ")
-				, ApiConstants.TypeDb);
+		internal Span StartSpan(IApmAgent agent, IDbCommand dbCommand, InstrumentationFlag instrumentationFlag)
+		{
+			var spanName = dbCommand.CommandText.Replace(Environment.NewLine, " ");
+			return ExecutionSegmentCommon.StartSpanOnCurrentExecutionSegment(agent, spanName, ApiConstants.TypeDb, instrumentationFlag: instrumentationFlag);
+		}
 
 		internal void EndSpan(Span span, IDbCommand dbCommand, TimeSpan? duration = null)
 		{

--- a/src/Elastic.Apm/Model/InstrumentationFlag.cs
+++ b/src/Elastic.Apm/Model/InstrumentationFlag.cs
@@ -1,0 +1,23 @@
+using System;
+
+namespace Elastic.Apm.Model
+{
+	/// <summary>
+	/// Represents a given instrumentation module. Each module can set its flag on a given transaction in
+	/// <see cref="Transaction.ActiveInstrumentationFlags" />.
+	/// With that every instrumentation module can know which other modules created spans on the given transaction.
+	/// In case of "competing modules" <see cref="Transaction.ActiveInstrumentationFlags" /> can be used to detect if a
+	/// competing instrumentation module already created spans on the given transaction.
+	/// </summary>
+	[Flags]
+	internal enum InstrumentationFlag : short
+	{
+		None = 0,
+		HttpClient = 1,
+		AspNetCore = 2,
+		EfCore = 4,
+		EfClassic = 8,
+		SqlClient = 16,
+		AspNetClassic = 32
+	}
+}

--- a/src/Elastic.Apm/Model/InstrumentationFlag.cs
+++ b/src/Elastic.Apm/Model/InstrumentationFlag.cs
@@ -3,11 +3,11 @@ using System;
 namespace Elastic.Apm.Model
 {
 	/// <summary>
-	/// Represents a given instrumentation module. Each module can set its flag on a given transaction in
-	/// <see cref="Transaction.ActiveInstrumentationFlags" />.
-	/// With that every instrumentation module can know which other modules created spans on the given transaction.
-	/// In case of "competing modules" <see cref="Transaction.ActiveInstrumentationFlags" /> can be used to detect if a
-	/// competing instrumentation module already created spans on the given transaction.
+	/// Represents the presence of a given instrumentation module. Each module can set its flag on a given span in
+	/// <see cref="Span.InstrumentationFlag" />.
+	/// With that every instrumentation module can know which other modules created the given span.
+	/// In case of "competing modules" <see cref="Span.InstrumentationFlag" /> can be used to detect if a
+	/// competing instrumentation module created the given span.
 	/// </summary>
 	[Flags]
 	internal enum InstrumentationFlag : short

--- a/src/Elastic.Apm/Model/Span.cs
+++ b/src/Elastic.Apm/Model/Span.cs
@@ -164,9 +164,11 @@ namespace Elastic.Apm.Model
 		public ISpan StartSpan(string name, string type, string subType = null, string action = null)
 			=> StartSpanInternal(name, type, subType, action);
 
-		internal Span StartSpanInternal(string name, string type, string subType = null, string action = null)
+		internal Span StartSpanInternal(string name, string type, string subType = null, string action = null, InstrumentationFlag instrumentationFlag = InstrumentationFlag.None)
 		{
 			var retVal = new Span(name, type, Id, TraceId, _enclosingTransaction, _payloadSender, _logger, _currentExecutionSegmentsContainer, this);
+			_enclosingTransaction.ActiveInstrumentationFlags |= instrumentationFlag;
+
 			if (!string.IsNullOrEmpty(subType)) retVal.Subtype = subType;
 
 			if (!string.IsNullOrEmpty(action)) retVal.Action = action;

--- a/src/Elastic.Apm/Model/Span.cs
+++ b/src/Elastic.Apm/Model/Span.cs
@@ -32,9 +32,11 @@ namespace Elastic.Apm.Model
 			IPayloadSender payloadSender,
 			IApmLogger logger,
 			ICurrentExecutionSegmentsContainer currentExecutionSegmentsContainer,
-			Span parentSpan = null
+			Span parentSpan = null,
+			InstrumentationFlag instrumentationFlag = InstrumentationFlag.None
 		)
 		{
+			InstrumentationFlag = instrumentationFlag;
 			Timestamp = TimeUtils.TimestampNow();
 			Id = RandomGenerator.GenerateRandomBytesAsString(new byte[8]);
 			_logger = logger?.Scoped($"{nameof(Span)}.{Id}");
@@ -74,18 +76,14 @@ namespace Elastic.Apm.Model
 		[JsonConverter(typeof(TrimmedStringJsonConverter))]
 		public string Action { get; set; }
 
+		[JsonIgnore]
+		private IConfigSnapshot ConfigSnapshot => _enclosingTransaction.ConfigSnapshot;
+
 		/// <summary>
 		/// Any other arbitrary data captured by the agent, optionally provided by the user.
 		/// <seealso cref="ShouldSerializeContext" />
 		/// </summary>
 		public SpanContext Context => _context.Value;
-
-		/// <summary>
-		/// Method to conditionally serialize <see cref="Context" /> - serialize only if it was accessed at least once.
-		/// See
-		/// <a href="https://www.newtonsoft.com/json/help/html/ConditionalProperties.htm">the relevant Json.NET Documentation</a>
-		/// </summary>
-		public bool ShouldSerializeContext() => _context.IsValueCreated;
 
 		/// <inheritdoc />
 		/// <summary>
@@ -99,14 +97,13 @@ namespace Elastic.Apm.Model
 		[JsonConverter(typeof(TrimmedStringJsonConverter))]
 		public string Id { get; set; }
 
+		internal InstrumentationFlag InstrumentationFlag { get; }
+
 		[JsonIgnore]
 		public bool IsSampled => _enclosingTransaction.IsSampled;
 
 		[JsonIgnore]
 		public Dictionary<string, string> Labels => Context.Labels;
-
-		[JsonIgnore]
-		private IConfigSnapshot ConfigSnapshot => _enclosingTransaction.ConfigSnapshot;
 
 		[JsonConverter(typeof(TrimmedStringJsonConverter))]
 		public string Name { get; set; }
@@ -150,6 +147,13 @@ namespace Elastic.Apm.Model
 		[JsonConverter(typeof(TrimmedStringJsonConverter))]
 		public string Type { get; set; }
 
+		/// <summary>
+		/// Method to conditionally serialize <see cref="Context" /> - serialize only if it was accessed at least once.
+		/// See
+		/// <a href="https://www.newtonsoft.com/json/help/html/ConditionalProperties.htm">the relevant Json.NET Documentation</a>
+		/// </summary>
+		public bool ShouldSerializeContext() => _context.IsValueCreated;
+
 		public override string ToString() => new ToStringBuilder(nameof(Span))
 		{
 			{ nameof(Id), Id },
@@ -164,10 +168,12 @@ namespace Elastic.Apm.Model
 		public ISpan StartSpan(string name, string type, string subType = null, string action = null)
 			=> StartSpanInternal(name, type, subType, action);
 
-		internal Span StartSpanInternal(string name, string type, string subType = null, string action = null, InstrumentationFlag instrumentationFlag = InstrumentationFlag.None)
+		internal Span StartSpanInternal(string name, string type, string subType = null, string action = null,
+			InstrumentationFlag instrumentationFlag = InstrumentationFlag.None
+		)
 		{
-			var retVal = new Span(name, type, Id, TraceId, _enclosingTransaction, _payloadSender, _logger, _currentExecutionSegmentsContainer, this);
-			_enclosingTransaction.ActiveInstrumentationFlags |= instrumentationFlag;
+			var retVal = new Span(name, type, Id, TraceId, _enclosingTransaction, _payloadSender, _logger, _currentExecutionSegmentsContainer, this,
+				instrumentationFlag);
 
 			if (!string.IsNullOrEmpty(subType)) retVal.Subtype = subType;
 
@@ -301,11 +307,12 @@ namespace Elastic.Apm.Model
 			{
 				return UrlUtils.ExtractDestination(Context.Http.OriginalUrl ?? new Uri(Context.Http.Url), _logger);
 			}
-			catch(Exception ex)
+			catch (Exception ex)
 			{
-				_logger.Trace()?.LogException(ex, "Failed to deduce destination info from Context.Http."
-					+ " Original URL: {OriginalUrl}. Context.Http.Url: {Context.Http.Url}."
-					, Context.Http.OriginalUrl, Context.Http.Url);
+				_logger.Trace()
+					?.LogException(ex, "Failed to deduce destination info from Context.Http."
+						+ " Original URL: {OriginalUrl}. Context.Http.Url: {Context.Http.Url}."
+						, Context.Http.OriginalUrl, Context.Http.Url);
 				return null;
 			}
 		}

--- a/src/Elastic.Apm/Model/Transaction.cs
+++ b/src/Elastic.Apm/Model/Transaction.cs
@@ -54,8 +54,7 @@ namespace Elastic.Apm.Model
 			DistributedTracingData distributedTracingData,
 			IPayloadSender sender,
 			IConfigSnapshot configSnapshot,
-			ICurrentExecutionSegmentsContainer currentExecutionSegmentsContainer,
-			InstrumentationFlag instrumentationFlag = InstrumentationFlag.None
+			ICurrentExecutionSegmentsContainer currentExecutionSegmentsContainer
 		)
 		{
 			ConfigSnapshot = configSnapshot;
@@ -70,7 +69,6 @@ namespace Elastic.Apm.Model
 			Name = name;
 			HasCustomName = false;
 			Type = type;
-			ActiveInstrumentationFlags = instrumentationFlag;
 
 			var isSamplingFromDistributedTracingData = false;
 			if (distributedTracingData == null)
@@ -113,14 +111,6 @@ namespace Elastic.Apm.Model
 		private bool _isEnded;
 
 		private string _name;
-
-		/// <summary>
-		/// Stores the currently active instrumentation on the given transaction.
-		/// This can be used in "competing instrumentation" scenarios.
-		/// E.g. if 2 instrumentation would create the same span, each can look for the other instrumentation's flag here
-		/// and know if the other already captured something on this transaction
-		/// </summary>
-		internal InstrumentationFlag ActiveInstrumentationFlags { get; set; }
 
 		/// <summary>
 		/// Holds configuration snapshot (which is immutable) that was current when this transaction started.
@@ -283,8 +273,7 @@ namespace Elastic.Apm.Model
 			InstrumentationFlag instrumentationFlag = InstrumentationFlag.None
 		)
 		{
-			var retVal = new Span(name, type, Id, TraceId, this, _sender, _logger, _currentExecutionSegmentsContainer);
-			ActiveInstrumentationFlags |= instrumentationFlag;
+			var retVal = new Span(name, type, Id, TraceId, this, _sender, _logger, _currentExecutionSegmentsContainer, instrumentationFlag: instrumentationFlag);
 
 			if (!string.IsNullOrEmpty(subType)) retVal.Subtype = subType;
 

--- a/test/Elastic.Apm.SqlClient.Tests/EfCoreWithMsSqlTests.cs
+++ b/test/Elastic.Apm.SqlClient.Tests/EfCoreWithMsSqlTests.cs
@@ -1,0 +1,85 @@
+using System;
+using System.Diagnostics;
+using System.Linq;
+using Elastic.Apm.EntityFrameworkCore;
+using Elastic.Apm.Tests.Mocks;
+using Elastic.Apm.Tests.TestHelpers;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Elastic.Apm.SqlClient.Tests
+{
+	/// <summary>
+	/// Elastic.Apm.SqlClient and Elastic.Apm.EntityFrameworkCore can be in a competing setup where both would capture the
+	/// same database calls causing db spans being captured twice.
+	/// This class creates such a setup, and tests if double-capturing of the same db call does not happen.
+	/// </summary>
+	public class EfCoreWithMsSqlTests : IDisposable, IClassFixture<DatabaseFixture>
+	{
+		private readonly ApmAgent _apmAgent;
+		private readonly string _connectionString;
+		private readonly MockPayloadSender _payloadSender;
+
+		public EfCoreWithMsSqlTests(ITestOutputHelper testOutputHelper, DatabaseFixture sqlClientListenerFixture)
+		{
+			_connectionString = sqlClientListenerFixture.ConnectionString;
+
+			_payloadSender = new MockPayloadSender();
+			_apmAgent = new ApmAgent(new AgentComponents(
+				new LineWriterToLoggerAdaptor(new XunitOutputToLineWriterAdaptor(testOutputHelper)),
+				payloadSender: _payloadSender));
+			_apmAgent.Subscribe(new SqlClientDiagnosticSubscriber(), new EfCoreDiagnosticsSubscriber());
+		}
+
+		/// <summary>
+		/// Executes a db query within a transaction while both SqlClient and EFCore capturing is active.
+		/// Makes sure that the db call is only captured once - so only 1 of them captures the call, the other one ignores it.
+		/// </summary>
+		[Fact]
+		public void BothEfCoreAndSqlClientCapturingActive()
+		{
+			var dbContextOptionsBuilder = new DbContextOptionsBuilder<TestDbContext>();
+			dbContextOptionsBuilder.UseSqlServer(_connectionString);
+
+			// Initialize outside the transaction
+			using var context = new TestDbContext(dbContextOptionsBuilder.Options);
+			context.Database.EnsureCreated();
+			context.SampleTable.Add(new DbItem { StrField = "abc" });
+			context.SaveChanges();
+
+			_apmAgent.Tracer.CaptureTransaction("transaction", "type", transaction =>
+			{
+				// ReSharper disable once AccessToDisposedClosure
+				var firstItemInDb = context.SampleTable.First();
+				Debug.WriteLine(firstItemInDb.StrField);
+			});
+
+			_payloadSender.SpansOnFirstTransaction.Should().HaveCount(1);
+			_payloadSender.FirstSpan.Should().NotBeNull();
+			_payloadSender.FirstSpan.Context?.Db?.Should().NotBeNull();
+			_payloadSender.FirstSpan.Context?.Db?.Should().NotBeNull();
+
+			_payloadSender.FirstSpan.Context?.Db?.Instance.Should().Be("master");
+			_payloadSender.FirstSpan.Context?.Db?.Type.Should().Be("sql");
+		}
+
+		public void Dispose() => _apmAgent?.Dispose();
+	}
+
+	public class TestDbContext : DbContext
+	{
+		public TestDbContext(DbContextOptions<TestDbContext> options)
+			: base(options) { }
+
+		// ReSharper disable once UnusedAutoPropertyAccessor.Global
+		public DbSet<DbItem> SampleTable { get; set; }
+	}
+
+	public class DbItem
+	{
+		public int Id { get; set; }
+		public string StrField { get; set; }
+	}
+}

--- a/test/Elastic.Apm.SqlClient.Tests/Elastic.Apm.SqlClient.Tests.csproj
+++ b/test/Elastic.Apm.SqlClient.Tests/Elastic.Apm.SqlClient.Tests.csproj
@@ -26,10 +26,12 @@
     <PackageReference Include="TestEnvironment.Docker.Containers.Mssql" Version="1.0.3" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.1.3" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\src\Elastic.Apm.EntityFrameworkCore\Elastic.Apm.EntityFrameworkCore.csproj" />
     <ProjectReference Include="..\..\src\Elastic.Apm.SqlClient\Elastic.Apm.SqlClient.csproj" />
     <ProjectReference Include="..\Elastic.Apm.Tests\Elastic.Apm.Tests.csproj" />
   </ItemGroup>

--- a/test/Elastic.Apm.SqlClient.Tests/SqlClientListenerFixture.cs
+++ b/test/Elastic.Apm.SqlClient.Tests/SqlClientListenerFixture.cs
@@ -6,12 +6,12 @@ using Xunit;
 
 namespace Elastic.Apm.SqlClient.Tests
 {
-	public class SqlClientListenerFixture : IDisposable, IAsyncLifetime
+	public class DatabaseFixture : IDisposable, IAsyncLifetime
 	{
 		private const string ContainerName = "mssql";
 		private readonly DockerEnvironment _environment;
 
-		public SqlClientListenerFixture() =>
+		public DatabaseFixture() =>
 			// BUILD_ID env variable is passed from the CI, therefore DockerInDocker is enabled.
 			_environment = new DockerEnvironmentBuilder()
 				.DockerInDocker(Environment.GetEnvironmentVariable("BUILD_ID") != null)

--- a/test/Elastic.Apm.SqlClient.Tests/SqlClientListenerTests.cs
+++ b/test/Elastic.Apm.SqlClient.Tests/SqlClientListenerTests.cs
@@ -12,7 +12,7 @@ using Xunit.Abstractions;
 
 namespace Elastic.Apm.SqlClient.Tests
 {
-	public class SqlClientListenerTests : IDisposable, IClassFixture<SqlClientListenerFixture>
+	public class SqlClientListenerTests : IDisposable, IClassFixture<DatabaseFixture>
 	{
 		private readonly ApmAgent _apmAgent;
 
@@ -21,7 +21,7 @@ namespace Elastic.Apm.SqlClient.Tests
 
 		private readonly string _expectedAddress;
 
-		public SqlClientListenerTests(ITestOutputHelper testOutputHelper, SqlClientListenerFixture sqlClientListenerFixture)
+		public SqlClientListenerTests(ITestOutputHelper testOutputHelper, DatabaseFixture sqlClientListenerFixture)
 		{
 			_connectionString = sqlClientListenerFixture.ConnectionString;
 
@@ -35,7 +35,6 @@ namespace Elastic.Apm.SqlClient.Tests
 				payloadSender: _payloadSender));
 			_apmAgent.Subscribe(new SqlClientDiagnosticSubscriber());
 		}
-
 
 		private readonly string _connectionString;
 

--- a/test/Elastic.Apm.Tests/InstrumentationFlagTests.cs
+++ b/test/Elastic.Apm.Tests/InstrumentationFlagTests.cs
@@ -1,0 +1,44 @@
+using Elastic.Apm.Model;
+using Elastic.Apm.Tests.Mocks;
+using FluentAssertions;
+using Xunit;
+
+namespace Elastic.Apm.Tests
+{
+	public class InstrumentationFlagTests
+	{
+		/// <summary>
+		/// Makes sure that <see cref="Transaction.StartSpanInternal"/> passes the instrumentation flag to the created span
+		/// </summary>
+		[Fact]
+		public void SpanOnTransactionWithSpecificInstrumentationFlag()
+		{
+			using var agent = new ApmAgent(new TestAgentComponents());
+			var transaction = agent.TracerInternal.StartTransactionInternal("test", "test");
+
+			var span1 = transaction.StartSpanInternal("span", "test", instrumentationFlag: InstrumentationFlag.SqlClient);
+
+			span1.InstrumentationFlag.Should().Be(InstrumentationFlag.SqlClient);
+			span1.End();
+			transaction.End();
+		}
+
+		/// <summary>
+		/// Makes sure that <see cref="Span.StartSpanInternal"/> passes the instrumentation flag to the created child span
+		/// </summary>
+		[Fact]
+		public void ChildSpanWithSpecificInstrumentationFlag()
+		{
+			using var agent = new ApmAgent(new TestAgentComponents());
+			var transaction = agent.TracerInternal.StartTransactionInternal("test", "test");
+
+			var span1 = transaction.StartSpanInternal("span", "test", instrumentationFlag: InstrumentationFlag.AspNetCore);
+			span1.InstrumentationFlag.Should().Be(InstrumentationFlag.AspNetCore);
+			var span2 = span1.StartSpanInternal("span", "test", instrumentationFlag: InstrumentationFlag.EfClassic);
+			span2.InstrumentationFlag.Should().Be(InstrumentationFlag.EfClassic);
+			span2.End();
+			span1.End();
+			transaction.End();
+		}
+	}
+}


### PR DESCRIPTION
Solves #802

(updated to store the info on a given span instead of storing it on the transaction)

Adds a flag to detect competing instrumentations. Each instrumenting module can set its own flag and with that, instrumenting modules can know which other module created a given span.

After this we can turn on both `SqlClient` and EFCore (or EF Classic) instrumentation. This means `Elastic.Apm.SqlClient` will know if `Elastic.Apm.EntityFrameworkCore` or `Elastic.Apm.EntityFramework6` created the currently active span and vice versa, so we avoid capturing the same db call twice.

Long term we can refine this and e.g. store this flag cover other scenarios. In this PR the focus is to create the base to turn on `SqlClient` instrumentation by default in additional to EFCore instrumentation.