### PR TITLE
Full Framework custom config: use envvar config as fallback

### DIFF
--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -142,6 +142,34 @@ Below is a sample `Web.config` configuration file for a ASP.NET application.
 </configuration>
 ----
 
+Additionally on ASP.NET you can also implement your own configuration reader. For this you need to implement the `IConfigurationReader` interface from the `Elastic.Apm.Config` namespace.
+
+Once you have your `IConfiguration` implementation you can use the <<config-full-framework-configuration-reader-type, FullFrameworkConfigurationReaderType>> setting.
+
+[float]
+[[config-full-framework-configuration-reader-type]]
+==== `FullFrameworkConfigurationReaderType`
+
+This setting is .NET Full Framework only.
+
+With this setting you can point an agent to a custom `IConfigurationReader` implementation and the agent will read configuration from your `IConfigurationReader` implementation.
+
+Use type name in  https://docs.microsoft.com/en-us/dotnet/api/system.type.assemblyqualifiedname?view=netcore-3.1#System_Type_AssemblyQualifiedName[AssemblyQualifiedName] format (e.g: `MyClass, MyNamespace`).
+
+[options="header"]
+|============
+| Environment variable name                              | Web.config key
+| `ELASTIC_APM_FULL_FRAMEWORK_CONFIGURATION_READER_TYPE` | `ElasticApm:FullFrameworkConfigurationReaderType`
+|============
+
+[options="header"]
+|============
+| Default                          | Type
+| None       | String
+|============
+
+NOTE: In case you set this setting both in the web.config file and as an environment variable then the web.config file has precedence.
+
 
 [[config-core]]
 === Core configuration options

--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -167,7 +167,7 @@ Use type name in  https://docs.microsoft.com/en-us/dotnet/api/system.type.assemb
 | None       | String
 |============
 
-NOTE: In case you set this setting both in the web.config file and as an environment variable then the web.config file has precedence.
+If this setting is set in both the web.config file and as an environment variable, then the web.config file has precedence.
 
 
 [[config-core]]

--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -142,9 +142,8 @@ Below is a sample `Web.config` configuration file for a ASP.NET application.
 </configuration>
 ----
 
-Additionally on ASP.NET you can also implement your own configuration reader. For this you need to implement the `IConfigurationReader` interface from the `Elastic.Apm.Config` namespace.
-
-Once you have your `IConfiguration` implementation you can use the <<config-full-framework-configuration-reader-type, FullFrameworkConfigurationReaderType>> setting.
+Additionally, on ASP.NET, you can implement your own configuration reader. To do this, implement the `IConfigurationReader` interface from the `Elastic.Apm.Config` namespace.
+Once implemented, you can make use of the <<config-full-framework-configuration-reader-type, `FullFrameworkConfigurationReaderType`>> setting.
 
 [float]
 [[config-full-framework-configuration-reader-type]]

--- a/src/Elastic.Apm.AspNetFullFramework/ElasticApmModule.cs
+++ b/src/Elastic.Apm.AspNetFullFramework/ElasticApmModule.cs
@@ -5,7 +5,6 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Specialized;
-using System.Configuration;
 using System.Reflection;
 using System.Web;
 using Elastic.Apm.Api;

--- a/src/Elastic.Apm.AspNetFullFramework/Helper/ConfigHelper.cs
+++ b/src/Elastic.Apm.AspNetFullFramework/Helper/ConfigHelper.cs
@@ -1,9 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Configuration;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Elastic.Apm.Config;
 using Elastic.Apm.Logging;
 
@@ -12,26 +8,41 @@ namespace Elastic.Apm.AspNetFullFramework.Helper
 	public class ConfigHelper
 	{
 		/// <summary>
-		/// Instantiate a custom configurationreader
+		/// Instantiate a custom ConfigurationReader
 		/// </summary>
 		/// <param name="logger"></param>
-		/// <returns></returns>
+		/// <returns>The custom <see cref="IConfigurationReader"/> implementation if it can be initialized, <code>null</code> otherwise</returns>
 		public static IConfigurationReader CreateReader(IApmLogger logger)
 		{
-			if (!string.IsNullOrEmpty(ConfigurationManager.AppSettings[ConfigConsts.KeyNames.ConfigurationReaderType]))
+			var expectedTypeName = ConfigurationManager.AppSettings[ConfigConsts.KeyNames.ConfigurationReaderType];
+			var isInEnvVarConfigured = false;
+
+			//fall back to read from env.var.
+			if (string.IsNullOrEmpty(expectedTypeName))
 			{
-				try
+				expectedTypeName = Environment.GetEnvironmentVariable(ConfigConsts.EnvVarNames.ConfigurationReaderType);
+				if (string.IsNullOrEmpty(expectedTypeName))
+					return null;
+
+				isInEnvVarConfigured = true;
+			}
+
+			try
+			{
+				var type = Type.GetType(expectedTypeName);
+				if (type == null)
 				{
-					var type = Type.GetType(ConfigurationManager.AppSettings[ConfigConsts.KeyNames.ConfigurationReaderType]);
-					if (Activator.CreateInstance(type, logger) is IConfigurationReader reader)
-					{
-						return reader;
-					}
+					var configName = isInEnvVarConfigured ? ConfigConsts.EnvVarNames.ConfigurationReaderType : ConfigConsts.KeyNames.ConfigurationReaderType;
+					logger.Warning()?.Log("Failed loading type for configuration reader, {configName}: {configValue}",
+						configName, expectedTypeName);
+					return null;
 				}
-				catch (Exception ex)
-				{
-					logger.Error()?.LogException(ex, "GetConfigReader exception");
-				}
+
+				if (Activator.CreateInstance(type, logger) is IConfigurationReader reader) return reader;
+			}
+			catch (Exception ex)
+			{
+				logger.Error()?.LogException(ex, "GetConfigReader exception");
 			}
 
 			return null;

--- a/src/Elastic.Apm/Config/ConfigConsts.cs
+++ b/src/Elastic.Apm/Config/ConfigConsts.cs
@@ -165,6 +165,7 @@ namespace Elastic.Apm.Config
 			public const string ExcludedNamespaces = "ElasticApm:ExcludedNamespaces";
 			public const string ApplicationNamespaces = "ElasticApm:ApplicationNamespaces";
 			public static string TransactionIgnoreUrls = "ElasticApm:TransactionIgnoreUrls";
+			//This setting is Full Framework only:
 			public const string ConfigurationReaderType = "ElasticApm:FullFrameworkConfigurationReaderType";
 		}
 

--- a/src/Elastic.Apm/Config/ConfigConsts.cs
+++ b/src/Elastic.Apm/Config/ConfigConsts.cs
@@ -4,7 +4,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Collections.ObjectModel;
 using Elastic.Apm.Helpers;
 
 namespace Elastic.Apm.Config
@@ -132,7 +131,8 @@ namespace Elastic.Apm.Config
 			public const string ExcludedNamespaces = Prefix + "EXCLUDED_NAMESPACES";
 			public const string ApplicationNamespaces = Prefix + "APPLICATION_NAMESPACES";
 			public static string TransactionIgnoreUrls = Prefix + "TRANSACTION_IGNORE_URLS";
-			public const string ConfigurationReaderType = Prefix + "CONFIGURATION_READER_TYPE";
+			//This setting is Full Framework only:
+			public const string ConfigurationReaderType = Prefix + "FULL_FRAMEWORK_CONFIGURATION_READER_TYPE";
 		}
 
 		public static class KeyNames
