### PR TITLE
Add HttpContextCurrentExecutionSegmentsContainer

### DIFF
--- a/sample/AspNetFullFrameworkSampleApp/AspNetFullFrameworkSampleApp.csproj
+++ b/sample/AspNetFullFrameworkSampleApp/AspNetFullFrameworkSampleApp.csproj
@@ -125,6 +125,13 @@
       <SubType>ASPXCodeBehind</SubType>
       <DependentUpon>Webforms.aspx</DependentUpon>
     </Compile>
+    <Compile Include="App_Start\WebApiConfig.cs" />
+    <Compile Include="Controllers\WebApiController.cs" />
+    <Compile Include="Controllers\DatabaseController.cs" />
+    <Compile Include="Models\CreateSampleDataViewModel.cs" />
+    <Compile Include="Mvc\JsonBadRequestResult.cs" />
+    <Compile Include="Mvc\JsonNetValueProviderFactory.cs" />
+    <Compile Include="Mvc\StreamResult.cs" />
   </ItemGroup>
   <ItemGroup Condition="'$(OS)' == 'WINDOWS_NT'">
     <Content Include="Content\bootstrap-grid.css" />
@@ -202,6 +209,9 @@
     <Content Include="Views\Account\ResetPassword.cshtml" />
     <Content Include="Views\Account\ResetPasswordConfirmation.cshtml" />
     <Content Include="Views\Shared\_LoginPartial.cshtml" />
+    <Content Include="Views\Shared\_LoginPartial.cshtml" />
+    <Content Include="Views\Database\Create.cshtml" />
+    <Content Include="Views\Database\Index.cshtml" />
     <Content Include="Areas\MyArea\Views\Home\Index.cshtml" />
     <Content Include="Areas\MyArea\Web.config" />
     <Content Include="Areas\MyArea\_ViewStart.cshtml" />
@@ -246,17 +256,29 @@
     <PackageReference Include="EntityFramework">
       <Version>6.3.0</Version>
     </PackageReference>
+    <PackageReference Include="Microsoft.AspNet.Identity.EntityFramework">
+      <Version>2.2.3</Version>
+    </PackageReference>
+    <PackageReference Include="Microsoft.AspNet.Identity.Owin">
+      <Version>2.2.3</Version>
+    </PackageReference>
     <PackageReference Include="Microsoft.AspNet.Mvc">
       <Version>5.2.4</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.AspNet.TelemetryCorrelation">
       <Version>1.0.7</Version>
     </PackageReference>
+    <PackageReference Include="Microsoft.AspNet.WebApi">
+      <Version>5.2.4</Version>
+    </PackageReference>
     <PackageReference Include="Microsoft.AspNet.Web.Optimization">
       <Version>1.1.3</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.CodeDom.Providers.DotNetCompilerPlatform">
       <Version>2.0.1</Version>
+    </PackageReference>
+    <PackageReference Include="Microsoft.Owin.Host.SystemWeb">
+      <Version>4.1.1</Version>
     </PackageReference>
     <PackageReference Include="Newtonsoft.Json">
       <Version>11.0.2</Version>
@@ -273,37 +295,6 @@
     <PackageReference Include="System.Memory">
       <Version>4.5.3</Version>
     </PackageReference>
-    <PackageReference Include="Microsoft.AspNet.Identity.EntityFramework">
-      <Version>2.2.3</Version>
-    </PackageReference>
-    <PackageReference Include="Microsoft.AspNet.Identity.Owin">
-      <Version>2.2.3</Version>
-    </PackageReference>
-    <PackageReference Include="Microsoft.Owin.Host.SystemWeb">
-      <Version>4.1.1</Version>
-    </PackageReference>
-  </ItemGroup>
-  <ItemGroup>
-    <Compile Include="App_Start\WebApiConfig.cs" />
-    <Compile Include="Controllers\WebApiController.cs" />
-    <Content Include="Views\Shared\_LoginPartial.cshtml" />
-    <Content Include="Views\Database\Create.cshtml" />
-    <Content Include="Views\Database\Index.cshtml" />
-  </ItemGroup>
-  <ItemGroup>
-    <PackageReference Include="Microsoft.AspNet.WebApi">
-      <Version>5.2.4</Version>
-    </PackageReference>
-    <Compile Include="ActionFilters\RedirectIfAuthenticatedAttribute.cs" />
-    <Compile Include="App_Start\Startup.cs" />
-    <Compile Include="Extensions\TempDataExtensions.cs" />
-    <Compile Include="Services\Auth\ApplicationUserClaimsIdentityFactory.cs" />
-    <Compile Include="Controllers\DatabaseController.cs" />
-    <Compile Include="Models\CreateSampleDataViewModel.cs" />
-    <Compile Include="Mvc\JsonBadRequestResult.cs" />
-    <Compile Include="Mvc\JsonNetValueProviderFactory.cs" />
-    <Compile Include="Mvc\StreamResult.cs" />
-    <Compile Include="Services\Auth\ApplicationUserClaimsIdentityFactory.cs" />
   </ItemGroup>
   <PropertyGroup Condition="'$(OS)' == 'WINDOWS_NT'">
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>

