### PR TITLE
#854 buffer request body when request is forms content type

### DIFF
--- a/src/Elastic.Apm.AspNetCore/Consts.cs
+++ b/src/Elastic.Apm.AspNetCore/Consts.cs
@@ -2,6 +2,8 @@
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
 
+using Microsoft.AspNetCore.Http.Features;
+
 namespace Elastic.Apm.AspNetCore
 {
 	internal static class Consts
@@ -13,5 +15,7 @@ namespace Elastic.Apm.AspNetCore
 			internal const string Email = "email";
 			internal const string UserId = "sub";
 		}
+
+		internal static FormOptions FormContentOptions => new FormOptions { BufferBody = true };
 	}
 }

--- a/src/Elastic.Apm.AspNetCore/Extensions/RequestExtentions.cs
+++ b/src/Elastic.Apm.AspNetCore/Extensions/RequestExtentions.cs
@@ -30,7 +30,7 @@ namespace Elastic.Apm.AspNetCore.Extensions
 			{
 				if (request.HasFormContentType)
 				{
-					var form = await request.ReadFormAsync();
+					var form = await request.ReadFormAsync(Consts.FormContentOptions);
 
 					var itemProcessed = 0;
 					if (form != null && form.Count > 0)


### PR DESCRIPTION
I guess it is better to pass FormOptions than call request.EnableBuffering() directly.