### PR TITLE
Adapt PlatfromDetection to support .NET 5 

### DIFF
--- a/src/Elastic.Apm/Api/Service.cs
+++ b/src/Elastic.Apm/Api/Service.cs
@@ -115,9 +115,7 @@ namespace Elastic.Apm.Api
 	{
 		internal const string DotNet5Name = ".NET 5";
 		internal const string DotNetCoreName = ".NET Core";
-
 		internal const string DotNetFullFrameworkName = ".NET Framework";
-
 		internal const string MonoName = "Mono";
 
 		[JsonConverter(typeof(TrimmedStringJsonConverter))]

--- a/src/Elastic.Apm/Api/Service.cs
+++ b/src/Elastic.Apm/Api/Service.cs
@@ -27,12 +27,12 @@ namespace Elastic.Apm.Api
 		[JsonConverter(typeof(TrimmedStringJsonConverter))]
 		public string Name { get; set; }
 
+		public Node Node { get; set; }
+
 		public Runtime Runtime { get; set; }
 
 		[JsonConverter(typeof(TrimmedStringJsonConverter))]
 		public string Version { get; set; }
-
-		public Node Node { get; set; }
 
 		public override string ToString() => new ToStringBuilder(nameof(Service))
 		{
@@ -113,6 +113,7 @@ namespace Elastic.Apm.Api
 	/// </summary>
 	public class Runtime
 	{
+		internal const string DotNet5Name = ".NET 5";
 		internal const string DotNetCoreName = ".NET Core";
 
 		internal const string DotNetFullFrameworkName = ".NET Framework";

--- a/test/Elastic.Apm.Tests/HelpersTests/PlatformDetectionTests.cs
+++ b/test/Elastic.Apm.Tests/HelpersTests/PlatformDetectionTests.cs
@@ -26,14 +26,17 @@ namespace Elastic.Apm.Tests.HelpersTests
 
 			switch (RuntimeInformation.FrameworkDescription)
 			{
-				case string str when str.StartsWith(PlatformDetection.MonoDescriptionPrefix, StringComparison.OrdinalIgnoreCase):
+				case { } str when str.StartsWith(PlatformDetection.MonoDescriptionPrefix, StringComparison.OrdinalIgnoreCase):
 					mockPayloadSender.FirstTransaction.Service.Runtime.Name.Should().Be(Runtime.MonoName);
 					break;
-				case string str when str.StartsWith(PlatformDetection.DotNetFullFrameworkDescriptionPrefix, StringComparison.OrdinalIgnoreCase):
+				case { } str when str.StartsWith(PlatformDetection.DotNetFullFrameworkDescriptionPrefix, StringComparison.OrdinalIgnoreCase):
 					mockPayloadSender.FirstTransaction.Service.Runtime.Name.Should().Be(Runtime.DotNetFullFrameworkName);
 					break;
-				case string str when str.StartsWith(PlatformDetection.DotNetCoreDescriptionPrefix, StringComparison.OrdinalIgnoreCase):
+				case { } str when str.StartsWith(PlatformDetection.DotNetCoreDescriptionPrefix, StringComparison.OrdinalIgnoreCase):
 					mockPayloadSender.FirstTransaction.Service.Runtime.Name.Should().Be(Runtime.DotNetCoreName);
+					break;
+				case { } str when str.StartsWith(PlatformDetection.DotNet5Prefix, StringComparison.OrdinalIgnoreCase):
+					mockPayloadSender.FirstTransaction.Service.Runtime.Name.Should().Be(Runtime.DotNet5Name);
 					break;
 			}
 		}


### PR DESCRIPTION
Solves #945. 

https://github.com/elastic/apm-agent-dotnet/issues/962 will be needed for more test coverage in CI.