### PR TITLE
Add outcome to transactions and spans

### DIFF
--- a/ElasticApmAgent.sln
+++ b/ElasticApmAgent.sln
@@ -86,6 +86,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SampleConsoleNetCoreApp", "
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Elastic.Apm.Elasticsearch.Tests", "test\Elastic.Apm.Elasticsearch.Tests\Elastic.Apm.Elasticsearch.Tests.csproj", "{E30DEF03-4E0B-46A0-87D0-E80545D99BBA}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ElasticsearchSample", "sample\ElasticsearchSample\ElasticsearchSample.csproj", "{0FE5E852-E3AF-45F9-BF3A-8CD739C0807F}"
+EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
 		test\Elastic.Apm.DatabaseTests.Common\Elastic.Apm.DatabaseTests.Common.projitems*{968e1e85-e996-42de-9845-d20dae16165a}*SharedItemsImports = 5
@@ -201,6 +203,10 @@ Global
 		{E30DEF03-4E0B-46A0-87D0-E80545D99BBA}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{E30DEF03-4E0B-46A0-87D0-E80545D99BBA}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{E30DEF03-4E0B-46A0-87D0-E80545D99BBA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0FE5E852-E3AF-45F9-BF3A-8CD739C0807F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0FE5E852-E3AF-45F9-BF3A-8CD739C0807F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0FE5E852-E3AF-45F9-BF3A-8CD739C0807F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0FE5E852-E3AF-45F9-BF3A-8CD739C0807F}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -232,6 +238,7 @@ Global
 		{77812373-D9CB-4DDC-B0D4-A192F7FC2330} = {3734A52F-2222-454B-BF58-1BA5C1F29D77}
 		{00AD0047-92A6-48CC-B67D-A3DB2812CE28} = {3C791D9C-6F19-4F46-B367-2EC0F818762D}
 		{E30DEF03-4E0B-46A0-87D0-E80545D99BBA} = {267A241E-571F-458F-B04C-B6C4DE79E735}
+		{0FE5E852-E3AF-45F9-BF3A-8CD739C0807F} = {3C791D9C-6F19-4F46-B367-2EC0F818762D}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {69E02FD9-C9DE-412C-AB6B-5B8BECC6BFA5}

--- a/ElasticApmAgent.sln
+++ b/ElasticApmAgent.sln
@@ -82,6 +82,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Elastic.Apm.Extensions.Host
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Elastic.Apm.Elasticsearch", "src\Elastic.Apm.Elasticsearch\Elastic.Apm.Elasticsearch.csproj", "{77812373-D9CB-4DDC-B0D4-A192F7FC2330}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SampleConsoleNetCoreApp", "sample\SampleConsoleNetCoreApp\SampleConsoleNetCoreApp.csproj", "{00AD0047-92A6-48CC-B67D-A3DB2812CE28}"
+EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
 		test\Elastic.Apm.DatabaseTests.Common\Elastic.Apm.DatabaseTests.Common.projitems*{968e1e85-e996-42de-9845-d20dae16165a}*SharedItemsImports = 5
@@ -189,6 +191,10 @@ Global
 		{77812373-D9CB-4DDC-B0D4-A192F7FC2330}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{77812373-D9CB-4DDC-B0D4-A192F7FC2330}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{77812373-D9CB-4DDC-B0D4-A192F7FC2330}.Release|Any CPU.Build.0 = Release|Any CPU
+		{00AD0047-92A6-48CC-B67D-A3DB2812CE28}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{00AD0047-92A6-48CC-B67D-A3DB2812CE28}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{00AD0047-92A6-48CC-B67D-A3DB2812CE28}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{00AD0047-92A6-48CC-B67D-A3DB2812CE28}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -218,6 +224,7 @@ Global
 		{7B18C4C5-099B-41D1-8CC2-2D2C412B80CD} = {3734A52F-2222-454B-BF58-1BA5C1F29D77}
 		{9BA642D5-2C8A-4B5E-AA75-50A4C29B0CCC} = {3734A52F-2222-454B-BF58-1BA5C1F29D77}
 		{77812373-D9CB-4DDC-B0D4-A192F7FC2330} = {3734A52F-2222-454B-BF58-1BA5C1F29D77}
+		{00AD0047-92A6-48CC-B67D-A3DB2812CE28} = {3C791D9C-6F19-4F46-B367-2EC0F818762D}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {69E02FD9-C9DE-412C-AB6B-5B8BECC6BFA5}

--- a/ElasticApmAgent.sln
+++ b/ElasticApmAgent.sln
@@ -84,6 +84,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Elastic.Apm.Elasticsearch",
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SampleConsoleNetCoreApp", "sample\SampleConsoleNetCoreApp\SampleConsoleNetCoreApp.csproj", "{00AD0047-92A6-48CC-B67D-A3DB2812CE28}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Elastic.Apm.Elasticsearch.Tests", "test\Elastic.Apm.Elasticsearch.Tests\Elastic.Apm.Elasticsearch.Tests.csproj", "{E30DEF03-4E0B-46A0-87D0-E80545D99BBA}"
+EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
 		test\Elastic.Apm.DatabaseTests.Common\Elastic.Apm.DatabaseTests.Common.projitems*{968e1e85-e996-42de-9845-d20dae16165a}*SharedItemsImports = 5
@@ -195,6 +197,10 @@ Global
 		{00AD0047-92A6-48CC-B67D-A3DB2812CE28}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{00AD0047-92A6-48CC-B67D-A3DB2812CE28}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{00AD0047-92A6-48CC-B67D-A3DB2812CE28}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E30DEF03-4E0B-46A0-87D0-E80545D99BBA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E30DEF03-4E0B-46A0-87D0-E80545D99BBA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E30DEF03-4E0B-46A0-87D0-E80545D99BBA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E30DEF03-4E0B-46A0-87D0-E80545D99BBA}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -225,6 +231,7 @@ Global
 		{9BA642D5-2C8A-4B5E-AA75-50A4C29B0CCC} = {3734A52F-2222-454B-BF58-1BA5C1F29D77}
 		{77812373-D9CB-4DDC-B0D4-A192F7FC2330} = {3734A52F-2222-454B-BF58-1BA5C1F29D77}
 		{00AD0047-92A6-48CC-B67D-A3DB2812CE28} = {3C791D9C-6F19-4F46-B367-2EC0F818762D}
+		{E30DEF03-4E0B-46A0-87D0-E80545D99BBA} = {267A241E-571F-458F-B04C-B6C4DE79E735}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {69E02FD9-C9DE-412C-AB6B-5B8BECC6BFA5}

--- a/sample/AspNetFullFrameworkSampleApp/Controllers/HomeController.cs
+++ b/sample/AspNetFullFrameworkSampleApp/Controllers/HomeController.cs
@@ -43,6 +43,11 @@ namespace AspNetFullFrameworkSampleApp.Controllers
 		internal const string DbOperationOutsideTransactionTestPageRelativePath =
 			HomePageRelativePath + "/" + nameof(DbOperationOutsideTransactionTest);
 
+		internal const string FailingDbCallTestPageRelativePath =
+			HomePageRelativePath + "/" + nameof(FailingDbCallTest);
+
+		internal const int FailingDbCallTestStatusCode = (int)HttpStatusCode.OK;
+
 		internal const int DbOperationOutsideTransactionTestStatusCode = (int)HttpStatusCode.Accepted;
 
 		internal const string DotNetRuntimeDescriptionHttpHeaderName = "DotNetRuntimeDescription";
@@ -192,6 +197,23 @@ namespace AspNetFullFrameworkSampleApp.Controllers
 					throw new InvalidOperationException($"dbCtx.Set<SampleData>().Count(): {dbCtx.Set<SampleData>().Count()}");
 				if (dbCtx.Set<SampleData>().First().Name != sampleDataName)
 					throw new InvalidOperationException($"dbCtx.Set<SampleData>().First().Name: {dbCtx.Set<SampleData>().First().Name}");
