### PR TITLE
Add ITransaction.SetService to overwrite service name and version

### DIFF
--- a/docs/public-api.asciidoc
+++ b/docs/public-api.asciidoc
@@ -415,14 +415,14 @@ Agent.Tracer.CaptureTransaction(transactionName, transactionType, (transaction) 
 [[api-transaction-set-service]]
 ==== `void SetService(string serviceName, string serviceVersion)` (added[1.7])
 
-With this method you can overwrite the service name and version on a per transaction basis. If this is not set, the transaction will be associated with the default service.
+Overwrite the service name and version on a per transaction basis. This is useful when you host multiple services in a single process.
 
-This method is useful when you host multiple services in a single process.
+When not set, transactions are associated with the default service.
 
-The method has 2 `string` parameters:
+This method has two `string` parameters:
 
-* `serviceName`: The name of the service which the transaction will be associated with.
-* `serviceVersion`: The version of the service which the transaction will be associated with.
+* `serviceName`: The name of the service to associate with the transaction.
+* `serviceVersion`: The version of the service to associate with the transaction.
 
 Usage:
 

--- a/docs/public-api.asciidoc
+++ b/docs/public-api.asciidoc
@@ -412,6 +412,39 @@ Agent.Tracer.CaptureTransaction(transactionName, transactionType, (transaction) 
 ----
 
 [float]
+[[api-transaction-set-service]]
+==== `void SetService(string serviceName, string serviceVersion)` (added[1.7])
+
+With this method you can overwrite the service name and version on a per transaction basis. If this is not set, the transaction will be associated with the default service.
+
+This method is useful when you host multiple services in a single process.
+
+The method has 2 `string` parameters:
+
+* `serviceName`: The name of the service which the transaction will be associated with.
+* `serviceVersion`: The version of the service which the transaction will be associated with.
+
+Usage:
+
+[source,csharp]
+----
+var transaction = agent.Tracer.StartTransaction("Transaction1", "sample");
+transaction.SetService("MyServiceName", "1.0-beta1");
+----
+
+It can also be used with the <<filter-api>>:
+
+[source,csharp]
+----
+Agent.AddFilter( transaction =>
+{
+	transaction.SetService("MyServiceName", "1.0-beta1");
+	return transaction;
+});
+----
+
+
+[float]
 [[api-transaction-context]]
 ==== `Context`
 You can attach additional context to manually captured transactions.

--- a/src/Elastic.Apm/Api/Context.cs
+++ b/src/Elastic.Apm/Api/Context.cs
@@ -41,6 +41,13 @@ namespace Elastic.Apm.Api
 		/// </summary>
 		public Response Response { get; set; }
 
+		/// <summary>
+		/// Service related information can be sent per event. Provided information will override the more generic information from
+		/// metadata, non provided fields will be set according to the metadata information.
+		/// </summary>
+		[JsonProperty("service")]
+		internal Service Service { get; set; }
+
 		public User User { get; set; }
 
 		/// <summary>

--- a/src/Elastic.Apm/Api/ITransaction.cs
+++ b/src/Elastic.Apm/Api/ITransaction.cs
@@ -4,12 +4,12 @@
 
 using System.Collections.Generic;
 using Elastic.Apm.Api.Constraints;
-using Elastic.Apm.Model;
 
 namespace Elastic.Apm.Api
 {
 	/// <summary>
-	/// A transaction describes an event captured by the APM agent instrumentation. They are a special kind of Span that have additional
+	/// A transaction describes an event captured by the APM agent instrumentation. They are a special kind of Span that have
+	/// additional
 	/// attributes associated with them.
 	/// </summary>
 	/// <remarks>
@@ -42,17 +42,17 @@ namespace Elastic.Apm.Api
 		string Result { get; set; }
 
 		/// <summary>
+		/// The total number of correlated spans, including started and dropped
+		/// </summary>
+		[Required]
+		SpanCount SpanCount { get; }
+
+		/// <summary>
 		/// The type of the transaction.
 		/// Example: 'request'
 		/// </summary>
 		[Required]
 		string Type { get; set; }
-
-		/// <summary>
-		/// The total number of correlated spans, including started and dropped
-		/// </summary>
-		[Required]
-		SpanCount SpanCount { get; }
 
 		/// <summary>
 		/// If the transaction does not have a ParentId yet, calling this method generates a new ID, sets it as the ParentId of
@@ -67,5 +67,13 @@ namespace Elastic.Apm.Api
 		/// existing one.
 		/// </returns>
 		string EnsureParentId();
+
+		/// <summary>
+		/// With this method you can overwrite the service name and version on a per transaction basis.
+		/// If this is not set, the transaction will be associated with the default service.
+		/// </summary>
+		/// <param name="serviceName">The name of the service which the transaction will be associated with.</param>
+		/// <param name="serviceVersion">The version of the service which the transaction will be associated with.</param>
+		void SetService(string serviceName, string serviceVersion);
 	}
 }

--- a/src/Elastic.Apm/Api/Service.cs
+++ b/src/Elastic.Apm/Api/Service.cs
@@ -15,6 +15,8 @@ namespace Elastic.Apm.Api
 	{
 		private Service() { }
 
+		internal Service(string name, string version) => (Name, Version) = (name, version);
+
 		public AgentC Agent { get; set; }
 
 		[MaxLength]

--- a/src/Elastic.Apm/Model/Transaction.cs
+++ b/src/Elastic.Apm/Model/Transaction.cs
@@ -289,6 +289,18 @@ namespace Elastic.Apm.Model
 		[MaxLength]
 		public string Type { get; set; }
 
+		///<inheritdoc/>
+		public void SetService(string serviceName, string serviceVersion)
+		{
+			if (Context.Service == null)
+				Context.Service = new Service(serviceName, serviceVersion);
+			else
+			{
+				Context.Service.Name = serviceName;
+				Context.Service.Version = serviceVersion;
+			}
+		}
+
 		public string EnsureParentId()
 		{
 			if (!string.IsNullOrEmpty(ParentId))


### PR DESCRIPTION
Solves #1001. 

Introduces an API to overwrite service info on a per transaction basis. Prior to this PR the agent auto detected the service name and the version for a given process (which is the name and version of the entry assembly - or the app pool name on ASP.NET Classic). This PR introduces a new API to overwrite the service name and version for a given transaction.

If the API is not used (in other words no custom service name/version is set) then the default service name will be used for the given transaction.

API:
```
ITransaction.SetService(string serviceName, string serviceVersion
```

Usage:
```
var transaction1 = agent.Tracer.StartTransaction("Transaction1", "test");
transaction1.SetService("Service1", "1.0-beta1");
```

Uses the Server intake API field defined [here](https://github.com/elastic/apm-server/blob/master/docs/spec/context.json#L62).
Technically we could expose the whole service, but at this point I don't really see any advantage doing so. Other fields would be things like `framework`, `runtime`, `langauge`, `agent` - I feel those are better be auto detected and exposing all would cause more confusion. If people wish to set those we could extend the API later.