### PR TITLE
Remove printing basic http auth info from APM Server url

### DIFF
--- a/src/Elastic.Apm/Api/Http.cs
+++ b/src/Elastic.Apm/Api/Http.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information
 
 using System;
+using System.Net.Http;
 using Elastic.Apm.Report.Serialization;
 using Newtonsoft.Json;
 
@@ -14,19 +15,25 @@ namespace Elastic.Apm.Api
 	/// </summary>
 	public class Http
 	{
-		private string _url;
 		private Uri _originalUrl;
+		private string _url;
 
 		[JsonConverter(typeof(TrimmedStringJsonConverter))]
 		public string Method { get; set; }
+
+		/// <summary>
+		/// The Url in its original form as it was passed to the Agent, without sanitization or any other trimming.
+		/// </summary>
+		internal Uri OriginalUrl => _originalUrl;
 
 		[JsonProperty("status_code")]
 		public int StatusCode { get; set; }
 
 		/// <summary>
 		/// Sets the URL of the HTTP request.
-		/// The setter will parse and sanitize the URL and filter out user name and password from the URL in case it contains those.
-		/// In case you have an <see cref="Uri"/> instance, consider using the <see cref="SetUrl"/> method on this class.
+		/// The setter will parse and sanitize the URL and filter out user name and password from the URL in case it contains
+		/// those.
+		/// In case you have an <see cref="Uri" /> instance, consider using the <see cref="SetUrl" /> method on this class.
 		/// </summary>
 		public string Url
 		{
@@ -56,11 +63,6 @@ namespace Elastic.Apm.Api
 		}
 
 		/// <summary>
-		/// The Url in its original form as it was passed to the Agent, without sanitization or any other trimming.
-		/// </summary>
-		internal Uri OriginalUrl => _originalUrl;
-
-		/// <summary>
 		/// Removes the username and password from the <paramref name="uri" /> and returns it as a <see cref="string" />.
 		/// If there is no username and password in the <paramref name="uri" />, the simple string representation is returned.
 		/// </summary>
@@ -70,6 +72,20 @@ namespace Elastic.Apm.Api
 		{
 			Sanitize(uri, out var result);
 			return result;
+		}
+
+		/// <summary>
+		/// Returns the .ToString representation of an <see cref="HttpRequestMessage" />
+		/// but makes sure that the username and the password is sanitized.
+		/// </summary>
+		/// <param name="msg"></param>
+		/// <returns></returns>
+		internal static string HttpRequestSanitizedToString(HttpRequestMessage msg)
+		{
+			if (!string.IsNullOrEmpty(msg.RequestUri?.UserInfo))
+				msg.RequestUri = new Uri(Sanitize(msg.RequestUri));
+
+			return msg.ToString();
 		}
 
 		private static bool Sanitize(string uriString, out string result, out Uri originalUrl)
@@ -123,14 +139,16 @@ namespace Elastic.Apm.Api
 
 		private static Uri SanitizeUserNameAndPassword(Uri uri)
 		{
-			var builder = new UriBuilder();
-			builder.Scheme = uri.Scheme;
-			builder.Host = uri.Host;
-			builder.Port = uri.Port;
-			builder.Query = uri.Query;
-			builder.Fragment = uri.Fragment;
-			builder.UserName = "[REDACTED]";
-			builder.Password = "[REDACTED]";
+			var builder = new UriBuilder
+			{
+				Scheme = uri.Scheme,
+				Host = uri.Host,
+				Port = uri.Port,
+				Query = uri.Query,
+				Fragment = uri.Fragment,
+				UserName = "[REDACTED]",
+				Password = "[REDACTED]"
+			};
 			return builder.Uri;
 		}
 	}

