### PR TITLE
Error capturing  improvements: better async stack traces + make fields public

### DIFF
--- a/sample/ApiSamples/Program.cs
+++ b/sample/ApiSamples/Program.cs
@@ -183,6 +183,52 @@ namespace ApiSamples
 		private static void WriteLineToConsole(string line) =>
 			Console.WriteLine($"[{Process.GetCurrentProcess().Id}] {line}");
 
+		/// <summary>
+		/// Registers some sample filters.
+		/// </summary>
+		// ReSharper disable once UnusedMember.Local
+		private static void FilterSample()
+		{
+			Agent.AddFilter((ITransaction transaction) =>
+			{
+				transaction.Name = "NewTransactionName";
+				return transaction;
+			});
+
+			Agent.AddFilter((ITransaction transaction) =>
+			{
+				transaction.Type = "NewSpanName";
+				return transaction;
+			});
+
+			Agent.AddFilter((ISpan span) =>
+			{
+				span.Name = "NewSpanName";
+				return span;
+			});
+
+			Agent.AddFilter(span =>
+			{
+				if (span.StackTrace.Count > 10)
+					span.StackTrace.RemoveRange(10, span.StackTrace.Count - 10);
+
+				return span;
+			});
+
+			Agent.AddFilter(error =>
+			{
+				if (error.Culprit == "SecretComponent")
+					return null;
+
+				if (error.Exception.Type == "SecretType")
+					error.Exception.Message = "[HIDDEN]";
+
+				Console.WriteLine(
+					$"Error printed in a filter - culprit: {error.Culprit}, id: {error.Id}, parentId: {error.ParentId}, traceId: {error.TraceId}, transactionId: {error.TransactionId}");
+				return error;
+			});
+		}
+
 		// ReSharper disable ArrangeMethodOrOperatorBody
 		public static void SampleSpanWithCustomContext()
 		{
@@ -211,43 +257,11 @@ namespace ApiSamples
 					{
 						span.Context.Db = new Database
 						{
-							Statement = "GET /_all/_search?q=tag:wow",
-							Type = Database.TypeElasticsearch,
-							Instance = "MyInstance"
+							Statement = "GET /_all/_search?q=tag:wow", Type = Database.TypeElasticsearch, Instance = "MyInstance"
 						};
 					});
 			});
 		}
 		// ReSharper restore ArrangeMethodOrOperatorBody
-
-		/// <summary>
-		/// Registers some sample filters.
-		/// </summary>
-		// ReSharper disable once UnusedMember.Local
-		private static void FilterSample()
-		{
-			Agent.AddFilter((ITransaction transaction) => {
-				transaction.Name = "NewTransactionName";
-				return transaction;
-			});
-
-			Agent.AddFilter((ITransaction transaction) =>
-			{
-				transaction.Type = "NewSpanName";
-				return transaction;
-			});
-
-			Agent.AddFilter((ISpan span) =>
-			{
-				span.Name = "NewSpanName";
-				return span;
-			});
-
-			Agent.AddFilter((IError error) =>
-			{
-				Console.WriteLine($"Error id printed in a filter: {error.Id}");
-				return error;
-			});
-		}
 	}
 }

--- a/sample/SampleAspNetCoreApp/Controllers/HomeController.cs
+++ b/sample/SampleAspNetCoreApp/Controllers/HomeController.cs
@@ -8,6 +8,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Net.Http;
+using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using Elastic.Apm;
 using Elastic.Apm.Api;
@@ -188,6 +189,32 @@ namespace SampleAspNetCoreApp.Controllers
 				Agent.Tracer.CurrentTransaction.Name = $"{HttpContext.Request.Method} {HttpContext.Request.Path}";
 			return Ok();
 		}
+
+		public async Task<IActionResult> VeryAsyncCall()
+		{
+			await T1();
+			return Ok();
+		}
+
+		[MethodImpl(MethodImplOptions.NoInlining)]
+		private async Task T1()
+		{
+			await Task.Delay(1);
+			await T2();
+		}
+
+		[MethodImpl(MethodImplOptions.NoInlining)]
+		private async Task T2()
+			=> await T3();
+
+		[MethodImpl(MethodImplOptions.NoInlining)]
+		private async Task T3()
+		{
+			await Task.Delay(1);
+			throw new Exception("This is a test exception");
+		}
+
+
 
 		[ResponseCache(Duration = 0, Location = ResponseCacheLocation.None, NoStore = true)]
 		public IActionResult Error() => View(new ErrorViewModel { RequestId = Activity.Current?.Id ?? HttpContext.TraceIdentifier });

