### PR TITLE
deploy.sh - fix package list

### DIFF
--- a/.ci/linux/deploy.sh
+++ b/.ci/linux/deploy.sh
@@ -4,7 +4,7 @@
 #
 set -euo pipefail
 
-declare -a projectsToPublish=("Elastic.Apm" "Elastic.Apm.AspNetCore" "Elastic.Apm.EntityFrameworkCore" "Elastic.Apm.NetCoreAll" "Elastic.Apm.EntityFramework6" "Elastic.Apm.AspNetFullFramework" "Elastic.Apm.SqlClient", "Elastic.Apm.Elasticsearch", "Elastic.Apm.Extensions.Hosting")
+declare -a projectsToPublish=("Elastic.Apm" "Elastic.Apm.AspNetCore" "Elastic.Apm.EntityFrameworkCore" "Elastic.Apm.NetCoreAll" "Elastic.Apm.EntityFramework6" "Elastic.Apm.AspNetFullFramework" "Elastic.Apm.SqlClient" "Elastic.Apm.Elasticsearch" "Elastic.Apm.Extensions.Hosting")
 
 for project in  "${projectsToPublish[@]}"
 do


### PR DESCRIPTION
Noticed during the release: Unnecessary `,` seems causing packages to be skipped.