### PR TITLE
ci(jenkins): opbeans bump from the tag releases

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -409,7 +409,6 @@ pipeline {
           when {
             anyOf {
               tag pattern: '\\d+\\.\\d+\\.\\d+', comparator: 'REGEXP'
-              expression { return params.Run_As_Master_Branch }
             }
           }
           stages {


### PR DESCRIPTION
## What

Disable opbeans for PRs or branches from the UI

## Why

When running the build from the Jenkins UI then this particular stage used to run and caused failures.
The stage is a post-release event therefore it should not be executed from PRs or branches that are not releases though.