### PR TITLE
New central configuration options: CaptureHeaders, LogLevel, SpanFramesMinDuration, StackTraceLimit

### DIFF
--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -649,7 +649,7 @@ This setting can be changed after agent's start.
 [[config-capture-headers]]
 ==== `CaptureHeaders` (performance)
 
-// <<dynamic-configuration, image:./images/dynamic-config.svg[] >>
+<<dynamic-configuration, image:./images/dynamic-config.svg[] >>
 
 [options="header"]
 |============
@@ -738,7 +738,7 @@ Namespaces are checked with `string.StartsWith()`, so "System." matches all Syst
 [[config-stack-trace-limit]]
 ==== `StackTraceLimit` (performance)
 
-// <<dynamic-configuration, image:./images/dynamic-config.svg[] >>
+<<dynamic-configuration, image:./images/dynamic-config.svg[] >>
 
 Setting it to 0 will disable stack trace collection. Any positive integer value will be used as the maximum number of frames to collect. Setting it to -1 means that all frames will be collected.
 
@@ -758,7 +758,7 @@ Setting it to 0 will disable stack trace collection. Any positive integer value 
 [[config-span-frames-min-duration]]
 ==== `SpanFramesMinDuration` (performance)
 
-// <<dynamic-configuration, image:./images/dynamic-config.svg[] >>
+<<dynamic-configuration, image:./images/dynamic-config.svg[] >>
 
 In its default settings,
 the APM agent collects a stack trace for every recorded span with duration longer than 5ms.
@@ -795,7 +795,7 @@ The default unit for this option is `ms`
 [[config-log-level]]
 ==== `LogLevel`
 
-// <<dynamic-configuration, image:./images/dynamic-config.svg[] >>
+<<dynamic-configuration, image:./images/dynamic-config.svg[] >>
 
 [options="header"]
 |============

--- a/src/Elastic.Apm/Agent.cs
+++ b/src/Elastic.Apm/Agent.cs
@@ -2,6 +2,7 @@
 using System.Runtime.CompilerServices;
 using Elastic.Apm.Api;
 using Elastic.Apm.BackendComm;
+using Elastic.Apm.BackendComm.CentralConfig;
 using Elastic.Apm.Config;
 using Elastic.Apm.DiagnosticSource;
 using Elastic.Apm.Logging;

--- a/src/Elastic.Apm/AgentComponents.cs
+++ b/src/Elastic.Apm/AgentComponents.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using Elastic.Apm.Api;
 using Elastic.Apm.BackendComm;
+using Elastic.Apm.BackendComm.CentralConfig;
 using Elastic.Apm.Config;
 using Elastic.Apm.Helpers;
 using Elastic.Apm.Logging;

