### PR TITLE
Rename Timestamp

### DIFF
--- a/src/Elastic.Apm/Api/IMetricSet.cs
+++ b/src/Elastic.Apm/Api/IMetricSet.cs
@@ -18,10 +18,9 @@ namespace Elastic.Apm.Api
 		[Required]
 		IEnumerable<MetricSample> Samples { get; set; }
 
-		// TODO: Rename to Timestamp for consistency?
 		/// <summary>
 		/// Number of milliseconds in unix time
 		/// </summary>
-		long TimeStamp { get; set; }
+		long Timestamp { get; set; }
 	}
 }

--- a/src/Elastic.Apm/Metrics/MetricSet.cs
+++ b/src/Elastic.Apm/Metrics/MetricSet.cs
@@ -12,14 +12,13 @@ namespace Elastic.Apm.Metrics
 	[JsonConverter(typeof(MetricSetConverter))]
 	internal class MetricSet : IMetricSet
 	{
-		public MetricSet(long timeStamp, IEnumerable<MetricSample> samples)
-			=> (TimeStamp, Samples) = (timeStamp, samples);
+		public MetricSet(long timestamp, IEnumerable<MetricSample> samples)
+			=> (Timestamp, Samples) = (timestamp, samples);
 
 		/// <inheritdoc />
 		public IEnumerable<MetricSample> Samples { get; set; }
 
 		/// <inheritdoc />
-		[JsonProperty("timestamp")]
-		public long TimeStamp { get; set; }
+		public long Timestamp { get; set; }
 	}
 }

--- a/src/Elastic.Apm/Report/Serialization/MetricSetConverter.cs
+++ b/src/Elastic.Apm/Report/Serialization/MetricSetConverter.cs
@@ -37,7 +37,7 @@ namespace Elastic.Apm.Report.Serialization
 
 			writer.WriteEndObject();
 			writer.WritePropertyName("timestamp");
-			writer.WriteValue(value.TimeStamp);
+			writer.WriteValue(value.Timestamp);
 			writer.WriteEndObject();
 		}
 

--- a/test/Elastic.Apm.Tests/SerializationTests.cs
+++ b/test/Elastic.Apm.Tests/SerializationTests.cs
@@ -404,7 +404,7 @@ namespace Elastic.Apm.Tests
 			json.Should().Be("{\"samples\":{\"sample_1\":{\"value\":1.0},\"sample__2\":{\"value\":2.0}},\"timestamp\":1603343944891}");
 
 			var deserialized = JsonConvert.DeserializeObject<Metrics.MetricSet>(json);
-			deserialized.TimeStamp.Should().Be(metricSet.TimeStamp);
+			deserialized.Timestamp.Should().Be(metricSet.Timestamp);
 			deserialized.Samples.Count().Should().Be(2);
 			var count = 0;
 			foreach (var sample in deserialized.Samples)


### PR DESCRIPTION
This commit renames Timestamp property
on MetricSet for consistency with casing
used.