### PR TITLE
Ignore Activity.Current.ParentId if no traceparent header is present

### DIFF
--- a/src/Elastic.Apm.AspNetCore/ApmMiddleware.cs
+++ b/src/Elastic.Apm.AspNetCore/ApmMiddleware.cs
@@ -113,17 +113,14 @@ namespace Elastic.Apm.AspNetCore
 								"Incoming request with invalid {TraceParentHeaderName} header (received value: {TraceParentHeaderValue}). Starting trace with new trace id.",
 								TraceContext.TraceParentHeaderNamePrefixed, headerValue);
 
-						// In case there is no traceparent header, we suppress activity reuse, this way the transaction.parentID WON't be set
-						// to the activity parent id if the activity from ASP.NET Core.
-						transaction = _tracer.StartTransactionInternal(transactionName, ApiConstants.TypeRequest, suppressActivityReuse: true);
+						transaction = _tracer.StartTransactionInternal(transactionName, ApiConstants.TypeRequest);
 					}
 				}
 				else
 				{
 					_logger.Debug()?.Log("Incoming request. Starting Trace.");
 
-					// Same suppressActivityReuse: true as above
-					transaction = _tracer.StartTransactionInternal(transactionName, ApiConstants.TypeRequest, suppressActivityReuse: true);
+					transaction = _tracer.StartTransactionInternal(transactionName, ApiConstants.TypeRequest);
 				}
 
 				return transaction;

--- a/src/Elastic.Apm.AspNetCore/ApmMiddleware.cs
+++ b/src/Elastic.Apm.AspNetCore/ApmMiddleware.cs
@@ -119,7 +119,6 @@ namespace Elastic.Apm.AspNetCore
 				else
 				{
 					_logger.Debug()?.Log("Incoming request. Starting Trace.");
-
 					transaction = _tracer.StartTransactionInternal(transactionName, ApiConstants.TypeRequest);
 				}
 

--- a/src/Elastic.Apm.AspNetCore/ApmMiddleware.cs
+++ b/src/Elastic.Apm.AspNetCore/ApmMiddleware.cs
@@ -113,13 +113,17 @@ namespace Elastic.Apm.AspNetCore
 								"Incoming request with invalid {TraceParentHeaderName} header (received value: {TraceParentHeaderValue}). Starting trace with new trace id.",
 								TraceContext.TraceParentHeaderNamePrefixed, headerValue);
 
-						transaction = _tracer.StartTransactionInternal(transactionName, ApiConstants.TypeRequest);
+						// In case there is no traceparent header, we suppress activity reuse, this way the transaction.parentID WON't be set
+						// to the activity parent id if the activity from ASP.NET Core.
+						transaction = _tracer.StartTransactionInternal(transactionName, ApiConstants.TypeRequest, suppressActivityReuse: true);
 					}
 				}
 				else
 				{
 					_logger.Debug()?.Log("Incoming request. Starting Trace.");
-					transaction = _tracer.StartTransactionInternal(transactionName, ApiConstants.TypeRequest);
+
+					// Same suppressActivityReuse: true as above
+					transaction = _tracer.StartTransactionInternal(transactionName, ApiConstants.TypeRequest, suppressActivityReuse: true);
 				}
 
 				return transaction;

--- a/src/Elastic.Apm/Api/Tracer.cs
+++ b/src/Elastic.Apm/Api/Tracer.cs
@@ -48,11 +48,11 @@ namespace Elastic.Apm.Api
 		public ITransaction StartTransaction(string name, string type, DistributedTracingData distributedTracingData = null) =>
 			StartTransactionInternal(name, type, distributedTracingData);
 
-		internal Transaction StartTransactionInternal(string name, string type, DistributedTracingData distributedTracingData = null, bool suppressActivityReuse = false)
+		internal Transaction StartTransactionInternal(string name, string type, DistributedTracingData distributedTracingData = null)
 		{
 			var currentConfig = _configProvider.CurrentSnapshot;
 			var retVal = new Transaction(_logger, name, type, new Sampler(currentConfig.TransactionSampleRate), distributedTracingData
-				, _sender, currentConfig, CurrentExecutionSegmentsContainer, suppressActivityReuse)
+				, _sender, currentConfig, CurrentExecutionSegmentsContainer)
 			{ Service = _service };
 
 			_logger.Debug()?.Log("Starting {TransactionValue}", retVal);