+			}
+
+			return new HttpStatusCodeResult(HttpStatusCode.OK);
+		}
+
+		public HttpStatusCodeResult FailingDbCallTest()
+		{
+			try
+			{
+				using (var dbCtx = new SampleDataDbContext())
+				{
+					dbCtx.Database.ExecuteSqlCommand("Select * From NonExistingTable");
+				}
+			}
+			catch
+			{
+				//ignore exception
 			}
 
 			return new HttpStatusCodeResult(HttpStatusCode.OK);

--- a/sample/AspNetFullFrameworkSampleApp/Controllers/HomeController.cs
+++ b/sample/AspNetFullFrameworkSampleApp/Controllers/HomeController.cs
@@ -28,6 +28,8 @@ namespace AspNetFullFrameworkSampleApp.Controllers
 
 		internal const string CaptureControllerActionAsSpanQueryStringKey = "captureControllerActionAsSpan";
 
+		internal const string ChildHttpSpanWithResponseForbiddenPath = HomePageRelativePath + "/" + nameof(ChildHttpSpanWithResponseForbidden);
+
 		internal const int ConcurrentDbTestNumberOfIterations = 10;
 		internal const string ConcurrentDbTestPageRelativePath = HomePageRelativePath + "/" + nameof(ConcurrentDbTest);
 		internal const string ConcurrentDbTestSpanType = "concurrent";
@@ -43,24 +45,23 @@ namespace AspNetFullFrameworkSampleApp.Controllers
 		internal const string DbOperationOutsideTransactionTestPageRelativePath =
 			HomePageRelativePath + "/" + nameof(DbOperationOutsideTransactionTest);
 
-		internal const string FailingDbCallTestPageRelativePath =
-			HomePageRelativePath + "/" + nameof(FailingDbCallTest);
-
-		internal const int FailingDbCallTestStatusCode = (int)HttpStatusCode.OK;
-
 		internal const int DbOperationOutsideTransactionTestStatusCode = (int)HttpStatusCode.Accepted;
 
 		internal const string DotNetRuntimeDescriptionHttpHeaderName = "DotNetRuntimeDescription";
 		internal const int DummyHttpStatusCode = 599;
 		internal const string ExceptionMessage = "For testing purposes";
 
-		internal const string ChildHttpSpanWithResponseForbiddenPath = HomePageRelativePath + "/" + nameof(ChildHttpSpanWithResponseForbidden);
-		internal static readonly Uri ChildHttpSpanWithResponseForbiddenUrl = new Uri("https://httpstat.us/403");
+		internal const string FailingDbCallTestPageRelativePath =
+			HomePageRelativePath + "/" + nameof(FailingDbCallTest);
+
+		internal const int FailingDbCallTestStatusCode = (int)HttpStatusCode.OK;
 
 		internal const string GenNSpansPageRelativePath = HomePageRelativePath + "/" + nameof(GenNSpans);
 
 		internal const string GetDotNetRuntimeDescriptionPageRelativePath = HomePageRelativePath + "/" + nameof(GetDotNetRuntimeDescription);
 		internal const string HomePageRelativePath = "Home";
+
+		internal const string NumberOfSpansQueryStringKey = "numberOfSpans";
 		internal const string ReturnBadRequestPageRelativePath = HomePageRelativePath + "/" + nameof(ReturnBadRequest);
 
 		internal const string SimpleDbTestPageRelativePath = HomePageRelativePath + "/" + nameof(SimpleDbTest);
@@ -74,8 +75,7 @@ namespace AspNetFullFrameworkSampleApp.Controllers
 
 		internal const string ThrowsInvalidOperationPageRelativePath = HomePageRelativePath + "/" + nameof(ThrowsInvalidOperation);
 		internal static readonly Uri ChildHttpCallToExternalServiceUrl = new Uri("https://elastic.co");
-
-		internal const string NumberOfSpansQueryStringKey = "numberOfSpans";
+		internal static readonly Uri ChildHttpSpanWithResponseForbiddenUrl = new Uri("https://httpstat.us/403");
 
 		public ActionResult Index() => View();
 
@@ -206,10 +206,7 @@ namespace AspNetFullFrameworkSampleApp.Controllers
 		{
 			try
 			{
-				using (var dbCtx = new SampleDataDbContext())
-				{
-					dbCtx.Database.ExecuteSqlCommand("Select * From NonExistingTable");
-				}
+				using (var dbCtx = new SampleDataDbContext()) dbCtx.Database.ExecuteSqlCommand("Select * From NonExistingTable");
 			}
 			catch
 			{

--- a/src/Elastic.Apm.AspNetCore/WebRequestTransactionCreator.cs
+++ b/src/Elastic.Apm.AspNetCore/WebRequestTransactionCreator.cs
@@ -17,7 +17,7 @@ using Microsoft.AspNetCore.Routing;
 namespace Elastic.Apm.AspNetCore
 {
 	/// <summary>
-	/// A helper class to capture an <see cref="HttpContext"/> as a transaction.
+	/// A helper class to capture an <see cref="HttpContext" /> as a transaction.
 	/// </summary>
 	internal static class WebRequestTransactionCreator
 	{
@@ -122,6 +122,7 @@ namespace Elastic.Apm.AspNetCore
 			configSnapshot.CaptureHeaders && headers != null
 				? headers.ToDictionary(header => header.Key, header => header.Value.ToString())
 				: null;
+
 		private static string GetRawUrl(HttpRequest httpRequest, IApmLogger logger)
 		{
 			try
@@ -133,7 +134,7 @@ namespace Elastic.Apm.AspNetCore
 
 				return rawPathAndQuery == null ? null : UriHelper.BuildAbsolute(httpRequest.Scheme, httpRequest.Host, rawPathAndQuery);
 			}
-			catch(Exception e)
+			catch (Exception e)
 			{
 				logger.Warning()?.LogException(e, "Failed reading RawUrl");
 				return null;

--- a/src/Elastic.Apm.AspNetCore/WebRequestTransactionCreator.cs
+++ b/src/Elastic.Apm.AspNetCore/WebRequestTransactionCreator.cs
@@ -191,6 +191,11 @@ namespace Elastic.Apm.AspNetCore
 
 				transaction.Result = Transaction.StatusCodeToResult(GetProtocolName(context.Request.Protocol), context.Response.StatusCode);
 
+				if (context.Response.StatusCode >= 500)
+					transaction.Outcome = Outcome.Failure;
+				else
+					transaction.Outcome = Outcome.Success;
+
 				if (transaction.IsSampled)
 				{
 					FillSampledTransactionContextResponse(context, transaction, logger);

--- a/src/Elastic.Apm.AspNetFullFramework/ElasticApmModule.cs
+++ b/src/Elastic.Apm.AspNetFullFramework/ElasticApmModule.cs
@@ -242,6 +242,11 @@ namespace Elastic.Apm.AspNetFullFramework
 
 			_currentTransaction.Result = Transaction.StatusCodeToResult("HTTP", httpResponse.StatusCode);
 
+			if (httpResponse.StatusCode >= 500)
+				_currentTransaction.Outcome = Outcome.Failure;
+			else
+				_currentTransaction.Outcome = Outcome.Success;
+
 			if (_currentTransaction.IsSampled)
 			{
 				FillSampledTransactionContextResponse(httpResponse, _currentTransaction);

--- a/src/Elastic.Apm.Elasticsearch/ElasticsearchDiagnosticsListenerBase.cs
+++ b/src/Elastic.Apm.Elasticsearch/ElasticsearchDiagnosticsListenerBase.cs
@@ -81,9 +81,11 @@ namespace Elastic.Apm.Elasticsearch
 		{
 			if (instance == null)
 				return;
-			span.Context.Destination = new Destination();
-			span.Context.Destination.Port = instance.Port;
-			span.Context.Destination.Address = instance.Host;
+			span.Context.Destination = new Destination
+			{
+				Port = instance.Port,
+				Address = instance.Host
+			};
 		}
 
 		internal bool TryGetCurrentElasticsearchSpan(out Span span, Uri instance = null)

--- a/src/Elastic.Apm.Elasticsearch/RequestPipelineDiagnosticsListener.cs
+++ b/src/Elastic.Apm.Elasticsearch/RequestPipelineDiagnosticsListener.cs
@@ -27,9 +27,17 @@ namespace Elastic.Apm.Elasticsearch
 
 				RegisterStatement(span, response);
 				RegisterError(span, response);
+
+				if (response.Success)
+					span.Outcome = Outcome.Success;
+				else
+					span.Outcome = Outcome.Failure;
 			}
 			else
+			{
 				span.Name += " (Exception)";
+				span.Outcome = Outcome.Failure;
+			}
 
 
 			Logger.Info()?.Log("Received an {Event} event from elasticsearch", @event);

--- a/src/Elastic.Apm.Elasticsearch/RequestPipelineDiagnosticsListener.cs
+++ b/src/Elastic.Apm.Elasticsearch/RequestPipelineDiagnosticsListener.cs
@@ -11,6 +11,14 @@ namespace Elastic.Apm.Elasticsearch
 {
 	public class RequestPipelineDiagnosticsListener : ElasticsearchDiagnosticsListenerBase
 	{
+		private const string CallStart = nameof(DiagnosticSources.RequestPipeline.CallElasticsearch) + StartSuffix;
+		private const string CallStop = nameof(DiagnosticSources.RequestPipeline.CallElasticsearch) + StopSuffix;
+
+		private const string PingStart = nameof(DiagnosticSources.RequestPipeline.Ping) + StartSuffix;
+		private const string PingStop = nameof(DiagnosticSources.RequestPipeline.Ping) + StopSuffix;
+		private const string SniffStart = nameof(DiagnosticSources.RequestPipeline.Sniff) + StartSuffix;
+		private const string SniffStop = nameof(DiagnosticSources.RequestPipeline.Sniff) + StopSuffix;
+
 		public RequestPipelineDiagnosticsListener(IApmAgent agent) : base(agent, DiagnosticSources.RequestPipeline.SourceName) =>
 			Observer = new RequestPipelineDiagnosticObserver(
 				a => OnRequestData(a.Key, a.Value),
@@ -49,11 +57,10 @@ namespace Elastic.Apm.Elasticsearch
 			//make sure db exists
 			var db = span.Context.Db ?? (span.Context.Db = new Database
 			{
-				Instance = response.Uri?.GetLeftPart(UriPartial.Authority), Type = Database.TypeElasticsearch,
+				Instance = response.Uri?.GetLeftPart(UriPartial.Authority), Type = Database.TypeElasticsearch
 			});
 
 			db.Statement = response.DebugInformation;
-
 		}
 
 		private static void RegisterError(ISpan span, IApiCallDetails response)
@@ -77,9 +84,9 @@ namespace Elastic.Apm.Elasticsearch
 			var culprit = "Client Error";
 
 			var message = $"{f.GetStringValue()} {exception?.Message}";
-			var stackFrames = exception == null ?  null : new StackTrace(exception, fNeedFileInfo: true).GetFrames();
+			var stackFrames = exception == null ? null : new StackTrace(exception, true).GetFrames();
 			if (stackFrames == null || stackFrames.Length == 0)
-				stackFrames = new StackTrace(fNeedFileInfo: true).GetFrames();
+				stackFrames = new StackTrace(true).GetFrames();
 
 			var causeOnServer = false;
 			if (response.ResponseBodyInBytes != null)
@@ -117,13 +124,6 @@ namespace Elastic.Apm.Elasticsearch
 				Logger.Info()?.Log("Received an {Event} event from elasticsearch", @event);
 			}
 		}
-
-		private const string PingStart = nameof(DiagnosticSources.RequestPipeline.Ping) + StartSuffix;
-		private const string PingStop = nameof(DiagnosticSources.RequestPipeline.Ping) + StopSuffix;
-		private const string SniffStart = nameof(DiagnosticSources.RequestPipeline.Sniff) + StartSuffix;
-		private const string SniffStop = nameof(DiagnosticSources.RequestPipeline.Sniff) + StopSuffix;
-		private const string CallStart = nameof(DiagnosticSources.RequestPipeline.CallElasticsearch) + StartSuffix;
-		private const string CallStop = nameof(DiagnosticSources.RequestPipeline.CallElasticsearch) + StopSuffix;
 
 		private static string ToName(string @event)
 		{

--- a/src/Elastic.Apm.EntityFramework6/Ef6Interceptor.cs
+++ b/src/Elastic.Apm.EntityFramework6/Ef6Interceptor.cs
@@ -50,8 +50,8 @@ namespace Elastic.Apm.EntityFramework6
 		/// <summary>
 		/// DB spans can be created only when there's a current transaction
 		/// which in turn means agent singleton instance should already be created.
-		///
-		/// Also checks for competing instrumentation. If SqlClient already instrumented, it'll return null, so the interceptor won't create
+		/// Also checks for competing instrumentation. If SqlClient already instrumented, it'll return null, so the interceptor
+		/// won't create
 		/// duplicate spans
 		/// </summary>
 		private Impl CreateImplIfReadyAndNoConflict()
@@ -63,6 +63,7 @@ namespace Elastic.Apm.EntityFramework6
 
 			// Make sure DB spans were not already captured
 			if (!(Agent.Tracer.CurrentSpan is Span span)) return impl;
+
 			return span.InstrumentationFlag == InstrumentationFlag.SqlClient ? null : impl;
 		}
 
@@ -137,7 +138,9 @@ namespace Elastic.Apm.EntityFramework6
 				interceptCtx.SetUserState(_userStateKey, span);
 			}
 
-			private void DoEndSpan<TResult>(IDbCommand command, DbCommandInterceptionContext<TResult> interceptCtx, Outcome outcome, string dbgOriginalCaller)
+			private void DoEndSpan<TResult>(IDbCommand command, DbCommandInterceptionContext<TResult> interceptCtx, Outcome outcome,
+				string dbgOriginalCaller
+			)
 			{
 				var span = (Span)interceptCtx.FindUserState(_userStateKey);
 				if (span == null)

--- a/src/Elastic.Apm.EntityFrameworkCore/EfCoreDiagnosticListener.cs
+++ b/src/Elastic.Apm.EntityFrameworkCore/EfCoreDiagnosticListener.cs
@@ -47,7 +47,7 @@ namespace Elastic.Apm.EntityFrameworkCore
 					if (kv.Value is CommandExecutedEventData commandExecutedEventData)
 					{
 						if (_spans.TryRemove(commandExecutedEventData.CommandId, out var span))
-							_agent.TracerInternal.DbSpanCommon.EndSpan(span, commandExecutedEventData.Command, commandExecutedEventData.Duration);
+							_agent.TracerInternal.DbSpanCommon.EndSpan(span, commandExecutedEventData.Command, Outcome.Success, commandExecutedEventData.Duration);
 					}
 					break;
 				case { } k when k == RelationalEventId.CommandError.Name:
@@ -56,7 +56,7 @@ namespace Elastic.Apm.EntityFrameworkCore
 						if (_spans.TryRemove(commandErrorEventData.CommandId, out var span))
 						{
 							span.CaptureException(commandErrorEventData.Exception);
-							_agent.TracerInternal.DbSpanCommon.EndSpan(span, commandErrorEventData.Command, commandErrorEventData.Duration);
+							_agent.TracerInternal.DbSpanCommon.EndSpan(span, commandErrorEventData.Command, Outcome.Failure, commandErrorEventData.Duration);
 						}
 					}
 					break;

--- a/src/Elastic.Apm.EntityFrameworkCore/EfCoreDiagnosticListener.cs
+++ b/src/Elastic.Apm.EntityFrameworkCore/EfCoreDiagnosticListener.cs
@@ -39,7 +39,8 @@ namespace Elastic.Apm.EntityFrameworkCore
 				case { } k when k == RelationalEventId.CommandExecuting.Name && _agent.Tracer.CurrentTransaction != null:
 					if (kv.Value is CommandEventData commandEventData)
 					{
-						var newSpan = _agent.TracerInternal.DbSpanCommon.StartSpan(_agent, commandEventData.Command, InstrumentationFlag.EfCore, captureStackTraceOnStart: true);
+						var newSpan = _agent.TracerInternal.DbSpanCommon.StartSpan(_agent, commandEventData.Command, InstrumentationFlag.EfCore,
+							captureStackTraceOnStart: true);
 						_spans.TryAdd(commandEventData.CommandId, newSpan);
 					}
 					break;
@@ -47,7 +48,8 @@ namespace Elastic.Apm.EntityFrameworkCore
 					if (kv.Value is CommandExecutedEventData commandExecutedEventData)
 					{
 						if (_spans.TryRemove(commandExecutedEventData.CommandId, out var span))
-							_agent.TracerInternal.DbSpanCommon.EndSpan(span, commandExecutedEventData.Command, Outcome.Success, commandExecutedEventData.Duration);
+							_agent.TracerInternal.DbSpanCommon.EndSpan(span, commandExecutedEventData.Command, Outcome.Success,
+								commandExecutedEventData.Duration);
 					}
 					break;
 				case { } k when k == RelationalEventId.CommandError.Name:
@@ -56,7 +58,8 @@ namespace Elastic.Apm.EntityFrameworkCore
 						if (_spans.TryRemove(commandErrorEventData.CommandId, out var span))
 						{
 							span.CaptureException(commandErrorEventData.Exception);
-							_agent.TracerInternal.DbSpanCommon.EndSpan(span, commandErrorEventData.Command, Outcome.Failure, commandErrorEventData.Duration);
+							_agent.TracerInternal.DbSpanCommon.EndSpan(span, commandErrorEventData.Command, Outcome.Failure,
+								commandErrorEventData.Duration);
 						}
 					}
 					break;

--- a/src/Elastic.Apm.SqlClient/SqlClientDiagnosticListener.cs
+++ b/src/Elastic.Apm.SqlClient/SqlClientDiagnosticListener.cs
@@ -92,7 +92,7 @@ namespace Elastic.Apm.SqlClient
 						statistics.ContainsKey("ExecutionTime") && statistics["ExecutionTime"] is long durationInMs && durationInMs > 0)
 						duration = TimeSpan.FromMilliseconds(durationInMs);
 
-					_apmAgent.TracerInternal.DbSpanCommon.EndSpan(span, dbCommand, duration);
+					_apmAgent.TracerInternal.DbSpanCommon.EndSpan(span, dbCommand, Outcome.Success, duration);
 				}
 			}
 			catch (Exception ex)
@@ -113,10 +113,11 @@ namespace Elastic.Apm.SqlClient
 					if (propertyFetcherSet.Exception.Fetch(payloadData) is Exception exception) span.CaptureException(exception);
 
 					if (propertyFetcherSet.ErrorCommand.Fetch(payloadData) is IDbCommand dbCommand)
-						_apmAgent.TracerInternal.DbSpanCommon.EndSpan(span, dbCommand);
+						_apmAgent.TracerInternal.DbSpanCommon.EndSpan(span, dbCommand, Outcome.Failure);
 					else
 					{
 						_logger.Warning()?.Log("Cannot extract database command from {PayloadData}", payloadData);
+						span.Outcome = Outcome.Failure;
 						span.End();
 					}
 				}

--- a/src/Elastic.Apm.SqlClient/SqlEventListener.cs
+++ b/src/Elastic.Apm.SqlClient/SqlEventListener.cs
@@ -15,6 +15,8 @@ namespace Elastic.Apm.SqlClient
 {
 	internal class SqlEventListener : EventListener
 	{
+		private const int BeginExecuteEventId = 1;
+		private const int EndExecuteId = 2;
 		private readonly ApmAgent _apmAgent;
 		private readonly IApmLogger _logger;
 
@@ -38,9 +40,6 @@ namespace Elastic.Apm.SqlClient
 
 			base.OnEventSourceCreated(eventSource);
 		}
-
-		private const int BeginExecuteEventId = 1;
-		private const int EndExecuteId = 2;
 
 		protected override void OnEventWritten(EventWrittenEventArgs eventData)
 		{
@@ -145,7 +144,7 @@ namespace Elastic.Apm.SqlClient
 			var isSqlException = (compositeState & 2) == 2;
 			// 4 - is synchronous
 
-			item.Span.Duration = ((stop - item.Start) / (double)Stopwatch.Frequency) * 1000;
+			item.Span.Duration = (stop - item.Start) / (double)Stopwatch.Frequency * 1000;
 
 			if (isSqlException)
 			{

--- a/src/Elastic.Apm.SqlClient/SqlEventListener.cs
+++ b/src/Elastic.Apm.SqlClient/SqlEventListener.cs
@@ -149,9 +149,12 @@ namespace Elastic.Apm.SqlClient
 
 			if (isSqlException)
 			{
+				item.Span.Outcome = Outcome.Failure;
 				item.Span.CaptureError("Exception has occurred", sqlExceptionNumber != 0 ? $"SQL Exception {sqlExceptionNumber}" : null,
 					null);
 			}
+			else
+				item.Span.Outcome = Outcome.Success;
 
 			item.Span.End();
 		}

--- a/src/Elastic.Apm/Api/IExecutionSegment.cs
+++ b/src/Elastic.Apm/Api/IExecutionSegment.cs
@@ -241,5 +241,10 @@ namespace Elastic.Apm.Api
 		/// <param name="action">The action of the span.</param>
 		/// <returns>Returns the newly created and active span.</returns>
 		ISpan StartSpan(string name, string type, string subType = null, string action = null);
+
+		/// <summary>
+		/// The outcome of the IExecutionSegment: success, failure, or unknown.
+		/// </summary>
+		public Outcome Outcome { get; set; }
 	}
 }

--- a/src/Elastic.Apm/Api/IExecutionSegment.cs
+++ b/src/Elastic.Apm/Api/IExecutionSegment.cs
@@ -35,7 +35,8 @@ namespace Elastic.Apm.Api
 
 		/// <summary>
 		/// A flat mapping of user-defined labels with string values.
-		/// Dots (<code>.</code>) in the keys are not allowed. In case you have a <code>.</code> in your label key, it will be replaced by <code>_</code>.
+		/// Dots (<code>.</code>) in the keys are not allowed. In case you have a <code>.</code> in your label key, it will be
+		/// replaced by <code>_</code>.
 		/// For example <code>foo.bar</code> will be stored as <code>foo_bar</code> in Elasticsearch.
 		/// </summary>
 		/// <exception cref="ArgumentException"><c>null</c> as key is not allowed.</exception>
@@ -45,6 +46,11 @@ namespace Elastic.Apm.Api
 		/// The name of the item.
 		/// </summary>
 		string Name { get; set; }
+
+		/// <summary>
+		/// The outcome of the IExecutionSegment: success, failure, or unknown.
+		/// </summary>
+		public Outcome Outcome { get; set; }
 
 		/// <summary>
 		/// Distributed tracing data for this segment as the distributed tracing caller.
@@ -241,10 +247,5 @@ namespace Elastic.Apm.Api
 		/// <param name="action">The action of the span.</param>
 		/// <returns>Returns the newly created and active span.</returns>
 		ISpan StartSpan(string name, string type, string subType = null, string action = null);
-
-		/// <summary>
-		/// The outcome of the IExecutionSegment: success, failure, or unknown.
-		/// </summary>
-		public Outcome Outcome { get; set; }
 	}
 }

