### PR TITLE
Fix compiler warnings

### DIFF
--- a/sample/AspNetFullFrameworkSampleApp/AspNetFullFrameworkSampleApp.csproj
+++ b/sample/AspNetFullFrameworkSampleApp/AspNetFullFrameworkSampleApp.csproj
@@ -218,7 +218,7 @@
       <Version>3.5.1</Version>
     </PackageReference>
     <PackageReference Include="EntityFramework">
-      <Version>6.2.0</Version>
+      <Version>6.3.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.AspNet.Mvc">
       <Version>5.2.4</Version>
@@ -258,6 +258,29 @@
   <PropertyGroup Condition="'$(OS)' == 'WINDOWS_NT'">
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+    <TypeScriptTarget>ES2016</TypeScriptTarget>
+    <TypeScriptJSXEmit>React</TypeScriptJSXEmit>
+    <TypeScriptModuleKind>AMD</TypeScriptModuleKind>
+    <TypeScriptCompileOnSaveEnabled>True</TypeScriptCompileOnSaveEnabled>
+    <TypeScriptNoImplicitAny>False</TypeScriptNoImplicitAny>
+    <TypeScriptRemoveComments>False</TypeScriptRemoveComments>
+    <TypeScriptOutFile />
+    <TypeScriptOutDir />
+    <TypeScriptGeneratesDeclarations>False</TypeScriptGeneratesDeclarations>
+    <TypeScriptNoEmitOnError>True</TypeScriptNoEmitOnError>
+    <TypeScriptSourceMap>True</TypeScriptSourceMap>
+    <TypeScriptMapRoot />
+    <TypeScriptSourceRoot />
+  </PropertyGroup>
+  <PropertyGroup>
+    <TypeScriptToolsVersion>Latest</TypeScriptToolsVersion>
+    <UseIISExpress>true</UseIISExpress>
+    <Use64BitIISExpress />
+    <IISExpressSSLPort />
+    <IISExpressAnonymousAuthentication />
+    <IISExpressWindowsAuthentication />
+    <IISExpressUseClassicPipelineMode />
+    <UseGlobalApplicationHostFile />
   </PropertyGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" Condition="'$(OS)' == 'WINDOWS_NT'" />
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\TypeScript\Microsoft.TypeScript.targets" Condition="'$(OS)' == 'WINDOWS_NT' AND Exists('$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\TypeScript\Microsoft.TypeScript.targets')" />

--- a/src/Elastic.Apm.AspNetCore/ApmMiddlewareExtension.cs
+++ b/src/Elastic.Apm.AspNetCore/ApmMiddlewareExtension.cs
@@ -75,7 +75,12 @@ namespace Elastic.Apm.AspNetCore
 		}
 
 		internal static string GetEnvironmentName(this IServiceProvider serviceProvider) =>
+#if NETCOREAPP3_0
+			(serviceProvider.GetService(typeof(IWebHostEnvironment)) as IWebHostEnvironment)?.EnvironmentName;
+#else
 			(serviceProvider.GetService(typeof(IHostingEnvironment)) as IHostingEnvironment)?.EnvironmentName;
+#endif
+
 
 		internal static IApmLogger GetApmLogger(this IServiceProvider serviceProvider) =>
 			serviceProvider.GetService(typeof(ILoggerFactory)) is ILoggerFactory loggerFactory

--- a/src/Elastic.Apm.AspNetCore/Elastic.Apm.AspNetCore.csproj
+++ b/src/Elastic.Apm.AspNetCore/Elastic.Apm.AspNetCore.csproj
@@ -20,6 +20,7 @@
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="3.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="3.0.0" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="DiagnosticListener\" />

--- a/src/Elastic.Apm/Metrics/MetricsProvider/SystemTotalCpuProvider.cs
+++ b/src/Elastic.Apm/Metrics/MetricsProvider/SystemTotalCpuProvider.cs
@@ -48,11 +48,11 @@ namespace Elastic.Apm.Metrics.MetricsProvider
 
 			if (!RuntimeInformation.IsOSPlatform(OSPlatform.Linux)) return;
 
-			var procStatValues = ReadProcStat();
-			if (!procStatValues.success) return;
+			var (success, idle, total) = ReadProcStat();
+			if (!success) return;
 
-			_prevIdleTime = procStatValues.idle;
-			_prevTotalTime = procStatValues.total;
+			_prevIdleTime = idle;
+			_prevTotalTime = total;
 		}
 
 		internal SystemTotalCpuProvider(IApmLogger logger, StreamReader procStatStreamReader)
@@ -112,15 +112,15 @@ namespace Elastic.Apm.Metrics.MetricsProvider
 
 			if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
 			{
-				var procStatValues = ReadProcStat();
-				if (!procStatValues.success) return null;
+				var (success, idle, total) = ReadProcStat();
+				if (!success) return null;
 
-				var idleTimeDelta = procStatValues.idle - _prevIdleTime;
-				var totalTimeDelta = procStatValues.total - _prevTotalTime;
+				var idleTimeDelta = idle - _prevIdleTime;
+				var totalTimeDelta = total - _prevTotalTime;
 				var notIdle = 1.0 - idleTimeDelta / (double)totalTimeDelta;
 
-				_prevIdleTime = procStatValues.idle;
-				_prevTotalTime = procStatValues.total;
+				_prevIdleTime = idle;
+				_prevTotalTime = total;
 
 				return new List<MetricSample> { new MetricSample(SystemCpuTotalPct, notIdle) };
 			}

--- a/test/Elastic.Apm.PerfTests/Elastic.Apm.PerfTests.csproj
+++ b/test/Elastic.Apm.PerfTests/Elastic.Apm.PerfTests.csproj
@@ -9,7 +9,6 @@
   <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" Version="0.12.0" />
     <PackageReference Include="Microsoft.Data.SqlClient" Version="1.0.19269.1" />
-    <PackageReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Elastic.CommonSchema.BenchmarkDotNetExporter" Version="1.5.0" />
   </ItemGroup>
 


### PR DESCRIPTION
Warnings fixed:

- EF6 version warning with NuGet in the Full Framework sample
- TypeScript version warning in the Full Framework sample
- Unnecessary `Microsoft.AspNetCore.App` in our perftests project (it's 3.0, so it's not needed)
- Tuple deconstruction code style error
- Deprecated `IHostingEnvironment` in `netcoreapp30`