### PR TITLE
Handling errors in runtime detection

### DIFF
--- a/src/Elastic.Apm/Api/Service.cs
+++ b/src/Elastic.Apm/Api/Service.cs
@@ -2,6 +2,7 @@
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
 
+using System;
 using System.Reflection;
 using Elastic.Apm.Config;
 using Elastic.Apm.Helpers;
@@ -48,7 +49,7 @@ namespace Elastic.Apm.Api
 		internal static Service GetDefaultService(IConfigurationReader configurationReader, IApmLogger loggerArg)
 		{
 			IApmLogger logger = loggerArg.Scoped(nameof(Service));
-			return new Service
+			var service = new Service
 			{
 				Name = configurationReader.ServiceName,
 				Version = configurationReader.ServiceVersion,
@@ -57,10 +58,21 @@ namespace Elastic.Apm.Api
 					Name = Consts.AgentName,
 					Version = typeof(Agent).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>().InformationalVersion
 				},
-				Runtime = PlatformDetection.GetServiceRuntime(logger),
 				Environment = configurationReader.Environment,
 				Node = new Node { ConfiguredName = configurationReader.ServiceNodeName }
 			};
+
+			//see https://github.com/elastic/apm-agent-dotnet/issues/859
+			try
+			{
+				service.Runtime = PlatformDetection.GetServiceRuntime(logger);
+			}
+			catch (Exception e)
+			{
+				logger.Warning()?.LogException(e, "Failed detecting runtime - no runtime name and version will be reported");
+			}
+
+			return service;
 		}
 
 		public class AgentC

--- a/src/Elastic.Apm/BackendComm/BackendCommUtils.cs
+++ b/src/Elastic.Apm/BackendComm/BackendCommUtils.cs
@@ -142,8 +142,12 @@ namespace Elastic.Apm.BackendComm
 				new ProductInfoHeaderValue($"elasticapm-{Consts.AgentName}", AdaptUserAgentValue(service.Agent.Version)));
 			httpClient.DefaultRequestHeaders.UserAgent.Add(new ProductInfoHeaderValue("System.Net.Http",
 				AdaptUserAgentValue(typeof(HttpClient).Assembly.GetCustomAttribute<AssemblyFileVersionAttribute>().Version)));
-			httpClient.DefaultRequestHeaders.UserAgent.Add(
-				new ProductInfoHeaderValue(AdaptUserAgentValue(service.Runtime.Name), AdaptUserAgentValue(service.Runtime.Version)));
+
+			if (service.Runtime != null)
+			{
+				httpClient.DefaultRequestHeaders.UserAgent.Add(
+					new ProductInfoHeaderValue(AdaptUserAgentValue(service.Runtime.Name), AdaptUserAgentValue(service.Runtime.Version)));
+			}
 
 			if (config.ApiKey != null)
 				httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("ApiKey", config.ApiKey);


### PR DESCRIPTION
Solves #859

Unfortunately I don't know where and how this could happen, but as discussed in [this](https://discuss.elastic.co/t/net-agent-instrumentation-for-iis-hosted-app) thread, an exception can happen during runtime detection, so we need to prepare for that.

`runtime` is optional, so in case we can't detect we just omit it - all works fine without it, we just simply don't report it.