--- a/sample/AspNetFullFrameworkSampleApp/AspNetFullFrameworkSampleApp.csproj
+++ b/sample/AspNetFullFrameworkSampleApp/AspNetFullFrameworkSampleApp.csproj
@@ -286,11 +286,24 @@
   <ItemGroup>
     <Compile Include="App_Start\WebApiConfig.cs" />
     <Compile Include="Controllers\WebApiController.cs" />
+    <Content Include="Views\Shared\_LoginPartial.cshtml" />
+    <Content Include="Views\Database\Create.cshtml" />
+    <Content Include="Views\Database\Index.cshtml" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNet.WebApi">
       <Version>5.2.4</Version>
     </PackageReference>
+    <Compile Include="ActionFilters\RedirectIfAuthenticatedAttribute.cs" />
+    <Compile Include="App_Start\Startup.cs" />
+    <Compile Include="Extensions\TempDataExtensions.cs" />
+    <Compile Include="Services\Auth\ApplicationUserClaimsIdentityFactory.cs" />
+    <Compile Include="Controllers\DatabaseController.cs" />
+    <Compile Include="Models\CreateSampleDataViewModel.cs" />
+    <Compile Include="Mvc\JsonBadRequestResult.cs" />
+    <Compile Include="Mvc\JsonNetValueProviderFactory.cs" />
+    <Compile Include="Mvc\StreamResult.cs" />
+    <Compile Include="Services\Auth\ApplicationUserClaimsIdentityFactory.cs" />
   </ItemGroup>
   <PropertyGroup Condition="'$(OS)' == 'WINDOWS_NT'">
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>

--- a/sample/AspNetFullFrameworkSampleApp/Bootstrap/Alert.cs
+++ b/sample/AspNetFullFrameworkSampleApp/Bootstrap/Alert.cs
@@ -18,6 +18,13 @@ namespace AspNetFullFrameworkSampleApp.Bootstrap
 		public SuccessAlert(string title, string message) : base(title, message) => Status = AlertStatus.Success;
 	}
 