--- a/src/Elastic.Apm/Api/Http.cs
+++ b/src/Elastic.Apm/Api/Http.cs
@@ -139,13 +139,8 @@ namespace Elastic.Apm.Api
 
 		private static Uri SanitizeUserNameAndPassword(Uri uri)
 		{
-			var builder = new UriBuilder
+			var builder = new UriBuilder(uri)
 			{
-				Scheme = uri.Scheme,
-				Host = uri.Host,
-				Port = uri.Port,
-				Query = uri.Query,
-				Fragment = uri.Fragment,
 				UserName = "[REDACTED]",
 				Password = "[REDACTED]"
 			};

--- a/src/Elastic.Apm/BackendComm/CentralConfig/CentralConfigFetcher.cs
+++ b/src/Elastic.Apm/BackendComm/CentralConfig/CentralConfigFetcher.cs
@@ -24,11 +24,11 @@ namespace Elastic.Apm.BackendComm.CentralConfig
 		internal static readonly TimeSpan WaitTimeIfAnyError = TimeSpan.FromMinutes(5);
 
 		private readonly IAgentTimer _agentTimer;
+		private readonly ICentralConfigResponseParser _centralConfigResponseParser;
 		private readonly IConfigStore _configStore;
 		private readonly Uri _getConfigAbsoluteUrl;
 		private readonly IConfigSnapshot _initialSnapshot;
 		private readonly IApmLogger _logger;
-		private readonly ICentralConfigResponseParser _centralConfigResponseParser;
 
 		internal CentralConfigFetcher(IApmLogger logger, IConfigStore configStore, ICentralConfigResponseParser centralConfigResponseParser,
 			Service service,
@@ -131,9 +131,14 @@ namespace Elastic.Apm.BackendComm.CentralConfig
 						+ Environment.NewLine + "+-> Request:{HttpRequest}"
 						+ Environment.NewLine + "+-> Response:{HttpResponse}"
 						+ Environment.NewLine + "+-> Response body [length: {HttpResponseBodyLength}]:{HttpResponseBody}"
-						, _eTag.AsNullableToString(), _getConfigAbsoluteUrl, HttpClientInstance.BaseAddress, waitInfo.Interval.ToHms(),
+						, _eTag.AsNullableToString()
+						, Http.Sanitize(_getConfigAbsoluteUrl, out var sanitizedAbsoluteUrl) ? sanitizedAbsoluteUrl : _getConfigAbsoluteUrl.ToString()
+						, Http.Sanitize(HttpClientInstance.BaseAddress, out var sanitizedBaseAddress)
+							? sanitizedBaseAddress
+							: HttpClientInstance.BaseAddress.ToString()
+						, waitInfo.Interval.ToHms(),
 						_dbgIterationsCount
-						, httpRequest == null ? " N/A" : Environment.NewLine + TextUtils.Indent(httpRequest.ToString())
+						, httpRequest == null ? " N/A" : Environment.NewLine + TextUtils.Indent(Http.HttpRequestSanitizedToString(httpRequest))
 						, httpResponse == null ? " N/A" : Environment.NewLine + TextUtils.Indent(httpResponse.ToString())
 						, httpResponseBody == null ? "N/A" : httpResponseBody.Length.ToString()
 						, httpResponseBody == null ? " N/A" : Environment.NewLine + TextUtils.Indent(httpResponseBody));
@@ -225,6 +230,9 @@ namespace Elastic.Apm.BackendComm.CentralConfig
 				DbgDescription = dbgDescription;
 			}
 
+			public string ApiKey => _wrapped.ApiKey;
+			public IReadOnlyCollection<string> ApplicationNamespaces => _wrapped.ApplicationNamespaces;
+
 			public string CaptureBody => _centralConfig.CaptureBody ?? _wrapped.CaptureBody;
 
 			public List<string> CaptureBodyContentTypes => _centralConfig.CaptureBodyContentTypes ?? _wrapped.CaptureBodyContentTypes;
@@ -237,11 +245,11 @@ namespace Elastic.Apm.BackendComm.CentralConfig
 			public IReadOnlyList<WildcardMatcher> DisableMetrics => _wrapped.DisableMetrics;
 
 			public string Environment => _wrapped.Environment;
+			public IReadOnlyCollection<string> ExcludedNamespaces => _wrapped.ExcludedNamespaces;
 
 			public TimeSpan FlushInterval => _wrapped.FlushInterval;
 
 			public IReadOnlyDictionary<string, string> GlobalLabels => _wrapped.GlobalLabels;
-			public IReadOnlyList<WildcardMatcher> TransactionIgnoreUrls => _wrapped.TransactionIgnoreUrls;
 
 			public LogLevel LogLevel => _centralConfig.LogLevel ?? _wrapped.LogLevel;
 
@@ -254,7 +262,6 @@ namespace Elastic.Apm.BackendComm.CentralConfig
 			public IReadOnlyList<WildcardMatcher> SanitizeFieldNames => _wrapped.SanitizeFieldNames;
 
 			public string SecretToken => _wrapped.SecretToken;