--- a/src/Elastic.Apm/Api/Outcome.cs
+++ b/src/Elastic.Apm/Api/Outcome.cs
@@ -1,7 +1,8 @@
-﻿using System;
-using System.Collections.Generic;
+﻿// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
 using System.Runtime.Serialization;
-using System.Text;
 
 namespace Elastic.Apm.Api
 {
@@ -9,8 +10,10 @@ namespace Elastic.Apm.Api
 	{
 		[EnumMember(Value = "unknown")]
 		Unknown = 0, //Make sure Unknown remains the default value
+
 		[EnumMember(Value = "success")]
 		Success,
+
 		[EnumMember(Value = "failure")]
 		Failure
 	}

--- a/src/Elastic.Apm/Api/Outcome.cs
+++ b/src/Elastic.Apm/Api/Outcome.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Runtime.Serialization;
+using System.Text;
+
+namespace Elastic.Apm.Api
+{
+	public enum Outcome
+	{
+		[EnumMember(Value = "unknown")]
+		Unknown = 0, //Make sure Unknown remains the default value
+		[EnumMember(Value = "success")]
+		Success,
+		[EnumMember(Value = "failure")]
+		Failure
+	}
+}

--- a/src/Elastic.Apm/DiagnosticListeners/HttpDiagnosticListenerImplBase.cs
+++ b/src/Elastic.Apm/DiagnosticListeners/HttpDiagnosticListenerImplBase.cs
@@ -205,7 +205,14 @@ namespace Elastic.Apm.DiagnosticListeners
 				if (responseObject != null)
 				{
 					if (responseObject is TResponse response)
+					{
 						span.Context.Http.StatusCode = ResponseGetStatusCode(response);
+
+						if (span.Context.Http.StatusCode < 400)
+							span.Outcome = Outcome.Success;
+						else
+							span.Outcome = Outcome.Failure;
+					}
 					else
 					{
 						Logger.Trace()

--- a/src/Elastic.Apm/Model/DbSpanCommon.cs
+++ b/src/Elastic.Apm/Model/DbSpanCommon.cs
@@ -30,7 +30,7 @@ namespace Elastic.Apm.Model
 			return ExecutionSegmentCommon.StartSpanOnCurrentExecutionSegment(agent, spanName, ApiConstants.TypeDb, subType, instrumentationFlag, captureStackTraceOnStart);
 		}
 
-		internal void EndSpan(Span span, IDbCommand dbCommand, TimeSpan? duration = null)
+		internal void EndSpan(Span span, IDbCommand dbCommand, Outcome outcome, TimeSpan? duration = null)
 		{
 			if (duration.HasValue) span.Duration = duration.Value.TotalMilliseconds;
 
@@ -50,6 +50,7 @@ namespace Elastic.Apm.Model
 				span.Context.Destination = GetDestination(dbCommand.Connection?.ConnectionString, isEmbeddedDb, defaultPort);
 			}
 
+			span.Outcome = outcome;
 			span.End();
 		}
 

--- a/src/Elastic.Apm/Model/DbSpanCommon.cs
+++ b/src/Elastic.Apm/Model/DbSpanCommon.cs
@@ -12,22 +12,25 @@ namespace Elastic.Apm.Model
 {
 	internal class DbSpanCommon
 	{
-		internal static class DefaultPorts
-		{
-			internal const int MsSql = 1433;
-			internal const int Oracle = 1521;
-			internal const int MySql = 3306;
-			internal const int PostgreSql = 5432;
-		}
-
 		private readonly DbConnectionStringParser _dbConnectionStringParser;
 
 		internal DbSpanCommon(IApmLogger logger) => _dbConnectionStringParser = new DbConnectionStringParser(logger);
 
-		internal Span StartSpan(IApmAgent agent, IDbCommand dbCommand, InstrumentationFlag instrumentationFlag, string subType = null, bool captureStackTraceOnStart = false)
+		internal static class DefaultPorts
+		{
+			internal const int MsSql = 1433;
+			internal const int MySql = 3306;
+			internal const int Oracle = 1521;
+			internal const int PostgreSql = 5432;
+		}
+
+		internal Span StartSpan(IApmAgent agent, IDbCommand dbCommand, InstrumentationFlag instrumentationFlag, string subType = null,
+			bool captureStackTraceOnStart = false
+		)
 		{
 			var spanName = dbCommand.CommandText.Replace(Environment.NewLine, " ");
-			return ExecutionSegmentCommon.StartSpanOnCurrentExecutionSegment(agent, spanName, ApiConstants.TypeDb, subType, instrumentationFlag, captureStackTraceOnStart);
+			return ExecutionSegmentCommon.StartSpanOnCurrentExecutionSegment(agent, spanName, ApiConstants.TypeDb, subType, instrumentationFlag,
+				captureStackTraceOnStart);
 		}
 
 		internal void EndSpan(Span span, IDbCommand dbCommand, Outcome outcome, TimeSpan? duration = null)
@@ -109,7 +112,7 @@ namespace Elastic.Apm.Model
 			if (isEmbeddedDb || dbConnectionString == null) return null;
 
 			var destination = _dbConnectionStringParser.ExtractDestination(dbConnectionString);
-			if (destination == null ) return null;
+			if (destination == null) return null;
 
 			if (!destination.Port.HasValue) destination.Port = defaultPort;
 

--- a/src/Elastic.Apm/Model/Span.cs
+++ b/src/Elastic.Apm/Model/Span.cs
@@ -111,14 +111,6 @@ namespace Elastic.Apm.Model
 		private IConfigSnapshot ConfigSnapshot => _enclosingTransaction.ConfigSnapshot;
 
 		/// <summary>
-		/// The outcome of the span: success, failure, or unknown.
-		/// Outcome may be one of a limited set of permitted values describing the success or failure of the span.
-		/// This field can be used for calculating error rates for outgoing requests.
-		/// </summary>
-		[JsonConverter(typeof(StringEnumConverter))]
-		public Outcome Outcome { get; set; }
-
-		/// <summary>
 		/// Any other arbitrary data captured by the agent, optionally provided by the user.
 		/// <seealso cref="ShouldSerializeContext" />
 		/// </summary>
@@ -146,6 +138,14 @@ namespace Elastic.Apm.Model
 
 		[JsonConverter(typeof(TrimmedStringJsonConverter))]
 		public string Name { get; set; }
+
+		/// <summary>
+		/// The outcome of the span: success, failure, or unknown.
+		/// Outcome may be one of a limited set of permitted values describing the success or failure of the span.
+		/// This field can be used for calculating error rates for outgoing requests.
+		/// </summary>
+		[JsonConverter(typeof(StringEnumConverter))]
+		public Outcome Outcome { get; set; }
 
 		[JsonIgnore]
 		public DistributedTracingData OutgoingDistributedTracingData => new DistributedTracingData(
@@ -270,7 +270,8 @@ namespace Elastic.Apm.Model
 					if (Duration >= ConfigSnapshot.SpanFramesMinDurationInMilliseconds
 						|| ConfigSnapshot.SpanFramesMinDurationInMilliseconds < 0)
 					{
-						StackTrace = StacktraceHelper.GenerateApmStackTrace(_stackFrames ?? new EnhancedStackTrace(new StackTrace(true)).GetFrames(), _logger,
+						StackTrace = StacktraceHelper.GenerateApmStackTrace(_stackFrames ?? new EnhancedStackTrace(new StackTrace(true)).GetFrames(),
+							_logger,
 							ConfigSnapshot, $"Span `{Name}'");
 					}
 				}

--- a/src/Elastic.Apm/Model/Span.cs
+++ b/src/Elastic.Apm/Model/Span.cs
@@ -201,6 +201,7 @@ namespace Elastic.Apm.Model
 			{ nameof(TraceId), TraceId },
 			{ nameof(Name), Name },
 			{ nameof(Type), Type },
+			{ nameof(Outcome), Outcome },
 			{ nameof(IsSampled), IsSampled }
 		}.ToString();
 

--- a/src/Elastic.Apm/Model/Span.cs
+++ b/src/Elastic.Apm/Model/Span.cs
@@ -13,6 +13,7 @@ using Elastic.Apm.Logging;
 using Elastic.Apm.Report;
 using Elastic.Apm.Report.Serialization;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
 
 namespace Elastic.Apm.Model
 {
@@ -108,6 +109,14 @@ namespace Elastic.Apm.Model
 
 		[JsonIgnore]
 		private IConfigSnapshot ConfigSnapshot => _enclosingTransaction.ConfigSnapshot;
+
+		/// <summary>
+		/// The outcome of the span: success, failure, or unknown.
+		/// Outcome may be one of a limited set of permitted values describing the success or failure of the span.
+		/// This field can be used for calculating error rates for outgoing requests.
+		/// </summary>
+		[JsonConverter(typeof(StringEnumConverter))]
+		public Outcome Outcome { get; set; }
 
 		/// <summary>
 		/// Any other arbitrary data captured by the agent, optionally provided by the user.

--- a/src/Elastic.Apm/Model/Transaction.cs
+++ b/src/Elastic.Apm/Model/Transaction.cs
@@ -13,6 +13,7 @@ using Elastic.Apm.Logging;
 using Elastic.Apm.Report;
 using Elastic.Apm.Report.Serialization;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
 
 namespace Elastic.Apm.Model
 {
@@ -48,7 +49,8 @@ namespace Elastic.Apm.Model
 		// This constructor is used only by tests that don't care about sampling and distributed tracing
 		internal Transaction(ApmAgent agent, string name, string type)
 			: this(agent.Logger, name, type, new Sampler(1.0), null, agent.PayloadSender, agent.ConfigStore.CurrentSnapshot,
-				agent.TracerInternal.CurrentExecutionSegmentsContainer) { }
+				agent.TracerInternal.CurrentExecutionSegmentsContainer)
+		{ }
 
 		/// <summary>
 		/// Creates a new transaction
@@ -93,7 +95,7 @@ namespace Elastic.Apm.Model
 			// For each transaction start, we fire an Activity
 			// If Activity.Current is null, then we create one with this and set its traceid, which will flow to all child activities and we also reuse it in Elastic APM, so it'll be the same on all Activities and in Elastic
 			// If Activity.Current is not null, we pick up its traceid and apply it in Elastic APM
-			if(!ignoreActivity)
+			if (!ignoreActivity)
 				StartActivity();
 
 			var isSamplingFromDistributedTracingData = false;
@@ -276,6 +278,14 @@ namespace Elastic.Apm.Model
 
 		[JsonConverter(typeof(TrimmedStringJsonConverter))]
 		public string Type { get; set; }
+
+		/// <summary>
+		/// The outcome of the transaction: success, failure, or unknown.
+		/// This is similar to 'result', but has a limited set of permitted values describing the success or failure of the transaction from the service's perspective.
+		/// This field can be used for calculating error rates for incoming requests.
+		/// </summary>
+		[JsonConverter(typeof(StringEnumConverter))]
+		public Outcome Outcome { get; set; }
 
 		public string EnsureParentId()
 		{

--- a/src/Elastic.Apm/Model/Transaction.cs
+++ b/src/Elastic.Apm/Model/Transaction.cs
@@ -313,6 +313,7 @@ namespace Elastic.Apm.Model
 			{ nameof(ParentId), ParentId },
 			{ nameof(Name), Name },
 			{ nameof(Type), Type },
+			{ nameof(Outcome), Outcome },
 			{ nameof(IsSampled), IsSampled }
 		}.ToString();
 

--- a/src/Elastic.Apm/Model/Transaction.cs
+++ b/src/Elastic.Apm/Model/Transaction.cs
@@ -49,8 +49,7 @@ namespace Elastic.Apm.Model
 		// This constructor is used only by tests that don't care about sampling and distributed tracing
 		internal Transaction(ApmAgent agent, string name, string type)
 			: this(agent.Logger, name, type, new Sampler(1.0), null, agent.PayloadSender, agent.ConfigStore.CurrentSnapshot,
-				agent.TracerInternal.CurrentExecutionSegmentsContainer)
-		{ }
+				agent.TracerInternal.CurrentExecutionSegmentsContainer) { }
 
 		/// <summary>
 		/// Creates a new transaction
@@ -62,11 +61,11 @@ namespace Elastic.Apm.Model
 		/// <param name="distributedTracingData">Distributed tracing data, in case this transaction is part of a distributed trace</param>
 		/// <param name="sender">The IPayloadSender implementation which will record this transaction</param>
 		/// <param name="configSnapshot">The current configuration snapshot which contains the up-do-date config setting values</param>
-		/// <param name="currentExecutionSegmentsContainer">
+		/// <param name="currentExecutionSegmentsContainer"/>
 		/// The ExecutionSegmentsContainer which makes sure this transaction flows
-		/// <paramref name="ignoreActivity"> If set the transaction will ignore Activity.Current and it's trace id,
-		/// otherwise the agent will try to keep ids in-sync </paramref>
-		/// across async work-flows
+		/// <param name="ignoreActivity">
+		/// If set the transaction will ignore Activity.Current and it's trace id,
+		/// otherwise the agent will try to keep ids in-sync across async work-flows
 		/// </param>
 		internal Transaction(
 			IApmLogger logger,
@@ -246,6 +245,15 @@ namespace Elastic.Apm.Model
 			}
 		}
 
+		/// <summary>
+		/// The outcome of the transaction: success, failure, or unknown.
+		/// This is similar to 'result', but has a limited set of permitted values describing the success or failure of the
+		/// transaction from the service's perspective.
+		/// This field can be used for calculating error rates for incoming requests.
+		/// </summary>
+		[JsonConverter(typeof(StringEnumConverter))]
+		public Outcome Outcome { get; set; }
+
 		[JsonIgnore]
 		public DistributedTracingData OutgoingDistributedTracingData => new DistributedTracingData(TraceId, Id, IsSampled, _traceState);
 
@@ -278,14 +286,6 @@ namespace Elastic.Apm.Model
 
 		[JsonConverter(typeof(TrimmedStringJsonConverter))]
 		public string Type { get; set; }
-
-		/// <summary>
-		/// The outcome of the transaction: success, failure, or unknown.
-		/// This is similar to 'result', but has a limited set of permitted values describing the success or failure of the transaction from the service's perspective.
-		/// This field can be used for calculating error rates for incoming requests.
-		/// </summary>
-		[JsonConverter(typeof(StringEnumConverter))]
-		public Outcome Outcome { get; set; }
 
 		public string EnsureParentId()
 		{

--- a/test/Elastic.Apm.AspNetCore.Tests/AspNetCoreBasicTests.cs
+++ b/test/Elastic.Apm.AspNetCore.Tests/AspNetCoreBasicTests.cs
@@ -117,6 +117,7 @@ namespace Elastic.Apm.AspNetCore.Tests
 			transaction.Name.Should().Be(transactionName);
 			transaction.Result.Should().Be("HTTP 2xx");
 			transaction.Duration.Should().BeGreaterThan(0);
+			transaction.Outcome.Should().Be(Outcome.Success);
 
 			transaction.Type.Should().Be("request");
 			transaction.Id.Should().NotBeEmpty();

--- a/test/Elastic.Apm.AspNetCore.Tests/FailedRequestTests.cs
+++ b/test/Elastic.Apm.AspNetCore.Tests/FailedRequestTests.cs
@@ -1,6 +1,7 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
+﻿// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
 using System.Net.Http;
 using System.Reflection;
 using System.Threading;
@@ -33,13 +34,13 @@ namespace Elastic.Apm.AspNetCore.Tests
 
 			_taskForApp1 = Program.CreateWebHostBuilder(null)
 				.ConfigureServices(services =>
-				{
-					Startup.ConfigureServicesExceptMvc(services);
+					{
+						Startup.ConfigureServicesExceptMvc(services);
 
-					services
-						.AddMvc()
-						.AddApplicationPart(Assembly.Load(new AssemblyName(nameof(SampleAspNetCoreApp))));
-				}
+						services
+							.AddMvc()
+							.AddApplicationPart(Assembly.Load(new AssemblyName(nameof(SampleAspNetCoreApp))));
+					}
 				)
 				.Configure(app =>
 				{
@@ -67,8 +68,9 @@ namespace Elastic.Apm.AspNetCore.Tests
 			res.IsSuccessStatusCode.Should().BeFalse();
 
 			_payloadSender1.Transactions.Count.Should().Be(1);
-			_payloadSender1.Transactions.FirstOrDefault().Result.Should().Be("HTTP 5xx");
-			_payloadSender1.Transactions.FirstOrDefault().Outcome.Should().Be(Outcome.Failure);
+			_payloadSender1.FirstTransaction.Should().NotBeNull();
+			_payloadSender1.FirstTransaction.Result.Should().Be("HTTP 5xx");
+			_payloadSender1.FirstTransaction.Outcome.Should().Be(Outcome.Failure);
 		}
 
 		public async Task DisposeAsync()

--- a/test/Elastic.Apm.AspNetCore.Tests/FailedRequestTests.cs
+++ b/test/Elastic.Apm.AspNetCore.Tests/FailedRequestTests.cs
@@ -1,0 +1,82 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using Elastic.Apm.Api;
+using Elastic.Apm.DiagnosticSource;
+using Elastic.Apm.EntityFrameworkCore;
+using Elastic.Apm.Tests.Mocks;
+using FluentAssertions;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.DependencyInjection;
+using SampleAspNetCoreApp;
+using Xunit;
+
+namespace Elastic.Apm.AspNetCore.Tests
+{
+	[Collection("DiagnosticListenerTest")]
+	public class FailedRequestTests : IAsyncLifetime
+	{
+		private readonly CancellationTokenSource _cancellationTokenSource = new CancellationTokenSource();
+
+		private readonly MockPayloadSender _payloadSender1 = new MockPayloadSender();
+		private ApmAgent _agent1;
+
+		private Task _taskForApp1;
+
+		public Task InitializeAsync()
+		{
+			_agent1 = new ApmAgent(new TestAgentComponents(payloadSender: _payloadSender1));
+
+			_taskForApp1 = Program.CreateWebHostBuilder(null)
+				.ConfigureServices(services =>
+				{
+					Startup.ConfigureServicesExceptMvc(services);
+
+					services
+						.AddMvc()
+						.AddApplicationPart(Assembly.Load(new AssemblyName(nameof(SampleAspNetCoreApp))));
+				}
+				)
+				.Configure(app =>
+				{
+					app.UseElasticApm(_agent1, new TestLogger(),
+						new HttpDiagnosticsSubscriber(), new EfCoreDiagnosticsSubscriber());
+					Startup.ConfigureAllExceptAgent(app);
+				})
+				.UseUrls("http://localhost:5901")
+				.Build()
+				.RunAsync(_cancellationTokenSource.Token);
+
+			return Task.CompletedTask;
+		}
+
+
+		/// <summary>
+		/// Calls Home/TriggerError (which throws an exception) and makes sure the result and the outcome are captured
+		/// </summary>
+		/// <returns></returns>
+		[Fact]
+		public async Task DistributedTraceAcross2Service()
+		{
+			var client = new HttpClient();
+			var res = await client.GetAsync("http://localhost:5901/Home/TriggerError");
+			res.IsSuccessStatusCode.Should().BeFalse();
+
+			_payloadSender1.Transactions.Count.Should().Be(1);
+			_payloadSender1.Transactions.FirstOrDefault().Result.Should().Be("HTTP 5xx");
+			_payloadSender1.Transactions.FirstOrDefault().Outcome.Should().Be(Outcome.Failure);
+		}
+
+		public async Task DisposeAsync()
+		{
+			_cancellationTokenSource.Cancel();
+			await Task.WhenAll(_taskForApp1);
+
+			_agent1?.Dispose();
+		}
+	}
+}

--- a/test/Elastic.Apm.AspNetCore.Tests/Helper.cs
+++ b/test/Elastic.Apm.AspNetCore.Tests/Helper.cs
@@ -73,7 +73,8 @@ namespace Elastic.Apm.AspNetCore.Tests
 						  {
 							  var subs = new List<IDiagnosticsSubscriber>()
 							{
-								new AspNetCoreErrorDiagnosticsSubscriber(),
+								new HttpDiagnosticsSubscriber(),
+								new EfCoreDiagnosticsSubscriber(),
 								new AspNetCoreDiagnosticSubscriber()
 							};
 							  agent.Subscribe(subs.ToArray());

--- a/test/Elastic.Apm.AspNetFullFramework.Tests/DbSpanTests.cs
+++ b/test/Elastic.Apm.AspNetFullFramework.Tests/DbSpanTests.cs
@@ -44,10 +44,7 @@ namespace Elastic.Apm.AspNetFullFramework.Tests
 				VerifyReceivedDataSharedConstraints(pageData, receivedData);
 
 				// See comment for TestsBase.SampleAppUrlPaths.SimpleDbTestPage
-				var dbStatements = new[]
-				{
-					"CREATE TABLE", "INSERT", "SELECT", "SELECT"
-				};
+				var dbStatements = new[] { "CREATE TABLE", "INSERT", "SELECT", "SELECT" };
 
 				var transaction = receivedData.Transactions.First();
 
@@ -154,10 +151,7 @@ namespace Elastic.Apm.AspNetFullFramework.Tests
 					indexInBranch[containedSpansBranchIndex] += 2;
 				});
 
-				var dbStatements = new List<string>
-				{
-					"CREATE TABLE", "SELECT", "SELECT"
-				};
+				var dbStatements = new List<string> { "CREATE TABLE", "SELECT", "SELECT" };
 				var allChildDbSpansFlattened = allChildDbSpans.SelectMany(x => x);
 				dbStatements.AddRange(Enumerable.Repeat("INSERT", allChildDbSpansFlattened.Count()));
 				topLevelDbSpans.Concat(allChildDbSpansFlattened)
@@ -212,7 +206,8 @@ namespace Elastic.Apm.AspNetFullFramework.Tests
 			{
 				receivedData.Spans.Should().NotBeNullOrEmpty();
 
-				var selectSpan = receivedData.Spans.Where(n => n.Context.Db != null && n.Context.Db.Statement.Contains("Select * From NonExistingTable")).First();
+				var selectSpan = receivedData.Spans
+					.First(n => n.Context.Db != null && n.Context.Db.Statement.Contains("Select * From NonExistingTable"));
 				selectSpan.Should().NotBeNull();
 				selectSpan.Outcome.Should().Be(Outcome.Failure);
 			});

--- a/test/Elastic.Apm.AspNetFullFramework.Tests/DistributedTracingTests.cs
+++ b/test/Elastic.Apm.AspNetFullFramework.Tests/DistributedTracingTests.cs
@@ -122,7 +122,7 @@ namespace Elastic.Apm.AspNetFullFramework.Tests
 		[AspNetFullFrameworkFact]
 		public async Task CallSoap11Request()
 		{
-			var rootTxData = SampleAppUrlPaths.CallSoapServiceProtocolV1_1;
+			var rootTxData = SampleAppUrlPaths.CallSoapServiceProtocolV11;
 			var fullUrl = Consts.SampleApp.RootUrl + "/" + rootTxData.RelativeUrlPath;
 			var action = "Ping";
 
@@ -159,7 +159,7 @@ namespace Elastic.Apm.AspNetFullFramework.Tests
 		[AspNetFullFrameworkFact]
 		public async Task CallSoap12Request()
 		{
-			var rootTxData = SampleAppUrlPaths.CallSoapServiceProtocolV1_2;
+			var rootTxData = SampleAppUrlPaths.CallSoapServiceProtocolV12;
 			var fullUrl = Consts.SampleApp.RootUrl + "/" + rootTxData.RelativeUrlPath;
 			var action = "Ping";
 

--- a/test/Elastic.Apm.AspNetFullFramework.Tests/ErrorsTests.cs
+++ b/test/Elastic.Apm.AspNetFullFramework.Tests/ErrorsTests.cs
@@ -6,6 +6,7 @@ using System;
 using System.Linq;
 using System.Threading.Tasks;
 using AspNetFullFrameworkSampleApp.Controllers;
+using Elastic.Apm.Api;
 using Elastic.Apm.Tests.Extensions;
 using Elastic.Apm.Tests.MockApmServer;
 using Elastic.Apm.Tests.TestHelpers;
@@ -33,6 +34,7 @@ namespace Elastic.Apm.AspNetFullFramework.Tests
 				var transaction = receivedData.Transactions.First();
 				transaction.Context.Request.Url.Search.Should().BeNull();
 				transaction.IsSampled.Should().BeTrue();
+				transaction.Outcome.Should().Be(Outcome.Failure);
 
 				var span = receivedData.Spans.First();
 				VerifySpanNameTypeSubtypeAction(span, HomeController.TestSpanPrefix);

--- a/test/Elastic.Apm.AspNetFullFramework.Tests/TestsBase.cs
+++ b/test/Elastic.Apm.AspNetFullFramework.Tests/TestsBase.cs
@@ -109,7 +109,7 @@ namespace Elastic.Apm.AspNetFullFramework.Tests
 			/// and exception propagates out of transaction as well so both span and transaction send an error event
 			/// </summary>
 			internal static readonly SampleAppUrlPathData CustomSpanThrowsExceptionPage =
-				new SampleAppUrlPathData(HomeController.CustomSpanThrowsPageRelativePath, 500, spansCount: 1, errorsCount: 2);
+				new SampleAppUrlPathData(HomeController.CustomSpanThrowsPageRelativePath, 500, spansCount: 1, errorsCount: 2, outcome: Outcome.Failure);
 
 			internal static readonly SampleAppUrlPathData HomePage =
 				new SampleAppUrlPathData(HomeController.HomePageRelativePath, 200);
@@ -512,6 +512,7 @@ namespace Elastic.Apm.AspNetFullFramework.Tests
 					}
 
 					transaction.Context.Response.StatusCode.Should().Be(sampleAppUrlPathData.StatusCode);
+					transaction.Outcome.Should().Be(sampleAppUrlPathData.Outcome);
 				}
 
 				var httpStatusFirstDigit = sampleAppUrlPathData.StatusCode / 100;
@@ -806,14 +807,16 @@ namespace Elastic.Apm.AspNetFullFramework.Tests
 			public readonly int SpansCount;
 			public readonly int StatusCode;
 			public readonly int TransactionsCount;
+			public readonly Outcome Outcome;
 
-			public SampleAppUrlPathData(string relativeUrlPath, int statusCode, int transactionsCount = 1, int spansCount = 0, int errorsCount = 0)
+			public SampleAppUrlPathData(string relativeUrlPath, int statusCode, int transactionsCount = 1, int spansCount = 0, int errorsCount = 0, Outcome outcome = Outcome.Success)
 			{
 				RelativeUrlPath = relativeUrlPath;
 				StatusCode = statusCode;
 				TransactionsCount = transactionsCount;
 				SpansCount = spansCount;
 				ErrorsCount = errorsCount;
+				Outcome = outcome;
 			}
 
 			public SampleAppUrlPathData Clone(
@@ -821,13 +824,15 @@ namespace Elastic.Apm.AspNetFullFramework.Tests
 				int? status = null,
 				int? transactionsCount = null,
 				int? spansCount = null,
-				int? errorsCount = null
+				int? errorsCount = null,
+				Outcome outcome = Outcome.Success
 			) => new SampleAppUrlPathData(
 				relativeUrlPath ?? RelativeUrlPath,
 				status ?? StatusCode,
 				transactionsCount ?? TransactionsCount,
 				spansCount ?? SpansCount,
-				errorsCount ?? ErrorsCount);
+				errorsCount ?? ErrorsCount,
+				outcome);
 		}
 	}
 }

