### PR TITLE
Capture body with large file does not error

### DIFF
--- a/sample/SampleAspNetCoreApp/Controllers/HomeController.cs
+++ b/sample/SampleAspNetCoreApp/Controllers/HomeController.cs
@@ -164,6 +164,11 @@ namespace SampleAspNetCoreApp.Controllers
 		//Used as test for optional route parameters
 		public IActionResult Sample(int id) => Ok(id);
 
+		[HttpPost]
+		[DisableRequestSizeLimit]
+		[RequestFormLimits(ValueLengthLimit = int.MaxValue, MultipartBodyLengthLimit = int.MaxValue)]
+		public long File(IFormFile file) => file.Length;
+
 		public IActionResult TransactionWithCustomName()
 		{
 			if (Agent.Tracer.CurrentTransaction != null) Agent.Tracer.CurrentTransaction.Name = "custom";


### PR DESCRIPTION
This commit adds a test to assert that the agent does not error whilst capturing the body when a large file is uploaded.

Closes #960