### PR TITLE
Calculate self-time of transactions and spans (part of agent breakdown metrics)

### DIFF
--- a/src/Elastic.Apm/BackendComm/CentralConfig/CentralConfigFetcher.cs
+++ b/src/Elastic.Apm/BackendComm/CentralConfig/CentralConfigFetcher.cs
@@ -276,6 +276,7 @@ namespace Elastic.Apm.BackendComm.CentralConfig
 			public bool VerifyServerCert => _wrapped.VerifyServerCert;
 			public IReadOnlyCollection<string> ExcludedNamespaces => _wrapped.ExcludedNamespaces;
 			public IReadOnlyCollection<string> ApplicationNamespaces => _wrapped.ApplicationNamespaces;
+			public bool BreakdownMetrics => _wrapped.BreakdownMetrics;
 		}
 	}
 }

--- a/src/Elastic.Apm/BackendComm/CentralConfig/CentralConfigFetcher.cs
+++ b/src/Elastic.Apm/BackendComm/CentralConfig/CentralConfigFetcher.cs
@@ -33,10 +33,8 @@ namespace Elastic.Apm.BackendComm.CentralConfig
 		internal CentralConfigFetcher(IApmLogger logger, IConfigStore configStore, ICentralConfigResponseParser centralConfigResponseParser,
 			Service service,
 			HttpMessageHandler httpMessageHandler = null, IAgentTimer agentTimer = null, string dbgName = null
-		) : this(logger, configStore, configStore.CurrentSnapshot, service, httpMessageHandler, agentTimer, dbgName)
-		{
+		) : this(logger, configStore, configStore.CurrentSnapshot, service, httpMessageHandler, agentTimer, dbgName) =>
 			_centralConfigResponseParser = centralConfigResponseParser;
-		}
 
 		internal CentralConfigFetcher(IApmLogger logger, IConfigStore configStore, Service service
 			, HttpMessageHandler httpMessageHandler = null, IAgentTimer agentTimer = null, string dbgName = null

--- a/src/Elastic.Apm/BackendComm/CentralConfig/CentralConfigResponseParser.cs
+++ b/src/Elastic.Apm/BackendComm/CentralConfig/CentralConfigResponseParser.cs
@@ -19,10 +19,7 @@ namespace Elastic.Apm.BackendComm.CentralConfig
 
 		internal static readonly TimeSpan WaitTimeIfNoCacheControlMaxAge = TimeSpan.FromMinutes(5);
 
-		internal CentralConfigResponseParser(IApmLogger logger)
-		{
-			_logger = logger?.Scoped(nameof(CentralConfigResponseParser));
-		}
+		internal CentralConfigResponseParser(IApmLogger logger) => _logger = logger?.Scoped(nameof(CentralConfigResponseParser));
 
 		public (CentralConfigReader, CentralConfigFetcher.WaitInfoS) ParseHttpResponse(HttpResponseMessage httpResponse,
 			string httpResponseBody
@@ -155,10 +152,7 @@ namespace Elastic.Apm.BackendComm.CentralConfig
 
 			private readonly IDictionary<string, string> _keyValues;
 
-			public CentralConfigPayload(IDictionary<string, string> keyValues)
-			{
-				_keyValues = keyValues;
-			}
+			public CentralConfigPayload(IDictionary<string, string> keyValues) => _keyValues = keyValues;
 
 			[JsonIgnore]
 			public IEnumerable<KeyValuePair<string, string>> UnknownKeys => _keyValues.Where(x => !SupportedOptions.Contains(x.Key));

--- a/src/Elastic.Apm/Config/AbstractConfigurationReader.cs
+++ b/src/Elastic.Apm/Config/AbstractConfigurationReader.cs
@@ -140,6 +140,7 @@ namespace Elastic.Apm.Config
 		protected bool ParseVerifyServerCert(ConfigurationKeyValue kv)
 		{
 			if (kv == null || string.IsNullOrEmpty(kv.Value)) return DefaultValues.VerifyServerCert;
+
 			// ReSharper disable once SimplifyConditionalTernaryExpression
 			return bool.TryParse(kv.Value, out var value) ? value : DefaultValues.VerifyServerCert;
 		}
@@ -724,6 +725,8 @@ namespace Elastic.Apm.Config
 		}
 
 		protected bool ParseCentralConfig(ConfigurationKeyValue kv) => ParseBoolOption(kv, DefaultValues.CentralConfig, "CentralConfig");
+
+		protected bool ParseBreakdownMetrics(ConfigurationKeyValue kv) => ParseBoolOption(kv, DefaultValues.BreakdownMetrics, "BreakdownMetrics");
 
 		private bool ParseBoolOption(ConfigurationKeyValue kv, bool defaultValue, string dbgOptionName)
 		{

--- a/src/Elastic.Apm/Config/AbstractConfigurationWithEnvFallbackReader.cs
+++ b/src/Elastic.Apm/Config/AbstractConfigurationWithEnvFallbackReader.cs
@@ -95,11 +95,14 @@ namespace Elastic.Apm.Config
 
 		public virtual bool VerifyServerCert =>
 			ParseVerifyServerCert(Read(ConfigConsts.KeyNames.VerifyServerCert, ConfigConsts.EnvVarNames.VerifyServerCert));
-		
-		public IReadOnlyCollection<string> ExcludedNamespaces => 
+
+		public IReadOnlyCollection<string> ExcludedNamespaces =>
 			ParseExcludedNamespaces(Read(ConfigConsts.KeyNames.ExcludedNamespaces, ConfigConsts.EnvVarNames.ExcludedNamespaces));
 
-		public IReadOnlyCollection<string> ApplicationNamespaces => 
+		public IReadOnlyCollection<string> ApplicationNamespaces =>
 			ParseExcludedNamespaces(Read(ConfigConsts.KeyNames.ApplicationNamespaces, ConfigConsts.EnvVarNames.ApplicationNamespaces));
+
+		public bool BreakdownMetrics =>
+			ParseBreakdownMetrics(Read(ConfigConsts.KeyNames.BreakdownMetrics, ConfigConsts.EnvVarNames.BreakdownMetrics));
 	}
 }

