### PR TITLE
Implements #922: Add GC time to the .Net Agent

### DIFF
--- a/src/Elastic.Apm/Metrics/MetricsCollector.cs
+++ b/src/Elastic.Apm/Metrics/MetricsCollector.cs
@@ -93,10 +93,12 @@ namespace Elastic.Apm.Metrics
 				GcMetricsProvider.GcGen2SizeName);
 			var collectGen3Size = !WildcardMatcher.IsAnyMatch(currentConfigSnapshot.DisableMetrics,
 				GcMetricsProvider.GcGen3SizeName);
+			var collectGcTime = !WildcardMatcher.IsAnyMatch(currentConfigSnapshot.DisableMetrics,
+				GcMetricsProvider.GcTimeName);
 			if (collectGcCount || collectGen0Size || collectGen1Size || collectGen2Size || collectGen3Size)
 			{
 				MetricsProviders.Add(new GcMetricsProvider(_logger, collectGcCount, collectGen0Size, collectGen1Size, collectGen2Size,
-					collectGen3Size));
+					collectGen3Size, collectGcTime));
 			}
 
 			var collectCgroupMemLimitBytes = !WildcardMatcher.IsAnyMatch(currentConfigSnapshot.DisableMetrics,

--- a/test/Elastic.Apm.Tests/MetricsTests.cs
+++ b/test/Elastic.Apm.Tests/MetricsTests.cs
@@ -296,6 +296,7 @@ namespace Elastic.Apm.Tests
 				// ReSharper disable once RedundantAssignment
 				var containsValue = false;
 				var hasGenSize = false;
+				var hasGcTime = false;
 
 
 				for (var j = 0; j < 1000; j++)
@@ -321,10 +322,11 @@ namespace Elastic.Apm.Tests
 						.Any(n => (n.KeyValue.Key.Contains("gen0size") || n.KeyValue.Key.Contains("gen1size")
 						|| n.KeyValue.Key.Contains("gen2size") || n.KeyValue.Key.Contains("gen3size"))
 						&& n.KeyValue.Value > 0);
+					hasGcTime = samples != null && samples
+						.Any(n => n.KeyValue.Key.Contains("clr.gc.time") && n.KeyValue.Value > 0);
 
-					if (containsValue && hasGenSize)
+					if (containsValue && hasGenSize && hasGcTime)
 						break;
-
 				}
 
 				if (PlatformDetection.IsDotNetFullFramework)
@@ -349,6 +351,7 @@ namespace Elastic.Apm.Tests
 
 				containsValue.Should().BeTrue();
 				hasGenSize.Should().BeTrue();
+				hasGcTime.Should().BeTrue();
 
 				gcMetricsProvider.IsMetricAlreadyCaptured.Should().BeTrue();
 #endif

--- a/test/Elastic.Apm.Tests/MetricsTests.cs
+++ b/test/Elastic.Apm.Tests/MetricsTests.cs
@@ -64,7 +64,8 @@ namespace Elastic.Apm.Tests
 		[Fact]
 		public void SystemCpu()
 		{
-			if (!RuntimeInformation.IsOSPlatform(OSPlatform.Linux) && !RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) return;
+			if (!RuntimeInformation.IsOSPlatform(OSPlatform.Linux) && !RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+				return;
 
 			using var systemTotalCpuProvider = new SystemTotalCpuProvider(new NoopLogger());
 			Thread.Sleep(1000); //See https://github.com/elastic/apm-agent-dotnet/pull/264#issuecomment-499778288
@@ -106,7 +107,8 @@ namespace Elastic.Apm.Tests
 				var providerWithException = new MetricsProviderWithException();
 				mc.MetricsProviders.Add(providerWithException);
 
-				for (var i = 0; i < MetricsCollector.MaxTryWithoutSuccess; i++) mc.CollectAllMetrics();
+				for (var i = 0; i < MetricsCollector.MaxTryWithoutSuccess; i++)
+					mc.CollectAllMetrics();
 
 				providerWithException.NumberOfGetValueCalls.Should().Be(MetricsCollector.MaxTryWithoutSuccess);
 
@@ -121,7 +123,8 @@ namespace Elastic.Apm.Tests
 						$"Failed reading {providerWithException.DbgName} {MetricsCollector.MaxTryWithoutSuccess} consecutively - the agent won't try reading {providerWithException.DbgName} anymore");
 
 				//make sure GetValue() in MetricsProviderWithException is not called anymore:
-				for (var i = 0; i < 10; i++) mc.CollectAllMetrics();
+				for (var i = 0; i < 10; i++)
+					mc.CollectAllMetrics();
 
 				var logLineBeforeStage2 = testLogger.Lines.Count;
 				//no more logs, no more calls to GetValue():
@@ -234,7 +237,8 @@ namespace Elastic.Apm.Tests
 			metricsCollector.MetricsProviders.Add(metricsProviderMock.Object);
 
 			// Act
-			foreach (var _ in Enumerable.Range(0, iterations)) metricsCollector.CollectAllMetrics();
+			foreach (var _ in Enumerable.Range(0, iterations))
+				metricsCollector.CollectAllMetrics();
 
 			// Assert
 			mockPayloadSender.Metrics.Should().BeEmpty();
@@ -265,7 +269,8 @@ namespace Elastic.Apm.Tests
 			metricsCollector.MetricsProviders.Add(metricsProviderMock.Object);
 
 			// Act
-			foreach (var _ in Enumerable.Range(0, iterations)) metricsCollector.CollectAllMetrics();
+			foreach (var _ in Enumerable.Range(0, iterations))
+				metricsCollector.CollectAllMetrics();
 
 			// Assert
 			mockPayloadSender.Metrics.Count.Should().Be(iterations);
@@ -292,6 +297,7 @@ namespace Elastic.Apm.Tests
 				var containsValue = false;
 				var hasGenSize = false;
 
+
 				for (var j = 0; j < 1000; j++)
 				{
 					for (var i = 0; i < 300_000; i++)
@@ -308,7 +314,7 @@ namespace Elastic.Apm.Tests
 
 					GC.Collect();
 
-					var samples = gcMetricsProvider.GetSamples();
+					var samples = gcMetricsProvider.GetSamples()?.ToArray();
 
 					containsValue = samples != null && samples.Any();
 					hasGenSize = samples != null && samples
@@ -318,6 +324,7 @@ namespace Elastic.Apm.Tests
 
 					if (containsValue && hasGenSize)
 						break;
+
 				}
 
 				if (PlatformDetection.IsDotNetFullFramework)


### PR DESCRIPTION
This adds `clr.gc.time` to the .Net GC Metrics. It's a little different than my original proposal--using `DurationInMs` instead of `PauseTimeInMs` for full framework to keep it consistent with the .Net Core metric, which can only determine duration and is not aware of whether a pause occurred.