### PR TITLE
Make Destination.Service public

### DIFF
--- a/src/Elastic.Apm/Api/Destination.cs
+++ b/src/Elastic.Apm/Api/Destination.cs
@@ -50,7 +50,7 @@ namespace Elastic.Apm.Api
 		/// Destination service context.
 		/// <see cref="DestinationService" />
 		/// </summary>
-		internal DestinationService Service
+		public DestinationService Service
 		{
 			get => _service.Value;
 			set => _service = new Optional<DestinationService>(value);


### PR DESCRIPTION
Solves  #908. 

`Destination.Service` was not serialized because it was marked at `internal`. 🤦 This should have been `public` from the beginning.