### PR TITLE
Add TransactionIgnoreUrls setting

### DIFF
--- a/ElasticApmAgent.sln
+++ b/ElasticApmAgent.sln
@@ -83,6 +83,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AspNetFullFrameworkSampleAp
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Elastic.Apm.AspNetFullFramework", "src\Elastic.Apm.AspNetFullFramework\Elastic.Apm.AspNetFullFramework.csproj", "{7A2EEC30-A6CD-452D-B938-AD25224ABE79}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Elastic.Apm.AspNetFullFramework.Tests", "test\Elastic.Apm.AspNetFullFramework.Tests\Elastic.Apm.AspNetFullFramework.Tests.csproj", "{F931907F-9483-475D-8A42-E052BD493435}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -192,6 +194,10 @@ Global
 		{7A2EEC30-A6CD-452D-B938-AD25224ABE79}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{7A2EEC30-A6CD-452D-B938-AD25224ABE79}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{7A2EEC30-A6CD-452D-B938-AD25224ABE79}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F931907F-9483-475D-8A42-E052BD493435}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F931907F-9483-475D-8A42-E052BD493435}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F931907F-9483-475D-8A42-E052BD493435}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F931907F-9483-475D-8A42-E052BD493435}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -222,6 +228,7 @@ Global
 		{36E2E2DA-2772-417C-AE39-91A34CBF8B41} = {3C791D9C-6F19-4F46-B367-2EC0F818762D}
 		{C45DCD78-7E8A-437C-ABBB-01D154ABCFC4} = {3C791D9C-6F19-4F46-B367-2EC0F818762D}
 		{7A2EEC30-A6CD-452D-B938-AD25224ABE79} = {3734A52F-2222-454B-BF58-1BA5C1F29D77}
+		{F931907F-9483-475D-8A42-E052BD493435} = {267A241E-571F-458F-B04C-B6C4DE79E735}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {69E02FD9-C9DE-412C-AB6B-5B8BECC6BFA5}

--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -672,6 +672,34 @@ the agent will capture request and response headers, including cookies.
 NOTE: Setting this to `false` reduces memory allocations, network bandwidth and disk space used by Elasticsearch.
 
 [float]
+[[config-transaction-ignore-urls]]
+==== `TransactionIgnoreUrls` (performance)
+
+[options="header"]
+|============
+| Environment variable name             | IConfiguration or Web.config key
+| `ELASTIC_APM_TRANSACTION_IGNORE_URLS` | `ElasticApm:TransactionIgnoreUrls`
+|============
+
+[options="header"]
+|============
+| Default                                                                                                                    | Type
+| `/VAADIN/*, /heartbeat*, /favicon.ico", *.js", *.css", *.jpg", *.jpeg", *.png", *.gif", *.webp", *.svg", *.woff", *.woff2` | List<string>
+|============
+
+Used to restrict requests to certain URLs from being instrumented.
+
+This property should be set to a list containing one or more strings.
+When an incoming HTTP request is detected, its request path will be tested against each element in this list.
+
+This option supports the wildcard `*`, which matches zero or more characters.
+Examples: `/foo/*/bar/*/baz*`, `*foo*`.
+Matching is case insensitive by default.
+Prepending an element with `(?-i)` makes the matching case sensitive.
+
+NOTE: All errors that are captured during a request to an ignored URL are still sent to the APM Server regardless of this setting.
+
+[float]
 [[config-use-elastic-apm-traceparent-header]]
 ==== `UseElasticTraceparentHeader` (added[1.3.0])
 
