### PR TITLE
ci: deploy to feedz.io

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -380,7 +380,7 @@ pipeline {
         }
       }
     }
-    stage('Release to AppVeyor') {
+    stage('Release to feedz.io') {
       options { skipDefaultCheckout() }
       when {
         beforeAgent true
@@ -393,7 +393,7 @@ pipeline {
         deleteDir()
         unstash 'source'
         dir("${BASE_DIR}"){
-          release('secret/apm-team/ci/elastic-observability-appveyor')
+          release('secret/apm-team/ci/elastic-observability-feedz.io')
         }
       }
       post{


### PR DESCRIPTION
Closes https://github.com/elastic/apm-agent-dotnet/issues/860

- [x] Requires credentials in the secret management system

```
vault list secret/apm-team/ci | grep feedz.io
elastic-observability-feedz.io
```

### Further referencies:

- https://github.com/elastic/elasticsearch-net-abstractions/blob/master/.github/workflows/ci.yml#L51