### PR TITLE
Improve metricset serialization

### DIFF
--- a/src/Elastic.Apm/Api/IMetricSet.cs
+++ b/src/Elastic.Apm/Api/IMetricSet.cs
@@ -16,6 +16,7 @@ namespace Elastic.Apm.Api
 		/// </summary>
 		IEnumerable<MetricSample> Samples { get; set; }
 
+		// TODO: Rename to Timestamp for consistency?
 		/// <summary>
 		/// Number of milliseconds in unix time
 		/// </summary>

--- a/src/Elastic.Apm/Metrics/MetricSet.cs
+++ b/src/Elastic.Apm/Metrics/MetricSet.cs
@@ -15,8 +15,10 @@ namespace Elastic.Apm.Metrics
 		public MetricSet(long timeStamp, IEnumerable<MetricSample> samples)
 			=> (TimeStamp, Samples) = (timeStamp, samples);
 
+		/// <inheritdoc />
 		public IEnumerable<MetricSample> Samples { get; set; }
 
+		/// <inheritdoc />
 		[JsonProperty("timestamp")]
 		public long TimeStamp { get; set; }
 	}


### PR DESCRIPTION
This commit improves the metricset serialization by
writing directly to the JSON writer instead of
allocating instances of JObject.

Add deserialization implementation and unit tests
to assert serialization behaviour.