+	public class DangerAlert : Alert
+	{
+		public DangerAlert(string message) : base(message) => Status = AlertStatus.Danger;
+
+		public DangerAlert(string title, string message) : base(title, message) => Status = AlertStatus.Danger;
+	}
+
 	public class Alert : IHtmlString
 	{
 		public Alert(string message) => Message = message;

--- a/sample/AspNetFullFrameworkSampleApp/Controllers/ControllerBase.cs
+++ b/sample/AspNetFullFrameworkSampleApp/Controllers/ControllerBase.cs
@@ -3,14 +3,20 @@
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
 
+using System.IO;
 using System.Web.Mvc;
 using AspNetFullFrameworkSampleApp.Bootstrap;
 using AspNetFullFrameworkSampleApp.Extensions;
+using AspNetFullFrameworkSampleApp.Mvc;
 
 namespace AspNetFullFrameworkSampleApp.Controllers
 {
 	public abstract class ControllerBase : Controller
 	{
 		protected void AddAlert(Alert alert) => TempData.Put("alert", alert);
+
+		protected ActionResult JsonBadRequest(object content) => new JsonBadRequestResult { Data = content, };
+
+		protected ActionResult Stream(Stream stream, string contentType, int statusCode) => new StreamResult(stream, contentType, statusCode);
 	}
 }

--- a/sample/AspNetFullFrameworkSampleApp/Controllers/DatabaseController.cs
+++ b/sample/AspNetFullFrameworkSampleApp/Controllers/DatabaseController.cs
@@ -1,0 +1,123 @@
+// Licensed to Elasticsearch B.V under
+// one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System.Collections.Generic;
+using System.Data.Entity;
+using System.Linq;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+using System.Web.Mvc;
+using AspNetFullFrameworkSampleApp.Bootstrap;
+using AspNetFullFrameworkSampleApp.Data;
+using AspNetFullFrameworkSampleApp.Models;
+using Newtonsoft.Json;
+
+namespace AspNetFullFrameworkSampleApp.Controllers
+{
+	/// <summary>
+	/// Demonstrates database functionality
+	/// </summary>
+	public class DatabaseController : ControllerBase
+	{
+		/// <summary>
+		/// List the sample data in the database
+		/// </summary>
+		/// <returns></returns>
+		public ActionResult Index()
+		{
+			using var context = new SampleDataDbContext();
+			var samples = context.Set<SampleData>().ToList();
+			return View(samples);
+		}
+
+		/// <summary>
+		/// Allows sample data to be inserted into the database
+		/// </summary>
+		public ActionResult Create() => View(new CreateSampleDataViewModel());
+
+		[HttpPost]
+		[ValidateAntiForgeryToken]
+		public async Task<ActionResult> Create(CreateSampleDataViewModel model)
+		{
+			if (!ModelState.IsValid)
+				return View(model);
+
+			int changes;
+			using (var context = new SampleDataDbContext())
+			{
+				var sampleData = new SampleData { Name = model.Name };
+				context.Set<SampleData>().Add(sampleData);
+				changes = await context.SaveChangesAsync();
+			}
+
+			AddAlert(new SuccessAlert("Sample added", $"{changes} sample was saved to the database"));
+			return RedirectToAction("Index");
+		}
+
+		// TODO: make this a web api controller action
+		/// <summary>
+		/// Generates the given count of sample data, and calls the bulk action to insert into the database
+		/// </summary>
+		/// <remarks>
+		/// This intentionally makes an async HTTP call to bulk insert.
+		/// </remarks>
+		/// <param name="count">The count of sample data to generate</param>
+		[HttpPost]
+		public async Task<ActionResult> Generate(int count)
+		{
+			if (!ModelState.IsValid)
+				return JsonBadRequest(new { success = false, message = "Invalid samples" });
+
+			if (count <= 0)
+				return JsonBadRequest(new { success = false, message = "count must be greater than 0" });
+
+			int existingCount;
+			using (var context = new SampleDataDbContext())
+				existingCount = await context.Set<SampleData>().CountAsync();
+
+			var samples = Enumerable.Range(existingCount, count)
+				.Select(i => new CreateSampleDataViewModel { Name = $"Generated sample {i}" });
+
+			var client = new HttpClient();
+			var bulkUrl = Url.Action("Bulk", "Database", null, Request.Url.Scheme);
+			var json = JsonConvert.SerializeObject(samples);
+			var contentType = "application/json";
+			var content = new StringContent(json, Encoding.UTF8, contentType);
+
+			var response = await client.PostAsync(bulkUrl, content).ConfigureAwait(false);
+			var responseStream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
+
+			return Stream(responseStream, contentType, (int)response.StatusCode);
+		}
+
+		// TODO: make this a web api controller action
+		/// <summary>
+		/// Bulk inserts sample data into the database
+		/// </summary>
+		/// <param name="model">The sample data to insert</param>
+		[HttpPost]
+		public async Task<ActionResult> Bulk(IEnumerable<CreateSampleDataViewModel> model)
+		{
+			if (!ModelState.IsValid)
+				return JsonBadRequest(new { success = false, message = "Invalid samples" });
+
+			var sampleData = model.Select(m => new SampleData { Name = m.Name });
+			int changes;
+
+			using (var context = new SampleDataDbContext())
+			using (var transaction = context.Database.BeginTransaction())
+			{
+				context.Configuration.AutoDetectChangesEnabled = false;
+				context.Configuration.ValidateOnSaveEnabled = false;
+				context.Set<SampleData>().AddRange(sampleData);
+				changes = await context.SaveChangesAsync();
+				transaction.Commit();
+			}
+
+			return Json(new { success = true, changes });
+		}
+	}
+}

--- a/sample/AspNetFullFrameworkSampleApp/Global.asax.cs
+++ b/sample/AspNetFullFrameworkSampleApp/Global.asax.cs
@@ -5,12 +5,14 @@
 using System;
 using System.Collections.Specialized;
 using System.Diagnostics;
+using System.Linq;
 using System.Web;
 using System.Web.Http;
 using System.Web.Http.Batch;
 using System.Web.Mvc;
 using System.Web.Optimization;
 using System.Web.Routing;
+using AspNetFullFrameworkSampleApp.Mvc;
 using Elastic.Apm;
 using NLog;
 
@@ -40,6 +42,9 @@ namespace AspNetFullFrameworkSampleApp
 			FilterConfig.RegisterGlobalFilters(GlobalFilters.Filters);
 			RouteConfig.RegisterRoutes(RouteTable.Routes);
 			BundleConfig.RegisterBundles(BundleTable.Bundles);
+
+			ValueProviderFactories.Factories.Remove(ValueProviderFactories.Factories.OfType<JsonValueProviderFactory>().FirstOrDefault());
+			ValueProviderFactories.Factories.Add(new JsonNetValueProviderFactory());
 		}
 
 		protected void Application_BeginRequest(object sender, EventArgs e)

--- a/sample/AspNetFullFrameworkSampleApp/Models/CreateSampleDataViewModel.cs
+++ b/sample/AspNetFullFrameworkSampleApp/Models/CreateSampleDataViewModel.cs
@@ -1,0 +1,15 @@
+// Licensed to Elasticsearch B.V under
+// one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System.ComponentModel.DataAnnotations;
+
+namespace AspNetFullFrameworkSampleApp.Models
+{
+	public class CreateSampleDataViewModel
+	{
+		[Required]
+		public string Name { get; set; }
+	}
+}

--- a/sample/AspNetFullFrameworkSampleApp/Mvc/JsonBadRequestResult.cs
+++ b/sample/AspNetFullFrameworkSampleApp/Mvc/JsonBadRequestResult.cs
@@ -1,0 +1,13 @@
+using System.Web.Mvc;
+
+namespace AspNetFullFrameworkSampleApp.Mvc
+{
+	public class JsonBadRequestResult : JsonResult
+	{
+		public override void ExecuteResult(ControllerContext context)
+		{
+			context.RequestContext.HttpContext.Response.StatusCode = 400;
+			base.ExecuteResult(context);
+		}
+	}
+}

