### PR TITLE
Make "unknown route" the route by default

### DIFF
--- a/src/Elastic.Apm.AspNetCore/WebRequestTransactionCreator.cs
+++ b/src/Elastic.Apm.AspNetCore/WebRequestTransactionCreator.cs
@@ -32,7 +32,7 @@ namespace Elastic.Apm.AspNetCore
 				}
 
 				Transaction transaction;
-				var transactionName = $"{context.Request.Method} Unknown Route";
+				var transactionName = $"{context.Request.Method} {context.Request.Path}";
 
 				if (context.Request.Headers.ContainsKey(TraceContext.TraceParentHeaderNamePrefixed)
 					|| context.Request.Headers.ContainsKey(TraceContext.TraceParentHeaderName))
@@ -186,6 +186,10 @@ namespace Elastic.Apm.AspNetCore
 						var name = GetNameFromRouteContext(routeData);
 
 						if (!string.IsNullOrWhiteSpace(name)) transaction.Name = $"{context.Request.Method} {name}";
+					}
+					else if (context.Response.StatusCode == StatusCodes.Status404NotFound)
+					{
+						transaction.Name = $"{context.Request.Method} Unknown Route";
 					}
 				}
 

--- a/src/Elastic.Apm.AspNetCore/WebRequestTransactionCreator.cs
+++ b/src/Elastic.Apm.AspNetCore/WebRequestTransactionCreator.cs
@@ -133,7 +133,7 @@ namespace Elastic.Apm.AspNetCore
 
 				return rawPathAndQuery == null ? null : UriHelper.BuildAbsolute(httpRequest.Scheme, httpRequest.Host, rawPathAndQuery);
 			}
-			catch(Exception e)
+			catch (Exception e)
 			{
 				logger.Warning()?.LogException(e, "Failed reading RawUrl");
 				return null;
@@ -181,14 +181,17 @@ namespace Elastic.Apm.AspNetCore
 					//fixup Transaction.Name - e.g. /user/profile/1 -> /user/profile/{id}
 					var routeData = context.GetRouteData()?.Values;
 
-					if (routeData != null)
+					if (routeData != null && context.Response.StatusCode != StatusCodes.Status404NotFound)
 					{
+						logger?.Trace()?.Log("Calculating transaction name based on route data");
 						var name = GetNameFromRouteContext(routeData);
 
 						if (!string.IsNullOrWhiteSpace(name)) transaction.Name = $"{context.Request.Method} {name}";
 					}
 					else if (context.Response.StatusCode == StatusCodes.Status404NotFound)
 					{
+						logger?.Trace()?
+							.Log("No route data found or status code is 404 - setting transaction name to 'unknown route");
 						transaction.Name = $"{context.Request.Method} unknown route";
 					}
 				}

--- a/src/Elastic.Apm.AspNetCore/WebRequestTransactionCreator.cs
+++ b/src/Elastic.Apm.AspNetCore/WebRequestTransactionCreator.cs
@@ -221,6 +221,8 @@ namespace Elastic.Apm.AspNetCore
 					StatusCode = context.Response.StatusCode,
 					Headers = GetHeaders(context.Response.Headers, transaction.ConfigSnapshot)
 				};
+
+				logger?.Trace()?.Log("Filling transaction.Context.Response, StatusCode: {statuscode}", transaction.Context.Response.StatusCode);
 			}
 			catch (Exception ex)
 			{

--- a/src/Elastic.Apm.AspNetCore/WebRequestTransactionCreator.cs
+++ b/src/Elastic.Apm.AspNetCore/WebRequestTransactionCreator.cs
@@ -189,7 +189,7 @@ namespace Elastic.Apm.AspNetCore
 					}
 					else if (context.Response.StatusCode == StatusCodes.Status404NotFound)
 					{
-						transaction.Name = $"{context.Request.Method} Unknown Route";
+						transaction.Name = $"{context.Request.Method} unknown route";
 					}
 				}
 

--- a/src/Elastic.Apm.AspNetCore/WebRequestTransactionCreator.cs
+++ b/src/Elastic.Apm.AspNetCore/WebRequestTransactionCreator.cs
@@ -32,7 +32,7 @@ namespace Elastic.Apm.AspNetCore
 				}
 
 				Transaction transaction;