--- a/src/Elastic.Apm/Config/ConfigConsts.cs
+++ b/src/Elastic.Apm/Config/ConfigConsts.cs
@@ -4,7 +4,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Collections.ObjectModel;
 using Elastic.Apm.Helpers;
 
 namespace Elastic.Apm.Config
@@ -36,8 +35,22 @@ namespace Elastic.Apm.Config
 			public const string UnknownServiceName = "unknown";
 			public const bool UseElasticTraceparentHeader = true;
 			public const bool VerifyServerCert = true;
-			public static readonly IReadOnlyCollection<string> DefaultExcludedNamespaces = new List<string>{"System.", "Microsoft.", "MS.", "FSharp.", "Newtonsoft.Json", "Serilog", "NLog", "Giraffe."}.AsReadOnly();
+
+			public static readonly IReadOnlyCollection<string> DefaultExcludedNamespaces =
+				new List<string>
+				{
+					"System.",
+					"Microsoft.",
+					"MS.",
+					"FSharp.",
+					"Newtonsoft.Json",
+					"Serilog",
+					"NLog",
+					"Giraffe."
+				}.AsReadOnly();
+
 			public static readonly IReadOnlyCollection<string> DefaultApplicationNamespaces = new List<string>().AsReadOnly();
+			public static readonly bool BreakdownMetrics = true;
 
 			public static List<WildcardMatcher> DisableMetrics = new List<WildcardMatcher>();
 
@@ -96,6 +109,7 @@ namespace Elastic.Apm.Config
 			public const string VerifyServerCert = Prefix + "VERIFY_SERVER_CERT";
 			public const string ExcludedNamespaces = Prefix + "EXCLUDED_NAMESPACES";
 			public const string ApplicationNamespaces = Prefix + "APPLICATION_NAMESPACES";
+			public const string BreakdownMetrics = Prefix + "BREAKDOWN_METRICS";
 		}
 
 		public static class KeyNames