--- a/test/Elastic.Apm.AspNetFullFramework.Tests/TestsBase.cs
+++ b/test/Elastic.Apm.AspNetFullFramework.Tests/TestsBase.cs
@@ -141,7 +141,7 @@ namespace Elastic.Apm.AspNetFullFramework.Tests
 			/// and exception propagates out of transaction as well so both spans and the transaction send an error event
 			/// </summary>
 			internal static readonly SampleAppUrlPathData CustomChildSpanThrowsExceptionPage =
-				new SampleAppUrlPathData(HomeController.CustomChildSpanThrowsPageRelativePath, 500, spansCount: 2, errorsCount: 3);
+				new SampleAppUrlPathData(HomeController.CustomChildSpanThrowsPageRelativePath, 500, spansCount: 2, errorsCount: 3, outcome: Outcome.Failure);
 
 
 			internal static readonly SampleAppUrlPathData ChildHttpSpanWithResponseForbiddenPage =
@@ -155,7 +155,7 @@ namespace Elastic.Apm.AspNetFullFramework.Tests
 				new SampleAppUrlPathData(HomeController.ReturnBadRequestPageRelativePath, (int)HttpStatusCode.BadRequest);
 
 			internal static readonly SampleAppUrlPathData ThrowsInvalidOperationPage =