-				var transactionName = $"{context.Request.Method} {context.Request.Path}";
+				var transactionName = $"{context.Request.Method} Unknown Route";
 
 				if (context.Request.Headers.ContainsKey(TraceContext.TraceParentHeaderNamePrefixed)
 					|| context.Request.Headers.ContainsKey(TraceContext.TraceParentHeaderName))

--- a/test/Elastic.Apm.AspNetCore.Tests/TransactionNameTests.cs
+++ b/test/Elastic.Apm.AspNetCore.Tests/TransactionNameTests.cs
@@ -6,10 +6,12 @@ using System;
 using System.Threading.Tasks;
 using Elastic.Apm.Extensions.Hosting;
 using Elastic.Apm.Tests.Mocks;
+using Elastic.Apm.Tests.TestHelpers;
 using FluentAssertions;
 using Microsoft.AspNetCore.Mvc.Testing;
 using SampleAspNetCoreApp;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Elastic.Apm.AspNetCore.Tests
 {
@@ -25,14 +27,20 @@ namespace Elastic.Apm.AspNetCore.Tests
 		private readonly WebApplicationFactory<Startup> _factory;
 		private readonly MockPayloadSender _payloadSender = new MockPayloadSender();
 
-		public TransactionNameTests(WebApplicationFactory<Startup> factory)
+		public TransactionNameTests(WebApplicationFactory<Startup> factory, ITestOutputHelper testOutputHelper)
 		{
 			_factory = factory;
 
+			var logger = new LineWriterToLoggerAdaptor(new XunitOutputToLineWriterAdaptor(testOutputHelper))
+			{
+				Level = Logging.LogLevel.Trace
+			};
+
 			_agent = new ApmAgent(new TestAgentComponents(payloadSender: _payloadSender,
+				logger: logger,
 				// _agent needs to share CurrentExecutionSegmentsContainer with Agent.Instance
 				// because the sample application used by the tests (SampleAspNetCoreApp) uses Agent.Instance.Tracer.CurrentTransaction/CurrentSpan
-				currentExecutionSegmentsContainer: Agent.Instance.TracerInternal.CurrentExecutionSegmentsContainer));
+				currentExecutionSegmentsContainer: Agent.Instance.TracerInternal.CurrentExecutionSegmentsContainer));;
 			HostBuilderExtensions.UpdateServiceInformation(_agent.Service);
 		}
 
@@ -115,8 +123,6 @@ namespace Elastic.Apm.AspNetCore.Tests
 			_payloadSender.FirstTransaction.Context.Request.Url.Full.Should().Be("http://localhost/");
 		}
 
-		
-
 		/// <summary>
 		/// Calls a URL that maps to no route and causes a 404
 		/// </summary>
@@ -128,6 +134,8 @@ namespace Elastic.Apm.AspNetCore.Tests
 			var httpClient = Helper.GetClient(_agent, _factory, diagnosticSourceOnly);
 			await httpClient.GetAsync("home/doesnotexist");
 			await httpClient.GetAsync("files/doesnotexist/somefile");
+
+			true.Should().BeFalse();
 
 			_payloadSender.Transactions.Should().OnlyContain(n => n.Name.Equals("GET unknown route", StringComparison.OrdinalIgnoreCase));
 			_payloadSender.Transactions.Should().HaveCount(2);

--- a/test/Elastic.Apm.AspNetCore.Tests/TransactionNameTests.cs
+++ b/test/Elastic.Apm.AspNetCore.Tests/TransactionNameTests.cs
@@ -127,8 +127,10 @@ namespace Elastic.Apm.AspNetCore.Tests
 		{
 			var httpClient = Helper.GetClient(_agent, _factory, diagnosticSourceOnly);
 			await httpClient.GetAsync("home/doesnotexist");
+			await httpClient.GetAsync("css/doesnotexist/somefile.css");
 
 			_payloadSender.Transactions.Should().OnlyContain(n => n.Name.Equals("GET unknown route", StringComparison.OrdinalIgnoreCase));
+			_payloadSender.Transactions.Should().HaveCount(2);
 		}
 
 		public void Dispose()

--- a/test/Elastic.Apm.AspNetCore.Tests/TransactionNameTests.cs
+++ b/test/Elastic.Apm.AspNetCore.Tests/TransactionNameTests.cs
@@ -135,8 +135,6 @@ namespace Elastic.Apm.AspNetCore.Tests
 			await httpClient.GetAsync("home/doesnotexist");
 			await httpClient.GetAsync("files/doesnotexist/somefile");
 
