### PR TITLE
[CI] archive nupkg files for PRs

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -97,6 +97,9 @@ pipeline {
                       dir("${BASE_DIR}"){
                         dotnet(){
                           sh '.ci/linux/build.sh'
+                          whenTrue(isPR()) {
+                            sh(label: 'Package', script: '.ci/linux/release.sh true')
+                          }
                         }
                       }
                     }
@@ -105,6 +108,11 @@ pipeline {
                     unsuccessful {
                       archiveArtifacts(allowEmptyArchive: true,
                         artifacts: "${MSBUILDDEBUGPATH}/**/MSBuild_*.failure.txt")
+                    }
+                    success {
+                      whenTrue(isPR()) {
+                        archiveArtifacts(allowEmptyArchive: true, artifacts: "${BASE_DIR}/**/bin/Release/**/*.nupkg")
+                      }
                     }
                   }
                 }


### PR DESCRIPTION
### What

Run `dotnet pack -C release` on a PR basis

Versioning with the format `alpha-TIMESTAMP`

### Test

See artifacts https://apm-ci.elastic.co/job/apm-agent-dotnet/job/apm-agent-dotnet-mbp/job/PR-947/1/artifact/apm-agent-dotnet/src/Elastic.Apm/bin/Release/