-			public string ApiKey => _wrapped.ApiKey;
 
 			public IReadOnlyList<Uri> ServerUrls => _wrapped.ServerUrls;
 
@@ -267,6 +274,7 @@ namespace Elastic.Apm.BackendComm.CentralConfig
 				_centralConfig.SpanFramesMinDurationInMilliseconds ?? _wrapped.SpanFramesMinDurationInMilliseconds;
 
 			public int StackTraceLimit => _centralConfig.StackTraceLimit ?? _wrapped.StackTraceLimit;
+			public IReadOnlyList<WildcardMatcher> TransactionIgnoreUrls => _wrapped.TransactionIgnoreUrls;
 
 			public int TransactionMaxSpans => _centralConfig.TransactionMaxSpans ?? _wrapped.TransactionMaxSpans;
 
@@ -275,8 +283,6 @@ namespace Elastic.Apm.BackendComm.CentralConfig
 			public bool UseElasticTraceparentHeader => _wrapped.UseElasticTraceparentHeader;
 
 			public bool VerifyServerCert => _wrapped.VerifyServerCert;
-			public IReadOnlyCollection<string> ExcludedNamespaces => _wrapped.ExcludedNamespaces;
-			public IReadOnlyCollection<string> ApplicationNamespaces => _wrapped.ApplicationNamespaces;
 		}
 	}
 }

--- a/test/Elastic.Apm.Tests/LoggerTests.cs
+++ b/test/Elastic.Apm.Tests/LoggerTests.cs
@@ -6,7 +6,11 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using Elastic.Apm.Api;
+using Elastic.Apm.BackendComm.CentralConfig;
+using Elastic.Apm.Config;
 using Elastic.Apm.Logging;
+using Elastic.Apm.Report;
 using Elastic.Apm.Tests.Mocks;
 using FluentAssertions;
 using Xunit;
@@ -315,6 +319,82 @@ namespace Elastic.Apm.Tests
 				currentTransaction.Should().NotBeNull();
 				testLogger.Lines.Count.Should().Be(numberOfLinesPreCurrentTransaction);
 			});
+		}
+
+		/// <summary>
+		/// Initializes a <see cref="PayloadSenderV2" /> with a server url which contains basic authentication.
+		/// In this test the server does not exist. The test makes sure that the user name and password from basic auth. is not
+		/// printed in the logs.
+		/// </summary>
+		[Fact]
+		public void PayloadSenderNoUserNamePwPrintedForServerUrl()
+		{
+			var userName = "abc";
+			var pw = "def";
+			var inMemoryLogger = new InMemoryBlockingLogger(LogLevel.Warning);
+			var configReader = new MockConfigSnapshot(serverUrls: $"http://{userName}:{pw}@localhost:8234", maxBatchEventCount: "0",
+				flushInterval: "0");
+
+			using var payloadSender = new PayloadSenderV2(inMemoryLogger, configReader,
+				Service.GetDefaultService(configReader, inMemoryLogger), new Api.System());
+
+			using var agent = new ApmAgent(new AgentComponents(payloadSender: payloadSender));
+
+			agent.Tracer.CaptureTransaction("Test", "TestTransaction", () => { });
+
+			inMemoryLogger.Lines.Should().HaveCount(1);
+			inMemoryLogger.Lines.Should().NotContain(n => n.Contains($"{userName}:{pw}"));
+			inMemoryLogger.Lines.Should().Contain(n => n.Contains("http://[REDACTED]:[REDACTED]@localhost:8234"));
+		}
+
+		/// <summary>
+		/// Initializes a <see cref="PayloadSenderV2" /> with a server url which contains basic authentication.
+		/// In this test the server exists and return HTTP 500.
+		/// The test makes sure that the user name and password from basic auth. is not printed in the logs.
+		/// </summary>
+		[Fact]
+		public void PayloadSenderNoUserNamePwPrintedForServerUrlWithServerReturn()
+		{
+			var userName = "abc";
+			var pw = "def";
+			var inMemoryLogger = new InMemoryBlockingLogger(LogLevel.Error);
+			var configReader = new MockConfigSnapshot(serverUrls: $"http://{userName}:{pw}@localhost:8082", maxBatchEventCount: "0",
+				flushInterval: "0");
+
+			using var payloadSender = new PayloadSenderV2(inMemoryLogger, configReader,
+				Service.GetDefaultService(configReader, inMemoryLogger), new Api.System());
+
+			using var localServer = new LocalServer(httpListenerContext => { httpListenerContext.Response.StatusCode = 500; });
+
+			using var agent = new ApmAgent(new AgentComponents(payloadSender: payloadSender));
+
+			agent.Tracer.CaptureTransaction("Test", "TestTransaction", () => { });
+
+			inMemoryLogger.Lines.Should().HaveCount(1);
+			inMemoryLogger.Lines.Should().NotContain(n => n.Contains($"{userName}:{pw}"));
+			inMemoryLogger.Lines.Should().Contain(n => n.Contains("http://[REDACTED]:[REDACTED]@localhost:8082"));
+		}
+
+		/// <summary>
+		/// Initializes a <see cref="CentralConfigFetcher" /> with a server url which contains basic authentication.
+		/// The test makes sure that the user name and password from basic auth. is not printed in the logs on error level.
+		/// </summary>
+		[Fact]
+		public void CentralConfigNoUserNamePwPrinted()
+		{
+			var userName = "abc";
+			var pw = "def";
+			var inMemoryLogger = new InMemoryBlockingLogger(LogLevel.Error);
+			var configReader = new MockConfigSnapshot(serverUrls: $"http://{userName}:{pw}@localhost:8123", maxBatchEventCount: "0",
+				flushInterval: "0");
+
+			var configStore = new ConfigStore(configReader, inMemoryLogger);
+			using var centralConfigFetcher =
+				new CentralConfigFetcher(inMemoryLogger, configStore, Service.GetDefaultService(configReader, inMemoryLogger));
+
+			inMemoryLogger.Lines.Should().HaveCount(1);
+			inMemoryLogger.Lines.Should().NotContain(n => n.Contains($"{userName}:{pw}"));
+			inMemoryLogger.Lines.Should().Contain(n => n.Contains("http://[REDACTED]:[REDACTED]@localhost:8123"));
 		}
 
 		private static TestLogger LogWithLevel(LogLevel logLevel)