--- a/src/Elastic.Apm/BackendComm/CentralConfig/CentralConfigReader.cs
+++ b/src/Elastic.Apm/BackendComm/CentralConfig/CentralConfigReader.cs
@@ -1,0 +1,79 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Elastic.Apm.Config;
+using Elastic.Apm.Helpers;
+using Elastic.Apm.Logging;
+
+namespace Elastic.Apm.BackendComm.CentralConfig
+{
+	internal class CentralConfigReader : AbstractConfigurationReader
+	{
+		private const string ThisClassName = nameof(CentralConfigFetcher) + "." + nameof(CentralConfigReader);
+
+		private readonly CentralConfigResponseParser.CentralConfigPayload _configPayload;
+
+		public CentralConfigReader(IApmLogger logger, CentralConfigResponseParser.CentralConfigPayload configPayload, string eTag) : base(logger, ThisClassName)
+		{
+			_configPayload = configPayload;
+			ETag = eTag;
+
+			UpdateConfigurationValues();
+		}
+
+		private void UpdateConfigurationValues()
+		{
+			CaptureBody = GetConfigurationValue(CentralConfigResponseParser.CentralConfigPayload.CaptureBodyKey, ParseCaptureBody);
+			CaptureBodyContentTypes = GetConfigurationValue(CentralConfigResponseParser.CentralConfigPayload.CaptureBodyContentTypesKey, ParseCaptureBodyContentTypes);
+			TransactionMaxSpans = GetSimpleConfigurationValue(CentralConfigResponseParser.CentralConfigPayload.TransactionMaxSpansKey, ParseTransactionMaxSpans);
+			TransactionSampleRate = GetSimpleConfigurationValue(CentralConfigResponseParser.CentralConfigPayload.TransactionSampleRateKey, ParseTransactionSampleRate);
+			CaptureHeaders = GetSimpleConfigurationValue(CentralConfigResponseParser.CentralConfigPayload.CaptureHeadersKey, ParseCaptureHeaders);
+			LogLevel = GetSimpleConfigurationValue(CentralConfigResponseParser.CentralConfigPayload.LogLevelKey, ParseLogLevel);
+			SpanFramesMinDurationInMilliseconds =
+				GetSimpleConfigurationValue(CentralConfigResponseParser.CentralConfigPayload.SpanFramesMinDurationKey, ParseSpanFramesMinDurationInMilliseconds);
+			StackTraceLimit = GetSimpleConfigurationValue(CentralConfigResponseParser.CentralConfigPayload.StackTraceLimitKey, ParseStackTraceLimit);
+		}
+
+		internal string ETag { get; }
+
+		internal string CaptureBody { get; private set; }
+
+		internal List<string> CaptureBodyContentTypes { get; private set; }
+
+		internal int? TransactionMaxSpans { get; private set; }
+
+		internal double? TransactionSampleRate { get; private set; }
+
+		internal bool? CaptureHeaders { get; private set; }
+
+		internal LogLevel? LogLevel { get; private set; }
+
+		internal double? SpanFramesMinDurationInMilliseconds { get; private set; }
+
+		internal int? StackTraceLimit { get; private set; }
+
+		private ConfigurationKeyValue BuildKv(string key, string value) =>
+			new ConfigurationKeyValue(key, value, /* readFrom */ $"Central configuration (ETag: `{ETag}')");
+
+		private T GetConfigurationValue<T>(string configurationKey, Func<ConfigurationKeyValue, T> parser)
+			where T : class =>
+			_configPayload[configurationKey]?.Let(value => parser(BuildKv(configurationKey, value)));
+
+		private T? GetSimpleConfigurationValue<T>(string configurationKey, Func<ConfigurationKeyValue, T> parser)
+			where T : struct =>
+			_configPayload[configurationKey]?.Let(value => parser(BuildKv(configurationKey, value)));
+
+		public override string ToString()
+		{
+			var builder = new ToStringBuilder($"[ETag: `{ETag}']");
+
+			if (CaptureBody != null) builder.Add(nameof(CaptureBody), CaptureBody);
+			if (CaptureBodyContentTypes != null)
+				builder.Add(nameof(CaptureBodyContentTypes), string.Join(", ", CaptureBodyContentTypes.Select(x => $"`{x}'")));
+			if (TransactionMaxSpans.HasValue) builder.Add(nameof(TransactionMaxSpans), TransactionMaxSpans.Value);
+			if (TransactionSampleRate.HasValue) builder.Add(nameof(TransactionSampleRate), TransactionSampleRate.Value);
+
+			return builder.ToString();
+		}
+	}
+}

