### PR TITLE
Avoid double initialization in HostBuilderExtensions.cs

### DIFF
--- a/ElasticApmAgent.sln
+++ b/ElasticApmAgent.sln
@@ -94,7 +94,9 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "GrpcClientSample", "sample\
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Elastic.Apm.GrpcClient", "src\Elastic.Apm.GrpcClient\Elastic.Apm.GrpcClient.csproj", "{8F1B46E1-F1A0-4744-9D9A-AA1BB33842C8}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Elastic.Apm.Grpc.Tests", "test\Elastic.Apm.Grpc.Tests\Elastic.Apm.Grpc.Tests.csproj", "{3AD5584E-057A-4C52-84EA-32A9BBE12F03}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Elastic.Apm.Grpc.Tests", "test\Elastic.Apm.Grpc.Tests\Elastic.Apm.Grpc.Tests.csproj", "{3AD5584E-057A-4C52-84EA-32A9BBE12F03}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Elastic.Apm.Extensions.Hosting.Tests", "test\Elastic.Apm.Extensions.Hosting.Tests\Elastic.Apm.Extensions.Hosting.Tests.csproj", "{3CCB9193-8416-49AF-A1A3-8D1118CFB25B}"
 EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
@@ -231,6 +233,10 @@ Global
 		{3AD5584E-057A-4C52-84EA-32A9BBE12F03}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{3AD5584E-057A-4C52-84EA-32A9BBE12F03}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{3AD5584E-057A-4C52-84EA-32A9BBE12F03}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3CCB9193-8416-49AF-A1A3-8D1118CFB25B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3CCB9193-8416-49AF-A1A3-8D1118CFB25B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3CCB9193-8416-49AF-A1A3-8D1118CFB25B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3CCB9193-8416-49AF-A1A3-8D1118CFB25B}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -267,6 +273,7 @@ Global
 		{CC52EA80-5E18-4370-ACB3-9424B6BB6B68} = {3C791D9C-6F19-4F46-B367-2EC0F818762D}
 		{8F1B46E1-F1A0-4744-9D9A-AA1BB33842C8} = {3734A52F-2222-454B-BF58-1BA5C1F29D77}
 		{3AD5584E-057A-4C52-84EA-32A9BBE12F03} = {267A241E-571F-458F-B04C-B6C4DE79E735}
+		{3CCB9193-8416-49AF-A1A3-8D1118CFB25B} = {267A241E-571F-458F-B04C-B6C4DE79E735}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {69E02FD9-C9DE-412C-AB6B-5B8BECC6BFA5}

