### PR TITLE
docs: Keep troubleshooting on one page

### DIFF
--- a/docs/troubleshooting.asciidoc
+++ b/docs/troubleshooting.asciidoc
@@ -28,21 +28,27 @@ it's a good idea to first check your logs and look for output just as the app st
 
 If you don't see anything suspicious in the agent logs (no warning or error), it's recommended to turn the log level to `Trace` for further investigation.
 
+[float]
+[[collect-agent-logs]]
 === Collecting agent logs
 
 The way to collect logs depends on the setup of your application.
 
-==== ASP.NET Core 
+[float]
+[[collect-logs-core]]
+==== ASP.NET Core
 
 When the Agent is activated with `UseAllElasticApm` or `UseElasticApm`, it will integrate with the
 https://docs.microsoft.com/en-us/aspnet/core/fundamentals/logging/?view=aspnetcore-3.1[ASP.NET Core logging infrastructure].
 This means the Agent will pick up the configured logging provider and log as any other component logs.
 
+[float]
+[[collect-logs-classic]]
 ==== ASP.NET Classic
 
 Unlike ASP.NET Core, ASP.NET (classic) does not have a predefined logging system.
 However, if you have a logging system in place, like NLog, Serilog, or similar, you can direct the agent logs into your
-logging system by creating a bridge between the agent's internal logger and your logging system. 
+logging system by creating a bridge between the agent's internal logger and your logging system.
 
 First implement the `IApmLogger` interface from the `Elastic.Apm.Logging` namespace:
 
@@ -79,7 +85,8 @@ AgentDependencies.Logger = new ApmLoggerBridge();
 The `AgentDependencies` class lives in the `Elastic.Apm.AspNetFullFramework` namespace.
 During initialization, the agent checks if an additional logger was configured--the agent only does this once, so it's important to set it as early in the process as possible (typically in the `Application_Start` method).
 
-
+[float]
+[[collect-logs-general]]
 ==== General .NET applications
 
 If none of the above cases apply to your application, you can still use a bridge and redirect agent logs into a .NET logging system (like NLog, Serilog, or similar).


### PR DESCRIPTION
A `[float]` tag was missing from the troubleshooting documentation which caused it to flow onto two pages. This PR adds the missing `[float]` tag and four URL slugs.

<img width="1143" alt="Screen Shot 2020-05-11 at 4 43 16 PM" src="https://user-images.githubusercontent.com/5618806/81622839-edb2e580-93a6-11ea-9d50-1dccfa67470d.png">