--- a/src/Elastic.Apm/BackendComm/CentralConfig/CentralConfigResponseParser.cs
+++ b/src/Elastic.Apm/BackendComm/CentralConfig/CentralConfigResponseParser.cs
@@ -1,0 +1,208 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using Elastic.Apm.Config;
+using Elastic.Apm.Helpers;
+using Elastic.Apm.Logging;
+using Newtonsoft.Json;
+
+namespace Elastic.Apm.BackendComm.CentralConfig
+{
+	internal class CentralConfigResponseParser : ICentralConfigResponseParser
+	{
+		private readonly IApmLogger _logger;
+
+		internal static readonly TimeSpan WaitTimeIfNoCacheControlMaxAge = TimeSpan.FromMinutes(5);
+
+		internal CentralConfigResponseParser(IApmLogger logger)
+		{
+			_logger = logger?.Scoped(nameof(CentralConfigResponseParser));
+		}
+
+		public (CentralConfigFetcher.ConfigDelta, CentralConfigFetcher.WaitInfoS) ParseHttpResponse(HttpResponseMessage httpResponse,
+			string httpResponseBody
+		)
+		{
+			_logger.Trace()
+				?.Log("Processing HTTP response..."
+					+ Environment.NewLine + "+-> Response:{HttpResponse}"
+					+ Environment.NewLine + "+-> Response body [length: {HttpResponseBodyLength}]:{HttpResponseBody}"
+					, httpResponse == null ? " N/A" : Environment.NewLine + TextUtils.Indent(httpResponse.ToString())
+					, httpResponseBody == null ? "N/A" : httpResponseBody.Length.ToString()
+					, httpResponseBody == null ? " N/A" : Environment.NewLine + TextUtils.Indent(httpResponseBody));
+
+			var waitInfo = ExtractWaitInfo(httpResponse);
+			try
+			{
+				if (!InterpretResponseStatusCode(httpResponse, waitInfo)) return (null, waitInfo);
+
+				if (httpResponse?.Headers?.ETag == null)
+					throw new CentralConfigFetcher.FailedToFetchConfigException("Response from APM Server doesn't have ETag header", waitInfo);
+
+				var keyValues = JsonConvert.DeserializeObject<IDictionary<string, string>>(httpResponseBody);
+				var configDelta = ParseConfigPayload(httpResponse, new CentralConfigPayload(keyValues));
+
+				return (configDelta, waitInfo);
+			}
+			catch (Exception ex) when (!(ex is CentralConfigFetcher.FailedToFetchConfigException))
+			{
+				throw new CentralConfigFetcher.FailedToFetchConfigException("Exception was thrown while parsing response from APM Server", waitInfo,
+					cause: ex);
+			}
+		}
+
+		private CentralConfigFetcher.ConfigDelta ParseConfigPayload(HttpResponseMessage httpResponse, CentralConfigPayload configPayload)
+		{
+			var eTag = httpResponse.Headers.ETag.ToString();
+
+			var configParser = new ConfigParser(_logger, configPayload, eTag);
+
+			if (configPayload.UnknownKeys != null && !configPayload.UnknownKeys.IsEmpty())
+			{
+				_logger.Info()
+					?.Log("Central configuration response contains keys that are not in the list of options"
+						+ " that can be changed after Agent start: {UnknownKeys}. Supported options: {ReloadableOptions}."
+						, string.Join(", ", configPayload.UnknownKeys.Select(k => $"`[{k.Key}, {k.Value}]'"))
+						, string.Join(", ", CentralConfigPayload.SupportedOptions.Select(k => $"`{k}'")));
+			}
+
+			return new CentralConfigFetcher.ConfigDelta(
+				captureBody: configParser.CaptureBody,
+				captureBodyContentTypes: configParser.CaptureBodyContentTypes,
+				transactionMaxSpans: configParser.TransactionMaxSpans,
+				transactionSampleRate: configParser.TransactionSampleRate,
+				eTag: eTag
+			);
+		}
+
+		private static CentralConfigFetcher.WaitInfoS ExtractWaitInfo(HttpResponseMessage httpResponse)
+		{
+			if (httpResponse.Headers?.CacheControl?.MaxAge != null)
+			{
+				return new CentralConfigFetcher.WaitInfoS(httpResponse.Headers.CacheControl.MaxAge.Value,
+					"Wait time is taken from max-age directive in Cache-Control header in APM Server's response");
+			}
+
+			return new CentralConfigFetcher.WaitInfoS(WaitTimeIfNoCacheControlMaxAge,
+				"Default wait time is used because there's no valid Cache-Control header with max-age directive in APM Server's response."
+				+ Environment.NewLine + "+-> Response:" + Environment.NewLine + TextUtils.Indent(httpResponse.ToString()));
+		}
+
+		private bool InterpretResponseStatusCode(HttpResponseMessage httpResponse, CentralConfigFetcher.WaitInfoS waitInfo)
+		{
+			if (httpResponse.IsSuccessStatusCode) return true;
+
+			var statusCode = (int)httpResponse.StatusCode;
+			var severity = 400 <= statusCode && statusCode < 500 ? LogLevel.Debug : LogLevel.Error;
+
+			string message;
+			var statusAsString = $"HTTP status code is {httpResponse.ReasonPhrase} ({(int)httpResponse.StatusCode})";
+			var msgPrefix = $"{statusAsString} which most likely means that ";
+			// ReSharper disable once SwitchStatementMissingSomeCases
+			switch (httpResponse.StatusCode)
+			{
+				case HttpStatusCode.NotModified: // 304
+					_logger.Trace()
+						?.Log("HTTP status code is {HttpResponseReasonPhrase} ({HttpStatusCode})"
+							+ " which means the configuration has not changed since the previous fetch."
+							+ " Response:{NewLine}{HttpResponse}"
+							, httpResponse.ReasonPhrase
+							, (int)httpResponse.StatusCode
+							, Environment.NewLine
+							, TextUtils.Indent(httpResponse.ToString()));
+					return false;
+
+				case HttpStatusCode.BadRequest: // 400
+					severity = LogLevel.Error;
+					message = $"{statusAsString} which is unexpected";
+					break;
+
+				case HttpStatusCode.Forbidden: // 403
+					message = msgPrefix + "APM Server supports the central configuration endpoint but Kibana connection is not enabled";
+					break;
+
+				case HttpStatusCode.NotFound: // 404
+					message = msgPrefix + "APM Server is an old (pre 7.3) version which doesn't support the central configuration endpoint";
+					break;
+
+				case HttpStatusCode.ServiceUnavailable: // 503
+					message = msgPrefix + "APM Server supports the central configuration endpoint and Kibana connection is enabled"
+						+ ", but Kibana connection is unavailable";
+					break;
+
+				default:
+					message = $"{statusAsString} signifies a failure";
+					break;
+			}
+
+			throw new CentralConfigFetcher.FailedToFetchConfigException(message, waitInfo, severity);
+		}
+
+		private class ConfigParser : AbstractConfigurationReader
+		{
+			// ReSharper disable once MemberHidesStaticFromOuterClass
+			private const string ThisClassName = nameof(CentralConfigFetcher) + "." + nameof(ConfigParser);
+
+			private readonly CentralConfigPayload _configPayload;
+			private readonly string _eTag;
+
+			public ConfigParser(IApmLogger logger, CentralConfigPayload configPayload, string eTag) : base(logger, ThisClassName)
+			{
+				_configPayload = configPayload;
+				_eTag = eTag;
+			}
+
+			internal string CaptureBody =>
+				_configPayload[CentralConfigPayload.CaptureBodyKey]
+					?.Let(value => ParseCaptureBody(BuildKv(CentralConfigPayload.CaptureBodyKey, value)));
+
+			internal List<string> CaptureBodyContentTypes =>
+				_configPayload[CentralConfigPayload.CaptureBodyContentTypesKey]
+					?.Let(value => ParseCaptureBodyContentTypes(BuildKv(CentralConfigPayload.CaptureBodyContentTypesKey, value)));
+
+			internal int? TransactionMaxSpans =>
+				_configPayload[CentralConfigPayload.TransactionMaxSpansKey]
+					?.Let(value => ParseTransactionMaxSpans(BuildKv(CentralConfigPayload.TransactionMaxSpansKey, value)));
+
+			internal double? TransactionSampleRate =>
+				_configPayload[CentralConfigPayload.TransactionSampleRateKey]
+					?.Let(value => ParseTransactionSampleRate(BuildKv(CentralConfigPayload.TransactionSampleRateKey, value)));
+
+			private ConfigurationKeyValue BuildKv(string key, string value) =>
+				new ConfigurationKeyValue(key, value, /* readFrom */ $"Central configuration (ETag: `{_eTag}')");
+		}
+
+		private class CentralConfigPayload
+		{
+			internal const string CaptureBodyContentTypesKey = "capture_body_content_types";
+			internal const string CaptureBodyKey = "capture_body";
+			internal const string TransactionMaxSpansKey = "transaction_max_spans";
+
+			internal const string TransactionSampleRateKey = "transaction_sample_rate";
+			// internal const string CaptureHeadersKey = "capture_headers";
+			// internal const string LogLevelKey = "log_level";
+			// internal const string SpanFramesMinDurationKey = "span_frames_min_duration";
+			// internal const string StackTraceLimitKey = "stack_trace_limit";
+
+			internal static readonly ISet<string> SupportedOptions = new HashSet<string>
+			{
+				CaptureBodyKey, CaptureBodyContentTypesKey, TransactionMaxSpansKey, TransactionSampleRateKey,
+				//CaptureHeadersKey, LogLevelKey, SpanFramesMinDurationKey, StackTraceLimitKey
+			};
+
+			private readonly IDictionary<string, string> _keyValues;
+
+			public CentralConfigPayload(IDictionary<string, string> keyValues)
+			{
+				_keyValues = keyValues;
+			}
+
+			[JsonIgnore]
+			public IEnumerable<KeyValuePair<string, string>> UnknownKeys => _keyValues.Where(x => !SupportedOptions.Contains(x.Key));
+
+			public string this[string key] => _keyValues.ContainsKey(key) ? _keyValues[key] : null;
+		}
+	}
+}