@@ -127,6 +141,7 @@ namespace Elastic.Apm.Config
 			public const string VerifyServerCert = "ElasticApm:VerifyServerCert";
 			public const string ExcludedNamespaces = "ElasticApm:ExcludedNamespaces";
 			public const string ApplicationNamespaces = "ElasticApm:ApplicationNamespaces";
+			public const string BreakdownMetrics = "ElasticApm:BreakdownMetrics";
 		}
 
 		public static class SupportedValues

--- a/src/Elastic.Apm/Config/ConfigSnapshotFromReader.cs
+++ b/src/Elastic.Apm/Config/ConfigSnapshotFromReader.cs
@@ -48,5 +48,6 @@ namespace Elastic.Apm.Config
 		public bool VerifyServerCert => _content.VerifyServerCert;
 		public IReadOnlyCollection<string> ExcludedNamespaces => _content.ExcludedNamespaces;
 		public IReadOnlyCollection<string> ApplicationNamespaces => _content.ApplicationNamespaces;
+		public bool BreakdownMetrics => _content.BreakdownMetrics;
 	}
 }

--- a/src/Elastic.Apm/Config/EnvironmentConfigurationReader.cs
+++ b/src/Elastic.Apm/Config/EnvironmentConfigurationReader.cs
@@ -76,10 +76,12 @@ namespace Elastic.Apm.Config
 		public bool UseElasticTraceparentHeader => ParseUseElasticTraceparentHeader(Read(ConfigConsts.EnvVarNames.UseElasticTraceparentHeader));
 
 		public bool VerifyServerCert => ParseVerifyServerCert(Read(ConfigConsts.EnvVarNames.VerifyServerCert));
-		
+
 		public IReadOnlyCollection<string> ExcludedNamespaces => ParseExcludedNamespaces(Read(ConfigConsts.EnvVarNames.ExcludedNamespaces));
 
 		public IReadOnlyCollection<string> ApplicationNamespaces => ParseApplicationNamespaces(Read(ConfigConsts.EnvVarNames.ApplicationNamespaces));
+
+		public bool BreakdownMetrics => ParseBreakdownMetrics(Read(ConfigConsts.EnvVarNames.BreakdownMetrics));
 
 		private ConfigurationKeyValue Read(string key) =>
 			new ConfigurationKeyValue(key, ReadEnvVarValue(key), Origin);

--- a/src/Elastic.Apm/Config/IConfigurationReader.cs
+++ b/src/Elastic.Apm/Config/IConfigurationReader.cs
@@ -165,5 +165,10 @@ namespace Elastic.Apm.Config
 		/// This suppresses any configuration of <see cref="ExcludedNamespaces"/>
 		/// </summary>
 		IReadOnlyCollection<string> ApplicationNamespaces { get; }
+
+		/// <summary>
+		/// Whether to collect breakdown metrics (`span.self_time`)
+		/// </summary>
+		bool BreakdownMetrics { get; }
 	}
 }

--- a/src/Elastic.Apm/Metrics/MetricsProvider/BreakdownMetricsProvider.cs
+++ b/src/Elastic.Apm/Metrics/MetricsProvider/BreakdownMetricsProvider.cs
@@ -1,0 +1,12 @@
+// Licensed to Elasticsearch B.V under
+// one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+namespace Elastic.Apm.Metrics.MetricsProvider
+{
+	public class BreakdownMetricsProvider
+	{
+		
+	}
+}

