### PR TITLE
Capture stack trace on span start for HttpClient

### DIFF
--- a/src/Elastic.Apm/DiagnosticListeners/HttpDiagnosticListenerImplBase.cs
+++ b/src/Elastic.Apm/DiagnosticListeners/HttpDiagnosticListenerImplBase.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
 using Elastic.Apm.Api;
@@ -130,7 +131,7 @@ namespace Elastic.Apm.DiagnosticListeners
 			}
 
 			var span = ExecutionSegmentCommon.StartSpanOnCurrentExecutionSegment(_agent, $"{RequestGetMethod(request)} {requestUrl.Host}",
-				ApiConstants.TypeExternal, ApiConstants.SubtypeHttp, InstrumentationFlag.HttpClient);
+				ApiConstants.TypeExternal, ApiConstants.SubtypeHttp, InstrumentationFlag.HttpClient, true);
 
 			if (!ProcessingRequests.TryAdd(request, span))
 			{

--- a/src/Elastic.Apm/DiagnosticListeners/HttpDiagnosticListenerImplBase.cs
+++ b/src/Elastic.Apm/DiagnosticListeners/HttpDiagnosticListenerImplBase.cs
@@ -5,7 +5,6 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
 using Elastic.Apm.Api;

--- a/src/Elastic.Apm/Model/ExecutionSegmentCommon.cs
+++ b/src/Elastic.Apm/Model/ExecutionSegmentCommon.cs
@@ -240,7 +240,7 @@ namespace Elastic.Apm.Model
 		internal static IExecutionSegment GetCurrentExecutionSegment(IApmAgent agent) =>
 			agent.Tracer.CurrentSpan ?? (IExecutionSegment)agent.Tracer.CurrentTransaction;
 
-		internal static Span StartSpanOnCurrentExecutionSegment(IApmAgent agent, string spanName, string spanType, string subType = null, InstrumentationFlag instrumentationFlag = InstrumentationFlag.None)
+		internal static Span StartSpanOnCurrentExecutionSegment(IApmAgent agent, string spanName, string spanType, string subType = null, InstrumentationFlag instrumentationFlag = InstrumentationFlag.None, bool captureStackTraceOnStart = false)
 		{
 			var currentExecutionSegment = GetCurrentExecutionSegment(agent);
 
@@ -249,8 +249,8 @@ namespace Elastic.Apm.Model
 
 			return currentExecutionSegment switch
 			{
-				Span span => span.StartSpanInternal(spanName, spanType, subType, instrumentationFlag: instrumentationFlag),
-				Transaction transaction => transaction.StartSpanInternal(spanName, spanType, subType, instrumentationFlag: instrumentationFlag),
+				Span span => span.StartSpanInternal(spanName, spanType, subType, instrumentationFlag: instrumentationFlag, captureStackTraceOnStart: captureStackTraceOnStart),
+				Transaction transaction => transaction.StartSpanInternal(spanName, spanType, subType, instrumentationFlag: instrumentationFlag, captureStackTraceOnStart: captureStackTraceOnStart),
 				_ => null
 			};
 		}

--- a/src/Elastic.Apm/Model/Span.cs
+++ b/src/Elastic.Apm/Model/Span.cs
@@ -27,6 +27,14 @@ namespace Elastic.Apm.Model
 		private readonly Span _parentSpan;
 		private readonly IPayloadSender _payloadSender;
 
+		/// <summary>
+		/// In some cases capturing the stacktrace in <see cref="End"/> results in a stack trace which is not very useful.
+		/// In such cases we capture the stacktrace on span start.
+		/// These are typically async calls - e.g. capturing stacktrace for outgoing HTTP requests in the System.Net.Http.HttpRequestOut.Stop
+		/// diagnostic source event produces a stack trace that does not contain the caller method in user code - therefore we capture the stacktrace is .Start
+		/// </summary>
+		private readonly StackFrame[] _stackFrames;
+
 		// This constructor is meant for deserialization
 		[JsonConstructor]
 		private Span(double duration, string id, string name, string parentId)
@@ -47,7 +55,8 @@ namespace Elastic.Apm.Model
 			IApmLogger logger,
 			ICurrentExecutionSegmentsContainer currentExecutionSegmentsContainer,
 			Span parentSpan = null,
-			InstrumentationFlag instrumentationFlag = InstrumentationFlag.None
+			InstrumentationFlag instrumentationFlag = InstrumentationFlag.None,
+			bool captureStackTraceOnStart = false
 		)
 		{
 			InstrumentationFlag = instrumentationFlag;
@@ -75,7 +84,12 @@ namespace Elastic.Apm.Model
 					enclosingTransaction.SpanCount.IncrementDropped();
 				}
 				else