--- a/src/Elastic.Apm/BackendComm/CentralConfig/ICentralConfigFetcher.cs
+++ b/src/Elastic.Apm/BackendComm/CentralConfig/ICentralConfigFetcher.cs
@@ -1,6 +1,6 @@
 using System;
 
-namespace Elastic.Apm.BackendComm
+namespace Elastic.Apm.BackendComm.CentralConfig
 {
 	internal interface ICentralConfigFetcher : IDisposable { }
 }

--- a/src/Elastic.Apm/BackendComm/CentralConfig/ICentralConfigResponseParser.cs
+++ b/src/Elastic.Apm/BackendComm/CentralConfig/ICentralConfigResponseParser.cs
@@ -4,6 +4,6 @@ namespace Elastic.Apm.BackendComm.CentralConfig
 {
 	internal interface ICentralConfigResponseParser
 	{
-		(CentralConfigFetcher.ConfigDelta, CentralConfigFetcher.WaitInfoS) ParseHttpResponse(HttpResponseMessage httpResponse, string httpResponseBody);
+		(CentralConfigReader, CentralConfigFetcher.WaitInfoS) ParseHttpResponse(HttpResponseMessage httpResponse, string httpResponseBody);
 	}
 }

--- a/src/Elastic.Apm/BackendComm/CentralConfig/ICentralConfigResponseParser.cs
+++ b/src/Elastic.Apm/BackendComm/CentralConfig/ICentralConfigResponseParser.cs
@@ -1,0 +1,9 @@
+using System.Net.Http;
+
+namespace Elastic.Apm.BackendComm.CentralConfig
+{
+	internal interface ICentralConfigResponseParser
+	{
+		(CentralConfigFetcher.ConfigDelta, CentralConfigFetcher.WaitInfoS) ParseHttpResponse(HttpResponseMessage httpResponse, string httpResponseBody);
+	}
+}