--- a/sample/SampleAspNetCoreApp/Controllers/HomeController.cs
+++ b/sample/SampleAspNetCoreApp/Controllers/HomeController.cs
@@ -214,8 +214,6 @@ namespace SampleAspNetCoreApp.Controllers
 			throw new Exception("This is a test exception");
 		}
 
-
-
 		[ResponseCache(Duration = 0, Location = ResponseCacheLocation.None, NoStore = true)]
 		public IActionResult Error() => View(new ErrorViewModel { RequestId = Activity.Current?.Id ?? HttpContext.TraceIdentifier });
 

--- a/src/Elastic.Apm/Api/CapturedException.cs
+++ b/src/Elastic.Apm/Api/CapturedException.cs
@@ -7,9 +7,9 @@ using Elastic.Apm.Helpers;
 using Elastic.Apm.Report.Serialization;
 using Newtonsoft.Json;
 
-namespace Elastic.Apm.Model
+namespace Elastic.Apm.Api
 {
-	internal class CapturedException
+	public class CapturedException
 	{
 		[JsonConverter(typeof(TrimmedStringJsonConverter))]
 		public string Code { get; set; }

--- a/src/Elastic.Apm/Api/CapturedStackFrame.cs
+++ b/src/Elastic.Apm/Api/CapturedStackFrame.cs
@@ -19,9 +19,6 @@ namespace Elastic.Apm.Api
 
 		public string Function { get; set; }
 
-		[JsonProperty("classname")]
-		public string ClassName { get; set; }
-
 		/// <summary>
 		/// The line number of code part of the stack frame.
 		/// Zero value means the actual line number could not have been obtained.

--- a/src/Elastic.Apm/Api/CapturedStackFrame.cs
+++ b/src/Elastic.Apm/Api/CapturedStackFrame.cs
@@ -4,9 +4,9 @@
 
 using Newtonsoft.Json;
 
-namespace Elastic.Apm.Model
+namespace Elastic.Apm.Api
 {
-	internal class CapturedStackFrame
+	public class CapturedStackFrame
 	{
 		/// <summary>
 		/// The absolute path of the file involved in the stack frame.
@@ -18,6 +18,9 @@ namespace Elastic.Apm.Model
 		public string FileName { get; set; }
 
 		public string Function { get; set; }
+
+		[JsonProperty("classname")]
+		public string ClassName { get; set; }
 
 		/// <summary>
 		/// The line number of code part of the stack frame.

--- a/src/Elastic.Apm/Api/IError.cs
+++ b/src/Elastic.Apm/Api/IError.cs
@@ -6,6 +6,15 @@ namespace Elastic.Apm.Api
 {
 	public interface IError
 	{
+		string Culprit { get; set; }
+
+		CapturedException Exception { get; }
 		string Id { get; }
+
+		string ParentId { get; }
+
+		string TraceId { get; }
+
+		string TransactionId { get; }
 	}
 }

--- a/src/Elastic.Apm/Api/IError.cs
+++ b/src/Elastic.Apm/Api/IError.cs
@@ -4,17 +4,40 @@
 
 namespace Elastic.Apm.Api
 {
+	/// <summary>
+	/// Represents an error which was captured by the agent.
+	/// </summary>
 	public interface IError
 	{
+		/// <summary>
+		/// The culprit that caused this error.
+		/// </summary>
 		string Culprit { get; set; }
 
+		/// <summary>
+		/// In case the error instance was caused by an exception, this property contains all the
+		/// details about the exception.
+		/// </summary>
 		CapturedException Exception { get; }
+
+		/// <summary>
+		/// The Id of the error. This unequally identifies the given error.
+		/// </summary>
 		string Id { get; }
 
+		/// <summary>
+		/// The Parent id of the error
+		/// </summary>
 		string ParentId { get; }
 
+		/// <summary>
+		/// The id of the trace where this error happened
+		/// </summary>
 		string TraceId { get; }
 
+		/// <summary>
+		/// The id of the transaction where this error happened
+		/// </summary>
 		string TransactionId { get; }
 	}
 }

--- a/src/Elastic.Apm/Api/ISpan.cs
+++ b/src/Elastic.Apm/Api/ISpan.cs
@@ -2,6 +2,8 @@
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
 
+using System.Collections.Generic;
+
 namespace Elastic.Apm.Api
 {
 	public interface ISpan : IExecutionSegment
@@ -16,6 +18,11 @@ namespace Elastic.Apm.Api
 		/// Any other arbitrary data captured by the agent, optionally provided by the user.
 		/// </summary>
 		SpanContext Context { get; }
+
+		/// <summary>
+		/// The stack trace which was captured for the given span.
+		/// </summary>
+		List<CapturedStackFrame> StackTrace { get; }
 
 		/// <summary>
 		/// The subtype of the span.

--- a/src/Elastic.Apm/BackendComm/CentralConfig/CentralConfigFetcher.cs
+++ b/src/Elastic.Apm/BackendComm/CentralConfig/CentralConfigFetcher.cs
@@ -33,10 +33,8 @@ namespace Elastic.Apm.BackendComm.CentralConfig
 		internal CentralConfigFetcher(IApmLogger logger, IConfigStore configStore, ICentralConfigResponseParser centralConfigResponseParser,
 			Service service,
 			HttpMessageHandler httpMessageHandler = null, IAgentTimer agentTimer = null, string dbgName = null
-		) : this(logger, configStore, configStore.CurrentSnapshot, service, httpMessageHandler, agentTimer, dbgName)
-		{
+		) : this(logger, configStore, configStore.CurrentSnapshot, service, httpMessageHandler, agentTimer, dbgName) =>
 			_centralConfigResponseParser = centralConfigResponseParser;
-		}
 
 		internal CentralConfigFetcher(IApmLogger logger, IConfigStore configStore, Service service
 			, HttpMessageHandler httpMessageHandler = null, IAgentTimer agentTimer = null, string dbgName = null

--- a/src/Elastic.Apm/BackendComm/CentralConfig/CentralConfigResponseParser.cs
+++ b/src/Elastic.Apm/BackendComm/CentralConfig/CentralConfigResponseParser.cs
@@ -19,10 +19,7 @@ namespace Elastic.Apm.BackendComm.CentralConfig
 
 		internal static readonly TimeSpan WaitTimeIfNoCacheControlMaxAge = TimeSpan.FromMinutes(5);
 
-		internal CentralConfigResponseParser(IApmLogger logger)
-		{
-			_logger = logger?.Scoped(nameof(CentralConfigResponseParser));
-		}
+		internal CentralConfigResponseParser(IApmLogger logger) => _logger = logger?.Scoped(nameof(CentralConfigResponseParser));
 
 		public (CentralConfigReader, CentralConfigFetcher.WaitInfoS) ParseHttpResponse(HttpResponseMessage httpResponse,
 			string httpResponseBody
@@ -155,10 +152,7 @@ namespace Elastic.Apm.BackendComm.CentralConfig
 
 			private readonly IDictionary<string, string> _keyValues;
 
-			public CentralConfigPayload(IDictionary<string, string> keyValues)
-			{
-				_keyValues = keyValues;
-			}
+			public CentralConfigPayload(IDictionary<string, string> keyValues) => _keyValues = keyValues;
 
 			[JsonIgnore]
 			public IEnumerable<KeyValuePair<string, string>> UnknownKeys => _keyValues.Where(x => !SupportedOptions.Contains(x.Key));

--- a/src/Elastic.Apm/Elastic.Apm.csproj
+++ b/src/Elastic.Apm/Elastic.Apm.csproj
@@ -17,5 +17,6 @@
     <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="2.0.2" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
     <PackageReference Include="System.Threading.Tasks.Dataflow" Version="4.9.0" />
+    <PackageReference Include="Ben.Demystifier" Version="0.1.6" />
   </ItemGroup>
 </Project>

--- a/src/Elastic.Apm/Helpers/StacktraceHelper.cs
+++ b/src/Elastic.Apm/Helpers/StacktraceHelper.cs
@@ -53,23 +53,19 @@ namespace Elastic.Apm.Helpers
 			{
 				foreach (var frame in frames)
 				{
-					var className = frame?.GetMethod()
+					var fileName = frame?.GetMethod()
 						?.DeclaringType?.FullName; //see: https://github.com/elastic/apm-agent-dotnet/pull/240#discussion_r289619196
 
 					var functionName = GetRealMethodName(frame?.GetMethod());
-					var fileName = frame?.GetFileName();
 
 					logger.Trace()?.Log("{MethodName}, {lineNo}", functionName, frame?.GetFileLineNumber());
 
 					retVal.Add(new CapturedStackFrame
 					{
 						Function = functionName ?? "N/A",
-						ClassName = string.IsNullOrWhiteSpace(className) ? "N/A" : className,
+						FileName = string.IsNullOrWhiteSpace(fileName) ? "N/A" : fileName,
 						Module = frame?.GetMethod()?.ReflectedType?.Assembly.FullName,
 						LineNo = frame?.GetFileLineNumber() ?? 0,
-						FileName = string.IsNullOrWhiteSpace(fileName)
-							? string.IsNullOrEmpty(frame?.GetMethod()?.Module.Name) ? "n/a" : frame.GetMethod()?.Module.Name
-							: fileName,
 						AbsPath = frame?.GetFileName() // optional property
 					});
 				}

--- a/src/Elastic.Apm/Helpers/StacktraceHelper.cs
+++ b/src/Elastic.Apm/Helpers/StacktraceHelper.cs
@@ -8,9 +8,9 @@ using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.CompilerServices;
+using Elastic.Apm.Api;
 using Elastic.Apm.Config;
 using Elastic.Apm.Logging;
-using Elastic.Apm.Model;
 
 namespace Elastic.Apm.Helpers
 {
@@ -53,19 +53,23 @@ namespace Elastic.Apm.Helpers
 			{
 				foreach (var frame in frames)
 				{
-					var fileName = frame?.GetMethod()
+					var className = frame?.GetMethod()
 						?.DeclaringType?.FullName; //see: https://github.com/elastic/apm-agent-dotnet/pull/240#discussion_r289619196
 
 					var functionName = GetRealMethodName(frame?.GetMethod());
+					var fileName = frame?.GetFileName();
 
 					logger.Trace()?.Log("{MethodName}, {lineNo}", functionName, frame?.GetFileLineNumber());
 
 					retVal.Add(new CapturedStackFrame
 					{
 						Function = functionName ?? "N/A",
-						FileName = string.IsNullOrWhiteSpace(fileName) ? "N/A" : fileName,
+						ClassName = string.IsNullOrWhiteSpace(className) ? "N/A" : className,
 						Module = frame?.GetMethod()?.ReflectedType?.Assembly.FullName,
 						LineNo = frame?.GetFileLineNumber() ?? 0,
+						FileName = string.IsNullOrWhiteSpace(fileName)
+							? string.IsNullOrEmpty(frame?.GetMethod()?.Module.Name) ? "n/a" : frame.GetMethod()?.Module.Name
+							: fileName,
 						AbsPath = frame?.GetFileName() // optional property
 					});
 				}

--- a/src/Elastic.Apm/Helpers/StacktraceHelper.cs
+++ b/src/Elastic.Apm/Helpers/StacktraceHelper.cs
@@ -106,7 +106,7 @@ namespace Elastic.Apm.Helpers
 			try
 			{
 				return GenerateApmStackTrace(
-					new StackTrace(exception, true).GetFrames(), logger, configurationReader, dbgCapturingFor);
+					new EnhancedStackTrace(exception).GetFrames(), logger, configurationReader, dbgCapturingFor);
 			}
 			catch (Exception e)
 			{

--- a/test/Elastic.Apm.Tests.MockApmServer/ErrorDto.cs
+++ b/test/Elastic.Apm.Tests.MockApmServer/ErrorDto.cs
@@ -2,6 +2,7 @@
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
 
+using Elastic.Apm.Api;
 using Elastic.Apm.Helpers;
 using Elastic.Apm.Model;
 using FluentAssertions;

--- a/test/Elastic.Apm.Tests.MockApmServer/SpanDto.cs
+++ b/test/Elastic.Apm.Tests.MockApmServer/SpanDto.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information
 
 using System.Collections.Generic;
+using Elastic.Apm.Api;
 using Elastic.Apm.Helpers;
 using Elastic.Apm.Model;
 using Newtonsoft.Json;


### PR DESCRIPTION
Addresses https://github.com/elastic/apm-agent-dotnet/issues/758 and https://github.com/elastic/apm-agent-dotnet/issues/6

2 main improvements:


- Making things in `IError` public. This will also allow doing more in Filters. 
- Using [`Ben.Demystifier`](https://github.com/benaadams/Ben.Demystifier) to capture nicer stack traces.


Sample for async improvement.

Code:

```
public async Task<IActionResult> VeryAsyncCall()
{
	await T1();
	return Ok();
}
[MethodImpl(MethodImplOptions.NoInlining)]
private async Task T1()
{
	await Task.Delay(1);
	await T2();
}
[MethodImpl(MethodImplOptions.NoInlining)]
private async Task T2()
	=> await T3();
[MethodImpl(MethodImplOptions.NoInlining)]
private async Task T3()
{
	await Task.Delay(1);
	throw new Exception("This is a test exception");
}
```

What we showed prior to this PR:

<img width="1176" alt="image" src="https://user-images.githubusercontent.com/1091853/81751059-fc84bf80-94ae-11ea-84a0-9fa4925bd3fc.png">

What we show with this PR:

<img width="1392" alt="image" src="https://user-images.githubusercontent.com/1091853/81750906-b3347000-94ae-11ea-9685-709903be7170.png">