--- a/sample/AspNetFullFrameworkSampleApp/Mvc/JsonNetValueProviderFactory.cs
+++ b/sample/AspNetFullFrameworkSampleApp/Mvc/JsonNetValueProviderFactory.cs
@@ -1,0 +1,130 @@
+// Licensed to Elasticsearch B.V under
+// one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+// https://gist.github.com/rorymurphy/db0b02e8267960a0881a
+// This is a slightly modified ValueProviderFactory based almost entirely on Microsoft's JsonValueProviderFactory.
+// That file is licensed under the Apache 2.0 license, but I am leaving the copyright statement below nonetheless.
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Dynamic;
+using System.Globalization;
+using System.IO;
+using System.Web.Mvc;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+
+namespace AspNetFullFrameworkSampleApp.Mvc
+{
+	/// <summary>
+	/// A value provider factory for application/json requests that uses
+	/// Json.NET to deserialize the request stream and provide the
+	/// value to subsequent steps.
+	/// </summary>
+	public sealed class JsonNetValueProviderFactory : ValueProviderFactory
+    {
+		private static readonly JsonSerializer Serializer = new JsonSerializer
+		{
+			Converters = { new ExpandoObjectConverter() }
+		};
+
+        private static void AddToBackingStore(EntryLimitedDictionary backingStore, string prefix, object value)
+        {
+			switch (value)
+			{
+				case IDictionary<string, object> d:
+				{
+					foreach (var entry in d)
+						AddToBackingStore(backingStore, MakePropertyKey(prefix, entry.Key), entry.Value);
+					return;
+				}
+				case IList l:
+				{
+					for (var i = 0; i < l.Count; i++)
+						AddToBackingStore(backingStore, MakeArrayKey(prefix, i), l[i]);
+					return;
+				}
+				default:
+					backingStore.Add(prefix, value);
+					break;
+			}
+		}
+
+        private static object GetDeserializedObject(ControllerContext controllerContext)
+        {
+			var request = controllerContext.HttpContext.Request;
+			if (!request.ContentType.StartsWith("application/json", StringComparison.OrdinalIgnoreCase))
+				return null;
+
+			string bodyText;
+			using (var reader = new StreamReader(request.InputStream))
+				bodyText = reader.ReadToEnd();
+
+			if (string.IsNullOrEmpty(bodyText))
+				return null;
+
+			object jsonData;
+            using (var reader = new StringReader(bodyText))
+			using (var jsonTextReader = new JsonTextReader(reader))
+			{
+				jsonTextReader.Read();
+				if (jsonTextReader.TokenType == JsonToken.StartArray)
+					jsonData = Serializer.Deserialize<List<ExpandoObject>>(jsonTextReader);
+				else
+					jsonData = Serializer.Deserialize<ExpandoObject>(jsonTextReader);
+			}
+
+			return jsonData;
+        }
+
+        public override IValueProvider GetValueProvider(ControllerContext controllerContext)
+        {
+            if (controllerContext == null)
+				throw new ArgumentNullException(nameof(controllerContext));
+
+			var jsonData = GetDeserializedObject(controllerContext);
+            if (jsonData == null) return null;
+
+			var backingStore = new Dictionary<string, object>(StringComparer.OrdinalIgnoreCase);
+            var backingStoreWrapper = new EntryLimitedDictionary(backingStore);
+            AddToBackingStore(backingStoreWrapper, string.Empty, jsonData);
+            return new DictionaryValueProvider<object>(backingStore, CultureInfo.CurrentCulture);
+        }
+
+        private static string MakeArrayKey(string prefix, int index) =>
+			prefix + "[" + index.ToString(CultureInfo.InvariantCulture) + "]";
+
+		private static string MakePropertyKey(string prefix, string propertyName) =>
+			string.IsNullOrEmpty(prefix) ? propertyName : prefix + "." + propertyName;
+
+		private class EntryLimitedDictionary
+        {
+            private static readonly int MaximumDepth = GetMaximumDepth();
+            private readonly IDictionary<string, object> _innerDictionary;
+            private int _itemCount;
+
+            public EntryLimitedDictionary(IDictionary<string, object> innerDictionary) =>
+				_innerDictionary = innerDictionary;
+
+			public void Add(string key, object value)
+            {
+                if (++_itemCount > MaximumDepth)
+					throw new InvalidOperationException("Request too large");
+
+				_innerDictionary.Add(key, value);
+            }
+
+            private static int GetMaximumDepth()
+            {
+                var appSettings = System.Configuration.ConfigurationManager.AppSettings;
+				var valueArray = appSettings?.GetValues("aspnet:MaxJsonDeserializerMembers");
+				if (valueArray == null || valueArray.Length <= 0) return 1000;
+				return int.TryParse(valueArray[0], out var result) ? result : 1000;
+			}
+        }
+    }
+}

--- a/sample/AspNetFullFrameworkSampleApp/Mvc/StreamResult.cs
+++ b/sample/AspNetFullFrameworkSampleApp/Mvc/StreamResult.cs
@@ -1,0 +1,45 @@
+// Licensed to Elasticsearch B.V under
+// one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System.IO;
+using System.Web.Mvc;
+
+namespace AspNetFullFrameworkSampleApp.Mvc
+{
+	public class StreamResult : ActionResult
+	{
+		private const int BufferSize = 4096;
+		private readonly Stream _stream;
+		private readonly string _contentType;
+		private readonly int _statusCode;
+
+		public StreamResult(Stream stream, string contentType, int statusCode = 200)
+		{
+			_stream = stream;
+			_contentType = contentType;
+			_statusCode = statusCode;
+		}
+
+		public override void ExecuteResult(ControllerContext context)
+		{
+			var response = context.RequestContext.HttpContext.Response;
+			response.StatusCode = _statusCode;
+			response.ContentType = _contentType;
+			var outputStream = response.OutputStream;
+			using (_stream)
+			{
+				var buffer = new byte[BufferSize];
+				while (true)
+				{
+					var count = _stream.Read(buffer, 0, BufferSize);
+					if (count != 0)
+						outputStream.Write(buffer, 0, count);
+					else
+						break;
+				}
+			}
+		}
+	}
+}

