### PR TITLE
Improve log message in StacktraceHelper.GenerateApmStackTrace

### DIFF
--- a/src/Elastic.Apm/Helpers/StacktraceHelper.cs
+++ b/src/Elastic.Apm/Helpers/StacktraceHelper.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to Elasticsearch B.V under one or more agreements.
+// Licensed to Elasticsearch B.V under one or more agreements.
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
 
@@ -106,7 +106,8 @@ namespace Elastic.Apm.Helpers
 			}
 			catch (Exception e)
 			{
-				logger?.Warning()?.LogException(e, "Failed extracting exception from stackTrace for {ApmContext}", dbgCapturingFor);
+				logger?.Warning()?.LogException(e, "Failed extracting stack trace from exception for {ApmContext}. Exception to extract from: {ExceptionToExtractFrom}.",
+					dbgCapturingFor, exception);
 			}
 
 			return null;


### PR DESCRIPTION
1. The phrase was inverse of the intended ("extracting exception from stackTrace")
2. Added logging of exception from which we are trying to extract stack trace.