+				{
 					enclosingTransaction.SpanCount.IncrementStarted();
+
+					if(captureStackTraceOnStart)
+						_stackFrames = new StackTrace(true).GetFrames();
+				}
 			}
 
 			_currentExecutionSegmentsContainer.CurrentSpan = this;
@@ -183,11 +197,11 @@ namespace Elastic.Apm.Model
 			=> StartSpanInternal(name, type, subType, action);
 
 		internal Span StartSpanInternal(string name, string type, string subType = null, string action = null,
-			InstrumentationFlag instrumentationFlag = InstrumentationFlag.None
+			InstrumentationFlag instrumentationFlag = InstrumentationFlag.None, bool captureStackTraceOnStart = false
 		)
 		{
 			var retVal = new Span(name, type, Id, TraceId, _enclosingTransaction, _payloadSender, _logger, _currentExecutionSegmentsContainer, this,
-				instrumentationFlag);
+				instrumentationFlag, captureStackTraceOnStart);
 
 			if (!string.IsNullOrEmpty(subType)) retVal.Subtype = subType;
 
@@ -237,7 +251,7 @@ namespace Elastic.Apm.Model
 					if (Duration >= ConfigSnapshot.SpanFramesMinDurationInMilliseconds
 						|| ConfigSnapshot.SpanFramesMinDurationInMilliseconds < 0)
 					{
-						StackTrace = StacktraceHelper.GenerateApmStackTrace(new StackTrace(true).GetFrames(), _logger,
+						StackTrace = StacktraceHelper.GenerateApmStackTrace(_stackFrames ?? new StackTrace(true).GetFrames(), _logger,
 							ConfigSnapshot, $"Span `{Name}'");
 					}
 				}