--- a/sample/AspNetFullFrameworkSampleApp/Views/Database/Create.cshtml
+++ b/sample/AspNetFullFrameworkSampleApp/Views/Database/Create.cshtml
@@ -1,0 +1,18 @@
+@model CreateSampleDataViewModel
+
+@using (Html.BeginForm("Create", "Database", FormMethod.Post, new { id = "createForm", @class = "form-horizontal", role = "form" }))
+{
+	@Html.AntiForgeryToken()
+	<h4>Add a new sample</h4>
+	<hr />
+	@Html.ValidationSummary(true, "", new { @class = "text-danger" })
+	<div class="form-group">
+		@Html.Hidden("samples.Index", "index")
+		@Html.Label("samples[index].Name")
+		@Html.TextBox("samples[index].Name", "", new { @class = "form-control" })
+		@Html.ValidationMessage("samples[index].Name", "", new { @class = "text-danger" })
+	</div>
+	<div class="form-group">
+		<input type="submit" value="Create" class="btn btn-primary" />
+	</div>
+}

--- a/sample/AspNetFullFrameworkSampleApp/Views/Database/Index.cshtml
+++ b/sample/AspNetFullFrameworkSampleApp/Views/Database/Index.cshtml
@@ -1,0 +1,26 @@
+@model IEnumerable<AspNetFullFrameworkSampleApp.Data.SampleData>
+
+@if (!Model.Any())
+{
+	<p>No samples in the database.</p>
+}
+else
+{
+	<table class="table table-striped">
+		<thead>
+			<tr>
+				<th scope="col">Id</th>
+				<th scope="col">Name</th>
+			</tr>
+		</thead>
+		<tbody>
+			@foreach (var sample in Model)
+			{
+				<tr>
+					<th scope="row">@sample.Id</th>
+					<td>@sample.Name</td>
+				</tr>
+			}
+		</tbody>
+	</table>
+}

--- a/src/Elastic.Apm.AspNetFullFramework/ElasticApmModule.cs
+++ b/src/Elastic.Apm.AspNetFullFramework/ElasticApmModule.cs
@@ -24,6 +24,7 @@ namespace Elastic.Apm.AspNetFullFramework
 		internal const string Email = "email";
 		internal const string UserId = "sub";
 	}
+
 	public class ElasticApmModule : IHttpModule
 	{
 		private static bool _isCaptureHeadersEnabled;
@@ -35,10 +36,6 @@ namespace Elastic.Apm.AspNetFullFramework
 
 		// ReSharper disable once ImpureMethodCallOnReadonlyValueField
 		public ElasticApmModule() => _dbgInstanceName = DbgInstanceNameGenerator.Generate($"{nameof(ElasticApmModule)}.#");
-
-		// We can store current transaction because each IHttpModule is used for at most one request at a time
-		// For example see https://bytes.com/topic/asp-net/answers/324305-httpmodule-multithreading-request-response-corelation
-		private ITransaction _currentTransaction;
 
 		private HttpApplication _httpApp;
 
@@ -126,14 +123,17 @@ namespace Elastic.Apm.AspNetFullFramework
 			if (soapAction != null) transactionName += $" {soapAction}";
 
 			var distributedTracingData = ExtractIncomingDistributedTracingData(httpRequest);
+			ITransaction transaction;
+
 			if (distributedTracingData != null)
 			{
 				_logger.Debug()
 					?.Log(
 						"Incoming request with {TraceParentHeaderName} header. DistributedTracingData: {DistributedTracingData} - continuing trace",
 						DistributedTracing.TraceContext.TraceParentHeaderNamePrefixed, distributedTracingData);
+
 				// we set ignoreActivity to true to avoid the HttpContext W3C DiagnosticSource issue (see https://github.com/elastic/apm-agent-dotnet/issues/867#issuecomment-650170150)
-				_currentTransaction = Agent.Instance.Tracer.StartTransaction(transactionName, ApiConstants.TypeRequest, distributedTracingData, true);
+				transaction = Agent.Instance.Tracer.StartTransaction(transactionName, ApiConstants.TypeRequest, distributedTracingData, true);
 			}
 			else
 			{
@@ -141,10 +141,10 @@ namespace Elastic.Apm.AspNetFullFramework
 					?.Log("Incoming request doesn't have valid incoming distributed tracing data - starting trace with new trace ID");
 
 				// we set ignoreActivity to true to avoid the HttpContext W3C DiagnosticSource issue(see https://github.com/elastic/apm-agent-dotnet/issues/867#issuecomment-650170150)
-				_currentTransaction = Agent.Instance.Tracer.StartTransaction(transactionName, ApiConstants.TypeRequest, ignoreActivity: true);
+				transaction = Agent.Instance.Tracer.StartTransaction(transactionName, ApiConstants.TypeRequest, ignoreActivity: true);
 			}
 
-			if (_currentTransaction.IsSampled) FillSampledTransactionContextRequest(httpRequest, _currentTransaction);
+			if (transaction.IsSampled) FillSampledTransactionContextRequest(httpRequest, transaction);
 		}
 
 		/// <summary>