-				new SampleAppUrlPathData(HomeController.ThrowsInvalidOperationPageRelativePath, 500, errorsCount: 1);
+				new SampleAppUrlPathData(HomeController.ThrowsInvalidOperationPageRelativePath, 500, errorsCount: 1, outcome: Outcome.Failure);
 
 			internal static readonly SampleAppUrlPathData GenNSpansPage =
 				new SampleAppUrlPathData(HomeController.GenNSpansPageRelativePath, (int)HttpStatusCode.Created);

--- a/test/Elastic.Apm.AspNetFullFramework.Tests/TestsBase.cs
+++ b/test/Elastic.Apm.AspNetFullFramework.Tests/TestsBase.cs
@@ -19,7 +19,6 @@ using Elastic.Apm.Api;
 using Elastic.Apm.Config;
 using Elastic.Apm.Helpers;
 using Elastic.Apm.Logging;
-using Elastic.Apm.Model;
 using Elastic.Apm.Tests.Extensions;
 using Elastic.Apm.Tests.MockApmServer;
 using Elastic.Apm.Tests.TestHelpers;
@@ -42,9 +41,9 @@ namespace Elastic.Apm.AspNetFullFramework.Tests
 
 
 		protected readonly AgentConfiguration AgentConfig = new AgentConfiguration();
