### PR TITLE
Update StacktraceHelper.cs

### DIFF
--- a/src/Elastic.Apm/Helpers/StacktraceHelper.cs
+++ b/src/Elastic.Apm/Helpers/StacktraceHelper.cs
@@ -27,7 +27,7 @@ namespace Elastic.Apm.Helpers
 		/// <param name="dbgCapturingFor">Just for logging.</param>
 		/// <param name="configurationReader">
 		/// Config reader - this controls the collection of stack traces (e.g. limit on frames,
-		/// etc)e
+		/// etc)
 		/// </param>
 		/// <returns>A prepared List that can be passed to the APM server</returns>
 		internal static List<CapturedStackFrame> GenerateApmStackTrace(StackFrame[] frames, IApmLogger logger,


### PR DESCRIPTION
Fixes #957 

This happened in an app running within IIS:

```
{Transaction} Failed extracting stack trace from exception for Transaction.CaptureException. Exception for failure to extract: System.IO.FileLoadException: Could not load file or assembly 'System.Reflection.Metadata, Version=1.4.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' or one of its dependencies. The located assembly's manifest definition does not match the assembly reference. (Exception from HRESULT: 0x80131040)
File name: 'System.Reflection.Metadata, Version=1.4.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a'
   at System.Diagnostics.Internal.PortablePdbReader..ctor()
   at System.Diagnostics.EnhancedStackTrace.GetFrames(StackTrace stackTrace)
   at System.Diagnostics.EnhancedStackTrace..ctor(Exception e)
   at Elastic.Apm.Helpers.StacktraceHelper.GenerateApmStackTrace(Exception exception, IApmLogger logger, String dbgCapturingFor, IConfigurationReader configurationReader)
```

I was unable to repro, so no test is contained here.

As planned in #957  we just fall back to use the same code we had before Ben.Demystifier.