@@ -242,11 +242,11 @@ namespace Elastic.Apm.AspNetFullFramework
 			var httpApp = (HttpApplication)eventSender;
 			var httpCtx = httpApp.Context;
 			var httpResponse = httpCtx.Response;
-			var transaction = _currentTransaction;
+			var transaction = Agent.Instance.Tracer.CurrentTransaction;
 
 			if (transaction == null) return;
 
-			SendErrorEventIfPresent(httpCtx);
+			SendErrorEventIfPresent(httpCtx, transaction);
 
 			// update the transaction name based on route values, if applicable
 			if (transaction is Transaction t && !t.HasCustomName)
@@ -292,27 +292,27 @@ namespace Elastic.Apm.AspNetFullFramework
 				}
 			}
 
-			_currentTransaction.Result = Transaction.StatusCodeToResult("HTTP", httpResponse.StatusCode);
+			transaction.Result = Transaction.StatusCodeToResult("HTTP", httpResponse.StatusCode);
 
 			if (httpResponse.StatusCode >= 500)
-				_currentTransaction.Outcome = Outcome.Failure;
+				transaction.Outcome = Outcome.Failure;
 			else
-				_currentTransaction.Outcome = Outcome.Success;
+				transaction.Outcome = Outcome.Success;
 
-			if (_currentTransaction.IsSampled)
+			if (transaction.IsSampled)
 			{
-				FillSampledTransactionContextResponse(httpResponse, _currentTransaction);
-				FillSampledTransactionContextUser(httpCtx, _currentTransaction);
+				FillSampledTransactionContextResponse(httpResponse, transaction);
+				FillSampledTransactionContextUser(httpCtx, transaction);
 			}
 
-			_currentTransaction.End();
-			_currentTransaction = null;
+			transaction.End();
+			transaction = null;
 		}
 
-		private void SendErrorEventIfPresent(HttpContext httpCtx)
+		private void SendErrorEventIfPresent(HttpContext httpCtx, ITransaction transaction)
 		{
 			var lastError = httpCtx.Server.GetLastError();
-			if (lastError != null) _currentTransaction.CaptureException(lastError);
+			if (lastError != null) transaction.CaptureException(lastError);
 		}
 
 		private static void FillSampledTransactionContextResponse(HttpResponse httpResponse, ITransaction transaction) =>
@@ -420,7 +420,13 @@ namespace Elastic.Apm.AspNetFullFramework
 
 			var reader = ConfigHelper.CreateReader(rootLogger) ?? new FullFrameworkConfigReader(rootLogger);
 
-			var agentComponents = new AgentComponents(rootLogger, reader);
+			var agentComponents = new AgentComponents(
+				rootLogger,
+				reader,
+				null,
+				null,
+				new HttpContextCurrentExecutionSegmentsContainer(),
+				null);
 
 			var aspNetVersion = FindAspNetVersion(scopedLogger);
 

--- a/src/Elastic.Apm.AspNetFullFramework/ElasticApmModule.cs
+++ b/src/Elastic.Apm.AspNetFullFramework/ElasticApmModule.cs
@@ -280,7 +280,7 @@ namespace Elastic.Apm.AspNetFullFramework
 
 						_logger?.Trace()?.Log("Calculating transaction name based on route data");
 						var name = Transaction.GetNameFromRouteContext(routeData);
