### PR TITLE
Add span.context.destination.service.* 

### DIFF
--- a/src/Elastic.Apm.Elasticsearch/AuditDiagnosticsListener.cs
+++ b/src/Elastic.Apm.Elasticsearch/AuditDiagnosticsListener.cs
@@ -13,9 +13,9 @@ namespace Elastic.Apm.Elasticsearch
 		{
 			var name = @audit.Event.GetStringValue();
 
-			if (@event.EndsWith(StartSuffix) && TryStartElasticsearchSpan(name, out _, audit.Node?.Uri.ToString()))
+			if (@event.EndsWith(StartSuffix) && TryStartElasticsearchSpan(name, out _, audit.Node?.Uri))
 				Logger.Info()?.Log("Received an {Event} event from elasticsearch", @event);
-			else if (@event.EndsWith(StopSuffix) && TryGetCurrentElasticsearchSpan(out var span, audit.Node?.Uri.ToString()))
+			else if (@event.EndsWith(StopSuffix) && TryGetCurrentElasticsearchSpan(out var span, audit.Node?.Uri))
 			{
 				Logger.Info()?.Log("Received an {Event} event from elasticsearch", @event);
 				span.End();

--- a/src/Elastic.Apm.Elasticsearch/HttpConnectionDiagnosticsListener.cs
+++ b/src/Elastic.Apm.Elasticsearch/HttpConnectionDiagnosticsListener.cs
@@ -32,7 +32,7 @@ namespace Elastic.Apm.Elasticsearch
 			if (requestData == null) return;
 
 			var instanceUri = requestData.Node?.Uri;
-			if (TryStartElasticsearchSpan(name, out var span, instanceUri?.ToString()))
+			if (TryStartElasticsearchSpan(name, out var span, instanceUri))
 			{
 				Logger.Info()?.Log("Received an {Event} event from elasticsearch", @event);
 				var requestUri = requestData.Uri;

--- a/src/Elastic.Apm.Elasticsearch/RequestPipelineDiagnosticsListener.cs
+++ b/src/Elastic.Apm.Elasticsearch/RequestPipelineDiagnosticsListener.cs
@@ -101,7 +101,7 @@ namespace Elastic.Apm.Elasticsearch
 		private void OnRequestData(string @event, RequestData requestData)
 		{
 			var name = ToName(@event);
-			if (TryStartElasticsearchSpan(name, out var span, requestData?.Node?.Uri.ToString()))
+			if (TryStartElasticsearchSpan(name, out var span, requestData?.Node?.Uri))
 			{
 				if (@event == CallStart && requestData != null)
 					span.Name = $"Elasticsearch: {requestData.Method.GetStringValue()} {requestData.Uri?.AbsolutePath}";

--- a/src/Elastic.Apm/Api/Destination.cs
+++ b/src/Elastic.Apm/Api/Destination.cs
@@ -15,12 +15,13 @@ namespace Elastic.Apm.Api
 	{
 		private Optional<string> _address;
 		private Optional<int?> _port;
+		private Optional<DestinationService> _service;
 
 		/// <summary>
 		/// Either an IP (v4 or v6) or a host/domain name.
 		/// See <a href="https://github.com/elastic/apm/issues/115#issuecomment-555814374">this issue</a> for more information.
-		/// If this property is not set via this public API it will be deduced from other parts of <see cref="SpanContext"/>
-		/// (for example <see cref="SpanContext.Http"/> or <see cref="SpanContext.Db"/>).
+		/// If this property is not set via this public API it will be deduced from other parts of <see cref="SpanContext" />
+		/// (for example <see cref="SpanContext.Http" /> or <see cref="SpanContext.Db" />).
 		/// Explicitly setting this property to <c>null</c> will prohibit this automatic deduction.
 		/// </summary>
 		[JsonConverter(typeof(TrimmedStringJsonConverter))]
@@ -30,11 +31,13 @@ namespace Elastic.Apm.Api
 			set => _address = new Optional<string>(value);
 		}
 
+		internal bool AddressHasValue => _address.HasValue;
+
 		/// <summary>
 		/// Port number - it should not be omitted even if it's the default port number for the corresponding protocol.
 		/// See <a href="https://github.com/elastic/apm/issues/115#issuecomment-555814374">this issue</a> for more information.
-		/// If this property is not set via this public API it will be deduced from other parts of <see cref="SpanContext"/>
-		/// (for example <see cref="SpanContext.Http"/> or <see cref="SpanContext.Db"/>).
+		/// If this property is not set via this public API it will be deduced from other parts of <see cref="SpanContext" />
+		/// (for example <see cref="SpanContext.Http" /> or <see cref="SpanContext.Db" />).
 		/// Explicitly setting this property to <c>null</c> will prohibit this automatic deduction.
 		/// </summary>
 		public int? Port
@@ -43,13 +46,48 @@ namespace Elastic.Apm.Api
 			set => _port = new Optional<int?>(value);
 		}
 
+		/// <summary>
+		/// Destination service context.
+		/// <see cref="DestinationService" />
+		/// </summary>
+		internal DestinationService Service
+		{
+			get => _service.Value;
+			set => _service = new Optional<DestinationService>(value);
+		}
+
 		internal void CopyMissingPropertiesFrom(Destination src)
 		{
 			if (!_address.HasValue) _address = src._address;
 			if (!_port.HasValue) _port = src._port;
+			if (!_service.HasValue) _service = src._service;
 		}
 
-		internal bool AddressHasValue => _address.HasValue;
+		/// <summary>
+		/// Destination service context.
+		/// This represents the logical destination of a span, in order to discover the unique connections between services.
+		/// </summary>
+		public class DestinationService
+		{
+			/// <summary>
+			/// Identifier for the destination service (e.g. 'http://elastic.co', 'elasticsearch', 'rabbitmq')"
+			/// </summary>
+			[JsonConverter(typeof(TrimmedStringJsonConverter))]
+			public string Name { get; set; }
+
+			/// <summary>
+			/// Identifier for the destination service resource being operated on (e.g. 'http://elastic.co:80', 'elasticsearch',
+			/// 'rabbitmq/queue_name')
+			/// </summary>
+			[JsonConverter(typeof(TrimmedStringJsonConverter))]
+			public string Resource { get; set; }
+
+			/// <summary>
+			/// Type of the destination service (e.g. 'db', 'elasticsearch'). Should typically be the same as span.type.
+			/// </summary>
+			[JsonConverter(typeof(TrimmedStringJsonConverter))]
+			public string Type { get; set; }
+		}
 
 		/// <summary>
 		/// The goal is to allow public API user to prohibit automatic deduction of any of  `context.destination` properties.

--- a/test/Elastic.Apm.SqlClient.Tests/SqlClientListenerTests.cs
+++ b/test/Elastic.Apm.SqlClient.Tests/SqlClientListenerTests.cs
@@ -106,6 +106,11 @@ namespace Elastic.Apm.SqlClient.Tests
 			span.Context.Destination.Should().NotBeNull();
 			span.Context.Destination.Address.Should().Be(_expectedAddress);
 			span.Context.Destination.Port.Should().NotBeNull();
+
+			span.Context.Destination.Service.Should().NotBeNull();
+			span.Context.Destination.Service.Name.Should().Be(ApiConstants.SubtypeMssql);
+			span.Context.Destination.Service.Resource.Should().Be(ApiConstants.SubtypeMssql);
+			span.Context.Destination.Service.Type.Should().Be(ApiConstants.TypeDb);
 		}
 
 		[Theory]
@@ -163,6 +168,11 @@ namespace Elastic.Apm.SqlClient.Tests
 			span.Context.Destination.Should().NotBeNull();
 			span.Context.Destination.Address.Should().Be(_expectedAddress);
 			span.Context.Destination.Port.Should().NotBeNull();
+
+			span.Context.Destination.Service.Should().NotBeNull();
+			span.Context.Destination.Service.Name.Should().Be(ApiConstants.SubtypeMssql);
+			span.Context.Destination.Service.Resource.Should().Be(ApiConstants.SubtypeMssql);
+			span.Context.Destination.Service.Type.Should().Be(ApiConstants.TypeDb);
 		}
 
 		public void Dispose() => _apmAgent?.Dispose();


### PR DESCRIPTION
Solves #650. This is needed for service map. Implements https://github.com/elastic/apm/issues/180

- Adds 3 new fields in `span.context.destination.service`
   - `Resource`
   - `Name`
   - `Type`
 
Also set `span.context.destination` in Elastic.Apm.Elasticsearch.

Includes tests for: 
- Outgoing HTTP
- SqlClient (which does not set `span.context.destination` as defined in https://github.com/elastic/apm/issues/180) 
- MSSQL
- Elasticsearch