--- a/src/Elastic.Apm/Api/Tracer.cs
+++ b/src/Elastic.Apm/Api/Tracer.cs
@@ -48,11 +48,11 @@ namespace Elastic.Apm.Api
 		public ITransaction StartTransaction(string name, string type, DistributedTracingData distributedTracingData = null) =>
 			StartTransactionInternal(name, type, distributedTracingData);
 
-		internal Transaction StartTransactionInternal(string name, string type, DistributedTracingData distributedTracingData = null)
+		internal Transaction StartTransactionInternal(string name, string type, DistributedTracingData distributedTracingData = null, bool suppressActivityReuse = false)
 		{
 			var currentConfig = _configProvider.CurrentSnapshot;
 			var retVal = new Transaction(_logger, name, type, new Sampler(currentConfig.TransactionSampleRate), distributedTracingData
-				, _sender, currentConfig, CurrentExecutionSegmentsContainer)
+				, _sender, currentConfig, CurrentExecutionSegmentsContainer, suppressActivityReuse)
 			{ Service = _service };
 
 			_logger.Debug()?.Log("Starting {TransactionValue}", retVal);

--- a/src/Elastic.Apm/Model/Transaction.cs
+++ b/src/Elastic.Apm/Model/Transaction.cs
@@ -125,6 +125,13 @@ namespace Elastic.Apm.Model
 			}
 			else
 			{
+				if (_activity != null)
+					Id = _activity.SpanId.ToHexString();
+				else
+				{
+					var idBytes = new byte[8];
+					Id = RandomGenerator.GenerateRandomBytesAsString(idBytes);
+				}
 				TraceId = distributedTracingData.TraceId;
 				ParentId = distributedTracingData.ParentId;
 				IsSampled = distributedTracingData.FlagRecorded;

--- a/src/Elastic.Apm/Sampler.cs
+++ b/src/Elastic.Apm/Sampler.cs
@@ -18,7 +18,8 @@ namespace Elastic.Apm
 	/// </summary>
 	internal readonly struct Sampler
 	{
-		private readonly ulong _maxSampledUInt64;
+		private readonly long _higherBound;
+		private readonly long _lowerBound;
 		private readonly double _rate;
 
 		/// <summary>
@@ -36,14 +37,17 @@ namespace Elastic.Apm
 			{
 				case 0:
 					Constant = false;
-					_maxSampledUInt64 = 0;
+					_higherBound = 0;
+					_lowerBound = 0;
 					break;
 				case 1:
 					Constant = true;
-					_maxSampledUInt64 = ulong.MaxValue;
+					_higherBound = long.MaxValue;
+					_lowerBound = long.MinValue;
 					break;
 				default:
-					_maxSampledUInt64 = Convert.ToUInt64(ulong.MaxValue * rate);
+					_higherBound = (long) (long.MaxValue * rate);
+					_lowerBound = -_higherBound;
 					Constant = null;
 					break;
 			}
@@ -60,7 +64,11 @@ namespace Elastic.Apm
 		/// than 8.
 		/// </exception>
 		/// <returns>True if and only if the decision is to sample</returns>
-		internal bool DecideIfToSample(byte[] randomBytes) => Constant ?? BitConverter.ToUInt64(randomBytes, 0) <= _maxSampledUInt64;
+		internal bool DecideIfToSample(byte[] randomBytes)
+		{
+			var longVal = BitConverter.ToInt64(randomBytes, 0);
+			return Constant ?? longVal > _lowerBound && longVal < _higherBound;
+		}
 
 		internal static bool IsValidRate(double rate) => 0 <= rate && rate <= 1.0;
 

--- a/test/Elastic.Apm.Tests/ActivityIntegrationTests.cs
+++ b/test/Elastic.Apm.Tests/ActivityIntegrationTests.cs
@@ -31,6 +31,7 @@ namespace Elastic.Apm.Tests
 				agent.Tracer.CaptureTransaction("TestTransaction", "Test", () => Thread.Sleep(10));
 
 			payloadSender.FirstTransaction.TraceId.Should().Be(activity.TraceId.ToString());
+			payloadSender.FirstTransaction.ParentId.Should().BeNullOrEmpty();
 
 			activity.Stop();
 		}
@@ -53,6 +54,7 @@ namespace Elastic.Apm.Tests
 				agent.Tracer.CaptureTransaction("TestTransaction", "Test", () => Thread.Sleep(10));
 
 			payloadSender.FirstTransaction.TraceId.Should().NotBe(activity.TraceId.ToString());
+			payloadSender.FirstTransaction.ParentId.Should().BeNullOrEmpty();
 
 			activity.Stop();
 		}