--- a/src/Elastic.Apm/Config/ConfigConsts.cs
+++ b/src/Elastic.Apm/Config/ConfigConsts.cs
@@ -132,7 +132,7 @@ namespace Elastic.Apm.Config
 			public const string CaptureBodyOff = "off";
 			public const string CaptureBodyTransactions = "transactions";
 
-			public static List<string> CaptureBodySupportedValues =
+			public static readonly List<string> CaptureBodySupportedValues =
 				new List<string> { CaptureBodyOff, CaptureBodyAll, CaptureBodyErrors, CaptureBodyTransactions };
 		}
 	}

--- a/test/Elastic.Apm.Tests/BackendCommTests/CentralConfig/CentralConfigFetcherTests.cs
+++ b/test/Elastic.Apm.Tests/BackendCommTests/CentralConfig/CentralConfigFetcherTests.cs
@@ -1,6 +1,6 @@
 using System.Threading;
 using Elastic.Apm.Api;
-using Elastic.Apm.BackendComm;
+using Elastic.Apm.BackendComm.CentralConfig;
 using Elastic.Apm.Config;
 using Elastic.Apm.Helpers;
 using Elastic.Apm.Report;
@@ -13,7 +13,7 @@ using Xunit.Abstractions;
 
 // ReSharper disable ImplicitlyCapturedClosure
 