+		protected readonly Dictionary<string, string> EnvVarsToSetForSampleAppPool;
 		protected readonly MockApmServer MockApmServer;
 		protected readonly bool SampleAppShouldHaveAccessToPerfCounters;
-		protected readonly Dictionary<string, string> EnvVarsToSetForSampleAppPool;
 		private readonly IisAdministration _iisAdministration;
 
 		private readonly IApmLogger _logger;
@@ -109,7 +108,8 @@ namespace Elastic.Apm.AspNetFullFramework.Tests
 			/// and exception propagates out of transaction as well so both span and transaction send an error event
 			/// </summary>
 			internal static readonly SampleAppUrlPathData CustomSpanThrowsExceptionPage =
-				new SampleAppUrlPathData(HomeController.CustomSpanThrowsPageRelativePath, 500, spansCount: 1, errorsCount: 2, outcome: Outcome.Failure);
+				new SampleAppUrlPathData(HomeController.CustomSpanThrowsPageRelativePath, 500, spansCount: 1, errorsCount: 2,
+					outcome: Outcome.Failure);
 
 			internal static readonly SampleAppUrlPathData HomePage =
 				new SampleAppUrlPathData(HomeController.HomePageRelativePath, 200);
@@ -133,6 +133,14 @@ namespace Elastic.Apm.AspNetFullFramework.Tests
 				new SampleAppUrlPathData(HomeController.CallReturnBadRequestPageRelativePath,
 					HomeController.DummyHttpStatusCode, /* transactionsCount: */ 2, /* spansCount: */ 1);
 