-						if (!string.IsNullOrWhiteSpace(name)) _currentTransaction.Name = $"{httpCtx.Request.HttpMethod} {name}";
+						if (!string.IsNullOrWhiteSpace(name)) transaction.Name = $"{httpCtx.Request.HttpMethod} {name}";
 					}
 					else
 					{

--- a/src/Elastic.Apm.AspNetFullFramework/HttpContextCurrentExecutionSegmentsContainer.cs
+++ b/src/Elastic.Apm.AspNetFullFramework/HttpContextCurrentExecutionSegmentsContainer.cs
@@ -1,0 +1,48 @@
+// Licensed to Elasticsearch B.V under
+// one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System.Threading;
+using System.Web;
+using Elastic.Apm.Model;
+
+namespace Elastic.Apm.AspNetFullFramework
+{
+	/// <summary>
+	/// An <see cref="ICurrentExecutionSegmentsContainer"/> that stores the current transaction
+	/// and current span in both async local storage and the current <see cref="HttpContext.Items"/>
+	/// </summary>
+	internal sealed class HttpContextCurrentExecutionSegmentsContainer : ICurrentExecutionSegmentsContainer
+	{
+		private readonly AsyncLocal<Span> _currentSpan = new AsyncLocal<Span>();
+		private readonly AsyncLocal<Transaction> _currentTransaction = new AsyncLocal<Transaction>();
+
+		private const string CurrentSpanKey = "Elastic.Apm.Agent.CurrentSpan";
+		private const string CurrentTransactionKey = "Elastic.Apm.Agent.CurrentTransaction";
+
+		public Span CurrentSpan
+		{
+			get => _currentSpan.Value ?? HttpContext.Current?.Items[CurrentSpanKey] as Span;
+			set
+			{
+				_currentSpan.Value = value;
+				var httpContext = HttpContext.Current;
+				if (httpContext != null)
+					httpContext.Items[CurrentSpanKey] = value;
+			}
+		}
+
+		public Transaction CurrentTransaction
+		{
+			get => _currentTransaction.Value ?? HttpContext.Current?.Items[CurrentTransactionKey] as Transaction;
+			set
+			{
+				_currentTransaction.Value = value;
+				var httpContext = HttpContext.Current;
+				if (httpContext != null)
+					httpContext.Items[CurrentTransactionKey] = value;
+			}
+		}
+	}
+}

--- a/src/Elastic.Apm/ICurrentExecutionSegmentsContainer.cs
+++ b/src/Elastic.Apm/ICurrentExecutionSegmentsContainer.cs
@@ -8,7 +8,14 @@ namespace Elastic.Apm
 {
 	internal interface ICurrentExecutionSegmentsContainer
 	{
+		/// <summary>
+		/// Gets or sets the current span
+		/// </summary>
 		Span CurrentSpan { get; set; }
+
+		/// <summary>
+		/// Gets or sets the current transaction
+		/// </summary>
 		Transaction CurrentTransaction { get; set; }
 	}
 }

--- a/test/Elastic.Apm.AspNetFullFramework.Tests/Elastic.Apm.AspNetFullFramework.Tests.csproj
+++ b/test/Elastic.Apm.AspNetFullFramework.Tests/Elastic.Apm.AspNetFullFramework.Tests.csproj
@@ -28,7 +28,7 @@
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
   </ItemGroup>
   <ItemGroup Condition="'$(OS)' == 'WINDOWS_NT'">
-    <ProjectReference Include="..\..\src\Elastic.Apm.AspNetFullFramework\Elastic.Apm.AspNetFullFramework.csproj" >
+    <ProjectReference Include="..\..\src\Elastic.Apm.AspNetFullFramework\Elastic.Apm.AspNetFullFramework.csproj">
       <SetTargetFramework>TargetFramework=net461</SetTargetFramework>
     </ProjectReference>
     <ProjectReference Include="..\Elastic.Apm.Tests\Elastic.Apm.Tests.csproj" />

--- a/test/Elastic.Apm.AspNetFullFramework.Tests/HttpContextCurrentExecutionSegmentsContainerTests.cs
+++ b/test/Elastic.Apm.AspNetFullFramework.Tests/HttpContextCurrentExecutionSegmentsContainerTests.cs
@@ -1,0 +1,88 @@
+// Licensed to Elasticsearch B.V under
+// one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System.Linq;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+using AspNetFullFrameworkSampleApp.Models;
+using FluentAssertions;
+using Newtonsoft.Json;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Elastic.Apm.AspNetFullFramework.Tests
+{
+	[Collection(Consts.AspNetFullFrameworkTestsCollection)]
+	public class HttpContextCurrentExecutionSegmentsContainerTests : TestsBase
+	{
+		public HttpContextCurrentExecutionSegmentsContainerTests(ITestOutputHelper testOutputHelper) : base(testOutputHelper)
+		{
+		}
+
+		[AspNetFullFrameworkFact]
+		public async Task Transaction_And_Spans_Captured_When_Large_Request()
+		{
+			var samples = Enumerable.Range(1, 1_000)
+				.Select(i => new CreateSampleDataViewModel { Name = $"Sample {i}" });
+
+			var json = JsonConvert.SerializeObject(samples);
+			var bytes = Encoding.UTF8.GetByteCount(json);
+
+			// larger than 20Kb
+			bytes.Should().BeGreaterThan(20_000);
+			var content = new StringContent(json, Encoding.UTF8, "application/json");
+
+			var client = new HttpClient();
+			var bulkSamplesUri = Consts.SampleApp.CreateUrl("/Database/Bulk");
+			var response = await client.PostAsync(bulkSamplesUri, content).ConfigureAwait(false);
+
+			var responseContent = await response.Content.ReadAsStringAsync();
+			response.IsSuccessStatusCode.Should().BeTrue(responseContent);
+
+			await WaitAndCustomVerifyReceivedData(received =>
+			{
+				received.Transactions.Count.Should().Be(1);
+				var transaction = received.Transactions.Single();
+
+				transaction.SpanCount.Started.Should().Be(500);
+				transaction.SpanCount.Dropped.Should().Be(501);
+				received.Spans.Count.Should().Be(500);
+			});
+		}
+
+		[AspNetFullFrameworkFact]
+		public async Task Transaction_And_Spans_Captured_When_Controller_Action_Makes_Async_Http_Call()
+		{
+			var count = 100;
+			var content = new StringContent($"{{\"count\":{count}}}", Encoding.UTF8, "application/json");
+
+			var client = new HttpClient();
+			var bulkSamplesUri = Consts.SampleApp.CreateUrl("/Database/Generate");
+			var response = await client.PostAsync(bulkSamplesUri, content).ConfigureAwait(false);
+
+			var responseContent = await response.Content.ReadAsStringAsync();
+			response.IsSuccessStatusCode.Should().BeTrue(responseContent);
+
+			await WaitAndCustomVerifyReceivedData(received =>
+			{
+				received.Transactions.Count.Should().Be(2);
+				var transactions = received.Transactions
+					.OrderByDescending(t => t.Timestamp)
+					.ToList();
+
+				var firstTransaction = transactions.First();
+				firstTransaction.Name.Should().EndWith("Bulk");
+				firstTransaction.SpanCount.Started.Should().Be(100);
+
+				var secondTransaction = transactions.Last();
+				secondTransaction.Name.Should().EndWith("Generate");
+				secondTransaction.SpanCount.Started.Should().Be(3);
+
+				received.Spans.Count.Should().Be(103);
+			});
+		}
+	}
+}

--- a/test/Elastic.Apm.AspNetFullFramework.Tests/HttpContextCurrentExecutionSegmentsContainerTests.cs
+++ b/test/Elastic.Apm.AspNetFullFramework.Tests/HttpContextCurrentExecutionSegmentsContainerTests.cs
@@ -3,6 +3,9 @@
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
 
+using System;
+using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Net.Http;
 using System.Text;
@@ -83,6 +86,73 @@ namespace Elastic.Apm.AspNetFullFramework.Tests
 
 				received.Spans.Count.Should().Be(103);
 			});