--- a/src/Elastic.Apm/Model/ExecutionSegment.cs
+++ b/src/Elastic.Apm/Model/ExecutionSegment.cs
@@ -1,0 +1,187 @@
+// Licensed to Elasticsearch B.V under
+// one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+using Elastic.Apm.Api;
+using Elastic.Apm.Helpers;
+using Elastic.Apm.Logging;
+using Elastic.Apm.Report.Serialization;
+using Newtonsoft.Json;
+
+namespace Elastic.Apm.Model
+{
+	internal abstract class ExecutionSegment : IExecutionSegment
+	{
+		protected readonly IApmLogger Logger;
+
+		private readonly ChildDurationTimer _childDurations = new ChildDurationTimer();
+
+		public ExecutionSegment(string name, IApmLogger logger)
+		{
+			Name = name;
+			Timestamp = TimeUtils.TimestampNow();
+
+			Logger = logger?.Scoped($"{GetType().Name}.{Id}");
+		}
+
+		public abstract void CaptureError(string message, string culprit, StackFrame[] frames, string parentId = null);
+
+		public abstract void CaptureException(Exception exception, string culprit = null, bool isHandled = false, string parentId = null);
+
+		protected abstract Span CreateSpan(string name, string type, InstrumentationFlag instrumentationFlag);
+
+		protected abstract void InternalEnd(bool isFirstEndCall, long endTimestamp);
+
+		public abstract Dictionary<string, string> Labels { get; }
+
+		public abstract string Name { get; set; }
+
+		public abstract DistributedTracingData OutgoingDistributedTracingData { get; }
+
+		protected abstract string SegmentName { get; }
+
+		private bool _isEnded;
+
+		/// <inheritdoc />
+		public double? Duration { get; set; }
+
+		public double? SelfDuration => Duration != null ? Duration - (_childDurations.Duration / 1000.0) : null;
+
+		/// <inheritdoc />
+		[JsonConverter(typeof(TrimmedStringJsonConverter))]
+		public string Id { get; set; }
+
+		/// <inheritdoc />
+		[JsonProperty("sampled")]
+		public virtual bool IsSampled { get; protected set; }
+
+		/// <inheritdoc />
+		[JsonConverter(typeof(TrimmedStringJsonConverter))]
+		[JsonProperty("parent_id")]
+		public string ParentId { get; set; }
+
+		/// <summary>
+		/// Recorded time of the event, UTC based and formatted as microseconds since Unix epoch
+		/// </summary>
+		public long Timestamp { get; }
+
+		/// <inheritdoc />
+		[JsonConverter(typeof(TrimmedStringJsonConverter))]
+		[JsonProperty("trace_id")]
+		public string TraceId { get; set; }
+
+		public void CaptureSpan(string name, string type, Action<ISpan> capturedAction, string subType = null, string action = null)
+			=> ExecutionSegmentCommon.CaptureSpan(StartSpan(name, type, subType, action), capturedAction);
+
+		public void CaptureSpan(string name, string type, Action capturedAction, string subType = null, string action = null)
+			=> ExecutionSegmentCommon.CaptureSpan(StartSpan(name, type, subType, action), capturedAction);
+
+		public T CaptureSpan<T>(string name, string type, Func<ISpan, T> func, string subType = null, string action = null)
+			=> ExecutionSegmentCommon.CaptureSpan(StartSpan(name, type, subType, action), func);
+
+		public T CaptureSpan<T>(string name, string type, Func<T> func, string subType = null, string action = null)
+			=> ExecutionSegmentCommon.CaptureSpan(StartSpan(name, type, subType, action), func);
+
+		public Task CaptureSpan(string name, string type, Func<Task> func, string subType = null, string action = null)
+			=> ExecutionSegmentCommon.CaptureSpan(StartSpan(name, type, subType, action), func);
+
+		public Task CaptureSpan(string name, string type, Func<ISpan, Task> func, string subType = null, string action = null)
+			=> ExecutionSegmentCommon.CaptureSpan(StartSpan(name, type, subType, action), func);
+
+		public Task<T> CaptureSpan<T>(string name, string type, Func<Task<T>> func, string subType = null, string action = null)
+			=> ExecutionSegmentCommon.CaptureSpan(StartSpan(name, type, subType, action), func);
+
+		public Task<T> CaptureSpan<T>(string name, string type, Func<ISpan, Task<T>> func, string subType = null, string action = null)
+			=> ExecutionSegmentCommon.CaptureSpan(StartSpan(name, type, subType, action), func);
+
+		public void End()
+		{
+			if (Duration.HasValue)
+			{
+				Logger.Trace()
+					?.Log($"Ended {{{SegmentName}}} (with Duration already set)." +
+						" Start time: {Time} (as timestamp: {Timestamp}), Duration: {Duration}ms",
+						this, TimeUtils.FormatTimestampForLog(Timestamp), Timestamp, Duration);
+			}
+			else
+			{
+				Assertion.IfEnabled?.That(!_isEnded,
+					$"{SegmentName}'s Duration doesn't have value even though {nameof(End)} method was already called." +
+					$" It contradicts the invariant enforced by {nameof(End)} method - Duration should have value when {nameof(End)} method exits" +
+					$" and {nameof(_isEnded)} field is set to true only when {nameof(End)} method exits." +
+					$" Context: this: {this}; {nameof(_isEnded)}: {_isEnded}");
+
+				var endTimestamp = TimeUtils.TimestampNow();
+				Duration = TimeUtils.DurationBetweenTimestamps(Timestamp, endTimestamp);
+				Logger.Trace()
+					?.Log($"Ended {{{SegmentName}}}. Start time: {{Time}} (as timestamp: {{Timestamp}})," +
+						" End time: {Time} (as timestamp: {Timestamp}), Duration: {Duration}ms",
+						this, TimeUtils.FormatTimestampForLog(Timestamp), Timestamp,
+						TimeUtils.FormatTimestampForLog(endTimestamp), endTimestamp, Duration);
+			}
+
+			var calculatedEndTimestamp = Timestamp + (long)(Duration.Value * 1000);
+
+			_childDurations.OnSegmentEnd(calculatedEndTimestamp);
+
+			var isFirstEndCall = !_isEnded;
+			_isEnded = true;
+
+			InternalEnd(isFirstEndCall, calculatedEndTimestamp);
+		}
+
+		public ISpan StartSpan(string name, string type, string subType = null, string action = null)
+			=> StartSpanInternal(name, type, subType, action);
+
+		internal Span StartSpanInternal(string name, string type, string subType = null, string action = null,
+			InstrumentationFlag instrumentationFlag = InstrumentationFlag.None
+		)
+		{
+			var span = CreateSpan(name, type, instrumentationFlag);
+
+			if (!string.IsNullOrEmpty(subType)) span.Subtype = subType;
+
+			if (!string.IsNullOrEmpty(action)) span.Action = action;
+
+			Logger.Trace()?.Log("Starting {SpanDetails}", span.ToString());
+
+			return span;
+		}
+
+		public void OnChildStart(long timestamp) => _childDurations.OnChildStart(timestamp);
+
+		public void OnChildEnd(long timestamp) => _childDurations.OnChildEnd(timestamp);
+
+		private class ChildDurationTimer
+		{
+			private int _activeChildren;
+			private long _duration;
+			private long _start;
+
+			public long Duration => Interlocked.Read(ref _duration);
+
+			public void OnChildStart(long startTimestamp)
+			{
+				if (Interlocked.Increment(ref _activeChildren) == 1) Interlocked.Exchange(ref _start, startTimestamp);
+			}
+
+			public void OnChildEnd(long endTimestamp)
+			{
+				if (Interlocked.Decrement(ref _activeChildren) == 0) IncrementDuration(endTimestamp);
+			}
+
+			public void OnSegmentEnd(long endTimestamp)
+			{
+				if (Interlocked.Exchange(ref _activeChildren, 0) != 0) IncrementDuration(endTimestamp);
+			}
+
+			private void IncrementDuration(long epochMicros) => Interlocked.Add(ref _duration, epochMicros - Interlocked.Read(ref _start));
+		}
+	}
+}