-namespace Elastic.Apm.Tests.BackendCommTests
+namespace Elastic.Apm.Tests.BackendCommTests.CentralConfig
 {
 	public class CentralConfigFetcherTests : LoggingTestBase
 	{

--- a/test/Elastic.Apm.Tests/BackendCommTests/CentralConfig/CentralConfigResponseParserTests.cs
+++ b/test/Elastic.Apm.Tests/BackendCommTests/CentralConfig/CentralConfigResponseParserTests.cs
@@ -1,0 +1,124 @@
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using Elastic.Apm.BackendComm.CentralConfig;
+using Elastic.Apm.Logging;
+using Elastic.Apm.Tests.Mocks;
+using FluentAssertions;
+using Xunit;
+
+namespace Elastic.Apm.Tests.BackendCommTests.CentralConfig
+{
+	public class CentralConfigResponseParserTests
+	{
+		private readonly CentralConfigResponseParser _parser;
+
+		public CentralConfigResponseParserTests()
+		{
+			_parser = new CentralConfigResponseParser(new NoopLogger());
+		}
+
+		[Fact]
+		public void ParseHttpResponse_ShouldUseMaxAgeHeader()
+		{
+			// Arrange
+			var response = new HttpResponseMessage
+			{
+				StatusCode = HttpStatusCode.NotModified,
+				Headers = { CacheControl = new CacheControlHeaderValue { MaxAge = TimeSpan.FromMinutes(5) } }
+			};
+
+			// Act
+			var (_, waitInfoS) = _parser.ParseHttpResponse(response, string.Empty);
+
+			// Assert
+			waitInfoS.Interval.Should().Be(TimeSpan.FromMinutes(5));
+		}
+
+		[Fact]
+		public void ParseHttpResponse_ShouldReturnNullConfigDelta_WhenResponseStatusCodeIs304()
+		{
+			// Arrange
+			var response = new HttpResponseMessage { StatusCode = HttpStatusCode.NotModified };
+
+			// Act
+			var (configDelta, _) = _parser.ParseHttpResponse(response, string.Empty);
+
+			// Assert
+			configDelta.Should().BeNull();
+		}
+
+		[Theory]
+		[InlineData(HttpStatusCode.Moved)]
+		[InlineData(HttpStatusCode.BadRequest)]
+		[InlineData(HttpStatusCode.Forbidden)]
+		[InlineData(HttpStatusCode.NotFound)]
+		[InlineData(HttpStatusCode.ServiceUnavailable)]
+		public void ParseHttpResponse_ShouldThrowException_WhenStatusCodeIsNotSuccessAndNot304(HttpStatusCode statusCode)
+		{
+			// Arrange
+			var response = new HttpResponseMessage { StatusCode = statusCode };
+
+			// Act + Assert
+			Assert.Throws<CentralConfigFetcher.FailedToFetchConfigException>(
+				() => _parser.ParseHttpResponse(response, string.Empty));
+		}
+
+		[Fact]
+		public void ParseHttpResponse_ShouldThrowException_WhenETagHeaderIsMissed()
+		{
+			// Arrange
+			var response = new HttpResponseMessage { StatusCode = HttpStatusCode.OK };
+
+			// Act + Assert
+			Assert.Throws<CentralConfigFetcher.FailedToFetchConfigException>(
+				() => _parser.ParseHttpResponse(response, string.Empty));
+		}
+
+		[Fact]
+		public void ParseHttpResponse_ShouldReturnEmptyConfigDelta_WhenResponseBodyIsEmpty()
+		{
+			// Arrange
+			var response = new HttpResponseMessage
+			{
+				StatusCode = HttpStatusCode.OK,
+				Headers = { ETag = new EntityTagHeaderValue("\"33a64df551425fcc55e4d42a148795d9f25f89d4\"") }
+			};
+
+			// Act
+			var (configDelta, _) = _parser.ParseHttpResponse(response, "{}");
+
+			// Assert
+			configDelta.Should().NotBeNull();
+			configDelta.CaptureBody.Should().BeNull();
+			configDelta.TransactionMaxSpans.Should().BeNull();
+			configDelta.TransactionSampleRate.Should().BeNull();
+			configDelta.CaptureBodyContentTypes.Should().BeNull();
+		}
+
+		[Fact]
+		public void ParseHttpResponse_ShouldLogUnknownKeys()
+		{
+			// Arrange
+			var testLogger = new TestLogger(LogLevel.Information);
+			var parser = new CentralConfigResponseParser(testLogger);
+
+			var response = new HttpResponseMessage
+			{
+				StatusCode = HttpStatusCode.OK,
+				Headers = { ETag = new EntityTagHeaderValue("\"33a64df551425fcc55e4d42a148795d9f25f89d4\"") }
+			};
+
+			// Act
+			parser.ParseHttpResponse(response, "{\"unknownKey\": \"value\"}");
+
+			// Assert
+			testLogger.Lines.Count.Should().Be(1);
+			testLogger.Lines[0]
+				.Should()
+				.Contain(
+					"Central configuration response contains keys that are not in the list of options that can be changed after Agent start: `[unknownKey, value]'");
+		}
+	}
+}

--- a/test/Elastic.Apm.Tests/BackendCommTests/CentralConfig/CentralConfigResponseParserTests.cs
+++ b/test/Elastic.Apm.Tests/BackendCommTests/CentralConfig/CentralConfigResponseParserTests.cs
@@ -1,8 +1,11 @@
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using Elastic.Apm.BackendComm.CentralConfig;
+using Elastic.Apm.Config;
 using Elastic.Apm.Logging;
 using Elastic.Apm.Tests.Mocks;
 using FluentAssertions;
@@ -13,10 +16,16 @@ namespace Elastic.Apm.Tests.BackendCommTests.CentralConfig
 	public class CentralConfigResponseParserTests
 	{
 		private readonly CentralConfigResponseParser _parser;
+		private readonly HttpResponseMessage _correctResponse;
 
 		public CentralConfigResponseParserTests()
 		{
 			_parser = new CentralConfigResponseParser(new NoopLogger());
+			_correctResponse = new HttpResponseMessage
+			{
+				StatusCode = HttpStatusCode.OK,
+				Headers = { ETag = new EntityTagHeaderValue("\"33a64df551425fcc55e4d42a148795d9f25f89d4\"") }
+			};
 		}
 
 		[Fact]
@@ -61,8 +70,10 @@ namespace Elastic.Apm.Tests.BackendCommTests.CentralConfig
 			var response = new HttpResponseMessage { StatusCode = statusCode };
 
 			// Act + Assert
-			Assert.Throws<CentralConfigFetcher.FailedToFetchConfigException>(
+			var exception = Assert.Throws<CentralConfigFetcher.FailedToFetchConfigException>(
 				() => _parser.ParseHttpResponse(response, string.Empty));
+
+			exception.Message.Should().Contain("HTTP status code is ");
 		}
 
 		[Fact]
@@ -72,22 +83,17 @@ namespace Elastic.Apm.Tests.BackendCommTests.CentralConfig
 			var response = new HttpResponseMessage { StatusCode = HttpStatusCode.OK };
 
 			// Act + Assert
-			Assert.Throws<CentralConfigFetcher.FailedToFetchConfigException>(
+			var exception = Assert.Throws<CentralConfigFetcher.FailedToFetchConfigException>(
 				() => _parser.ParseHttpResponse(response, string.Empty));
+
+			exception.Message.Should().Contain("doesn't have ETag header");
 		}
 
 		[Fact]
 		public void ParseHttpResponse_ShouldReturnEmptyConfigDelta_WhenResponseBodyIsEmpty()
 		{
-			// Arrange
-			var response = new HttpResponseMessage
-			{
-				StatusCode = HttpStatusCode.OK,
-				Headers = { ETag = new EntityTagHeaderValue("\"33a64df551425fcc55e4d42a148795d9f25f89d4\"") }
-			};
-
-			// Act
-			var (configDelta, _) = _parser.ParseHttpResponse(response, "{}");
+			// Arrange + Act
+			var (configDelta, _) = _parser.ParseHttpResponse(_correctResponse, "{}");
 
 			// Assert
 			configDelta.Should().NotBeNull();
@@ -95,6 +101,10 @@ namespace Elastic.Apm.Tests.BackendCommTests.CentralConfig
 			configDelta.TransactionMaxSpans.Should().BeNull();
 			configDelta.TransactionSampleRate.Should().BeNull();
 			configDelta.CaptureBodyContentTypes.Should().BeNull();
+			configDelta.CaptureHeaders.Should().BeNull();
+			configDelta.LogLevel.Should().BeNull();
+			configDelta.SpanFramesMinDurationInMilliseconds.Should().BeNull();
+			configDelta.StackTraceLimit.Should().BeNull();
 		}
 
 		[Fact]
@@ -104,14 +114,8 @@ namespace Elastic.Apm.Tests.BackendCommTests.CentralConfig
 			var testLogger = new TestLogger(LogLevel.Information);
 			var parser = new CentralConfigResponseParser(testLogger);
 
-			var response = new HttpResponseMessage
-			{
-				StatusCode = HttpStatusCode.OK,
-				Headers = { ETag = new EntityTagHeaderValue("\"33a64df551425fcc55e4d42a148795d9f25f89d4\"") }
-			};
-
 			// Act
-			parser.ParseHttpResponse(response, "{\"unknownKey\": \"value\"}");
+			parser.ParseHttpResponse(_correctResponse, "{\"unknownKey\": \"value\"}");
 
 			// Assert
 			testLogger.Lines.Count.Should().Be(1);
@@ -119,6 +123,130 @@ namespace Elastic.Apm.Tests.BackendCommTests.CentralConfig
 				.Should()
 				.Contain(
 					"Central configuration response contains keys that are not in the list of options that can be changed after Agent start: `[unknownKey, value]'");
+		}
+
+		public static IEnumerable<object[]> ConfigDeltaData
+		{
+			get
+			{
+				foreach (var value in ConfigConsts.SupportedValues.CaptureBodySupportedValues)
+				{
+					yield return new object[]
+					{
+						$"{{\"{CentralConfigResponseParser.CentralConfigPayload.CaptureBodyKey}\": \"{value}\"}}",
+						new Action<CentralConfigReader>(cfg =>
+						{
+							cfg.CaptureBody.Should()
+								.NotBeNull()
+								.And.Be(value);
+						})
+					};
+				}
+
+				yield return new object[]
+				{
+					$"{{\"{CentralConfigResponseParser.CentralConfigPayload.TransactionMaxSpansKey}\": \"{100}\"}}",
+					new Action<CentralConfigReader>(cfg =>
+					{
+						cfg.TransactionMaxSpans.Should()
+							.NotBeNull()
+							.And.Be(100);
+					})
+				};
+
+				yield return new object[]
+				{
+					$"{{\"{CentralConfigResponseParser.CentralConfigPayload.TransactionSampleRateKey}\": \"{0.75}\"}}",
+					new Action<CentralConfigReader>(cfg =>
+					{
+						cfg.TransactionSampleRate.Should()
+							.NotBeNull()
+							.And.Be(0.75);
+					})
+				};
+
+				var captureBodyContentTypes = "application/x-www-form-urlencoded*, application/json*";
+				yield return new object[]
+				{
+					$"{{\"{CentralConfigResponseParser.CentralConfigPayload.CaptureBodyContentTypesKey}\": \"{captureBodyContentTypes}\"}}",
+					new Action<CentralConfigReader>(cfg =>
+					{
+						cfg.CaptureBodyContentTypes.Should()
+							.NotBeNull()
+							.And.BeEquivalentTo(captureBodyContentTypes.Split(',').Select(x => x.Trim()));
+					})
+				};
+
+				yield return new object[]
+				{
+					$"{{\"{CentralConfigResponseParser.CentralConfigPayload.StackTraceLimitKey}\": \"{150}\"}}",
+					new Action<CentralConfigReader>(cfg =>
+					{
+						cfg.StackTraceLimit.Should()
+							.NotBeNull()
+							.And.Be(150);
+					})
+				};
+
+				yield return new object[]
+				{
+					$"{{\"{CentralConfigResponseParser.CentralConfigPayload.SpanFramesMinDurationKey}\": \"{150}\"}}",
+					new Action<CentralConfigReader>(cfg =>
+					{
+						cfg.SpanFramesMinDurationInMilliseconds.Should()
+							.NotBeNull()
+							.And.Be(150);
+					})
+				};
+
+				yield return new object[]
+				{
+					$"{{\"{CentralConfigResponseParser.CentralConfigPayload.CaptureHeadersKey}\": \"{false}\"}}",
+					new Action<CentralConfigReader>(cfg =>
+					{
+						cfg.CaptureHeaders.Should()
+							.NotBeNull()
+							.And.Be(false);
+					})
+				};
+
+				yield return new object[]
+				{
+					$"{{\"{CentralConfigResponseParser.CentralConfigPayload.CaptureHeadersKey}\": \"{true}\"}}",
+					new Action<CentralConfigReader>(cfg =>
+					{
+						cfg.CaptureHeaders.Should()
+							.NotBeNull()
+							.And.Be(true);
+					})
+				};
+
+				foreach (var value in Enum.GetValues(typeof(LogLevel)))
+				{
+					yield return new object[]
+					{
+						$"{{\"{CentralConfigResponseParser.CentralConfigPayload.LogLevelKey}\": \"{value}\"}}",
+						new Action<CentralConfigReader>(cfg =>
+						{
+							cfg.LogLevel.Should()
+								.NotBeNull()
+								.And.Be(value);
+						})
+					};
+				}
+			}
+		}
+
+		[Theory]
+		[MemberData(nameof(ConfigDeltaData))]
+		internal void ParseHttpResponse_ShouldCorrectlyCalculateConfigDelta(string httpResponseBody, Action<CentralConfigReader> assert)
+		{
+			// Arrange + Act
+			var (configDelta, _) = _parser.ParseHttpResponse(_correctResponse, httpResponseBody);
+
+			// Assert
+			configDelta.Should().NotBeNull();
+			assert.Invoke(configDelta);
 		}
 	}
 }

