### PR TITLE
Prepare release of Elastic.Apm.SqlClient

### DIFF
--- a/.ci/linux/deploy.sh
+++ b/.ci/linux/deploy.sh
@@ -4,7 +4,7 @@
 #
 set -euo pipefail
 
-declare -a projectsToPublish=("Elastic.Apm" "Elastic.Apm.AspNetCore" "Elastic.Apm.EntityFrameworkCore" "Elastic.Apm.NetCoreAll" "Elastic.Apm.EntityFramework6" "Elastic.Apm.AspNetFullFramework")
+declare -a projectsToPublish=("Elastic.Apm" "Elastic.Apm.AspNetCore" "Elastic.Apm.EntityFrameworkCore" "Elastic.Apm.NetCoreAll" "Elastic.Apm.EntityFramework6" "Elastic.Apm.AspNetFullFramework" "Elastic.Apm.SqlClient")
 
 for project in  "${projectsToPublish[@]}"
 do

--- a/src/Elastic.Apm.NetCoreAll/ApmMiddlewareExtension.cs
+++ b/src/Elastic.Apm.NetCoreAll/ApmMiddlewareExtension.cs
@@ -1,5 +1,6 @@
 ﻿using Elastic.Apm.DiagnosticSource;
 using Elastic.Apm.EntityFrameworkCore;
+using Elastic.Apm.SqlClient;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.Configuration;
 
@@ -24,6 +25,7 @@ namespace Elastic.Apm.NetCoreAll
 			this IApplicationBuilder builder,
 			IConfiguration configuration = null
 		) => AspNetCore.ApmMiddlewareExtension
-			.UseElasticApm(builder, configuration, new HttpDiagnosticsSubscriber(), new EfCoreDiagnosticsSubscriber());
+			.UseElasticApm(builder, configuration, new HttpDiagnosticsSubscriber(), new EfCoreDiagnosticsSubscriber(),
+				new SqlClientDiagnosticSubscriber());
 	}
 }

--- a/src/Elastic.Apm.NetCoreAll/Elastic.Apm.NetCoreAll.csproj
+++ b/src/Elastic.Apm.NetCoreAll/Elastic.Apm.NetCoreAll.csproj
@@ -7,8 +7,9 @@
     <PackageTags>apm, monitoring, elastic, elasticapm, analytics, aspnetcore, entiryframeworkcore, efcore</PackageTags>
   </PropertyGroup>
   <ItemGroup>
-    <ProjectReference Include="..\Elastic.Apm.AspNetCore\Elastic.Apm.AspNetCore.csproj"/>
-    <ProjectReference Include="..\Elastic.Apm.EntityFrameworkCore\Elastic.Apm.EntityFrameworkCore.csproj"/>
-    <ProjectReference Include="..\Elastic.Apm\Elastic.Apm.csproj"/>
+    <ProjectReference Include="..\Elastic.Apm.AspNetCore\Elastic.Apm.AspNetCore.csproj" />
+    <ProjectReference Include="..\Elastic.Apm.EntityFrameworkCore\Elastic.Apm.EntityFrameworkCore.csproj" />
+    <ProjectReference Include="..\Elastic.Apm.SqlClient\Elastic.Apm.SqlClient.csproj" />
+    <ProjectReference Include="..\Elastic.Apm\Elastic.Apm.csproj" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Follow up from #809

- Turns on `SqlClientDiagnosticSubscriber` from `Elastic.Apm.SqlClient` by default in `UseAllElasticApm` for ASP.NET Core
- Adapted the deploy script to push the `Elastic.Apm.SqlClient` NuGet package

With this I think we are ready to release `Elastic.Apm.SqlClient` when we push our next release.

cc @vhatsura  🎉 👏