--- a/src/Elastic.Apm/Model/ExecutionSegmentCommon.cs
+++ b/src/Elastic.Apm/Model/ExecutionSegmentCommon.cs
@@ -15,12 +15,13 @@ using Elastic.Apm.Report;
 
 namespace Elastic.Apm.Model
 {
+	// todo: move into ExecutionSegment
 	/// <summary>
 	/// Encapsulates common functionality shared between <see cref="Span" /> and <see cref="Transaction" />
 	/// </summary>
 	internal static class ExecutionSegmentCommon
 	{
-		internal static void CaptureSpan(Span span, Action<ISpan> capturedAction)
+		internal static void CaptureSpan(ISpan span, Action<ISpan> capturedAction)
 		{
 			try
 			{
@@ -33,7 +34,7 @@ namespace Elastic.Apm.Model
 			}
 		}
 
-		internal static void CaptureSpan(Span span, Action capturedAction)
+		internal static void CaptureSpan(ISpan span, Action capturedAction)
 		{
 			try
 			{
@@ -46,7 +47,7 @@ namespace Elastic.Apm.Model
 			}
 		}
 
-		internal static T CaptureSpan<T>(Span span, Func<ISpan, T> func)
+		internal static T CaptureSpan<T>(ISpan span, Func<ISpan, T> func)
 		{
 			var retVal = default(T);
 			try
@@ -62,7 +63,7 @@ namespace Elastic.Apm.Model
 			return retVal;
 		}
 
-		internal static T CaptureSpan<T>(Span span, Func<T> func)
+		internal static T CaptureSpan<T>(ISpan span, Func<T> func)
 		{
 			var retVal = default(T);
 			try
@@ -78,21 +79,21 @@ namespace Elastic.Apm.Model
 			return retVal;
 		}
 
-		internal static Task CaptureSpan(Span span, Func<Task> func)
+		internal static Task CaptureSpan(ISpan span, Func<Task> func)
 		{
 			var task = func();
 			RegisterContinuation(task, span);
 			return task;
 		}
 
-		internal static Task CaptureSpan(Span span, Func<ISpan, Task> func)
+		internal static Task CaptureSpan(ISpan span, Func<ISpan, Task> func)
 		{
 			var task = func(span);
 			RegisterContinuation(task, span);
 			return task;
 		}
 
-		internal static Task<T> CaptureSpan<T>(Span span, Func<Task<T>> func)
+		internal static Task<T> CaptureSpan<T>(ISpan span, Func<Task<T>> func)
 		{
 			var task = func();
 			RegisterContinuation(task, span);
@@ -100,7 +101,7 @@ namespace Elastic.Apm.Model
 			return task;
 		}
 
-		internal static Task<T> CaptureSpan<T>(Span span, Func<ISpan, Task<T>> func)
+		internal static Task<T> CaptureSpan<T>(ISpan span, Func<ISpan, Task<T>> func)
 		{
 			var task = func(span);
 			RegisterContinuation(task, span);

--- a/src/Elastic.Apm/Model/Span.cs
+++ b/src/Elastic.Apm/Model/Span.cs
@@ -47,7 +47,7 @@ namespace Elastic.Apm.Model
 			ICurrentExecutionSegmentsContainer currentExecutionSegmentsContainer,
 			Span parentSpan = null,
 			InstrumentationFlag instrumentationFlag = InstrumentationFlag.None
-		) : base(name, logger)
+		) : base(name, logger, enclosingTransaction.ConfigSnapshot)
 		{
 			InstrumentationFlag = instrumentationFlag;
 			Id = RandomGenerator.GenerateRandomBytesAsString(new byte[8]);
@@ -87,9 +87,6 @@ namespace Elastic.Apm.Model
 		[JsonConverter(typeof(TrimmedStringJsonConverter))]
 		public string Action { get; set; }
 
-		[JsonIgnore]
-		private IConfigSnapshot ConfigSnapshot => _enclosingTransaction.ConfigSnapshot;
-
 		/// <summary>
 		/// Any other arbitrary data captured by the agent, optionally provided by the user.
 		/// <seealso cref="ShouldSerializeContext" />
@@ -103,9 +100,6 @@ namespace Elastic.Apm.Model
 
 		[JsonIgnore]
 		public override Dictionary<string, string> Labels => Context.Labels;
-
-		[JsonConverter(typeof(TrimmedStringJsonConverter))]
-		public override string Name { get; set; }
 
 		[JsonIgnore]
 		public override DistributedTracingData OutgoingDistributedTracingData => new DistributedTracingData(

--- a/src/Elastic.Apm/Report/PayloadSenderV2.cs
+++ b/src/Elastic.Apm/Report/PayloadSenderV2.cs
@@ -277,12 +277,12 @@ namespace Elastic.Apm.Report
 			}
 
 			// Executes filters for the given filter collection and handles return value and errors
-			T TryExecuteFilter<T>(IEnumerable<Func<T, T>> filters, T item) where T : class
+			T TryExecuteFilter<T>(IReadOnlyCollection<Func<T, T>> filters, T item) where T : class
 			{
-				var enumerable = filters as Func<T, T>[] ?? filters.ToArray();
-				if (!enumerable.Any()) return item;
+				//var enumerable = filters as Func<T, T>[] ?? filters.ToArray();
+				if (!filters.Any()) return item;
 
-				foreach (var filter in enumerable)
+				foreach (var filter in filters)
 				{
 					try
 					{

--- a/test/Elastic.Apm.Tests/ConstructorTests.cs
+++ b/test/Elastic.Apm.Tests/ConstructorTests.cs
@@ -68,6 +68,8 @@ namespace Elastic.Apm.Tests
 			public bool UseElasticTraceparentHeader => ConfigConsts.DefaultValues.UseElasticTraceparentHeader;
 
 			public int TransactionMaxSpans => ConfigConsts.DefaultValues.TransactionMaxSpans;
+
+			public bool BreakdownMetrics => ConfigConsts.DefaultValues.BreakdownMetrics;
 			// ReSharper restore UnassignedGetOnlyAutoProperty
 		}
 	}

--- a/test/Elastic.Apm.Tests/Mocks/MockConfigSnapshot.cs
+++ b/test/Elastic.Apm.Tests/Mocks/MockConfigSnapshot.cs
@@ -43,6 +43,7 @@ namespace Elastic.Apm.Tests.Mocks
 		private readonly string _transactionSampleRate;
 		private readonly string _useElasticTraceparentHeader;
 		private readonly string _verifyServerCert;
+		private readonly string _breakdownMetrics;
 
 		public MockConfigSnapshot(IApmLogger logger = null,
 			string logLevel = null,
@@ -72,7 +73,8 @@ namespace Elastic.Apm.Tests.Mocks
 			string verifyServerCert = null,
 			string useElasticTraceparentHeader = null,
 			string applicationNamespaces = null,
-			string excludedNamespaces = null
+			string excludedNamespaces = null,
+			string breakdownMetrics = null
 		) : base(logger, ThisClassName)
 		{
 			_serverUrls = serverUrls;
@@ -103,12 +105,15 @@ namespace Elastic.Apm.Tests.Mocks
 			_useElasticTraceparentHeader = useElasticTraceparentHeader;
 			_applicationNamespaces = applicationNamespaces;
 			_excludedNamespaces = excludedNamespaces;
+			_breakdownMetrics = breakdownMetrics;
 		}
 
 		public string ApiKey => ParseApiKey(Kv(ConfigConsts.EnvVarNames.ApiKey, _apiKey, Origin));
 
 		public IReadOnlyCollection<string> ApplicationNamespaces =>
 			ParseApplicationNamespaces(new ConfigurationKeyValue(ConfigConsts.EnvVarNames.ApplicationNamespaces, _applicationNamespaces, Origin));
+
+		public bool BreakdownMetrics => ParseBreakdownMetrics(Kv(ConfigConsts.EnvVarNames.BreakdownMetrics, _breakdownMetrics, Origin));
 
 		public string CaptureBody => ParseCaptureBody(Kv(ConfigConsts.EnvVarNames.CaptureBody, _captureBody, Origin));
 


### PR DESCRIPTION
related to #227 

The PR address only the first important part of agent breakdown metrics: calculate self-time of transaction and spans.

I opened PR as early as possible to get feedback about changes under the hood. The main change is in extracting logic from `Span` and `Transaction` classes into the separate `ExecutionSegment` abstract class.

## To be done

In case it makes sense the following changes should be applied to the PR:

* Reanimate `FilterApiTests` due to commenting `JsonConstructor`
* Move methods from `ExecutionSegmentCommon` to `ExecutionSegment` class
* Go through `Span` and `Transaction` and move shared logic to `ExecutionSegment`

## Questions:

* Maybe, it makes sense to create shared `breakdownmetrics` branch for the feature and do each option from the checklist as a separate PR?

/cc @gregkalapos 