--- a/src/Elastic.Apm/Model/Transaction.cs
+++ b/src/Elastic.Apm/Model/Transaction.cs
@@ -303,10 +303,11 @@ namespace Elastic.Apm.Model
 			=> StartSpanInternal(name, type, subType, action);
 
 		internal Span StartSpanInternal(string name, string type, string subType = null, string action = null,
-			InstrumentationFlag instrumentationFlag = InstrumentationFlag.None
+			InstrumentationFlag instrumentationFlag = InstrumentationFlag.None, bool captureStackTraceOnStart = false
 		)
 		{
-			var retVal = new Span(name, type, Id, TraceId, this, _sender, _logger, _currentExecutionSegmentsContainer, instrumentationFlag: instrumentationFlag);
+			var retVal = new Span(name, type, Id, TraceId, this, _sender, _logger, _currentExecutionSegmentsContainer,
+				instrumentationFlag: instrumentationFlag, captureStackTraceOnStart: captureStackTraceOnStart);
 
 			if (!string.IsNullOrEmpty(subType)) retVal.Subtype = subType;
 

--- a/test/Elastic.Apm.Tests/HttpDiagnosticListenerTests.cs
+++ b/test/Elastic.Apm.Tests/HttpDiagnosticListenerTests.cs
@@ -739,8 +739,15 @@ namespace Elastic.Apm.Tests
 		{
 			var (_, payloadSender, _) = RegisterListenerAndStartTransaction();
 
-			var httpClient = new HttpClient();
-			await httpClient.GetAsync("https://elastic.co");
+			try
+			{
+				var httpClient = new HttpClient();
+				await httpClient.GetAsync("https://elastic.co");
+			}
+			catch (Exception e)
+			{
+				// ignore - only thing we care about in this stack is the callstack.
+			}
 
 			payloadSender.FirstSpan.StackTrace.Should().NotBeNull();
 			payloadSender.FirstSpan.StackTrace.Should().Contain(n => n.Function.Contains(nameof(CallStackContainsCallerMethod)));

--- a/test/Elastic.Apm.Tests/HttpDiagnosticListenerTests.cs
+++ b/test/Elastic.Apm.Tests/HttpDiagnosticListenerTests.cs
@@ -741,6 +741,11 @@ namespace Elastic.Apm.Tests
 
 			try
 			{
+				ServicePointManager.Expect100Continue = true;
+				ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls
+					| SecurityProtocolType.Tls11
+					| SecurityProtocolType.Tls12;
+
 				var httpClient = new HttpClient();
 				await httpClient.GetAsync("https://elastic.co");
 			}

--- a/test/Elastic.Apm.Tests/HttpDiagnosticListenerTests.cs
+++ b/test/Elastic.Apm.Tests/HttpDiagnosticListenerTests.cs
@@ -747,7 +747,7 @@ namespace Elastic.Apm.Tests
 					| SecurityProtocolType.Tls12;
 
 				var httpClient = new HttpClient();
-				await httpClient.GetAsync("https://elastic.co");
+				await httpClient.GetAsync("http://elastic.co");
 			}
 			catch (Exception e)
 			{

--- a/test/Elastic.Apm.Tests/HttpDiagnosticListenerTests.cs
+++ b/test/Elastic.Apm.Tests/HttpDiagnosticListenerTests.cs
@@ -734,7 +734,7 @@ namespace Elastic.Apm.Tests
 		/// <summary>
 		/// Makes sure that in case of an async outgoing http call the caller method shows up in the captured callstack
 		/// </summary>
-		[Fact]
+		[NetCoreFact]
 		public async Task CallStackContainsCallerMethod()
 		{
 			var (_, payloadSender, _) = RegisterListenerAndStartTransaction();

--- a/test/Elastic.Apm.Tests/HttpDiagnosticListenerTests.cs
+++ b/test/Elastic.Apm.Tests/HttpDiagnosticListenerTests.cs
@@ -741,17 +741,13 @@ namespace Elastic.Apm.Tests
 
 			try
 			{
-				ServicePointManager.Expect100Continue = true;
-				ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls
-					| SecurityProtocolType.Tls11
-					| SecurityProtocolType.Tls12;
-
+				using var localServer = new LocalServer();
 				var httpClient = new HttpClient();
-				await httpClient.GetAsync("http://elastic.co");
+				await httpClient.GetAsync(localServer.Uri);
 			}
-			catch (Exception e)
+			catch (Exception)
 			{
-				// ignore - only thing we care about in this stack is the callstack.
+				// ignore - only thing we care about in this stack is the stack trace.
 			}
 
 			payloadSender.FirstSpan.StackTrace.Should().NotBeNull();

--- a/test/Elastic.Apm.Tests/HttpDiagnosticListenerTests.cs
+++ b/test/Elastic.Apm.Tests/HttpDiagnosticListenerTests.cs
@@ -731,6 +731,21 @@ namespace Elastic.Apm.Tests
 			logger.Lines.Should().NotContain(line => line.ToLower().Contains("warn"));
 		}
 
+		/// <summary>
+		/// Makes sure that in case of an async outgoing http call the caller method shows up in the captured callstack
+		/// </summary>
+		[Fact]
+		public async Task CallStackContainsCallerMethod()
+		{
+			var (_, payloadSender, _) = RegisterListenerAndStartTransaction();
+
+			var httpClient = new HttpClient();
+			await httpClient.GetAsync("https://elastic.co");
+
+			payloadSender.FirstSpan.StackTrace.Should().NotBeNull();
+			payloadSender.FirstSpan.StackTrace.Should().Contain(n => n.Function.Contains(nameof(CallStackContainsCallerMethod)));
+		}
+
 		internal static (IDisposable, MockPayloadSender, ApmAgent) RegisterListenerAndStartTransaction()
 		{
 			var payloadSender = new MockPayloadSender();


### PR DESCRIPTION
Solves #844

Implements https://github.com/elastic/apm-agent-dotnet/issues/844#issuecomment-626821726. 

Stacktrace prior to this PR (caller code in user code is not visible - because we captured the stack in `Span.End()` called during the 2. diagnostic source call):
<img width="1121" alt="Screen Shot 2020-05-11 at 22 57 57" src="https://user-images.githubusercontent.com/1091853/81613396-b2340d80-93de-11ea-9dbe-601700e14b01.png">

Stacktrace after this PR (user code shows up):
<img width="1204" alt="Screen Shot 2020-05-11 at 22 58 09" src="https://user-images.githubusercontent.com/1091853/81613466-d263cc80-93de-11ea-8f21-706fa985b3ea.png">


More stack frame improvements coming...