### PR TITLE
Use Request.Unvalidated to extract request details

### DIFF
--- a/test/Elastic.Apm.AspNetFullFramework.Tests/Soap/Soap12Tests.cs
+++ b/test/Elastic.Apm.AspNetFullFramework.Tests/Soap/Soap12Tests.cs
@@ -186,7 +186,7 @@ namespace Elastic.Apm.Tests.Soap
 		public void Soap12Parser_ParsesHeaderAndBody(string soap, string expectedAction)
 		{
 			var requestStream = new MemoryStream(Encoding.UTF8.GetBytes(soap));
-			var action = HttpRequestExtensions.GetSoap12ActionInternal(requestStream);
+			var action = SoapRequest.GetSoap12ActionInternal(requestStream);
 
 			action.Should().Be(expectedAction);
 		}


### PR DESCRIPTION
This commit updates the ElasticApmModule to use
Request.Unvalidated to extract details about the
request.

Using properties such as Request.Path, Request.Url,
etc. directly can trigger ASP.NET's request validation
, if enabled (recommended):

https://docs.microsoft.com/en-us/previous-versions/hh882339(v=vs.100)