### PR TITLE
Increase timeout of Jenkins to 75 minutes

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,7 +16,7 @@ pipeline {
     OPBEANS_REPO = 'opbeans-dotnet'
   }
   options {
-    timeout(time: 1, unit: 'HOURS')
+    timeout(time: 75, unit: 'MINUTES')
     buildDiscarder(logRotator(numToKeepStr: '20', artifactNumToKeepStr: '20', daysToKeepStr: '30'))
     timestamps()
     ansiColor('xterm')


### PR DESCRIPTION
Increasing timeout to 75 minutes, per request from @gregkalapos 

The long-term solution will be to pre-install VS but this is a stopgap in the meantime.