--- a/test/Elastic.Apm.Tests/Mocks/NoopCentralConfigFetcher.cs
+++ b/test/Elastic.Apm.Tests/Mocks/NoopCentralConfigFetcher.cs
@@ -1,4 +1,5 @@
 using Elastic.Apm.BackendComm;
+using Elastic.Apm.BackendComm.CentralConfig;
 
 namespace Elastic.Apm.Tests.Mocks
 {

--- a/test/Elastic.Apm.Tests/Mocks/TestAgentComponents.cs
+++ b/test/Elastic.Apm.Tests/Mocks/TestAgentComponents.cs
@@ -1,4 +1,5 @@
 using Elastic.Apm.BackendComm;
+using Elastic.Apm.BackendComm.CentralConfig;
 using Elastic.Apm.Config;
 using Elastic.Apm.Logging;
 using Elastic.Apm.Report;


### PR DESCRIPTION
closes #794 

@gregkalapos, sorry, too late when I saw that you assigned the issue to yourself

### What was done

* Extract logic of reading HTTP response message and body to the `CentralConfigResponseParser` class. It allows covering such functionality by unit tests (`CentralConfigResponseParserTests`)
* Simplify central configuration:
  - Simplify `CentralConfigPayload` class: store all configuration options in the dictionary instead of inner properties
  - Remove the necessity of `ConfigDelta` class, which was used as a snapshot to not parse option value every time.
* Uncomment dynamic badges in docs for new central configuration options