### PR TITLE
Describe CLA and mail address in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,7 +31,7 @@ We aim to maintain high code quality, therefore every PR goes through the same r
 
 Generally, we require that you test any code you add or modify. This means you run all existing tests and in case you add new code you make sure it's covered by at least 1 test.
 
-No new feature will be merged without tests covering it.
+**No new feature will be merged without tests covering it.**
 
 Once your changes are ready to submit for review:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,39 +27,18 @@ or that there are particular issues that you should know about before implementi
 
 We aim to maintain high code quality, therefore every PR goes through the same review process, no matter who opened the PR.
 
-### General advice
-
-Please make sure that your PR addresses a single issue and its size is reasonable to review. There are no hard rules, but please keep in mind that every line of your PR will be reviewed and it's not uncommon that a longer discussion evolves in case of a sensitive change.
-
-Therefore it's preferred to have multiple smaller PRs over a single big PR.
-
-This makes sure that changes that have consensus get merged quickly and don't get blocked by unrelated changes. Additionally, the repository will also have a useful and searchable history by doing so.
-
-Please do:
-- Try to get feedback as early as possible and prefer to ask questions in issues before you start submitting code.
-- Add a description to your PR which describes your intention and gives a high level summary about your changes.
-- Run all the tests from the `test` folder and make sure that all of them are green. See [Testing](###Testing).
-- In case of new code, make sure it's covered by at least 1 test.
-- make sure your IDE uses the `.editorconfig` from the repo and you follow our coding guidelines. See [Coding-guidelines](###Coding-guidelines).
-- Feel free to close a PR and create a new one in case you changed your mind, or found a better solution.
-- Feel free to fix typos.
-- Feel free to use the draft PR feature of GitHub, in case you would like to show some work in progress code and get feedback on it.
-
-Please don't:
-- Create a PR where you address multiple issues at once.
-- Create a giant PR with a huge change set. There is no hard rule, but if your change grows over 1000 lines, it's maybe worth thinking about making it self contained and submit it as a PR and address follow-up issues in a subsequent PR. (of course there can be exceptions)
-- Actively push code to a PR until you have received feedback. Of course if you spot some minor things after you opened a PR, it's perfectly fine to push a small fix. But please don't do active work on a PR that haven't received any feedback. It's very possible that someone already looked at it and is about to write a detailed review. If you actively add new changes to a PR then the reviewer will have a hard time to provide up to date feedback. If you just want to show work-in-progress code, feel free to use the draft feature of github, or indicate in the title, that the work is not 100% done yet. Of course, once you have feedback on a PR, it's perfectly fine, or rather encouraged to start working collaboratively on the PR and push new changes and address issues and suggestions from the reviewer.
-- Change or add dependencies, unless you are really sure about it (it's best to ask about this in an issue first) - see [compatibility](####compatibility).
-
-
 ### Submitting your changes
 
-Generally, we require that you test any code you are adding or modifying.
+Generally, we require that you test any code you add or modify. This means you run all existing tests and in case you add new code you make sure it's covered by at least 1 test.
+
+No new feature will be merged without tests covering it.
+
 Once your changes are ready to submit for review:
 
 1. Sign the Contributor License Agreement
 
-    Please make sure you have signed our [Contributor License Agreement](https://www.elastic.co/contributor-agreement/).
+    Please make sure you have signed our [Contributor License Agreement](https://www.elastic.co/contributor-agreement/). The CLA checker identifies your commits based on your email address, so make sure you sign the CLA with the same mail address that you use for your commits. A single commit in a PR with an email address with no CLA signature will prevent us from merging your PR.
+
     We are not asking you to assign copyright to us,
     but to give us the right to distribute your code without restriction.
     We ask this of all contributors in order to assure our users of the origin and continuing existence of the code.
@@ -100,15 +79,7 @@ Once your changes are ready to submit for review:
 
 The test suite consists of xUnit tests.
 
-To run all tests, including the integration tests, execute these two commands from the root of the repository:
-
-```bash
-dotnet test test/Elastic.Apm.Tests/
-```
-
-```bash
-dotnet test test/Elastic.Apm.AspNetCore.Tests/
-```
+To run all tests, including the integration tests, execute `dotnet test` on every project from the `/test` folder.
 
 ### Workflow
 
@@ -117,6 +88,30 @@ Pull requests should be reviewed by someone with commit access.
 Once approved, the author of the pull request,
 or reviewer if the author does not have commit access,
 should "Squash and merge".
+
+### General advice
+
+Please make sure that your PR addresses a single issue and its size is reasonable to review. There are no hard rules, but please keep in mind that every line of your PR will be reviewed and it's not uncommon that a longer discussion evolves in case of a sensitive change.
+
+Therefore it's preferred to have multiple smaller PRs over a single big PR.
+
+This makes sure that changes that have consensus get merged quickly and don't get blocked by unrelated changes. Additionally, the repository will also have a useful and searchable history by doing so.
+
+Please do:
+- Try to get feedback as early as possible and prefer to ask questions in issues before you start submitting code.
+- Add a description to your PR which describes your intention and gives a high level summary about your changes.
+- Run all the tests from the `test` folder and make sure that all of them are green. See [Testing](###Testing).
+- In case of new code, make sure it's covered by at least 1 test.
+- make sure your IDE uses the `.editorconfig` from the repo and you follow our coding guidelines. See [Coding-guidelines](###Coding-guidelines).
+- Feel free to close a PR and create a new one in case you changed your mind, or found a better solution.
+- Feel free to fix typos.
+- Feel free to use the draft PR feature of GitHub, in case you would like to show some work in progress code and get feedback on it.
+
+Please don't:
+- Create a PR where you address multiple issues at once.
+- Create a giant PR with a huge change set. There is no hard rule, but if your change grows over 1000 lines, it's maybe worth thinking about making it self contained and submit it as a PR and address follow-up issues in a subsequent PR. (of course there can be exceptions)
+- Actively push code to a PR until you have received feedback. Of course if you spot some minor things after you opened a PR, it's perfectly fine to push a small fix. But please don't do active work on a PR that haven't received any feedback. It's very possible that someone already looked at it and is about to write a detailed review. If you actively add new changes to a PR then the reviewer will have a hard time to provide up to date feedback. If you just want to show work-in-progress code, feel free to use the draft feature of github, or indicate in the title, that the work is not 100% done yet. Of course, once you have feedback on a PR, it's perfectly fine, or rather encouraged to start working collaboratively on the PR and push new changes and address issues and suggestions from the reviewer.
+- Change or add dependencies, unless you are really sure about it (it's best to ask about this in an issue first) - see [compatibility](####compatibility).
 
 ### Design considerations
 
@@ -161,4 +156,4 @@ Coming soon
 
 ### Releasing
 
-Coming soon.
+See [RELEASING.md](RELEASING.md).


### PR DESCRIPTION
Triggered by https://github.com/elastic/apm-agent-dotnet/pull/912 (the CLA part)

- The email address that a committer uses on GitHub must be the same as the mail address in the git commit.
- I see some PRs without any test - I'd like to make it clear that tests are necessary for new code.
- Updated outdated info (running tests and linked the release info).