### PR TITLE
Use EnhancedStackTrace for spans; start the stack trace on start for EF Core

### DIFF
--- a/src/Elastic.Apm.EntityFrameworkCore/EfCoreDiagnosticListener.cs
+++ b/src/Elastic.Apm.EntityFrameworkCore/EfCoreDiagnosticListener.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using Elastic.Apm.Api;
 using Elastic.Apm.DiagnosticSource;
 using Elastic.Apm.Model;
 using Microsoft.EntityFrameworkCore.Diagnostics;
@@ -38,7 +39,8 @@ namespace Elastic.Apm.EntityFrameworkCore
 				case { } k when k == RelationalEventId.CommandExecuting.Name && _agent.Tracer.CurrentTransaction != null:
 					if (kv.Value is CommandEventData commandEventData)
 					{
-						var newSpan = _agent.TracerInternal.DbSpanCommon.StartSpan(_agent, commandEventData.Command, InstrumentationFlag.EfCore);
+						var spanName = commandEventData.Command.CommandText.Replace(Environment.NewLine, " ");
+						var newSpan = ExecutionSegmentCommon.StartSpanOnCurrentExecutionSegment(_agent, spanName, ApiConstants.TypeDb, null, InstrumentationFlag.EfCore, true);
 						_spans.TryAdd(commandEventData.CommandId, newSpan);
 					}
 					break;

--- a/src/Elastic.Apm.EntityFrameworkCore/EfCoreDiagnosticListener.cs
+++ b/src/Elastic.Apm.EntityFrameworkCore/EfCoreDiagnosticListener.cs
@@ -39,8 +39,7 @@ namespace Elastic.Apm.EntityFrameworkCore
 				case { } k when k == RelationalEventId.CommandExecuting.Name && _agent.Tracer.CurrentTransaction != null:
 					if (kv.Value is CommandEventData commandEventData)
 					{
-						var spanName = commandEventData.Command.CommandText.Replace(Environment.NewLine, " ");
-						var newSpan = ExecutionSegmentCommon.StartSpanOnCurrentExecutionSegment(_agent, spanName, ApiConstants.TypeDb, null, InstrumentationFlag.EfCore, true);
+						var newSpan = _agent.TracerInternal.DbSpanCommon.StartSpan(_agent, commandEventData.Command, InstrumentationFlag.EfCore, captureStackTraceOnStart: true);
 						_spans.TryAdd(commandEventData.CommandId, newSpan);
 					}
 					break;

--- a/src/Elastic.Apm/Model/DbSpanCommon.cs
+++ b/src/Elastic.Apm/Model/DbSpanCommon.cs
@@ -24,10 +24,10 @@ namespace Elastic.Apm.Model
 
 		internal DbSpanCommon(IApmLogger logger) => _dbConnectionStringParser = new DbConnectionStringParser(logger);
 
-		internal Span StartSpan(IApmAgent agent, IDbCommand dbCommand, InstrumentationFlag instrumentationFlag, string subType = null)
+		internal Span StartSpan(IApmAgent agent, IDbCommand dbCommand, InstrumentationFlag instrumentationFlag, string subType = null, bool captureStackTraceOnStart = false)
 		{
 			var spanName = dbCommand.CommandText.Replace(Environment.NewLine, " ");
-			return ExecutionSegmentCommon.StartSpanOnCurrentExecutionSegment(agent, spanName, ApiConstants.TypeDb, subType, instrumentationFlag);
+			return ExecutionSegmentCommon.StartSpanOnCurrentExecutionSegment(agent, spanName, ApiConstants.TypeDb, subType, instrumentationFlag, captureStackTraceOnStart);
 		}
 
 		internal void EndSpan(Span span, IDbCommand dbCommand, TimeSpan? duration = null)

--- a/src/Elastic.Apm/Model/Span.cs
+++ b/src/Elastic.Apm/Model/Span.cs
@@ -90,7 +90,7 @@ namespace Elastic.Apm.Model
 					enclosingTransaction.SpanCount.IncrementStarted();
 
 					if (captureStackTraceOnStart)
-						_stackFrames = new StackTrace(true).GetFrames();
+						_stackFrames = new EnhancedStackTrace(new StackTrace(true)).GetFrames();
 				}
 			}
 
@@ -260,7 +260,7 @@ namespace Elastic.Apm.Model
 					if (Duration >= ConfigSnapshot.SpanFramesMinDurationInMilliseconds
 						|| ConfigSnapshot.SpanFramesMinDurationInMilliseconds < 0)
 					{
-						StackTrace = StacktraceHelper.GenerateApmStackTrace(_stackFrames ?? new StackTrace(true).GetFrames(), _logger,
+						StackTrace = StacktraceHelper.GenerateApmStackTrace(_stackFrames ?? new EnhancedStackTrace(new StackTrace(true)).GetFrames(), _logger,
 							ConfigSnapshot, $"Span `{Name}'");
 					}
 				}

--- a/test/Elastic.Apm.EntityFrameworkCore.Tests/FakeDbContext.cs
+++ b/test/Elastic.Apm.EntityFrameworkCore.Tests/FakeDbContext.cs
@@ -2,13 +2,27 @@
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
 
+using System;
+using System.ComponentModel.DataAnnotations;
 using Microsoft.EntityFrameworkCore;
 
 namespace Elastic.Apm.EntityFrameworkCore.Tests
 {
 	public class FakeDbContext : DbContext
 	{
+		// Data structure to allow running EFCore linq queries; requires running EnsureCreated() inside tests
+		public virtual DbSet<FakeData> Data { get; set; }
+
 		public FakeDbContext(DbContextOptions<FakeDbContext> options)
 			: base(options) { }
+	}
+
+	/// <summary>
+	/// Data structure to allow running EFCore linq queries; requires running EnsureCreated() inside tests
+	/// </summary>
+	public class FakeData
+	{
+		[Key]
+		public Guid Id { get; set; }
 	}
 }


### PR DESCRIPTION
Addresses https://github.com/elastic/apm-agent-dotnet/issues/944 : Entity Framework Core stacktraces are now captured at the beginning of the request to avoid async stacktrace shenanigans; I've also replaced the StackTrace from `Span` with `EnhancedStackTrace` to reduce noise in traces.

This might have a performance impact due to capturing stack traces before we can evalute  the span length, but I'm not quite sure if it's possible to get around that. It might be prudent to add a flag to disable trace capture for EF Core. @gregkalapos thoughts?