### PR TITLE
Publish new packages and add es auto-instrumentation to `All` package 

### DIFF
--- a/.ci/linux/deploy.sh
+++ b/.ci/linux/deploy.sh
@@ -4,7 +4,7 @@
 #
 set -euo pipefail
 
-declare -a projectsToPublish=("Elastic.Apm" "Elastic.Apm.AspNetCore" "Elastic.Apm.EntityFrameworkCore" "Elastic.Apm.NetCoreAll" "Elastic.Apm.EntityFramework6" "Elastic.Apm.AspNetFullFramework" "Elastic.Apm.SqlClient")
+declare -a projectsToPublish=("Elastic.Apm" "Elastic.Apm.AspNetCore" "Elastic.Apm.EntityFrameworkCore" "Elastic.Apm.NetCoreAll" "Elastic.Apm.EntityFramework6" "Elastic.Apm.AspNetFullFramework" "Elastic.Apm.SqlClient", "Elastic.Apm.Elasticsearch", "Elastic.Apm.Extensions.Hosting")
 
 for project in  "${projectsToPublish[@]}"
 do

--- a/src/Elastic.Apm.NetCoreAll/ApmMiddlewareExtension.cs
+++ b/src/Elastic.Apm.NetCoreAll/ApmMiddlewareExtension.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information
 
 using Elastic.Apm.DiagnosticSource;
+using Elastic.Apm.Elasticsearch;
 using Elastic.Apm.EntityFrameworkCore;
 using Elastic.Apm.SqlClient;
 using Microsoft.AspNetCore.Builder;
@@ -30,6 +31,6 @@ namespace Elastic.Apm.NetCoreAll
 			IConfiguration configuration = null
 		) => AspNetCore.ApmMiddlewareExtension
 			.UseElasticApm(builder, configuration, new HttpDiagnosticsSubscriber(), new EfCoreDiagnosticsSubscriber(),
-				new SqlClientDiagnosticSubscriber());
+				new SqlClientDiagnosticSubscriber(), new ElasticsearchDiagnosticsSubscriber());
 	}
 }

--- a/src/Elastic.Apm.NetCoreAll/Elastic.Apm.NetCoreAll.csproj
+++ b/src/Elastic.Apm.NetCoreAll/Elastic.Apm.NetCoreAll.csproj
@@ -8,6 +8,7 @@
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Elastic.Apm.AspNetCore\Elastic.Apm.AspNetCore.csproj" />
+    <ProjectReference Include="..\Elastic.Apm.Elasticsearch\Elastic.Apm.Elasticsearch.csproj" />
     <ProjectReference Include="..\Elastic.Apm.EntityFrameworkCore\Elastic.Apm.EntityFrameworkCore.csproj" />
     <ProjectReference Include="..\Elastic.Apm.SqlClient\Elastic.Apm.SqlClient.csproj" />
     <ProjectReference Include="..\Elastic.Apm\Elastic.Apm.csproj" />

--- a/src/Elastic.Apm.NetCoreAll/HostBuilderExtensions.cs
+++ b/src/Elastic.Apm.NetCoreAll/HostBuilderExtensions.cs
@@ -4,6 +4,7 @@
 // See the LICENSE file in the project root for more information
 
 using Elastic.Apm.DiagnosticSource;
+using Elastic.Apm.Elasticsearch;
 using Elastic.Apm.EntityFrameworkCore;
 using Elastic.Apm.Extensions.Hosting;
 using Elastic.Apm.SqlClient;
@@ -20,6 +21,7 @@ namespace Elastic.Apm.NetCoreAll
 		/// <param name="builder">Builder.</param>
 		public static IHostBuilder UseAllElasticApm(this IHostBuilder builder) => builder.UseElasticApm(new HttpDiagnosticsSubscriber(),
 			new EfCoreDiagnosticsSubscriber(),
-			new SqlClientDiagnosticSubscriber());
+			new SqlClientDiagnosticSubscriber(),
+			new ElasticsearchDiagnosticsSubscriber());
 	}
 }


### PR DESCRIPTION
- Adapted deploy script to publish 2 new packages:
  - `Elastic.Apm.Elasticsearch`
  - `Elastic.Apm.Extensions.Hosting`
- Added Elasticsearch instrumentation as part of `Elastic.Apm.NetCoreAll` - so it'll be turn on by default when that package is used.