+			internal static readonly SampleAppUrlPathData CallSoapServiceProtocolV11 =
+				new SampleAppUrlPathData("Asmx/Health.asmx", (int)HttpStatusCode.OK);
+
+			internal static readonly SampleAppUrlPathData CallSoapServiceProtocolV12 =
+				new SampleAppUrlPathData("Asmx/Health.asmx", (int)HttpStatusCode.OK);
+
+			internal static readonly SampleAppUrlPathData ChildHttpSpanWithResponseForbiddenPage =
+				new SampleAppUrlPathData(HomeController.ChildHttpSpanWithResponseForbiddenPath, 200, spansCount: 1, errorsCount: 1);
 
 			/// <summary>
 			/// errorsCount is 3 because the exception is thrown inside a child span of a another span -
@@ -141,11 +149,11 @@ namespace Elastic.Apm.AspNetFullFramework.Tests
 			/// and exception propagates out of transaction as well so both spans and the transaction send an error event
 			/// </summary>
 			internal static readonly SampleAppUrlPathData CustomChildSpanThrowsExceptionPage =
-				new SampleAppUrlPathData(HomeController.CustomChildSpanThrowsPageRelativePath, 500, spansCount: 2, errorsCount: 3, outcome: Outcome.Failure);
+				new SampleAppUrlPathData(HomeController.CustomChildSpanThrowsPageRelativePath, 500, spansCount: 2, errorsCount: 3,
+					outcome: Outcome.Failure);
 
-
-			internal static readonly SampleAppUrlPathData ChildHttpSpanWithResponseForbiddenPage =
-				new SampleAppUrlPathData(HomeController.ChildHttpSpanWithResponseForbiddenPath, 200, spansCount: 1, errorsCount: 1);
+			internal static readonly SampleAppUrlPathData GenNSpansPage =
+				new SampleAppUrlPathData(HomeController.GenNSpansPageRelativePath, (int)HttpStatusCode.Created);
 
 			internal static readonly SampleAppUrlPathData GetDotNetRuntimeDescriptionPage =
 				new SampleAppUrlPathData(HomeController.GetDotNetRuntimeDescriptionPageRelativePath, 200);
@@ -156,15 +164,6 @@ namespace Elastic.Apm.AspNetFullFramework.Tests
 
 			internal static readonly SampleAppUrlPathData ThrowsInvalidOperationPage =
 				new SampleAppUrlPathData(HomeController.ThrowsInvalidOperationPageRelativePath, 500, errorsCount: 1, outcome: Outcome.Failure);
-
-			internal static readonly SampleAppUrlPathData GenNSpansPage =
-				new SampleAppUrlPathData(HomeController.GenNSpansPageRelativePath, (int)HttpStatusCode.Created);
-
-			internal static readonly SampleAppUrlPathData CallSoapServiceProtocolV1_1 =
-				new SampleAppUrlPathData("Asmx/Health.asmx", (int)HttpStatusCode.OK);
-
-			internal static readonly SampleAppUrlPathData CallSoapServiceProtocolV1_2 =
-			new SampleAppUrlPathData("Asmx/Health.asmx", (int)HttpStatusCode.OK);
 		}
 
 		private TimedEvent? _sampleAppClientCallTiming;
@@ -803,13 +802,15 @@ namespace Elastic.Apm.AspNetFullFramework.Tests
 		public class SampleAppUrlPathData
 		{
 			public readonly int ErrorsCount;
+			public readonly Outcome Outcome;
 			public readonly string RelativeUrlPath;
 			public readonly int SpansCount;
 			public readonly int StatusCode;
 			public readonly int TransactionsCount;
-			public readonly Outcome Outcome;
 
-			public SampleAppUrlPathData(string relativeUrlPath, int statusCode, int transactionsCount = 1, int spansCount = 0, int errorsCount = 0, Outcome outcome = Outcome.Success)
+			public SampleAppUrlPathData(string relativeUrlPath, int statusCode, int transactionsCount = 1, int spansCount = 0, int errorsCount = 0,
+				Outcome outcome = Outcome.Success
+			)
 			{
 				RelativeUrlPath = relativeUrlPath;
 				StatusCode = statusCode;

--- a/test/Elastic.Apm.Elasticsearch.Tests/VirtualElasticsearchTests.cs
+++ b/test/Elastic.Apm.Elasticsearch.Tests/VirtualElasticsearchTests.cs
@@ -86,7 +86,10 @@ namespace Elastic.Apm.Elasticsearch.Tests
 					);
 					searchResponse.Should().NotBeNull();
 				}
-				catch (Exception) { }
+				catch (Exception)
+				{
+					// ignored
+				}
 
 				var spans = payloadSender.SpansOnFirstTransaction;
 				spans.Should().NotBeEmpty();

--- a/test/Elastic.Apm.Elasticsearch.Tests/VirtualElasticsearchTests.cs
+++ b/test/Elastic.Apm.Elasticsearch.Tests/VirtualElasticsearchTests.cs
@@ -61,6 +61,8 @@ namespace Elastic.Apm.Elasticsearch.Tests
 				spans.First(n => n.Subtype == ApiConstants.SubtypeElasticsearch)
 					.Context.Destination.Service.Resource.Should()
 					.Be(ApiConstants.SubtypeElasticsearch);
+
+				spans.First(n => n.Subtype == ApiConstants.SubtypeElasticsearch).Outcome.Should().Be(Outcome.Success);
 			}
 		}
 
@@ -91,7 +93,10 @@ namespace Elastic.Apm.Elasticsearch.Tests
 				spans.Should().Contain(s => s.Context.Db.Statement != null);
 				//ensure we the last span is closed even if the listener does not receive a response
 				spans.Where(s => s.Action == "Ping").Should().HaveCount(2);
+				spans.Where(s => s.Action == "Ping").All(n => n.Outcome == Outcome.Success).Should().BeTrue();
+
 				spans.Where(s => s.Action == "CallElasticsearch").Should().HaveCount(2);
+				spans.Where(s => s.Action == "CallElasticsearch").All(n => n.Outcome == Outcome.Failure).Should().BeTrue();
 
 				payloadSender.Errors.Should().Contain(e => ((Error)e).Exception.Message == "boom!");
 			}
@@ -116,6 +121,7 @@ namespace Elastic.Apm.Elasticsearch.Tests
 
 				var spans = payloadSender.SpansOnFirstTransaction;
 				var span = spans.Should().NotBeEmpty().And.HaveCount(1).And.Subject.First();
+				span.Outcome.Should().Be(Outcome.Failure);
 				var error = (Error)payloadSender.Errors.Should().HaveCount(1).And.Subject.First();
 
 				error.Culprit.Should().StartWith("Elasticsearch.Net.VirtualizedCluster.VirtualClusterConnection");
@@ -172,6 +178,7 @@ namespace Elastic.Apm.Elasticsearch.Tests
 
 				var spans = payloadSender.SpansOnFirstTransaction;
 				var span = spans.Should().NotBeEmpty().And.HaveCount(1).And.Subject.First();
+				span.Outcome.Should().Be(Outcome.Failure);
 				var error = (Error)payloadSender.Errors.Should().HaveCount(1).And.Subject.First();
 
 				error.Culprit.Should().StartWith("Elasticsearch Server Error: script_exception");

--- a/test/Elastic.Apm.EntityFrameworkCore.Tests/EfCoreDiagnosticListenerTests.cs
+++ b/test/Elastic.Apm.EntityFrameworkCore.Tests/EfCoreDiagnosticListenerTests.cs
@@ -4,7 +4,6 @@
 
 using System;
 using System.Data.Common;
-using System.Linq;
 using System.Threading.Tasks;
 using Elastic.Apm.Api;
 using Elastic.Apm.Tests.Mocks;
@@ -121,14 +120,12 @@ namespace Elastic.Apm.EntityFrameworkCore.Tests
 		public async Task EfCoreDiagnosticListener_ShouldCaptureCallingMember_WhenCalledInAsyncContext()
 		{
 			// Arrange + Act
-			await _apmAgent.Tracer.CaptureTransaction("transaction", "type", async transaction =>
-			{
-				await _dbContext.Data.FirstOrDefaultAsync();
-			});
+			await _apmAgent.Tracer.CaptureTransaction("transaction", "type", async transaction => { await _dbContext.Data.FirstOrDefaultAsync(); });
 
 			// Assert
 			_payloadSender.FirstSpan.StackTrace.Should().NotBeNull();
-			_payloadSender.FirstSpan.StackTrace.Should().Contain(n => n.Function.Contains(nameof(EfCoreDiagnosticListener_ShouldCaptureCallingMember_WhenCalledInAsyncContext)));
+			_payloadSender.FirstSpan.StackTrace.Should()
+				.Contain(n => n.Function.Contains(nameof(EfCoreDiagnosticListener_ShouldCaptureCallingMember_WhenCalledInAsyncContext)));
 		}
 	}
 }

--- a/test/Elastic.Apm.EntityFrameworkCore.Tests/EfCoreDiagnosticListenerTests.cs
+++ b/test/Elastic.Apm.EntityFrameworkCore.Tests/EfCoreDiagnosticListenerTests.cs
@@ -66,6 +66,8 @@ namespace Elastic.Apm.EntityFrameworkCore.Tests
 
 			// Assert
 			_payloadSender.Spans.Count.Should().Be(1);
+			_payloadSender.FirstSpan.Should().NotBeNull();
+			_payloadSender.FirstSpan.Outcome.Should().Be(Outcome.Failure);
 
 			_payloadSender.Errors.Count.Should().Be(1);
 			_payloadSender.FirstError.Exception.Type.Should().Be(typeof(SqliteException).FullName);
@@ -91,6 +93,9 @@ namespace Elastic.Apm.EntityFrameworkCore.Tests
 			// Assert
 			_payloadSender.Spans.Count.Should().Be(1);
 			_payloadSender.Errors.Count.Should().Be(0);
+
+			_payloadSender.FirstSpan.Should().NotBeNull();
+			_payloadSender.FirstSpan.Outcome.Should().Be(Outcome.Success);
 		}
 
 		[Fact]