+		}
+
+		[AspNetFullFrameworkFact]
+		public async Task Transaction_And_Spans_Captured_When_Multiple_Concurrent_Requests()
+		{
+			static HttpRequestMessage CreateMessage(int i)
+			{
+				var message = new HttpRequestMessage(HttpMethod.Get, Consts.SampleApp.CreateUrl("/Home/Contact"));
+				message.Headers.Add("X-HttpRequest", i.ToString(CultureInfo.InvariantCulture));
+				return message;
+			}
+
+			var count = 9;
+			var messages = Enumerable.Range(1, count)
+				.Select(i => CreateMessage(i))
+				.ToList();
+
+			// infinite timespan
+			var client = new HttpClient { Timeout = TimeSpan.FromMilliseconds(-1) };
+
+			var tasks = new List<Task<HttpResponseMessage>>(messages.Count);
+			foreach (var message in messages)
+				tasks.Add(client.SendAsync(message));
+
+			await Task.WhenAll(tasks).ConfigureAwait(false);
+
+			for (var index = 0; index < tasks.Count; index++)
+			{
+				var task = tasks[index];
+				task.IsCompletedSuccessfully.Should().BeTrue();
+				var response = task.Result;
+				var responseContent = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+				response.IsSuccessStatusCode.Should().BeTrue($"response {index}: {responseContent}");
+			}
+
+			await WaitAndCustomVerifyReceivedData(received =>
+			{
+				received.Transactions.Count.Should().Be(count * 2);
+
+				var contactTransactions = received.Transactions
+					.Where(t => t.Name == "GET Home/Contact")
+					.ToList();
+
+				contactTransactions.Should().HaveCount(count);
+
+				var aboutTransactions = received.Transactions
+					.Where(t => t.Name == "GET Home/About")
+					.ToList();
+
+				aboutTransactions.Should().HaveCount(count);
+
+				// assert that each aboutTransaction is a child of a span associated with a contactTransaction
+				foreach (var contactTransaction in contactTransactions)
+				{
+					contactTransaction.ParentId.Should().BeNull();
+					var spans = received.Spans.Where(s => s.TransactionId == contactTransaction.Id)
+						.ToList();
+
+					spans.Should().HaveCount(2);
+
+					var localHostSpan = spans.SingleOrDefault(s => s.Name == "GET localhost");
+					localHostSpan.Should().NotBeNull();
+
+					var aboutTransaction = aboutTransactions.SingleOrDefault(t => t.ParentId == localHostSpan.Id);
+					aboutTransaction.Should().NotBeNull();
+				}
+			}).ConfigureAwait(false);
 		}
 	}
 }


### PR DESCRIPTION
This commit adds an implementation of `ICurrentExecutionSegmentsContainer` that gets/sets the current transaction and span in `HttpContext.Items`, in addition to `AsyncLocal<T>`, making them available within the ExecutionContext of IIS.

`AsyncLocal<T>` are not propagated across the ASP.NET ExecutionContext running in IIS, resulting in the current transaction set in `Application_BeginRequest` returning as null from `Agent.Tracer.CurrentTransaction` in later subsequent IIS events, when such events execute asynchronously. ASP.NET does however propagate the current HttpContext through `HttpContext.Current`, allowing values to be stored in `HttpContext.Items` hashtable and shared across IIS events. The `HttpContextCurrentExecutionSegmentsContainer` uses both `AsyncLocal<T>` and `HttpContext.Items` to get/set the current transaction and span, allowing them to be available in both IIS events and async contexts. `AsyncLocal<T>` is still needed for places where `HttpContext.Current` is null, for example, DiagnosticSourceListeners running on a separate thread in an async flow; in such cases `HttpContext.Current`, which is set/get on `CallContext.HostContext`, is not propagated over async
flows.

It seems it _may_ be possible for the current transaction and current span instances stored in `AsyncLocal<T>` and `HttpContext.Items` to be different in such scenarios where one is available but not the other on beginning
the transaction/span, and where availability is reversed on end. Unsure how likely this is in practice however, and using both `AsyncLocal<T>` and `HttpContext.Items` is the common approach in resolving this issue in < .NET 4.7.1.

For .NET 4.7.1, a new `OnExecuteRequestStep` method has been added to `HttpApplication`, to allow the execution context to be restored/saved:

https://devblogs.microsoft.com/dotnet/net-framework-4-7-1-asp-net-and-configuration-features/#asp-net-execution-step-feature

Closes #934
Closes #972