--- a/test/Elastic.Apm.Tests/Mocks/InMemoryBlockingLogger.cs
+++ b/test/Elastic.Apm.Tests/Mocks/InMemoryBlockingLogger.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using System.Timers;
+using Elastic.Apm.Logging;
+
+namespace Elastic.Apm.Tests.Mocks
+{
+	/// <summary>
+	/// An in-memory logger which blocks until the 1. log line is received or a timeout is reached
+	/// </summary>
+	public class InMemoryBlockingLogger : IApmLogger
+	{
+		private readonly List<string> _lines = new List<string>();
+		private readonly LogLevel _logLevel;
+
+		private readonly TaskCompletionSource<List<string>> _transactionTaskCompletionSource = new TaskCompletionSource<List<string>>();
+
+		public InMemoryBlockingLogger(LogLevel level) => _logLevel = level;
+
+		/// <summary>
+		/// Returns the log lines that the logger collected.
+		/// Blocks until as long as the list is empty or a timeout is reached.
+		/// </summary>
+		public IEnumerable<string> Lines
+		{
+			get
+			{
+				var timer = new Timer { Interval = 10000, Enabled = true };
+				timer.Elapsed += (a, b) =>
+				{
+					_transactionTaskCompletionSource.TrySetCanceled();
+					timer.Stop();
+				};
+				timer.Start();
+
+				try
+				{
+					_transactionTaskCompletionSource.Task.Wait();
+					return _transactionTaskCompletionSource.Task.Result;
+				}
+				catch
+				{
+					return new List<string>();
+				}
+			}
+		}
+
+		public bool IsEnabled(LogLevel level)
+			=> _logLevel <= level;
+
+		public void Log<TState>(LogLevel level, TState state, Exception e, Func<TState, Exception, string> formatter)
+		{
+			if (!IsEnabled(level)) return;
+
+			_lines.Add(formatter(state, e));
+			_transactionTaskCompletionSource.TrySetResult(_lines);
+		}
+	}
+}


### PR DESCRIPTION
Fixes #975. 

In case APM Server is configured with basic HTTP auth. in some error logs the auth. info shows up - this PR sanitizes this info.

Also includes tests with specific cases that were reported in #975.