--- a/test/Elastic.Apm.SqlClient.Tests/SqlClientListenerTests.cs
+++ b/test/Elastic.Apm.SqlClient.Tests/SqlClientListenerTests.cs
@@ -21,10 +21,11 @@ namespace Elastic.Apm.SqlClient.Tests
 	{
 		private readonly ApmAgent _apmAgent;
 
+		private readonly string _connectionString;
+		private readonly string _expectedAddress;
+
 		private readonly MockPayloadSender _payloadSender;
 		private readonly ITestOutputHelper _testOutputHelper;
-
-		private readonly string _expectedAddress;
 
 		public SqlClientListenerTests(ITestOutputHelper testOutputHelper, DatabaseFixture sqlClientListenerFixture)
 		{
@@ -40,8 +41,6 @@ namespace Elastic.Apm.SqlClient.Tests
 				payloadSender: _payloadSender));
 			_apmAgent.Subscribe(new SqlClientDiagnosticSubscriber());
 		}
-
-		private readonly string _connectionString;
 
 		public static IEnumerable<object[]> Connections
 		{
@@ -72,17 +71,14 @@ namespace Elastic.Apm.SqlClient.Tests
 
 			await _apmAgent.Tracer.CaptureTransaction("transaction", "type", async transaction =>
 			{
-				using (var dbConnection = connectionCreator.Invoke(_connectionString))
+				using var dbConnection = connectionCreator.Invoke(_connectionString);
+				await dbConnection.OpenAsync();
+				using var sqlCommand = dbConnection.CreateCommand();
+				sqlCommand.CommandText = commandText;
+				// ReSharper disable once MethodHasAsyncOverload
+				using (sqlCommand.ExecuteReader())
 				{
-					await dbConnection.OpenAsync();
-					using (var sqlCommand = dbConnection.CreateCommand())
-					{
-						sqlCommand.CommandText = commandText;
-						using (sqlCommand.ExecuteReader())
-						{
-							// ignore
-						}
-					}
+					// ignore
 				}
 			});
 
@@ -130,24 +126,21 @@ namespace Elastic.Apm.SqlClient.Tests
 
 			await _apmAgent.Tracer.CaptureTransaction("transaction", "type", async transaction =>
 			{
-				using (var dbConnection = connectionCreator.Invoke(_connectionString))
+				using var dbConnection = connectionCreator.Invoke(_connectionString);
+				await dbConnection.OpenAsync();
+				using var sqlCommand = dbConnection.CreateCommand();
+				sqlCommand.CommandText = commandText;
+				try
 				{
-					await dbConnection.OpenAsync();
-					using (var sqlCommand = dbConnection.CreateCommand())
+					// ReSharper disable once MethodHasAsyncOverload
+					using (sqlCommand.ExecuteReader())
 					{
-						sqlCommand.CommandText = commandText;
-						try
-						{
-							using (sqlCommand.ExecuteReader())
-							{
-								// ignore
-							}
-						}
-						catch
-						{
-							// ignore
-						}
+						// ignore
 					}
+				}
+				catch
+				{
+					// ignore
 				}
 			});
 

--- a/test/Elastic.Apm.SqlClient.Tests/SqlClientListenerTests.cs
+++ b/test/Elastic.Apm.SqlClient.Tests/SqlClientListenerTests.cs
@@ -90,6 +90,9 @@ namespace Elastic.Apm.SqlClient.Tests
 			_payloadSender.Spans.Count.Should().Be(1);
 			_payloadSender.Errors.Count.Should().Be(0);
 
+			_payloadSender.FirstSpan.Should().NotBeNull();
+			_payloadSender.FirstSpan.Outcome.Should().Be(Outcome.Success);
+
 			var span = _payloadSender.FirstSpan;
 
 #if !NETFRAMEWORK
@@ -151,6 +154,9 @@ namespace Elastic.Apm.SqlClient.Tests
 			// Assert
 			_payloadSender.Spans.Count.Should().Be(1);
 			_payloadSender.Errors.Count.Should().Be(1);
+
+			_payloadSender.FirstSpan.Should().NotBeNull();
+			_payloadSender.FirstSpan.Outcome.Should().Be(Outcome.Failure);
 
 			var span = _payloadSender.FirstSpan;
 

--- a/test/Elastic.Apm.Tests.MockApmServer/SpanDto.cs
+++ b/test/Elastic.Apm.Tests.MockApmServer/SpanDto.cs
@@ -30,6 +30,8 @@ namespace Elastic.Apm.Tests.MockApmServer
 
 		public string Subtype { get; set; }
 
+		public Outcome Outcome { get; set; }
+
 		public long Timestamp { get; set; }
 
 		[JsonProperty("trace_id")]

--- a/test/Elastic.Apm.Tests.MockApmServer/SpanDto.cs
+++ b/test/Elastic.Apm.Tests.MockApmServer/SpanDto.cs
@@ -5,7 +5,6 @@
 using System.Collections.Generic;
 using Elastic.Apm.Api;
 using Elastic.Apm.Helpers;
-using Elastic.Apm.Model;
 using Newtonsoft.Json;
 
 // ReSharper disable MemberCanBePrivate.Global
@@ -22,6 +21,8 @@ namespace Elastic.Apm.Tests.MockApmServer
 		public string Id { get; set; }
 		public string Name { get; set; }
 
+		public Outcome Outcome { get; set; }
+
 		[JsonProperty("parent_id")]
 		public string ParentId { get; set; }
 
@@ -29,8 +30,6 @@ namespace Elastic.Apm.Tests.MockApmServer
 		public List<CapturedStackFrame> StackTrace { get; set; }
 
 		public string Subtype { get; set; }
-
-		public Outcome Outcome { get; set; }
 
 		public long Timestamp { get; set; }
 

--- a/test/Elastic.Apm.Tests.MockApmServer/TransactionDto.cs
+++ b/test/Elastic.Apm.Tests.MockApmServer/TransactionDto.cs
@@ -23,12 +23,12 @@ namespace Elastic.Apm.Tests.MockApmServer
 
 		public string Name { get; set; }
 
+		public Outcome Outcome { get; set; }
+
 		[JsonProperty("parent_id")]
 		public string ParentId { get; set; }
 
 		public string Result { get; set; }
-
-		public Outcome Outcome { get; set; }
 
 		[JsonProperty("span_count")]
 		public SpanCountDto SpanCount { get; set; }

--- a/test/Elastic.Apm.Tests.MockApmServer/TransactionDto.cs
+++ b/test/Elastic.Apm.Tests.MockApmServer/TransactionDto.cs
@@ -2,6 +2,7 @@
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
 
+using Elastic.Apm.Api;
 using Elastic.Apm.Helpers;
 using FluentAssertions;
 using Newtonsoft.Json;
@@ -26,6 +27,8 @@ namespace Elastic.Apm.Tests.MockApmServer
 		public string ParentId { get; set; }
 
 		public string Result { get; set; }
+
+		public Outcome Outcome { get; set; }
 
 		[JsonProperty("span_count")]
 		public SpanCountDto SpanCount { get; set; }

--- a/test/Elastic.Apm.Tests/HttpDiagnosticListenerTests.cs
+++ b/test/Elastic.Apm.Tests/HttpDiagnosticListenerTests.cs
@@ -140,6 +140,7 @@ namespace Elastic.Apm.Tests
 			firstSpan.Context.Http.Method.Should().Be(HttpMethod.Get.Method);
 			firstSpan.Context.Destination.Address.Should().Be(request.RequestUri.Host);
 			firstSpan.Context.Destination.Port.Should().Be(UrlUtilsTests.DefaultHttpsPort);
+			firstSpan.Outcome.Should().Be(Outcome.Success);
 		}
 
 		/// <summary>
@@ -249,6 +250,7 @@ namespace Elastic.Apm.Tests
 				firstSpan.Should().NotBeNull();
 				firstSpan.Context.Http.Url.Should().Be(localServer.Uri);
 				firstSpan.Context.Http.StatusCode.Should().Be(200);
+				firstSpan.Outcome.Should().Be(Outcome.Success);
 				firstSpan.Context.Http.Method.Should().Be(HttpMethod.Get.Method);
 				firstSpan.Context.Destination.Address.Should().Be(new Uri(localServer.Uri).Host);
 				firstSpan.Context.Destination.Port.Should().Be(new Uri(localServer.Uri).Port);
@@ -313,6 +315,7 @@ namespace Elastic.Apm.Tests
 				firstSpan.Should().NotBeNull();
 				firstSpan.Context.Http.Url.Should().Be(localServer.Uri);
 				firstSpan.Context.Http.StatusCode.Should().Be(500);
+				firstSpan.Outcome.Should().Be(Outcome.Failure);
 				firstSpan.Context.Http.Method.Should().Be(HttpMethod.Post.Method);
 				firstSpan.Context.Destination.Address.Should().Be(new Uri(localServer.Uri).Host);
 				firstSpan.Context.Destination.Port.Should().Be(new Uri(localServer.Uri).Port);

--- a/test/Elastic.Apm.Tests/HttpDiagnosticListenerTests.cs
+++ b/test/Elastic.Apm.Tests/HttpDiagnosticListenerTests.cs
@@ -271,11 +271,7 @@ namespace Elastic.Apm.Tests
 			{
 				var uri = new Uri(localServer.Uri);
 
-				var uriBuilder = new UriBuilder(uri)
-				{
-					UserName = "TestUser",
-					Password = "TestPassword"
-				};
+				var uriBuilder = new UriBuilder(uri) { UserName = "TestUser", Password = "TestPassword" };
 
 				var httpClient = new HttpClient();
 				var res = await httpClient.GetAsync(uriBuilder.Uri);
@@ -565,11 +561,7 @@ namespace Elastic.Apm.Tests
 			using (var localServer = new LocalServer())
 			using (var httpClient = new HttpClient())
 			{
-				var uriBuilder = new UriBuilder(localServer.Uri)
-				{
-					UserName = "TestUser289421",
-					Password = "Password973243"
-				};
+				var uriBuilder = new UriBuilder(localServer.Uri) { UserName = "TestUser289421", Password = "Password973243" };
 
 				var res = await httpClient.GetAsync(uriBuilder.Uri);
 				res.IsSuccessStatusCode.Should().BeTrue();


### PR DESCRIPTION
Solves #940

- Introduces `Outcome` field on `ISpan` and `ITransaction`.
- Sets this field on all auto generated transactions and spans.
- Adds test to cover that automatically setting this fields in auto instrumentation works as expected. 