@@ -165,7 +165,7 @@ namespace Elastic.Apm.Config
 			public const string ExcludedNamespaces = "ElasticApm:ExcludedNamespaces";
 			public const string ApplicationNamespaces = "ElasticApm:ApplicationNamespaces";
 			public static string TransactionIgnoreUrls = "ElasticApm:TransactionIgnoreUrls";
-			public const string ConfigurationReaderType = "ElasticApm:ConfigurationReaderType";
+			public const string ConfigurationReaderType = "ElasticApm:FullFrameworkConfigurationReaderType";
 		}
 
 		public static class SupportedValues

--- a/src/Elastic.Apm/Elastic.Apm.csproj
+++ b/src/Elastic.Apm/Elastic.Apm.csproj
@@ -17,7 +17,6 @@
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="4.6.0" />
     <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="2.0.2" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.7.0" />   
     <PackageReference Include="System.Threading.Tasks.Dataflow" Version="4.9.0" />
     <PackageReference Include="Ben.Demystifier" Version="0.1.6" />
   </ItemGroup>

--- a/test/Elastic.Apm.AspNetFullFramework.Tests/AppSettingsTests.cs
+++ b/test/Elastic.Apm.AspNetFullFramework.Tests/AppSettingsTests.cs
@@ -2,7 +2,6 @@
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
 using System;
-using System.Web;
 using System.Collections.Generic;
 using System.Configuration;
 using Elastic.Apm.Config;
@@ -19,7 +18,6 @@ namespace Elastic.Apm.AspNetFullFramework.Tests
 		private readonly IApmLogger _logger;
 		private const string ThisClassName = nameof(ConfigTestReader);
 
-		//public ConfigTestReader(IApmLogger logger, string defaultEnvironmentName, string dbgDerivedClassName) : base(logger, defaultEnvironmentName, dbgDerivedClassName) => _logger = logger?.Scoped("TestReader");
 
 		public ConfigTestReader(IApmLogger logger = null)
 			: base(logger, null, null) => _logger = logger?.Scoped(ThisClassName);
@@ -86,7 +84,7 @@ namespace Elastic.Apm.AspNetFullFramework.Tests
 		}
 
 		[Fact]
-		public void ConfigReaderTest()
+		public void CreateConfigurationReaderThroughApSettings()
 		{
 			var logger = new ConsoleLogger(LogLevel.Information);
 			var config = new Dictionary<string, string>();
@@ -97,10 +95,24 @@ namespace Elastic.Apm.AspNetFullFramework.Tests
 
 			UpdateAppSettings(config);
 
-			var reader = Elastic.Apm.AspNetFullFramework.Helper.ConfigHelper.CreateReader(logger);
+			var reader = Helper.ConfigHelper.CreateReader(logger);
 
 			Assert.NotNull(reader);
+		}
 
+		[Fact]
+		public void CreateConfigurationReaderThroughEnvVar()
+		{
+			var logger = new ConsoleLogger(LogLevel.Information);
+			var config = new Dictionary<string, string>();
+
+			var type = "Elastic.Apm.AspNetFullFramework.Tests.ConfigTestReader, Elastic.Apm.AspNetFullFramework.Tests";
+			Environment.SetEnvironmentVariable(ConfigConsts.EnvVarNames.ConfigurationReaderType, type);
+
+			UpdateAppSettings(config);
+			var reader = Helper.ConfigHelper.CreateReader(logger);
+
+			Assert.NotNull(reader);
 		}
 	}
 }


### PR DESCRIPTION
Follow up from #912.

@kodigo35 feel free to chime on.

Summary:
- Added docs (Added @bmorelli25 to review)
- Made sure that similarly to other settings, this can also be configured both in `web.config` and as an environment variable
- Added a test to also cover the environment variable case
- Some nits, like removing unused `using`s and some unused references