@@ -131,6 +133,7 @@ namespace Elastic.Apm.Tests
 			}
 
 			payloadSender.Transactions.Should().HaveCount(2);
+			payloadSender.Transactions[0].ParentId.Should().BeNullOrEmpty();
 			payloadSender.Transactions[0].TraceId.Should().Be(activity.TraceId.ToString());
 			payloadSender.Transactions[1].TraceId.Should().Be(activity.TraceId.ToString());
 			payloadSender.Transactions[0].Id.Should().NotBe(payloadSender.Transactions[1].Id);

--- a/test/Elastic.Apm.Tests/SamplerTests.cs
+++ b/test/Elastic.Apm.Tests/SamplerTests.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information
 
 using System;
+using System.Diagnostics;
 using Elastic.Apm.Helpers;
 using Elastic.Apm.Model;
 using Elastic.Apm.Tests.Mocks;
@@ -71,6 +72,9 @@ namespace Elastic.Apm.Tests
 
 			total.Repeat(i =>
 			{
+				// reset current activity, otherwise all transactions share the same traceid which influences the sampling decision
+				Activity.Current = null;
+
 				var transaction = new Transaction(noopLogger, "test transaction name", "test transaction type", sampler,
 					/* distributedTracingData: */ null, noopPayloadSender, configurationReader, currentExecutionSegmentsContainer);
 				if (transaction.IsSampled) ++sampledCount;


### PR DESCRIPTION
Addressing #883


### Description of the problem this PR solves

In our UI every trace must start with a transaction where the `parentid` is `null` - if that's not the case then it's not considered as a trace, therefore under "traces" in kibana, the given trace won't show up.


### Activity Parent id in the 1. service of a chain.

We keep trace id and also parentid in sync with [`System.Diagnostics.Activity`](https://docs.microsoft.com/en-us/dotnet/api/system.diagnostics.activity?view=netcore-3.1), and ASP.NET Core itself already creates an activity - also in case this is the 1. service in a chain. Prior to this PR we did this when we created the transaction: `ParentId = Activity.Current.ParentId;` that's why there was never a transaction with `null` trace id. So in case the agent is in the 1. service of a chain, this PR will fix the the problem described above.

### Context propagation in ASP.NET Core

The other thing is context propagation in ASP.NET Core described [here](https://devblogs.microsoft.com/aspnet/improvements-in-net-core-3-0-for-troubleshooting-and-monitoring-distributed-apps/). Since .NET Core and ASP.NET Core 3.0 the framework itself creates traceids and propagates those across HTTP calls. By default it uses the `Request-Id` header, so our agent will ignore it. With this in case A -> B (A calls B) in B we will have an Activity with a prentId which points to an Activity in A - so far so good, no issue for us. But users can opt-in to use the W3C TraceContext standard and in that case the context propagation happens in the `traceparent` header, which our agent will read. Once users opt-in, and let's say B is monitored by us but A isn't then we'll have the issue described above, because our first transaction will have a parent id in this case pointing to an Activity from A. There is no way to know this when we start the transaction in B and this is a more general problem and I'd argue a bug in our TraceContext support. This PR does not solve this issue - This problem is discussed here: https://github.com/elastic/apm/issues/286. I'd like to emphasis that the usage of the `traceparent` header is opt-in; so this only happens if users actively set `Activity.DefaultIdFormat = ActivityIdFormat.W3C;` - I expect this to be a fairly uncommon case today.