@@ -849,6 +877,7 @@ you must instead set the `LogLevel` for the internal APM logger under the `Loggi
 | <<config-service-version,`ServiceVersion`>> | No | Core
 | <<config-span-frames-min-duration,`SpanFramesMinDuration`>> | No | Stacktrace, Performance
 | <<config-stack-trace-limit,`StackTraceLimit`>> | No | Stacktrace, Performance
+| <<config-transaction-ignore-urls,`TransactionIgnoreUrls`>>  | No | HTTP, Performance
 | <<config-transaction-max-spans,`TransactionMaxSpans`>>  | Yes | Core, Performance
 | <<config-transaction-sample-rate,`TransactionSampleRate`>> | Yes | Core, Performance
 | <<config-use-elastic-apm-traceparent-header,`UseElasticTraceparentHeader`>> | No | HTTP

--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -691,6 +691,14 @@ Used to restrict requests to certain URLs from being instrumented.
 
 This property should be set to a list containing one or more strings.
 When an incoming HTTP request is detected, its request path will be tested against each element in this list.
+For example, adding `/home/index` to this list would match and remove instrumentation from the following URLs:
+
+[source,txt]
+----
+https://www.mycoolsite.com/home/index
+http://localhost/home/index
+http://whatever.com/home/index?value1=123
+----
 
 This option supports the wildcard `*`, which matches zero or more characters.
 Examples: `/foo/*/bar/*/baz*`, `*foo*`.

--- a/sample/AspNetFullFrameworkSampleApp/Controllers/HomeController.cs
+++ b/sample/AspNetFullFrameworkSampleApp/Controllers/HomeController.cs
@@ -99,7 +99,7 @@ namespace AspNetFullFrameworkSampleApp.Controllers
 			return SafeCaptureSpan<ActionResult>($"{ContactSpanPrefix}{SpanNameSuffix}", $"{ContactSpanPrefix}{SpanTypeSuffix}", async () =>
 			{
 				var callToThisAppUrl =
-					new Uri(HttpContext.ApplicationInstance.Request.Url.ToString().ToLower().Replace(ContactPageRelativePath.ToLower(), AboutPageRelativePath));
+					new Uri(HttpContext.ApplicationInstance.Request.Url.ToString().Replace(ContactPageRelativePath, AboutPageRelativePath));
 				var responseFromLocalHost = await GetContentFromUrl(callToThisAppUrl);
 				var callToExternalServiceUrl = ChildHttpCallToExternalServiceUrl;
 				var responseFromElasticCo = await GetContentFromUrl(callToExternalServiceUrl);

--- a/src/Elastic.Apm.AspNetFullFramework/ElasticApmModule.cs
+++ b/src/Elastic.Apm.AspNetFullFramework/ElasticApmModule.cs
@@ -106,6 +106,12 @@ namespace Elastic.Apm.AspNetFullFramework
 			var httpApp = (HttpApplication)eventSender;
 			var httpRequest = httpApp.Context.Request;
 
+			if (WildcardMatcher.IsAnyMatch(Agent.Instance.ConfigurationReader.TransactionIgnoreUrls, httpRequest.Path))
+			{
+				_logger.Debug()?.Log("Request ignored based on TransactionIgnoreUrls, url: {urlPath}", httpRequest.Path);
+				return;
+			}
+
 			var transactionName = $"{httpRequest.HttpMethod} {httpRequest.Path}";
 
 			var soapAction = httpRequest.ExtractSoapAction(_logger);

--- a/src/Elastic.Apm/BackendComm/CentralConfig/CentralConfigFetcher.cs
+++ b/src/Elastic.Apm/BackendComm/CentralConfig/CentralConfigFetcher.cs
@@ -241,6 +241,7 @@ namespace Elastic.Apm.BackendComm.CentralConfig
 			public TimeSpan FlushInterval => _wrapped.FlushInterval;
 
 			public IReadOnlyDictionary<string, string> GlobalLabels => _wrapped.GlobalLabels;
+			public IReadOnlyList<WildcardMatcher> TransactionIgnoreUrls => _wrapped.TransactionIgnoreUrls;
 
 			public LogLevel LogLevel => _centralConfig.LogLevel ?? _wrapped.LogLevel;
 

--- a/src/Elastic.Apm/Config/AbstractConfigurationReader.cs
+++ b/src/Elastic.Apm/Config/AbstractConfigurationReader.cs
@@ -91,7 +91,7 @@ namespace Elastic.Apm.Config
 				var sanitizeFieldNames = kv.Value.Split(',').Where(n => !string.IsNullOrEmpty(n)).ToList();
 
 				var retVal = new List<WildcardMatcher>(sanitizeFieldNames.Count);
-				foreach (var item in sanitizeFieldNames) retVal.Add(WildcardMatcher.ValueOf(item));
+				foreach (var item in sanitizeFieldNames) retVal.Add(WildcardMatcher.ValueOf(item.Trim()));
 				return retVal;
 			}
 			catch (Exception e)
@@ -116,7 +116,7 @@ namespace Elastic.Apm.Config
 				var disableMetrics = kv.Value.Split(',').Where(n => !string.IsNullOrEmpty(n)).ToList();
 
 				var retVal = new List<WildcardMatcher>(disableMetrics.Count);
-				foreach (var item in disableMetrics) retVal.Add(WildcardMatcher.ValueOf(item));
+				foreach (var item in disableMetrics) retVal.Add(WildcardMatcher.ValueOf(item.Trim()));
 				return retVal;
 			}
 			catch (Exception e)
@@ -302,7 +302,7 @@ namespace Elastic.Apm.Config
 				var transactionIgnoreUrls = kv.Value.Split(',').Where(n => !string.IsNullOrEmpty(n)).ToList();
 
 				var retVal = new List<WildcardMatcher>(transactionIgnoreUrls.Count);
-				foreach (var item in transactionIgnoreUrls) retVal.Add(WildcardMatcher.ValueOf(item));
+				foreach (var item in transactionIgnoreUrls) retVal.Add(WildcardMatcher.ValueOf(item.Trim()));
 				return retVal;
 			}
 			catch (Exception e)

--- a/src/Elastic.Apm/Config/AbstractConfigurationWithEnvFallbackReader.cs
+++ b/src/Elastic.Apm/Config/AbstractConfigurationWithEnvFallbackReader.cs
@@ -54,6 +54,9 @@ namespace Elastic.Apm.Config
 		public IReadOnlyDictionary<string, string> GlobalLabels =>
 			ParseGlobalLabels(Read(ConfigConsts.KeyNames.GlobalLabels, ConfigConsts.EnvVarNames.GlobalLabels));
 
+		public IReadOnlyList<WildcardMatcher> TransactionIgnoreUrls =>
+			ParseTransactionIgnoreUrls(Read(ConfigConsts.KeyNames.TransactionIgnoreUrls, ConfigConsts.EnvVarNames.TransactionIgnoreUrls));
+
 		public virtual LogLevel LogLevel => ParseLogLevel(Read(ConfigConsts.KeyNames.LogLevel, ConfigConsts.EnvVarNames.LogLevel));
 
 		public virtual int MaxBatchEventCount =>

--- a/src/Elastic.Apm/Config/ConfigConsts.cs
+++ b/src/Elastic.Apm/Config/ConfigConsts.cs
@@ -36,12 +36,27 @@ namespace Elastic.Apm.Config
 			public const string UnknownServiceName = "unknown";
 			public const bool UseElasticTraceparentHeader = true;
 			public const bool VerifyServerCert = true;
-			public static readonly IReadOnlyCollection<string> DefaultExcludedNamespaces = new List<string>{"System.", "Microsoft.", "MS.", "FSharp.", "Newtonsoft.Json", "Serilog", "NLog", "Giraffe."}.AsReadOnly();
+
+			public static readonly IReadOnlyCollection<string> DefaultExcludedNamespaces =
+				new List<string>
+				{
+					"System.",
+					"Microsoft.",
+					"MS.",
+					"FSharp.",
+					"Newtonsoft.Json",
+					"Serilog",
+					"NLog",
+					"Giraffe."
+				}.AsReadOnly();
+
 			public static readonly IReadOnlyCollection<string> DefaultApplicationNamespaces = new List<string>().AsReadOnly();
 
 			public static List<WildcardMatcher> DisableMetrics = new List<WildcardMatcher>();
 
 			public static List<WildcardMatcher> SanitizeFieldNames;
+
+			public static List<WildcardMatcher> TransactionIgnoreUrls;
 
 			static DefaultValues()
 			{
@@ -61,6 +76,26 @@ namespace Elastic.Apm.Config
 					"set-cookie"
 				})
 					SanitizeFieldNames.Add(WildcardMatcher.ValueOf(item));
+
+				TransactionIgnoreUrls = new List<WildcardMatcher>();
+
+				foreach (var item in new List<string>
+				{
+					"/VAADIN/*",
+					"/heartbeat*",
+					"/favicon.ico",
+					"*.js",
+					"*.css",
+					"*.jpg",
+					"*.jpeg",
+					"*.png",
+					"*.gif",
+					"*.webp",
+					"*.svg",
+					"*.woff",
+					"*.woff2"
+				})
+					TransactionIgnoreUrls.Add(WildcardMatcher.ValueOf(item));
 			}
 
 			public static Uri ServerUri => new Uri($"http://localhost:{ApmServerPort}");
@@ -96,6 +131,7 @@ namespace Elastic.Apm.Config
 			public const string VerifyServerCert = Prefix + "VERIFY_SERVER_CERT";
 			public const string ExcludedNamespaces = Prefix + "EXCLUDED_NAMESPACES";
 			public const string ApplicationNamespaces = Prefix + "APPLICATION_NAMESPACES";
+			public static string TransactionIgnoreUrls = Prefix + "TRANSACTION_IGNORE_URLS";
 		}
 
 		public static class KeyNames
@@ -127,6 +163,7 @@ namespace Elastic.Apm.Config
 			public const string VerifyServerCert = "ElasticApm:VerifyServerCert";
 			public const string ExcludedNamespaces = "ElasticApm:ExcludedNamespaces";
 			public const string ApplicationNamespaces = "ElasticApm:ApplicationNamespaces";
+			public static string TransactionIgnoreUrls = "ElasticApm:TransactionIgnoreUrls";
 		}
 
 		public static class SupportedValues

--- a/src/Elastic.Apm/Config/ConfigSnapshotFromReader.cs
+++ b/src/Elastic.Apm/Config/ConfigSnapshotFromReader.cs
@@ -28,6 +28,7 @@ namespace Elastic.Apm.Config
 		public string Environment => _content.Environment;
 		public TimeSpan FlushInterval => _content.FlushInterval;
 		public IReadOnlyDictionary<string, string> GlobalLabels => _content.GlobalLabels;
+		public IReadOnlyList<WildcardMatcher> TransactionIgnoreUrls => _content.TransactionIgnoreUrls;
 		public LogLevel LogLevel => _content.LogLevel;
 		public int MaxBatchEventCount => _content.MaxBatchEventCount;
 		public int MaxQueueEventCount => _content.MaxQueueEventCount;

--- a/src/Elastic.Apm/Config/EnvironmentConfigurationReader.cs
+++ b/src/Elastic.Apm/Config/EnvironmentConfigurationReader.cs
@@ -43,6 +43,7 @@ namespace Elastic.Apm.Config
 		public TimeSpan FlushInterval => ParseFlushInterval(Read(ConfigConsts.EnvVarNames.FlushInterval));
 
 		public IReadOnlyDictionary<string, string> GlobalLabels => ParseGlobalLabels(Read(ConfigConsts.EnvVarNames.GlobalLabels));
+		public IReadOnlyList<WildcardMatcher> TransactionIgnoreUrls => ParseTransactionIgnoreUrls(Read(ConfigConsts.EnvVarNames.TransactionIgnoreUrls));
 
 		public LogLevel LogLevel => ParseLogLevel(Read(ConfigConsts.EnvVarNames.LogLevel));
 

--- a/src/Elastic.Apm/Config/IConfigurationReader.cs
+++ b/src/Elastic.Apm/Config/IConfigurationReader.cs
@@ -11,6 +11,15 @@ namespace Elastic.Apm.Config
 {
 	public interface IConfigurationReader
 	{
+		string ApiKey { get; }
+
+		/// <summary>
+		/// When defined, all namespaces not starting with one of the values of this collection are ignored when determining
+		/// Exception culprit.
+		/// This suppresses any configuration of <see cref="ExcludedNamespaces" />
+		/// </summary>
+		IReadOnlyCollection<string> ApplicationNamespaces { get; }
+
 		string CaptureBody { get; }
 		List<string> CaptureBodyContentTypes { get; }
 		bool CaptureHeaders { get; }
@@ -23,6 +32,12 @@ namespace Elastic.Apm.Config
 		IReadOnlyList<WildcardMatcher> DisableMetrics { get; }
 
 		string Environment { get; }
+
+		/// <summary>
+		/// A list of namespaces to exclude when reading an exception's StackTrace to determine the culprit.
+		/// Namespaces are checked with string.StartsWith() so "System." matches all System namespaces
+		/// </summary>
+		IReadOnlyCollection<string> ExcludedNamespaces { get; }
 
 		/// <summary>
 		/// The maximal amount of time (in seconds) events are held in queue until there is enough to send a batch.
@@ -53,6 +68,11 @@ namespace Elastic.Apm.Config
 		TimeSpan FlushInterval { get; }
 
 		IReadOnlyDictionary<string, string> GlobalLabels { get; }
+
+		/// <summary>
+		/// A list of patterns to match HTTP requests to ignore. An incoming HTTP request whose request line matches any of the patterns will not be reported as a transaction.
+		/// </summary>
+		IReadOnlyList<WildcardMatcher> TransactionIgnoreUrls { get; }
 
 		LogLevel LogLevel { get; }
 
@@ -108,7 +128,6 @@ namespace Elastic.Apm.Config
 		// </summary>
 		IReadOnlyList<WildcardMatcher> SanitizeFieldNames { get; }
 		string SecretToken { get; }
-		string ApiKey { get; }
 		IReadOnlyList<Uri> ServerUrls { get; }
 		string ServiceName { get; }
 
@@ -153,17 +172,5 @@ namespace Elastic.Apm.Config
 		/// Verification can be disabled by setting to <c>false</c>.
 		/// </summary>
 		bool VerifyServerCert { get; }
-
-		/// <summary>
-		/// A list of namespaces to exclude when reading an exception's StackTrace to determine the culprit.
-		/// Namespaces are checked with string.StartsWith() so "System." matches all System namespaces
-		/// </summary>
-		IReadOnlyCollection<string> ExcludedNamespaces { get; }
-
-		/// <summary>
-		/// When defined, all namespaces not starting with one of the values of this collection are ignored when determining Exception culprit.
-		/// This suppresses any configuration of <see cref="ExcludedNamespaces"/>
-		/// </summary>
-		IReadOnlyCollection<string> ApplicationNamespaces { get; }
 	}
 }

--- a/src/Elastic.Apm/Filters/TransactionIgnoreUrlsFilter.cs
+++ b/src/Elastic.Apm/Filters/TransactionIgnoreUrlsFilter.cs
@@ -1,0 +1,22 @@
+﻿// Licensed to Elasticsearch B.V under
+// one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using Elastic.Apm.Api;
+using Elastic.Apm.Config;
+using Elastic.Apm.Helpers;
+
+namespace Elastic.Apm.Filters
+{
+	/// <summary>
+	/// Contains a transaction filter which filters out transactions based on request url path.
+	/// </summary>
+	internal class TransactionIgnoreUrlsFilter
+	{
+		private readonly IConfigSnapshot _configSnapshot;
+		public TransactionIgnoreUrlsFilter(IConfigSnapshot configSnapshot) => _configSnapshot = configSnapshot;
+		public ITransaction Filter(ITransaction transaction) =>
+			WildcardMatcher.IsAnyMatch(_configSnapshot.TransactionIgnoreUrls, transaction?.Context?.Request?.Url?.PathName) ? null : transaction;
+	}
+}

--- a/src/Elastic.Apm/Report/PayloadSenderV2.cs
+++ b/src/Elastic.Apm/Report/PayloadSenderV2.cs
@@ -13,6 +13,7 @@ using System.Threading.Tasks.Dataflow;
 using Elastic.Apm.Api;
 using Elastic.Apm.BackendComm;
 using Elastic.Apm.Config;
+using Elastic.Apm.Filters;
 using Elastic.Apm.Helpers;
 using Elastic.Apm.Logging;
 using Elastic.Apm.Metrics;
@@ -88,7 +89,7 @@ namespace Elastic.Apm.Report
 					, _intakeV2EventsAbsoluteUrl, _flushInterval.ToHms(), config.MaxBatchEventCount, _maxQueueEventCount);
 
 			_eventQueue = new BatchBlock<object>(config.MaxBatchEventCount);
-
+			TransactionFilters.Add(new TransactionIgnoreUrlsFilter(config).Filter);
 			StartWorkLoop();
 		}
 
@@ -219,6 +220,7 @@ namespace Elastic.Apm.Report
 					_cachedMetadataJsonLine = "{\"metadata\": " + _payloadItemSerializer.SerializeObject(_metadata) + "}";
 				ndjson.AppendLine(_cachedMetadataJsonLine);
 
+				// Apply filters
 				foreach (var item in queueItems)
 				{
 					switch (item)

--- a/test/Elastic.Apm.AspNetCore.Tests/TransactionIgnoreUrlsTest.cs
+++ b/test/Elastic.Apm.AspNetCore.Tests/TransactionIgnoreUrlsTest.cs
@@ -51,7 +51,6 @@ namespace Elastic.Apm.AspNetCore.Tests
 #endif
 		}
 
-
 		/// <summary>
 		/// In the ctor we add `*SimplePage` to the ignoreUrl list. This test makes sure that /home/SimplePage is indeed ignored.
 		/// </summary>

--- a/test/Elastic.Apm.AspNetCore.Tests/TransactionIgnoreUrlsTest.cs
+++ b/test/Elastic.Apm.AspNetCore.Tests/TransactionIgnoreUrlsTest.cs
@@ -29,7 +29,6 @@ namespace Elastic.Apm.AspNetCore.Tests
 
 		private readonly HttpClient _client;
 
-
 		public TransactionIgnoreUrlsTest(WebApplicationFactory<Startup> factory, ITestOutputHelper xUnitOutputHelper) : base(xUnitOutputHelper)
 		{
 			_factory = factory;

--- a/test/Elastic.Apm.AspNetCore.Tests/TransactionIgnoreUrlsTest.cs
+++ b/test/Elastic.Apm.AspNetCore.Tests/TransactionIgnoreUrlsTest.cs
@@ -1,0 +1,68 @@
+﻿using System.Net.Http;
+using System.Threading.Tasks;
+using Elastic.Apm.Extensions.Hosting;
+using Elastic.Apm.Logging;
+using Elastic.Apm.Tests.Mocks;
+using Elastic.Apm.Tests.TestHelpers;
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc.Testing;
+using SampleAspNetCoreApp;
+using Xunit;
+using Xunit.Abstractions;
+
+#if NETCOREAPP3_0 || NETCOREAPP3_1
+using System;
+#endif
+
+namespace Elastic.Apm.AspNetCore.Tests
+{
+	[Collection("DiagnosticListenerTest")]
+	public class TransactionIgnoreUrlsTest : LoggingTestBase, IClassFixture<WebApplicationFactory<Startup>>
+	{
+		private const string ThisClassName = nameof(AspNetCoreMiddlewareTests);
+		private readonly ApmAgent _agent;
+		private readonly MockPayloadSender _capturedPayload;
+		private readonly WebApplicationFactory<Startup> _factory;
+
+		// ReSharper disable once PrivateFieldCanBeConvertedToLocalVariable
+		private readonly IApmLogger _logger;
+
+		private readonly HttpClient _client;
+
+
+		public TransactionIgnoreUrlsTest(WebApplicationFactory<Startup> factory, ITestOutputHelper xUnitOutputHelper) : base(xUnitOutputHelper)
+		{
+			_factory = factory;
+			_logger = LoggerBase.Scoped(ThisClassName);
+
+			_agent = new ApmAgent(new TestAgentComponents(
+				_logger,
+				new MockConfigSnapshot(_logger, transactionIgnoreUrls: "*SimplePage"),
+				// _agent needs to share CurrentExecutionSegmentsContainer with Agent.Instance
+				// because the sample application used by the tests (SampleAspNetCoreApp) uses Agent.Instance.Tracer.CurrentTransaction/CurrentSpan
+				currentExecutionSegmentsContainer: Agent.Instance.TracerInternal.CurrentExecutionSegmentsContainer)
+			);
+			HostBuilderExtensions.UpdateServiceInformation(_agent.Service);
+
+			_capturedPayload = _agent.PayloadSender as MockPayloadSender;
+			_client = Helper.GetClient(_agent, _factory);
+#if NETCOREAPP3_0 || NETCOREAPP3_1
+			_client.DefaultRequestVersion = new Version(2, 0);
+#endif
+		}
+
+
+		/// <summary>
+		/// In the ctor we add `*SimplePage` to the ignoreUrl list. This test makes sure that /home/SimplePage is indeed ignored.
+		/// </summary>
+		/// <returns></returns>
+		[Fact]
+		public async Task IgnoreSimplePage()
+		{
+			var response = await _client.GetAsync("/Home/SimplePage");
+
+			response.IsSuccessStatusCode.Should().BeTrue();
+			_capturedPayload.Transactions.Should().BeEmpty();
+		}
+	}
+}

--- a/test/Elastic.Apm.AspNetCore.Tests/TransactionIgnoreUrlsTest.cs
+++ b/test/Elastic.Apm.AspNetCore.Tests/TransactionIgnoreUrlsTest.cs
@@ -57,7 +57,7 @@ namespace Elastic.Apm.AspNetCore.Tests
 		[Fact]
 		public async Task IgnoreSimplePage()
 		{
-			var response = await _client.GetAsync("/Home/SimplePage");
+			var response = await _client.GetAsync("/Home/SimplePage?myUrlParam=123");
 
 			response.IsSuccessStatusCode.Should().BeTrue();
 			_capturedPayload.Transactions.Should().BeEmpty();

--- a/test/Elastic.Apm.AspNetCore.Tests/TransactionIgnoreUrlsTest.cs
+++ b/test/Elastic.Apm.AspNetCore.Tests/TransactionIgnoreUrlsTest.cs
@@ -37,7 +37,7 @@ namespace Elastic.Apm.AspNetCore.Tests
 
 			_agent = new ApmAgent(new TestAgentComponents(
 				_logger,
-				new MockConfigSnapshot(_logger, transactionIgnoreUrls: "*SimplePage"),
+				new MockConfigSnapshot(_logger, transactionIgnoreUrls: "*simplepage"),
 				// _agent needs to share CurrentExecutionSegmentsContainer with Agent.Instance
 				// because the sample application used by the tests (SampleAspNetCoreApp) uses Agent.Instance.Tracer.CurrentTransaction/CurrentSpan
 				currentExecutionSegmentsContainer: Agent.Instance.TracerInternal.CurrentExecutionSegmentsContainer)
@@ -63,6 +63,8 @@ namespace Elastic.Apm.AspNetCore.Tests
 
 			response.IsSuccessStatusCode.Should().BeTrue();
 			_capturedPayload.Transactions.Should().BeEmpty();
+			_capturedPayload.Spans.Should().BeEmpty();
+			_capturedPayload.Errors.Should().BeEmpty();
 		}
 	}
 }

--- a/test/Elastic.Apm.AspNetFullFramework.Tests/TransactionIgnoreUrlsTest.cs
+++ b/test/Elastic.Apm.AspNetFullFramework.Tests/TransactionIgnoreUrlsTest.cs
@@ -1,0 +1,36 @@
+﻿// Licensed to Elasticsearch B.V under
+// one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Elastic.Apm.Config;
+using FluentAssertions;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Elastic.Apm.AspNetFullFramework.Tests
+{
+	[Collection(Consts.AspNetFullFrameworkTestsCollection)]
+	public class TransactionIgnoreUrlsTest : TestsBase
+	{
+		public TransactionIgnoreUrlsTest(ITestOutputHelper xUnitOutputHelper)
+			: base(xUnitOutputHelper,
+				envVarsToSetForSampleAppPool: new Dictionary<string, string> { { ConfigConsts.EnvVarNames.TransactionIgnoreUrls, "/home" } }) { }
+
+		[AspNetFullFrameworkFact]
+		public async Task Test()
+		{
+			var sampleAppUrlPathData = SampleAppUrlPaths.HomePage;
+			await SendGetRequestToSampleAppAndVerifyResponse(sampleAppUrlPathData.RelativeUrlPath, sampleAppUrlPathData.StatusCode);
+
+			await WaitAndCustomVerifyReceivedData(receivedData =>
+			{
+				receivedData.Transactions.Should().BeEmpty();
+				receivedData.Spans.Should().BeEmpty();
+				receivedData.Errors.Should().BeEmpty();
+			});
+		}
+	}
+}

--- a/test/Elastic.Apm.Tests/ConfigTests.cs
+++ b/test/Elastic.Apm.Tests/ConfigTests.cs
@@ -45,7 +45,7 @@ namespace Elastic.Apm.Tests
 			{ "k=,=", new Dictionary<string, string> { { "k", "" }, { "", "" } } },
 
 			// key and value are empty strings in the middle pair
-			{ "key1=value1,=,key3=value3", new Dictionary<string, string> { { "key1", "value1" }, { "", "" }, { "key3", "value3" } } },
+			{ "key1=value1,=,key3=value3", new Dictionary<string, string> { { "key1", "value1" }, { "", "" }, { "key3", "value3" } } }
 		};
 
 		[Fact]
@@ -766,7 +766,6 @@ namespace Elastic.Apm.Tests
 		}
 
 
-
 		/// <summary>
 		/// Disables CPU metrics and makes sure that remaining metrics are still captured
 		/// </summary>
@@ -808,6 +807,66 @@ namespace Elastic.Apm.Tests
 		{
 			var agent = new ApmAgent(new TestAgentComponents(config: new MockConfigSnapshot(verifyServerCert: verifyServerCert)));
 			agent.ConfigurationReader.VerifyServerCert.Should().Be(expected);
+		}
+
+		/// <summary>
+		/// Sets the TransactionIgnoreUrls setting and makes sure the agent config contains those
+		/// </summary>
+		[Fact]
+		public void TransactionIgnoreUrlsTestWithCustomSetting()
+		{
+			var agent = new ApmAgent(new TestAgentComponents(config: new MockConfigSnapshot(transactionIgnoreUrls: "*index,*myPageToIgnore*")));
+			WildcardMatcher.IsAnyMatch(agent.ConfigurationReader.TransactionIgnoreUrls, "INDEX").Should().BeTrue();
+			WildcardMatcher.IsAnyMatch(agent.ConfigurationReader.TransactionIgnoreUrls, "/home/INDEX").Should().BeTrue();
+			WildcardMatcher.IsAnyMatch(agent.ConfigurationReader.TransactionIgnoreUrls, "INdEX").Should().BeTrue();
+			WildcardMatcher.IsAnyMatch(agent.ConfigurationReader.TransactionIgnoreUrls, "index").Should().BeTrue();
+			WildcardMatcher.IsAnyMatch(agent.ConfigurationReader.TransactionIgnoreUrls, "myPageToIgnore").Should().BeTrue();
+
+			// default list is not applied when TransactionIgnoreUrls is set
+			WildcardMatcher.IsAnyMatch(agent.ConfigurationReader.TransactionIgnoreUrls, "myJsScripts.js").Should().BeFalse();
+			WildcardMatcher.IsAnyMatch(agent.ConfigurationReader.TransactionIgnoreUrls, "bootstrap.css").Should().BeFalse();
+		}
+
+		/// <summary>
+		/// Tests case sensitive TransactionIgnoreUrls
+		/// </summary>
+		[Fact]
+		public void TransactionIgnoreUrlsTestWithCustomCaseSensitiveSetting()
+		{
+			var agent = new ApmAgent(
+				new TestAgentComponents(config: new MockConfigSnapshot(transactionIgnoreUrls: "(?-i)*index,(?-i)*myPageToIgnore*")));
+			WildcardMatcher.IsAnyMatch(agent.ConfigurationReader.TransactionIgnoreUrls, "index").Should().BeTrue();
+			WildcardMatcher.IsAnyMatch(agent.ConfigurationReader.TransactionIgnoreUrls, "INDEX").Should().BeFalse();
+			WildcardMatcher.IsAnyMatch(agent.ConfigurationReader.TransactionIgnoreUrls, "/home/INDEX").Should().BeFalse();
+			WildcardMatcher.IsAnyMatch(agent.ConfigurationReader.TransactionIgnoreUrls, "INdEX").Should().BeFalse();
+			WildcardMatcher.IsAnyMatch(agent.ConfigurationReader.TransactionIgnoreUrls, "myPageToIgnore").Should().BeTrue();
+			WildcardMatcher.IsAnyMatch(agent.ConfigurationReader.TransactionIgnoreUrls, "myPagetoignore").Should().BeFalse();
+
+			// default list is not applied when TransactionIgnoreUrls is set
+			WildcardMatcher.IsAnyMatch(agent.ConfigurationReader.TransactionIgnoreUrls, "myJsScripts.js").Should().BeFalse();
+			WildcardMatcher.IsAnyMatch(agent.ConfigurationReader.TransactionIgnoreUrls, "bootstrap.css").Should().BeFalse();
+		}
+
+		/// <summary>
+		/// Applies the default agent settings and makes sure that *js and *css are filtered out, but
+		/// some other random urls are not ignored.
+		/// </summary>
+		[Fact]
+		public void TransactionIgnoreUrlsTestWithDefaultSetting()
+		{
+			// use default settings
+			var agent = new ApmAgent(new TestAgentComponents(config: new MockConfigSnapshot()));
+
+			// some random pages should be captured
+			WildcardMatcher.IsAnyMatch(agent.ConfigurationReader.TransactionIgnoreUrls, "INDEX").Should().BeFalse();
+			WildcardMatcher.IsAnyMatch(agent.ConfigurationReader.TransactionIgnoreUrls, "/home/INDEX").Should().BeFalse();
+			WildcardMatcher.IsAnyMatch(agent.ConfigurationReader.TransactionIgnoreUrls, "INdEX").Should().BeFalse();
+			WildcardMatcher.IsAnyMatch(agent.ConfigurationReader.TransactionIgnoreUrls, "index").Should().BeFalse();
+			WildcardMatcher.IsAnyMatch(agent.ConfigurationReader.TransactionIgnoreUrls, "myRandomPage").Should().BeFalse();
+
+			// *js and *css is by default ignored
+			WildcardMatcher.IsAnyMatch(agent.ConfigurationReader.TransactionIgnoreUrls, "myJsScripts.js").Should().BeTrue();
+			WildcardMatcher.IsAnyMatch(agent.ConfigurationReader.TransactionIgnoreUrls, "bootstrap.css").Should().BeTrue();
 		}
 
 		private static double MetricsIntervalTestCommon(string configValue)

--- a/test/Elastic.Apm.Tests/ConfigTests.cs
+++ b/test/Elastic.Apm.Tests/ConfigTests.cs
@@ -813,9 +813,28 @@ namespace Elastic.Apm.Tests
 		/// Sets the TransactionIgnoreUrls setting and makes sure the agent config contains those
 		/// </summary>
 		[Fact]
-		public void TransactionIgnoreUrlsTestWithCustomSetting()
+		public void TransactionIgnoreUrlsTestWithCustomSettingNoSpace()
 		{
 			var agent = new ApmAgent(new TestAgentComponents(config: new MockConfigSnapshot(transactionIgnoreUrls: "*index,*myPageToIgnore*")));
+			WildcardMatcher.IsAnyMatch(agent.ConfigurationReader.TransactionIgnoreUrls, "INDEX").Should().BeTrue();
+			WildcardMatcher.IsAnyMatch(agent.ConfigurationReader.TransactionIgnoreUrls, "/home/INDEX").Should().BeTrue();
+			WildcardMatcher.IsAnyMatch(agent.ConfigurationReader.TransactionIgnoreUrls, "INdEX").Should().BeTrue();
+			WildcardMatcher.IsAnyMatch(agent.ConfigurationReader.TransactionIgnoreUrls, "index").Should().BeTrue();
+			WildcardMatcher.IsAnyMatch(agent.ConfigurationReader.TransactionIgnoreUrls, "myPageToIgnore").Should().BeTrue();
+
+			// default list is not applied when TransactionIgnoreUrls is set
+			WildcardMatcher.IsAnyMatch(agent.ConfigurationReader.TransactionIgnoreUrls, "myJsScripts.js").Should().BeFalse();
+			WildcardMatcher.IsAnyMatch(agent.ConfigurationReader.TransactionIgnoreUrls, "bootstrap.css").Should().BeFalse();
+		}
+
+		/// <summary>
+		/// Sets the TransactionIgnoreUrls setting and makes sure the agent config contains those.
+		/// It uses a space in the list.
+		/// </summary>
+		[Fact]
+		public void TransactionIgnoreUrlsTestWithCustomSettingWithSpace()
+		{
+			var agent = new ApmAgent(new TestAgentComponents(config: new MockConfigSnapshot(transactionIgnoreUrls: "*index, *myPageToIgnore*")));
 			WildcardMatcher.IsAnyMatch(agent.ConfigurationReader.TransactionIgnoreUrls, "INDEX").Should().BeTrue();
 			WildcardMatcher.IsAnyMatch(agent.ConfigurationReader.TransactionIgnoreUrls, "/home/INDEX").Should().BeTrue();
 			WildcardMatcher.IsAnyMatch(agent.ConfigurationReader.TransactionIgnoreUrls, "INdEX").Should().BeTrue();

--- a/test/Elastic.Apm.Tests/ConstructorTests.cs
+++ b/test/Elastic.Apm.Tests/ConstructorTests.cs
@@ -47,6 +47,7 @@ namespace Elastic.Apm.Tests
 			public string ServiceNodeName { get; }
 			public TimeSpan FlushInterval => TimeSpan.FromMilliseconds(ConfigConsts.DefaultValues.FlushIntervalInMilliseconds);
 			public IReadOnlyDictionary<string, string> GlobalLabels => new Dictionary<string, string>();
+			public IReadOnlyList<WildcardMatcher> TransactionIgnoreUrls => ConfigConsts.DefaultValues.TransactionIgnoreUrls;
 			public LogLevel LogLevel { get; }
 			public int MaxBatchEventCount => ConfigConsts.DefaultValues.MaxBatchEventCount;
 			public int MaxQueueEventCount => ConfigConsts.DefaultValues.MaxQueueEventCount;

--- a/test/Elastic.Apm.Tests/Mocks/MockConfigSnapshot.cs
+++ b/test/Elastic.Apm.Tests/Mocks/MockConfigSnapshot.cs
@@ -43,6 +43,7 @@ namespace Elastic.Apm.Tests.Mocks
 		private readonly string _transactionSampleRate;
 		private readonly string _useElasticTraceparentHeader;
 		private readonly string _verifyServerCert;
+		private readonly string _transactionIgnoreUrls;
 
 		public MockConfigSnapshot(IApmLogger logger = null,
 			string logLevel = null,
@@ -72,7 +73,8 @@ namespace Elastic.Apm.Tests.Mocks
 			string verifyServerCert = null,
 			string useElasticTraceparentHeader = null,
 			string applicationNamespaces = null,
-			string excludedNamespaces = null
+			string excludedNamespaces = null,
+			string transactionIgnoreUrls = null
 		) : base(logger, ThisClassName)
 		{
 			_serverUrls = serverUrls;
@@ -103,6 +105,7 @@ namespace Elastic.Apm.Tests.Mocks
 			_useElasticTraceparentHeader = useElasticTraceparentHeader;
 			_applicationNamespaces = applicationNamespaces;
 			_excludedNamespaces = excludedNamespaces;
+			_transactionIgnoreUrls = transactionIgnoreUrls;
 		}
 
 		public string ApiKey => ParseApiKey(Kv(ConfigConsts.EnvVarNames.ApiKey, _apiKey, Origin));
@@ -132,6 +135,9 @@ namespace Elastic.Apm.Tests.Mocks
 
 		public IReadOnlyDictionary<string, string> GlobalLabels =>
 			ParseGlobalLabels(Kv(ConfigConsts.EnvVarNames.GlobalLabels, _globalLabels, Origin));
+
+		public IReadOnlyList<WildcardMatcher> TransactionIgnoreUrls =>
+			ParseTransactionIgnoreUrls(Kv(ConfigConsts.EnvVarNames.TransactionIgnoreUrls, _transactionIgnoreUrls, Origin));
 
 		public LogLevel LogLevel => ParseLogLevel(Kv(ConfigConsts.EnvVarNames.LogLevel, _logLevel, Origin));
 		public int MaxBatchEventCount => ParseMaxBatchEventCount(Kv(ConfigConsts.EnvVarNames.MaxBatchEventCount, _maxBatchEventCount, Origin));

--- a/test/Elastic.Apm.Tests/Mocks/MockPayloadSender.cs
+++ b/test/Elastic.Apm.Tests/Mocks/MockPayloadSender.cs
@@ -43,7 +43,7 @@ namespace Elastic.Apm.Tests.Mocks
 
 		public void QueueError(IError error) => DoUnderLock(() => { _errors.Add(error); });
 
-		public void QueueTransaction(ITransaction transaction) => DoUnderLock(() => { _transactions.Add(transaction); });
+		public virtual void QueueTransaction(ITransaction transaction) => DoUnderLock(() => { _transactions.Add(transaction); });
 
 		public void QueueSpan(ISpan span) => DoUnderLock(() => { _spans.Add(span); });
 

--- a/test/Elastic.Apm.Tests/Mocks/MockPayloadSenderWithFilters.cs
+++ b/test/Elastic.Apm.Tests/Mocks/MockPayloadSenderWithFilters.cs
@@ -1,0 +1,28 @@
+﻿// Licensed to Elasticsearch B.V under
+// one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System;
+using System.Collections.Generic;
+using Elastic.Apm.Api;
+using Elastic.Apm.Filters;
+
+namespace Elastic.Apm.Tests.Mocks
+{
+	internal class MockPayloadSenderWithFilters : MockPayloadSender
+	{
+		private readonly List<Func<ITransaction, ITransaction>> _transactionFilters = new List<Func<ITransaction, ITransaction>>();
+
+		public MockPayloadSenderWithFilters() => _transactionFilters.Add(new TransactionIgnoreUrlsFilter(new MockConfigSnapshot()).Filter);
+
+		public override void QueueTransaction(ITransaction transaction)
+		{
+			foreach (var filter in _transactionFilters)
+			{
+				if(filter(transaction) != null)
+					base.QueueTransaction(transaction);
+			}
+		}
+	}
+}

--- a/test/Elastic.Apm.Tests/TransactionIgnoreUrlsTests.cs
+++ b/test/Elastic.Apm.Tests/TransactionIgnoreUrlsTests.cs
@@ -1,0 +1,44 @@
+﻿// Licensed to Elasticsearch B.V under
+// one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using Elastic.Apm.Api;
+using Elastic.Apm.Report;
+using Elastic.Apm.Tests.Mocks;
+using FluentAssertions;
+using Xunit;
+
+namespace Elastic.Apm.Tests
+{
+	public class TransactionIgnoreUrlsTests
+	{
+		[Fact]
+		public void TransactionWithDefaultIgnoreUrlsSetting()
+		{
+			var payloadSender = new MockPayloadSenderWithFilters();
+			using var agent = new ApmAgent(new TestAgentComponents(payloadSender: payloadSender));
+
+			agent.Tracer.CaptureTransaction("Test", "Test",
+				transaction =>
+				{
+					transaction.Context.Request =
+						new Request("GET", new Url { Full = "http://localhost/bootstrap.css", PathName = "/bootstrap.css" });
+				});
+			payloadSender.Transactions.Should().BeEmpty();
+
+			agent.Tracer.CaptureTransaction("Test", "Test",
+				transaction =>
+				{
+					transaction.Context.Request =
+						new Request("GET", new Url { Full = "http://localhost/home/index", PathName = "/home/index" });
+				});
+			payloadSender.Transactions.Count.Should().Be(1);
+
+			agent.Tracer.CaptureTransaction("Test", "Test",
+				transaction => { });
+
+			payloadSender.Transactions.Count.Should().Be(2);
+		}
+	}
+}


### PR DESCRIPTION
Solves https://github.com/elastic/apm-agent-dotnet/issues/688, implements https://github.com/elastic/apm/issues/144

The `TransactionIgnoreUrls` config takes a list and matches each url path against it. If the given url path is in the list, then it'll be ignored - meaning no transaction will be captured.

It checks the path part of the url. E.g. adding `/home/index` will match all of the followings:
- `https://www.myCoolSite.com/home/index`
- `http://localhost/home/index`
- `http://whatever.com/home/index?value1=123` (so query string is ignored for matching)

By default it's case insensitive.

ToDo:
- [x] Apply this also in ASP.NET Classic
- [x] More tests 
- [x] Think about custom transactions and how to apply it there