### PR TITLE
Allow to load configuration from another configuration reader

### DIFF
--- a/src/Elastic.Apm.AspNetFullFramework/ElasticApmModule.cs
+++ b/src/Elastic.Apm.AspNetFullFramework/ElasticApmModule.cs
@@ -46,7 +46,7 @@ namespace Elastic.Apm.AspNetFullFramework
 					+ Environment.NewLine + linePrefix + $"+-> Exception: {ex.GetType().FullName}: {ex.Message}"
 					+ Environment.NewLine + TextUtils.PrefixEveryLine(ex.StackTrace, linePrefix + " ".Repeat(4))
 				);
-			}x²²
+			}
 		}
 
 		private void InitImpl(HttpApplication httpApp)


### PR DESCRIPTION
Gives the abilty to load APM settings from external service instead of using default appsettings keys.