--- a/sample/SampleConsoleNetCoreApp/HostedService.cs
+++ b/sample/SampleConsoleNetCoreApp/HostedService.cs
@@ -22,6 +22,7 @@ namespace SampleConsoleNetCoreApp
 		{
 			var response = await _apmAgent.Tracer.CaptureTransaction("Console .Net Core Example", "background", async () =>
 			{
+				Console.WriteLine("HostedService running");
 				// Make sure Agent.Tracer.CurrentTransaction is not null
 				var currentTransaction = Agent.Tracer.CurrentTransaction;
 				if (currentTransaction == null) throw new Exception("Agent.Tracer.CurrentTransaction returns null");

--- a/src/Elastic.Apm.Extensions.Hosting/HostBuilderExtensions.cs
+++ b/src/Elastic.Apm.Extensions.Hosting/HostBuilderExtensions.cs
@@ -41,7 +41,8 @@ namespace Elastic.Apm.Extensions.Hosting
 				services.AddSingleton<IApmAgent, ApmAgent>(sp =>
 				{
 					var apmAgent = new ApmAgent(sp.GetService<AgentComponents>());
-					Agent.Setup(sp.GetService<AgentComponents>());
+					if(!Agent.IsConfigured)
+						Agent.Setup(sp.GetService<AgentComponents>());
 					return apmAgent;
 				});
 

--- a/src/Elastic.Apm.Extensions.Hosting/HostBuilderExtensions.cs
+++ b/src/Elastic.Apm.Extensions.Hosting/HostBuilderExtensions.cs
@@ -27,23 +27,49 @@ namespace Elastic.Apm.Extensions.Hosting
 		{
 			builder.ConfigureServices((ctx, services) =>
 			{
-				services.AddSingleton<IApmLogger, NetCoreLogger>();
-				services.AddSingleton<IConfigurationReader>(sp =>
+				//If the static agent doesn't exist, we create one here. If there is already 1 agent created, we reuse it.
+
+				if (!Agent.IsConfigured)
+				{
+					services.AddSingleton<IApmLogger, NetCoreLogger>();
+					services.AddSingleton<IConfigurationReader>(sp =>
 					new MicrosoftExtensionsConfig(ctx.Configuration, sp.GetService<IApmLogger>(), ctx.HostingEnvironment.EnvironmentName));
+				}
+				else
+				{
+					services.AddSingleton<IApmLogger>(Agent.Instance.Logger);
+					services.AddSingleton<IConfigurationReader>(Agent.Instance.ConfigurationReader);
+				}
 
 				services.AddSingleton(sp =>
 				{
-					var components = new AgentComponents(sp.GetService<IApmLogger>(), sp.GetService<IConfigurationReader>());
-					UpdateServiceInformation(components.Service);
-					return components;
+					if (!Agent.IsConfigured)
+					{
+						var logger = sp.GetService<IApmLogger>();
+						var configReader = sp.GetService<IConfigurationReader>();
+
+						var components = new AgentComponents(logger, configReader);
+						UpdateServiceInformation(components.Service);
+						return components;
+					}
+					else
+					{
+						return Agent.Components;
+					}
 				});
 
 				services.AddSingleton<IApmAgent, ApmAgent>(sp =>
 				{
-					var apmAgent = new ApmAgent(sp.GetService<AgentComponents>());
-					if(!Agent.IsConfigured)
+					if (!Agent.IsConfigured)
+					{
+						var apmAgent = new ApmAgent(sp.GetService<AgentComponents>());
 						Agent.Setup(sp.GetService<AgentComponents>());
-					return apmAgent;
+						return apmAgent;
+					}
+					else
+					{
+						return Agent.Instance;
+					}
 				});
 
 				if (subscribers != null && subscribers.Any() && Agent.IsConfigured) Agent.Subscribe(subscribers);

--- a/src/Elastic.Apm/Agent.cs
+++ b/src/Elastic.Apm/Agent.cs
@@ -125,9 +125,11 @@ namespace Elastic.Apm
 
 	public static class Agent
 	{
-		private static readonly Lazy<ApmAgent> LazyApmAgent = new Lazy<ApmAgent>(() => new ApmAgent(_components));
-		private static AgentComponents _components;
+		private static readonly Lazy<ApmAgent> LazyApmAgent = new Lazy<ApmAgent>(() => new ApmAgent(Components));
 		private static volatile bool _isConfigured;
+
+
+		internal static AgentComponents Components { get; private set; }
 
 		public static IConfigurationReader Config => Instance.ConfigurationReader;
 
@@ -152,11 +154,17 @@ namespace Elastic.Apm
 		/// you can also control if the <see cref="ITransaction" /> should be sent to the server or not.
 		/// If the
 		/// <param name="filter"></param>
-		/// returns a non-null <see cref="ITransaction"/> instance then it will be sent to the APM Server -
+		/// returns a non-null <see cref="ITransaction" /> instance then it will be sent to the APM Server -
 		/// if it returns <code>null</code>, the event will be dropped and won't be sent to the APM server.
 		/// </summary>
-		/// <param name="filter">The filter that can process the <see cref="ITransaction"/> and decide if it should be sent to APM Server or not.</param>
-		/// <returns><code>true</code> if the filter was added successfully, <code>false</code> otherwise. In case the method returns <code>false</code> the filter won't be called.</returns>
+		/// <param name="filter">
+		/// The filter that can process the <see cref="ITransaction" /> and decide if it should be sent to APM
+		/// Server or not.
+		/// </param>
+		/// <returns>
+		/// <code>true</code> if the filter was added successfully, <code>false</code> otherwise. In case the method
+		/// returns <code>false</code> the filter won't be called.
+		/// </returns>
 		public static bool AddFilter(Func<ITransaction, ITransaction> filter) => CheckAndAddFilter(p => p.TransactionFilters.Add(filter));
 
 		/// <summary>
@@ -169,11 +177,17 @@ namespace Elastic.Apm
 		/// you can also control if the <see cref="ISpan" /> should be sent to the server or not.
 		/// If the
 		/// <param name="filter"></param>
-		/// returns a non-null <see cref="ISpan"/> instance then it will be sent to the APM Server -
+		/// returns a non-null <see cref="ISpan" /> instance then it will be sent to the APM Server -
 		/// if it returns <code>null</code>, the event will be dropped and won't be sent to the APM server.
 		/// </summary>
-		/// <param name="filter">The filter that can process the <see cref="ISpan"/> and decide if it should be sent to APM Server or not.</param>
-		/// <returns><code>true</code> if the filter was added successfully, <code>false</code> otherwise. In case the method returns <code>false</code> the filter won't be called.</returns>
+		/// <param name="filter">
+		/// The filter that can process the <see cref="ISpan" /> and decide if it should be sent to APM Server
+		/// or not.
+		/// </param>
+		/// <returns>
+		/// <code>true</code> if the filter was added successfully, <code>false</code> otherwise. In case the method
+		/// returns <code>false</code> the filter won't be called.
+		/// </returns>
 		public static bool AddFilter(Func<ISpan, ISpan> filter) => CheckAndAddFilter(p => p.SpanFilters.Add(filter));
 
 		/// <summary>
@@ -186,11 +200,17 @@ namespace Elastic.Apm
 		/// you can also control if the <see cref="IError" /> should be sent to the server or not.
 		/// If the
 		/// <param name="filter"></param>
-		/// returns a non-null <see cref="IError"/> instance then it will be sent to the APM Server -
+		/// returns a non-null <see cref="IError" /> instance then it will be sent to the APM Server -
 		/// if it returns <code>null</code>, the event will be dropped and won't be sent to the APM server.
 		/// </summary>
-		/// <param name="filter">The filter that can process the <see cref="IError"/> and decide if it should be sent to APM Server or not.</param>
-		/// <returns><code>true</code> if the filter was added successfully, <code>false</code> otherwise. In case the method returns <code>false</code> the filter won't be called.</returns>
+		/// <param name="filter">
+		/// The filter that can process the <see cref="IError" /> and decide if it should be sent to APM
+		/// Server or not.
+		/// </param>
+		/// <returns>
+		/// <code>true</code> if the filter was added successfully, <code>false</code> otherwise. In case the method
+		/// returns <code>false</code> the filter won't be called.
+		/// </returns>
 		public static bool AddFilter(Func<IError, IError> filter) => CheckAndAddFilter(p => p.ErrorFilters.Add(filter));
 
 		private static bool CheckAndAddFilter(Action<PayloadSenderV2> action)
@@ -219,7 +239,7 @@ namespace Elastic.Apm
 			if (LazyApmAgent.IsValueCreated)
 				throw new InstanceAlreadyCreatedException("The singleton APM agent has already been instantiated and can no longer be configured.");
 
-			_components = agentComponents;
+			Components = agentComponents;
 			_isConfigured = true;
 		}
 

--- a/test/Elastic.Apm.Extensions.Hosting.Tests/Elastic.Apm.Extensions.Hosting.Tests.csproj
+++ b/test/Elastic.Apm.Extensions.Hosting.Tests/Elastic.Apm.Extensions.Hosting.Tests.csproj
@@ -1,0 +1,28 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="FluentAssertions" Version="5.6.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
+    <PackageReference Include="coverlet.collector" Version="1.2.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Moq" Version="4.12.0" />
+    <PackageReference Include="xunit" Version="2.3.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+    <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
+
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="3.1.5" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\sample\SampleConsoleNetCoreApp\SampleConsoleNetCoreApp.csproj" />
+    <ProjectReference Include="..\..\src\Elastic.Apm.NetCoreAll\Elastic.Apm.NetCoreAll.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/test/Elastic.Apm.Extensions.Hosting.Tests/HostBuilderExtensionTests.cs
+++ b/test/Elastic.Apm.Extensions.Hosting.Tests/HostBuilderExtensionTests.cs
@@ -1,0 +1,32 @@
+﻿using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using SampleConsoleNetCoreApp;
+using Xunit;
+
+namespace Elastic.Apm.Extensions.Hosting.Tests
+{
+	public class HostBuilderExtensionTests
+	{
+		/// <summary>
+		/// Makes sure in case of 2 IHostBuilder insatnces when both call UseElasticApm no exception is thrown
+		/// </summary>
+		/// <returns></returns>
+		[Fact]
+		public async Task TwoHostBuildersNoException()
+		{
+			var hostBuilder1 = CreateHostBuilder().Build();
+			var hostBuilder2 = CreateHostBuilder().Build();
+			var builder1Task = hostBuilder1.StartAsync();
+			var builder2Task = hostBuilder2.StartAsync();
+
+			await Task.WhenAll(builder1Task, builder2Task);
+			await Task.WhenAll(hostBuilder1.StopAsync(), hostBuilder2.StopAsync());
+		}
+
+		private static IHostBuilder CreateHostBuilder() =>
+				Host.CreateDefaultBuilder()
+					.ConfigureServices((context, services) => { services.AddHostedService<HostedService>(); })
+					.UseElasticApm();
+	}
+}


### PR DESCRIPTION
In case the extension method `UseElasticApm()` on `IHostBuilder` runs multiple times (e.g. because there are multiple `IHostBuilder`s in a single process, then the agent throws an exception due to double initialization.

```
private static IHostBuilder CreateHostBuilder(string[] args) =>
	Host.CreateDefaultBuilder(args)
		.ConfigureServices((context, services) => { services.AddHostedService<HostedService>(); })
		.UseElasticApm(new HttpDiagnosticsSubscriber());
```

### Background of the issue

Currently the agent does not support multiple instances in a single process - I strongly thing we should keep this (multiple instances would mean multiple metrics capturing instances, multiple payloadsenders, potentially multiple configreaders - none of this is supported). 

### Proposed solution in this PR 

Let's check in `UseElasticApm` if an agent is already initialized and reuse that agent.