-			true.Should().BeFalse();
-
 			_payloadSender.Transactions.Should().OnlyContain(n => n.Name.Equals("GET unknown route", StringComparison.OrdinalIgnoreCase));
 			_payloadSender.Transactions.Should().HaveCount(2);
 		}

--- a/test/Elastic.Apm.AspNetCore.Tests/TransactionNameTests.cs
+++ b/test/Elastic.Apm.AspNetCore.Tests/TransactionNameTests.cs
@@ -126,17 +126,18 @@ namespace Elastic.Apm.AspNetCore.Tests
 		/// <summary>
 		/// Calls a URL that maps to no route and causes a 404
 		/// </summary>
-		[InlineData(true)]
-		[InlineData(false)]
+		[InlineData("home/doesnotexist", true)]
+		[InlineData("home/doesnotexist", false)]
+		[InlineData("files/doesnotexist/somefile", true)]
+		[InlineData("files/doesnotexist/somefile", false)]
 		[Theory]
-		public async Task NotFoundRoute_ShouldBe_Aggregatable(bool diagnosticSourceOnly)
+		public async Task NotFoundRoute_ShouldBe_Aggregatable(string url, bool diagnosticSourceOnly)
 		{
 			var httpClient = Helper.GetClient(_agent, _factory, diagnosticSourceOnly);
-			await httpClient.GetAsync("home/doesnotexist");
-			await httpClient.GetAsync("files/doesnotexist/somefile");
+			await httpClient.GetAsync(url);
 
 			_payloadSender.Transactions.Should().OnlyContain(n => n.Name.Equals("GET unknown route", StringComparison.OrdinalIgnoreCase));
-			_payloadSender.Transactions.Should().HaveCount(2);
+			_payloadSender.Transactions.Should().HaveCount(1);
 		}
 
 		public void Dispose()

--- a/test/Elastic.Apm.AspNetCore.Tests/TransactionNameTests.cs
+++ b/test/Elastic.Apm.AspNetCore.Tests/TransactionNameTests.cs
@@ -127,7 +127,7 @@ namespace Elastic.Apm.AspNetCore.Tests
 		{
 			var httpClient = Helper.GetClient(_agent, _factory, diagnosticSourceOnly);
 			await httpClient.GetAsync("home/doesnotexist");
-			await httpClient.GetAsync("css/doesnotexist/somefile.css");
+			await httpClient.GetAsync("files/doesnotexist/somefile");
 
 			_payloadSender.Transactions.Should().OnlyContain(n => n.Name.Equals("GET unknown route", StringComparison.OrdinalIgnoreCase));
 			_payloadSender.Transactions.Should().HaveCount(2);

--- a/test/Elastic.Apm.AspNetCore.Tests/TransactionNameTests.cs
+++ b/test/Elastic.Apm.AspNetCore.Tests/TransactionNameTests.cs
@@ -115,6 +115,22 @@ namespace Elastic.Apm.AspNetCore.Tests
 			_payloadSender.FirstTransaction.Context.Request.Url.Full.Should().Be("http://localhost/");
 		}
 
+		
+
+		/// <summary>
+		/// Calls a URL that maps to no route and causes a 404
+		/// </summary>
+		[InlineData(true)]
+		[InlineData(false)]
+		[Theory]
+		public async Task NotFoundRoute_ShouldBe_Aggregatable(bool diagnosticSourceOnly)
+		{
+			var httpClient = Helper.GetClient(_agent, _factory, diagnosticSourceOnly);
+			await httpClient.GetAsync("home/doesnotexist");
+
+			_payloadSender.Transactions.Should().OnlyContain(n => n.Name.Equals("GET unknown route", StringComparison.OrdinalIgnoreCase));
+		}
+
 		public void Dispose()
 		{
 			_agent?.Dispose();


### PR DESCRIPTION
Addresses https://github.com/elastic/apm-agent-dotnet/issues/952 and https://github.com/elastic/apm-agent-dotnet/issues/930.

@gregkalapos This I feel this needs further tests, including testing for paths that do not map to a controller. Sadly, with the current test setup, adding a HTTP request such as 
```cs
await httpClient.GetAsync("css/doesnotexist/somefile.css")
``` 

results in the payload sender not capturing the transaction at all. I'm not entirely sure why that is. On the bright side, all other tests seem to still pass without a problem. I've added a broken test like above, it *should* work I think, should have it fixed before this is merged