### PR TITLE
Add Cloud Metadata

### DIFF
--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -639,7 +639,7 @@ This option supports the wildcard `*`, which matches zero or more characters. Ex
 
 Allows you to specify which cloud provider should be assumed for metadata collection. By default, the agent will attempt to detect the cloud provider and, if that fails, use trial and error to collect the metadata.
 
-Valid options are `"aws"`, `"gcp"`, and `"azure"`. If this config value is set to `"false"`, no cloud metadata will be collected.
+Valid options are `"aws"`, `"gcp"`, `"azure"`, and `"false"`. If this config value is set to `"false"`, no cloud metadata will be collected.
 
 [options="header"]
 |============

--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -633,6 +633,26 @@ This option supports the wildcard `*`, which matches zero or more characters. Ex
 | `ELASTIC_APM_DISABLE_METRICS` | `ElasticApm:DisableMetrics`
 |============
 
+[float]
+[[config-cloud-provider]]
+==== `CloudProvider` (added[1.7.0])
+
+Allows you to specify which cloud provider should be assumed for metadata collection. By default, the agent will attempt to detect the cloud provider and, if that fails, use trial and error to collect the metadata.
+
+Valid options are `"aws"`, `"gcp"`, and `"azure"`. If this config value is set to `"false"`, no cloud metadata will be collected.
+
+[options="header"]
+|============
+| Environment variable name      | IConfiguration or Web.config key
+| `ELASTIC_APM_CLOUD_PROVIDER`   | `ElasticApm:CloudProvider`
+|============
+
+[options="header"]
+|============
+| Default | Type
+| `null`  | String
+|============
+
 [[config-http]]
 === HTTP configuration options
 
@@ -915,6 +935,7 @@ you must instead set the `LogLevel` for the internal APM logger under the `Loggi
 | <<config-capture-body-content-types,`CaptureBodyContentTypes`>> | Yes | HTTP, Performance
 | <<config-capture-headers,`CaptureHeaders`>> | No | HTTP, Performance
 | <<config-central-config,`CentralConfig`>> | No | Core
+| <<config-cloud-provider,`CloudProvider`>> | No | Reporter
 | <<config-disable-metrics,`DisableMetrics`>> | No | Reporter
 | <<config-environment,`Environment`>> | No | Core
 | <<config-excluded-namespaces,`ExcludedNamespaces`>> | No | Stacktrace

--- a/sample/AspNetFullFrameworkSampleApp/Web.config
+++ b/sample/AspNetFullFrameworkSampleApp/Web.config
@@ -17,6 +17,7 @@
 		<add key="ClientValidationEnabled" value="true"/>
 		<add key="UnobtrusiveJavaScriptEnabled" value="true"/>
 		<add key="ElasticApm:MaxQueueEventCount" value="9128"/>
+		<add key="ElasticApm:CloudProvider" value="false"/>
 	</appSettings>
 	<system.web>
 		<compilation debug="true" targetFramework="4.6.1"/>

--- a/sample/GrpcServiceSample/appsettings.json
+++ b/sample/GrpcServiceSample/appsettings.json
@@ -11,5 +11,8 @@
     "EndpointDefaults": {
       "Protocols": "Http2"
     }
+  },
+  "ElasticApm": {
+    "CloudProvider": "false"
   }
 }

--- a/sample/SampleAspNetCoreApp/appsettings.json
+++ b/sample/SampleAspNetCoreApp/appsettings.json
@@ -10,6 +10,7 @@
     "ServerUrls": "http://localhost:8200",
     "TransactionSampleRate": 1.0,
     "CaptureBody": "all",
-    "CaptureBodyContentTypes": "application/x-www-form-urlencoded*, text/*, application/json*, application/xml*"
+    "CaptureBodyContentTypes": "application/x-www-form-urlencoded*, text/*, application/json*, application/xml*",
+    "CloudProvider": "false"
   }
 }

--- a/sample/WebApiSample/appsettings.json
+++ b/sample/WebApiSample/appsettings.json
@@ -9,6 +9,7 @@
   "ElasticApm": {
     "ServerUrls": "http://localhost:8200",
     "CaptureBody": "all",
-    "CaptureBodyContentTypes": "application/x-www-form-urlencoded*, text/*, application/json*, application/xml*"
+    "CaptureBodyContentTypes": "application/x-www-form-urlencoded*, text/*, application/json*, application/xml*",
+    "CloudProvider": "false"
   }
 }

--- a/src/Elastic.Apm/AgentComponents.cs
+++ b/src/Elastic.Apm/AgentComponents.cs
@@ -6,6 +6,7 @@ using System;
 using Elastic.Apm.Api;
 using Elastic.Apm.BackendComm;
 using Elastic.Apm.BackendComm.CentralConfig;
+using Elastic.Apm.Cloud;
 using Elastic.Apm.Config;
 using Elastic.Apm.Helpers;
 using Elastic.Apm.Logging;
@@ -40,7 +41,6 @@ namespace Elastic.Apm
 			var system = systemInfoHelper.ParseSystemInfo(ConfigurationReader.HostName);
 
 			ConfigStore = new ConfigStore(new ConfigSnapshotFromReader(ConfigurationReader, "local"), Logger);
-
 			PayloadSender = payloadSender ?? new PayloadSenderV2(Logger, ConfigStore.CurrentSnapshot, Service, system);
 
 			MetricsCollector = metricsCollector ?? new MetricsCollector(Logger, PayloadSender, ConfigurationReader);

--- a/src/Elastic.Apm/Api/Cloud.cs
+++ b/src/Elastic.Apm/Api/Cloud.cs
@@ -1,0 +1,98 @@
+// Licensed to Elasticsearch B.V under
+// one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using Elastic.Apm.Api.Constraints;
+using Newtonsoft.Json;
+
+namespace Elastic.Apm.Api
+{
+	/// <summary>
+	/// Fields related to the cloud or infrastructure the events are coming from.
+	/// </summary>
+	// TODO: Add Spec attribute once https://github.com/elastic/apm-agent-dotnet/pull/984 is merged.
+	public class Cloud
+	{
+		public CloudAccount Account { get; set; }
+
+		public CloudInstance Instance { get; set; }
+
+		[MaxLength]
+		[JsonProperty("availability_zone")]
+		public string AvailabilityZone { get; set; }
+
+		public CloudMachine Machine { get; set; }
+
+		/// <summary>
+		/// The cloud provider, for example, aws, gcp, azure.
+		/// </summary>
+		[MaxLength]
+		[Required]
+		public string Provider { get; set; }
+
+		[MaxLength]
+		public string Region { get; set; }
+		public CloudProject Project { get; set; }
+	}
+
+	public class CloudProject
+	{
+		/// <summary>
+		/// Cloud project name
+		/// </summary>
+		[MaxLength]
+		public string Name { get; set; }
+
+		/// <summary>
+		/// Cloud project id
+		/// </summary>
+		[MaxLength]
+		public string Id { get; set; }
+	}
+
+	/// <summary>
+	/// An instance in a cloud provider
+	/// </summary>
+	public class CloudInstance
+	{
+		/// <summary>
+		/// Instance ID of the host machine.
+		/// </summary>
+		[MaxLength]
+		public string Id { get; set; }
+
+		/// <summary>
+		/// Instance name of the host machine.
+		/// </summary>
+		[MaxLength]
+		public string Name { get; set; }
+	}
+
+	public class CloudAccount
+	{
+		/// <summary>
+		/// The cloud account or organization id used to identify different entities in a multi-tenant environment.
+		/// <para/>
+		/// <para/>
+		/// Examples: AWS account id, Google Cloud ORG Id, or other unique identifier.
+		/// </summary>
+		[MaxLength]
+		public string Id { get; set; }
+
+		/// <summary>
+		/// The cloud account name
+		/// </summary>
+		[MaxLength]
+		public string Name { get; set; }
+	}
+
+	public class CloudMachine
+	{
+		/// <summary>
+		/// Machine type of the host machine.
+		/// </summary>
+		[MaxLength]
+		public string Type { get; set; }
+	}
+}

--- a/src/Elastic.Apm/BackendComm/CentralConfig/CentralConfigFetcher.cs
+++ b/src/Elastic.Apm/BackendComm/CentralConfig/CentralConfigFetcher.cs
@@ -240,6 +240,8 @@ namespace Elastic.Apm.BackendComm.CentralConfig
 			public bool CaptureHeaders => _centralConfig.CaptureHeaders ?? _wrapped.CaptureHeaders;
 			public bool CentralConfig => _wrapped.CentralConfig;
 
+			public string CloudProvider => _wrapped.CloudProvider;
+
 			public string DbgDescription { get; }
 
 			public IReadOnlyList<WildcardMatcher> DisableMetrics => _wrapped.DisableMetrics;

--- a/src/Elastic.Apm/Cloud/AwsCloudMetadataProvider.cs
+++ b/src/Elastic.Apm/Cloud/AwsCloudMetadataProvider.cs
@@ -1,0 +1,92 @@
+// Licensed to Elasticsearch B.V under
+// one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System;
+using System.IO;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Elastic.Apm.Api;
+using Elastic.Apm.Logging;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace Elastic.Apm.Cloud
+{
+	/// <summary>
+	/// Provides cloud metadata for Amazon Web Services (AWS)
+	/// </summary>
+	internal class AwsCloudMetadataProvider : ICloudMetadataProvider
+	{
+		internal const string TokenUri = "http://169.254.169.254/latest/api/token";
+		internal const string MetadataUri = "http://169.254.169.254/latest/dynamic/instance-identity/document";
+		internal const string Name = "aws";
+
+		private readonly HttpMessageHandler _handler;
+		private readonly IApmLogger _logger;
+
+		public AwsCloudMetadataProvider(IApmLogger logger) : this(new HttpClientHandler(), logger)
+		{
+		}
+
+		internal AwsCloudMetadataProvider(HttpMessageHandler handler, IApmLogger logger)
+		{
+			_handler = handler;
+			_logger = logger.Scoped(nameof(AwsCloudMetadataProvider));
+		}
+
+		/// <inheritdoc />
+		public string Provider { get; } = Name;
+
+		/// <inheritdoc />
+		public async Task<Api.Cloud> GetMetadataAsync()
+		{
+			var client = new HttpClient(_handler, false);
+			try
+			{
+				string awsToken;
+				using (var requestMessage = new HttpRequestMessage(HttpMethod.Put, TokenUri))
+				{
+					requestMessage.Headers.Add("X-aws-ec2-metadata-token-ttl-seconds", "300");
+					using var tokenSource = new CancellationTokenSource(TimeSpan.FromSeconds(3));
+					var responseMessage = await client.SendAsync(requestMessage, tokenSource.Token).ConfigureAwait(false);
+					awsToken = await responseMessage.Content.ReadAsStringAsync().ConfigureAwait(false);
+				}
+
+				JObject metadata;
+				using (var requestMessage = new HttpRequestMessage(HttpMethod.Put, MetadataUri))
+				{
+					requestMessage.Headers.Add("X-aws-ec2-metadata-token", awsToken);
+					using var tokenSource = new CancellationTokenSource(TimeSpan.FromSeconds(3));
+					var responseMessage = await client.SendAsync(requestMessage, tokenSource.Token).ConfigureAwait(false);
+
+					using var stream = await responseMessage.Content.ReadAsStreamAsync().ConfigureAwait(false);
+					using var streamReader = new StreamReader(stream, Encoding.UTF8);
+					using var jsonReader = new JsonTextReader(streamReader);
+
+					var serializer = new JsonSerializer();
+					metadata = serializer.Deserialize<JObject>(jsonReader);
+				}
+
+				return new Api.Cloud
+				{
+					Account = new CloudAccount { Id = metadata["accountId"].Value<string>() },
+					Instance = new CloudInstance { Id = metadata["instanceId"].Value<string>() },
+					AvailabilityZone = metadata["availabilityZone"].Value<string>(),
+					Machine = new CloudMachine { Type = metadata["instanceType"].Value<string>() },
+					Provider = Provider,
+					Region = metadata["region"].Value<string>()
+				};
+
+			}
+			catch (Exception e)
+			{
+				_logger.Warning()?.LogException(e, "Unable to get {Provider} cloud metadata", Provider);
+				return null;
+			}
+		}
+	}
+}

--- a/src/Elastic.Apm/Cloud/AzureCloudMetadataProvider.cs
+++ b/src/Elastic.Apm/Cloud/AzureCloudMetadataProvider.cs
@@ -1,0 +1,82 @@
+// Licensed to Elasticsearch B.V under
+// one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System;
+using System.IO;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Elastic.Apm.Api;
+using Elastic.Apm.Logging;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace Elastic.Apm.Cloud
+{
+	/// <summary>
+	/// Provides cloud metadata for Microsoft Azure VM
+	/// </summary>
+	internal class AzureCloudMetadataProvider : ICloudMetadataProvider
+	{
+		internal const string MetadataUri = "http://169.254.169.254/metadata/instance/compute?api-version=2019-08-15";
+		internal const string Name = "azure";
+
+		private readonly HttpMessageHandler _handler;
+		private readonly IApmLogger _logger;
+
+		internal AzureCloudMetadataProvider(HttpMessageHandler handler, IApmLogger logger)
+		{
+			_handler = handler;
+			_logger = logger.Scoped(nameof(AzureCloudMetadataProvider));
+		}
+
+		public AzureCloudMetadataProvider(IApmLogger logger) : this(new HttpClientHandler(), logger)
+		{
+		}
+
+		/// <inheritdoc />
+		public string Provider { get; } = Name;
+
+		/// <inheritdoc />
+		public async Task<Api.Cloud> GetMetadataAsync()
+		{
+			var client = new HttpClient(_handler, false);
+			try
+			{
+				JObject metadata;
+				using (var requestMessage = new HttpRequestMessage(HttpMethod.Get, MetadataUri))
+				{
+					requestMessage.Headers.Add("Metadata", "true");
+					using var tokenSource = new CancellationTokenSource(TimeSpan.FromSeconds(3));
+					var responseMessage = await client.SendAsync(requestMessage, tokenSource.Token).ConfigureAwait(false);
+
+					using var stream = await responseMessage.Content.ReadAsStreamAsync().ConfigureAwait(false);
+					using var streamReader = new StreamReader(stream, Encoding.UTF8);
+					using var jsonReader = new JsonTextReader(streamReader);
+
+					var serializer = new JsonSerializer();
+					metadata = serializer.Deserialize<JObject>(jsonReader);
+				}
+
+				return new Api.Cloud
+				{
+					Account = new CloudAccount { Id = metadata["subscriptionId"].Value<string>() },
+					Instance = new CloudInstance { Id = metadata["vmId"].Value<string>(), Name = metadata["name"].Value<string>() },
+					Project = new CloudProject { Name = metadata["resourceGroupName"].Value<string>() },
+					AvailabilityZone = metadata["zone"].Value<string>(),
+					Machine = new CloudMachine { Type = metadata["vmSize"].Value<string>() },
+					Provider = Provider,
+					Region = metadata["location"].Value<string>()
+				};
+			}
+			catch (Exception e)
+			{
+				_logger.Warning()?.LogException(e, "Unable to get {Provider} cloud metadata", Provider);
+				return null;
+			}
+		}
+	}
+}

--- a/src/Elastic.Apm/Cloud/CloudMetadataProviderCollection.cs
+++ b/src/Elastic.Apm/Cloud/CloudMetadataProviderCollection.cs
@@ -1,0 +1,68 @@
+// Licensed to Elasticsearch B.V under
+// one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System;
+using System.Collections.ObjectModel;
+using System.Threading.Tasks;
+using Elastic.Apm.Logging;
+using static Elastic.Apm.Config.ConfigConsts;
+
+namespace Elastic.Apm.Cloud
+{
+	/// <summary>
+	/// A collection of <see cref="ICloudMetadataProvider"/> that provide metadata for cloud platforms
+	/// </summary>
+	public class CloudMetadataProviderCollection : KeyedCollection<string, ICloudMetadataProvider>
+	{
+		protected override string GetKeyForItem(ICloudMetadataProvider item) => item.Provider;
+
+		public CloudMetadataProviderCollection(string cloudProvider, IApmLogger logger)
+		{
+			switch (cloudProvider?.ToLowerInvariant())
+			{
+				case AwsCloudMetadataProvider.Name:
+					Add(new AwsCloudMetadataProvider(logger));
+					break;
+				case GcpCloudMetadataProvider.Name:
+					Add(new GcpCloudMetadataProvider(logger));
+					break;
+				case AzureCloudMetadataProvider.Name:
+					Add(new AzureCloudMetadataProvider(logger));
+					break;
+				case SupportedValues.CloudProviderFalse:
+					break;
+				case "":
+				case null:
+					// keyed collection is ordered
+					Add(new AwsCloudMetadataProvider(logger));
+					Add(new GcpCloudMetadataProvider(logger));
+					Add(new AzureCloudMetadataProvider(logger));
+					break;
+				default:
+					throw new ArgumentException($"Unknown cloud provider {cloudProvider}", nameof(cloudProvider));
+			}
+		}
+
+		/// <summary>
+		/// Retrieves the cloud metadata for the given provider(s)
+		/// </summary>
+		/// <returns></returns>
+		public async Task<Api.Cloud> GetMetadataAsync()
+		{
+			foreach (var provider in this)
+			{
+				var cloud = await provider.GetMetadataAsync().ConfigureAwait(false);
+				if (cloud != null)
+					return cloud;
+			}
+
+			return null;
+		}
+
+		public bool TryGetValue(string key, out ICloudMetadataProvider provider) => Dictionary.TryGetValue(key, out provider);
+
+		public override string ToString() => string.Join(",", Dictionary.Keys);
+	}
+}

--- a/src/Elastic.Apm/Cloud/CloudMetadataProviderCollection.cs
+++ b/src/Elastic.Apm/Cloud/CloudMetadataProviderCollection.cs
@@ -22,13 +22,13 @@ namespace Elastic.Apm.Cloud
 		{
 			switch (cloudProvider?.ToLowerInvariant())
 			{
-				case AwsCloudMetadataProvider.Name:
+				case SupportedValues.CloudProviderAws:
 					Add(new AwsCloudMetadataProvider(logger));
 					break;
-				case GcpCloudMetadataProvider.Name:
+				case SupportedValues.CloudProviderGcp:
 					Add(new GcpCloudMetadataProvider(logger));
 					break;
-				case AzureCloudMetadataProvider.Name:
+				case SupportedValues.CloudProviderAzure:
 					Add(new AzureCloudMetadataProvider(logger));
 					break;
 				case SupportedValues.CloudProviderFalse:

--- a/src/Elastic.Apm/Cloud/GcpCloudMetadataProvider.cs
+++ b/src/Elastic.Apm/Cloud/GcpCloudMetadataProvider.cs
@@ -1,0 +1,98 @@
+// Licensed to Elasticsearch B.V under
+// one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System;
+using System.Globalization;
+using System.IO;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Elastic.Apm.Api;
+using Elastic.Apm.Logging;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace Elastic.Apm.Cloud
+{
+	/// <summary>
+	/// Provides cloud metadata for Google Cloud Platform (GCP)
+	/// </summary>
+	internal class GcpCloudMetadataProvider : ICloudMetadataProvider
+	{
+		internal const string MetadataUri = "http://metadata.google.internal/computeMetadata/v1/?recursive=true";
+		internal const string Name = "gcp";
+
+		private readonly HttpMessageHandler _handler;
+		private readonly IApmLogger _logger;
+
+		internal GcpCloudMetadataProvider(HttpMessageHandler handler, IApmLogger logger)
+		{
+			_handler = handler;
+			_logger = logger.Scoped(nameof(GcpCloudMetadataProvider));
+		}
+
+		public GcpCloudMetadataProvider(IApmLogger logger) : this(new HttpClientHandler(), logger)
+		{
+		}
+
+		/// <inheritdoc />
+		public string Provider { get; } = Name;
+
+		/// <inheritdoc />
+		public async Task<Api.Cloud> GetMetadataAsync()
+		{
+			var client = new HttpClient(_handler, false);
+			try
+			{
+				JObject metadata;
+				using (var requestMessage = new HttpRequestMessage(HttpMethod.Get, MetadataUri))
+				{
+					requestMessage.Headers.Add("Metadata-Flavor", "Google");
+					using var tokenSource = new CancellationTokenSource(TimeSpan.FromSeconds(3));
+					var responseMessage = await client.SendAsync(requestMessage, tokenSource.Token).ConfigureAwait(false);
+
+					using var stream = await responseMessage.Content.ReadAsStreamAsync().ConfigureAwait(false);
+					using var streamReader = new StreamReader(stream, Encoding.UTF8);
+					using var jsonReader = new JsonTextReader(streamReader);
+
+					var serializer = new JsonSerializer();
+					metadata = serializer.Deserialize<JObject>(jsonReader);
+				}
+
+				var availabilityZone = Path.GetFileName(metadata["instance"]["zone"].Value<string>());
+
+				var lastHyphen = availabilityZone.LastIndexOf('-');
+				var region = lastHyphen > -1
+					? availabilityZone.Substring(0, lastHyphen)
+					: availabilityZone;
+
+				return new Api.Cloud
+				{
+					Instance =
+						new CloudInstance
+						{
+							Id = metadata["instance"]["id"].Value<long>().ToString(CultureInfo.InvariantCulture),
+							Name = metadata["instance"]["name"].Value<string>()
+						},
+					Project = new CloudProject
+					{
+						Id = metadata["project"]["numericProjectId"].Value<long>().ToString(CultureInfo.InvariantCulture),
+						Name = metadata["project"]["projectId"].Value<string>()
+					},
+					AvailabilityZone = availabilityZone,
+					Machine = new CloudMachine { Type = metadata["instance"]["machineType"].Value<string>() },
+					Provider = Provider,
+					Region = region
+				};
+			}
+			catch (Exception e)
+			{
+				_logger.Warning()?.LogException(e, "Unable to get {Provider} cloud metadata", Provider);
+				return null;
+			}
+		}
+	}
+}

--- a/src/Elastic.Apm/Cloud/ICloudMetadataProvider.cs
+++ b/src/Elastic.Apm/Cloud/ICloudMetadataProvider.cs
@@ -1,0 +1,26 @@
+// Licensed to Elasticsearch B.V under
+// one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System.Threading.Tasks;
+
+namespace Elastic.Apm.Cloud
+{
+	/// <summary>
+	/// Provides metadata for a cloud provider
+	/// </summary>
+	public interface ICloudMetadataProvider
+	{
+		/// <summary>
+		/// The name of the cloud provider
+		/// </summary>
+		string Provider { get; }
+
+		/// <summary>
+		/// Retrieves the cloud metadata for the provider
+		/// </summary>
+		/// <returns></returns>
+		Task<Api.Cloud> GetMetadataAsync();
+	}
+}

--- a/src/Elastic.Apm/Config/AbstractConfigurationReader.cs
+++ b/src/Elastic.Apm/Config/AbstractConfigurationReader.cs
@@ -752,6 +752,25 @@ namespace Elastic.Apm.Config
 
 		protected bool ParseCentralConfig(ConfigurationKeyValue kv) => ParseBoolOption(kv, DefaultValues.CentralConfig, "CentralConfig");
 
+		protected string ParseCloudProvider(ConfigurationKeyValue kv)
+		{
+			var cloudProvider = kv.Value;
+			if (string.IsNullOrEmpty(cloudProvider))
+				return DefaultValues.CloudProvider;
+
+			if (!SupportedValues.CloudProviders.Contains(cloudProvider))
+			{
+				_logger?.Error()
+					?.Log("The CloudProvider value '{CloudProvider}' is not supported. " +
+						"Falling back to {DefaultValue}. Supported values are: {SupportedValues} or leave empty",
+						cloudProvider, DefaultValues.CloudProvider, string.Join(", ", SupportedValues.CloudProviders));
+
+				return DefaultValues.CloudProvider;
+			}
+
+			return cloudProvider.ToLowerInvariant();
+		}
+
 		private bool ParseBoolOption(ConfigurationKeyValue kv, bool defaultValue, string dbgOptionName)
 		{
 			if (kv == null || string.IsNullOrWhiteSpace(kv.Value))

--- a/src/Elastic.Apm/Config/AbstractConfigurationWithEnvFallbackReader.cs
+++ b/src/Elastic.Apm/Config/AbstractConfigurationWithEnvFallbackReader.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using Elastic.Apm.Helpers;
 using Elastic.Apm.Logging;
+using static Elastic.Apm.Config.ConfigConsts;
 
 namespace Elastic.Apm.Config
 {
@@ -23,88 +24,90 @@ namespace Elastic.Apm.Config
 			_defaultEnvironmentName = defaultEnvironmentName;
 
 			_stackTraceLimit =
-				new Lazy<int>(() => ParseStackTraceLimit(Read(ConfigConsts.KeyNames.StackTraceLimit, ConfigConsts.EnvVarNames.StackTraceLimit)));
+				new Lazy<int>(() => ParseStackTraceLimit(Read(KeyNames.StackTraceLimit, EnvVarNames.StackTraceLimit)));
 
 			_spanFramesMinDurationInMilliseconds = new Lazy<double>(() =>
-				ParseSpanFramesMinDurationInMilliseconds(Read(ConfigConsts.KeyNames.SpanFramesMinDuration,
-					ConfigConsts.EnvVarNames.SpanFramesMinDuration)));
+				ParseSpanFramesMinDurationInMilliseconds(Read(KeyNames.SpanFramesMinDuration,
+					EnvVarNames.SpanFramesMinDuration)));
 		}
 
 		protected abstract ConfigurationKeyValue Read(string key, string fallBackEnvVarName);
 
-		public virtual string CaptureBody => ParseCaptureBody(Read(ConfigConsts.KeyNames.CaptureBody, ConfigConsts.EnvVarNames.CaptureBody));
+		public virtual string CaptureBody => ParseCaptureBody(Read(KeyNames.CaptureBody, EnvVarNames.CaptureBody));
 
 		public virtual List<string> CaptureBodyContentTypes =>
-			ParseCaptureBodyContentTypes(Read(ConfigConsts.KeyNames.CaptureBodyContentTypes, ConfigConsts.EnvVarNames.CaptureBodyContentTypes));
+			ParseCaptureBodyContentTypes(Read(KeyNames.CaptureBodyContentTypes, EnvVarNames.CaptureBodyContentTypes));
 
 		public virtual bool CaptureHeaders =>
-			ParseCaptureHeaders(Read(ConfigConsts.KeyNames.CaptureHeaders, ConfigConsts.EnvVarNames.CaptureHeaders));
+			ParseCaptureHeaders(Read(KeyNames.CaptureHeaders, EnvVarNames.CaptureHeaders));
 
-		public bool CentralConfig => ParseCentralConfig(Read(ConfigConsts.KeyNames.CentralConfig, ConfigConsts.EnvVarNames.CentralConfig));
+		public bool CentralConfig => ParseCentralConfig(Read(KeyNames.CentralConfig, EnvVarNames.CentralConfig));
+
+		public virtual string CloudProvider => ParseCloudProvider(Read(KeyNames.CloudProvider, EnvVarNames.CloudProvider));
 
 		public IReadOnlyList<WildcardMatcher> DisableMetrics =>
-			ParseDisableMetrics(Read(ConfigConsts.KeyNames.DisableMetrics, ConfigConsts.EnvVarNames.DisableMetrics));
+			ParseDisableMetrics(Read(KeyNames.DisableMetrics, EnvVarNames.DisableMetrics));
 
-		public virtual string Environment => ParseEnvironment(Read(ConfigConsts.KeyNames.Environment, ConfigConsts.EnvVarNames.Environment))
+		public virtual string Environment => ParseEnvironment(Read(KeyNames.Environment, EnvVarNames.Environment))
 			?? _defaultEnvironmentName;
 
 		public virtual TimeSpan FlushInterval =>
-			ParseFlushInterval(Read(ConfigConsts.KeyNames.FlushInterval, ConfigConsts.EnvVarNames.FlushInterval));
+			ParseFlushInterval(Read(KeyNames.FlushInterval, EnvVarNames.FlushInterval));
 
 		public IReadOnlyDictionary<string, string> GlobalLabels =>
-			ParseGlobalLabels(Read(ConfigConsts.KeyNames.GlobalLabels, ConfigConsts.EnvVarNames.GlobalLabels));
+			ParseGlobalLabels(Read(KeyNames.GlobalLabels, EnvVarNames.GlobalLabels));
 
-		public virtual string HostName => ParseHostName(Read(ConfigConsts.KeyNames.HostName, ConfigConsts.EnvVarNames.HostName));
+		public virtual string HostName => ParseHostName(Read(KeyNames.HostName, EnvVarNames.HostName));
 
 		public IReadOnlyList<WildcardMatcher> TransactionIgnoreUrls =>
-			ParseTransactionIgnoreUrls(Read(ConfigConsts.KeyNames.TransactionIgnoreUrls, ConfigConsts.EnvVarNames.TransactionIgnoreUrls));
+			ParseTransactionIgnoreUrls(Read(KeyNames.TransactionIgnoreUrls, EnvVarNames.TransactionIgnoreUrls));
 
-		public virtual LogLevel LogLevel => ParseLogLevel(Read(ConfigConsts.KeyNames.LogLevel, ConfigConsts.EnvVarNames.LogLevel));
+		public virtual LogLevel LogLevel => ParseLogLevel(Read(KeyNames.LogLevel, EnvVarNames.LogLevel));
 
 		public virtual int MaxBatchEventCount =>
-			ParseMaxBatchEventCount(Read(ConfigConsts.KeyNames.MaxBatchEventCount, ConfigConsts.EnvVarNames.MaxBatchEventCount));
+			ParseMaxBatchEventCount(Read(KeyNames.MaxBatchEventCount, EnvVarNames.MaxBatchEventCount));
 
 		public virtual int MaxQueueEventCount =>
-			ParseMaxQueueEventCount(Read(ConfigConsts.KeyNames.MaxQueueEventCount, ConfigConsts.EnvVarNames.MaxQueueEventCount));
+			ParseMaxQueueEventCount(Read(KeyNames.MaxQueueEventCount, EnvVarNames.MaxQueueEventCount));
 
 		public virtual double MetricsIntervalInMilliseconds =>
-			ParseMetricsInterval(Read(ConfigConsts.KeyNames.MetricsInterval, ConfigConsts.EnvVarNames.MetricsInterval));
+			ParseMetricsInterval(Read(KeyNames.MetricsInterval, EnvVarNames.MetricsInterval));
 
 		public IReadOnlyList<WildcardMatcher> SanitizeFieldNames =>
-			ParseSanitizeFieldNames(Read(ConfigConsts.KeyNames.SanitizeFieldNames, ConfigConsts.EnvVarNames.SanitizeFieldNames));
+			ParseSanitizeFieldNames(Read(KeyNames.SanitizeFieldNames, EnvVarNames.SanitizeFieldNames));
 
-		public virtual string SecretToken => ParseSecretToken(Read(ConfigConsts.KeyNames.SecretToken, ConfigConsts.EnvVarNames.SecretToken));
-		public string ApiKey => ParseApiKey(Read(ConfigConsts.KeyNames.ApiKey, ConfigConsts.EnvVarNames.ApiKey));
+		public virtual string SecretToken => ParseSecretToken(Read(KeyNames.SecretToken, EnvVarNames.SecretToken));
+		public string ApiKey => ParseApiKey(Read(KeyNames.ApiKey, EnvVarNames.ApiKey));
 
-		public virtual IReadOnlyList<Uri> ServerUrls => ParseServerUrls(Read(ConfigConsts.KeyNames.ServerUrls, ConfigConsts.EnvVarNames.ServerUrls));
+		public virtual IReadOnlyList<Uri> ServerUrls => ParseServerUrls(Read(KeyNames.ServerUrls, EnvVarNames.ServerUrls));
 
-		public virtual string ServiceName => ParseServiceName(Read(ConfigConsts.KeyNames.ServiceName, ConfigConsts.EnvVarNames.ServiceName));
+		public virtual string ServiceName => ParseServiceName(Read(KeyNames.ServiceName, EnvVarNames.ServiceName));
 
-		public string ServiceNodeName => ParseServiceNodeName(Read(ConfigConsts.KeyNames.ServiceNodeName, ConfigConsts.EnvVarNames.ServiceNodeName));
+		public string ServiceNodeName => ParseServiceNodeName(Read(KeyNames.ServiceNodeName, EnvVarNames.ServiceNodeName));
 
 		public virtual string ServiceVersion =>
-			ParseServiceVersion(Read(ConfigConsts.KeyNames.ServiceVersion, ConfigConsts.EnvVarNames.ServiceVersion));
+			ParseServiceVersion(Read(KeyNames.ServiceVersion, EnvVarNames.ServiceVersion));
 
 		public virtual double SpanFramesMinDurationInMilliseconds => _spanFramesMinDurationInMilliseconds.Value;
 
 		public virtual int StackTraceLimit => _stackTraceLimit.Value;
 
 		public virtual int TransactionMaxSpans =>
-			ParseTransactionMaxSpans(Read(ConfigConsts.KeyNames.TransactionMaxSpans, ConfigConsts.EnvVarNames.TransactionMaxSpans));
+			ParseTransactionMaxSpans(Read(KeyNames.TransactionMaxSpans, EnvVarNames.TransactionMaxSpans));
 
 		public virtual double TransactionSampleRate =>
-			ParseTransactionSampleRate(Read(ConfigConsts.KeyNames.TransactionSampleRate, ConfigConsts.EnvVarNames.TransactionSampleRate));
+			ParseTransactionSampleRate(Read(KeyNames.TransactionSampleRate, EnvVarNames.TransactionSampleRate));
 
-		public bool UseElasticTraceparentHeader => ParseUseElasticTraceparentHeader(Read(ConfigConsts.KeyNames.UseElasticTraceparentHeader,
-			ConfigConsts.EnvVarNames.UseElasticTraceparentHeader));
+		public bool UseElasticTraceparentHeader => ParseUseElasticTraceparentHeader(Read(KeyNames.UseElasticTraceparentHeader,
+			EnvVarNames.UseElasticTraceparentHeader));
 
 		public virtual bool VerifyServerCert =>
-			ParseVerifyServerCert(Read(ConfigConsts.KeyNames.VerifyServerCert, ConfigConsts.EnvVarNames.VerifyServerCert));
+			ParseVerifyServerCert(Read(KeyNames.VerifyServerCert, EnvVarNames.VerifyServerCert));
 
 		public IReadOnlyCollection<string> ExcludedNamespaces =>
-			ParseExcludedNamespaces(Read(ConfigConsts.KeyNames.ExcludedNamespaces, ConfigConsts.EnvVarNames.ExcludedNamespaces));
+			ParseExcludedNamespaces(Read(KeyNames.ExcludedNamespaces, EnvVarNames.ExcludedNamespaces));
 
 		public IReadOnlyCollection<string> ApplicationNamespaces =>
-			ParseExcludedNamespaces(Read(ConfigConsts.KeyNames.ApplicationNamespaces, ConfigConsts.EnvVarNames.ApplicationNamespaces));
+			ParseExcludedNamespaces(Read(KeyNames.ApplicationNamespaces, EnvVarNames.ApplicationNamespaces));
 	}
 }

--- a/src/Elastic.Apm/Config/ConfigConsts.cs
+++ b/src/Elastic.Apm/Config/ConfigConsts.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Generic;
+using Elastic.Apm.Cloud;
 using Elastic.Apm.Helpers;
 
 namespace Elastic.Apm.Config
@@ -22,6 +23,7 @@ namespace Elastic.Apm.Config
 			public const string CaptureBodyContentTypes = "application/x-www-form-urlencoded*, text/*, application/json*, application/xml*";
 			public const bool CaptureHeaders = true;
 			public const bool CentralConfig = true;
+			public const string CloudProvider = "";
 			public const int FlushIntervalInMilliseconds = 10_000; // 10 seconds
 			public const int MaxBatchEventCount = 10;
 			public const int MaxQueueEventCount = 1000;
@@ -107,6 +109,7 @@ namespace Elastic.Apm.Config
 			public const string CaptureBodyContentTypes = Prefix + "CAPTURE_BODY_CONTENT_TYPES";
 			public const string CaptureHeaders = Prefix + "CAPTURE_HEADERS";
 			public const string CentralConfig = Prefix + "CENTRAL_CONFIG";
+			public const string CloudProvider = Prefix + "CLOUD_PROVIDER";
 			public const string DisableMetrics = Prefix + "DISABLE_METRICS";
 			public const string Environment = Prefix + "ENVIRONMENT";
 			public const string FlushInterval = Prefix + "FLUSH_INTERVAL";
@@ -144,6 +147,7 @@ namespace Elastic.Apm.Config
 			public const string CaptureBodyContentTypes = Prefix + nameof(CaptureBodyContentTypes);
 			public const string CaptureHeaders = Prefix + nameof(CaptureHeaders);
 			public const string CentralConfig = Prefix + nameof(CentralConfig);
+			public const string CloudProvider = Prefix + nameof(CloudProvider);
 			public const string DisableMetrics = Prefix + nameof(DisableMetrics);
 			public const string Environment = Prefix + nameof(Environment);
 			public const string FlushInterval = Prefix + nameof(FlushInterval);
@@ -182,6 +186,16 @@ namespace Elastic.Apm.Config
 
 			public static readonly List<string> CaptureBodySupportedValues =
 				new List<string> { CaptureBodyOff, CaptureBodyAll, CaptureBodyErrors, CaptureBodyTransactions };
+
+			public const string CloudProviderAws = AwsCloudMetadataProvider.Name;
+			public const string CloudProviderAzure = AzureCloudMetadataProvider.Name;
+			public const string CloudProviderGcp = GcpCloudMetadataProvider.Name;
+			public const string CloudProviderFalse = "false";
+
+			public static readonly HashSet<string> CloudProviders = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+			{
+				CloudProviderAws, CloudProviderAzure, CloudProviderGcp, CloudProviderFalse
+			};
 		}
 	}
 }

--- a/src/Elastic.Apm/Config/ConfigSnapshotFromReader.cs
+++ b/src/Elastic.Apm/Config/ConfigSnapshotFromReader.cs
@@ -23,6 +23,7 @@ namespace Elastic.Apm.Config
 		public List<string> CaptureBodyContentTypes => _content.CaptureBodyContentTypes;
 		public bool CaptureHeaders => _content.CaptureHeaders;
 		public bool CentralConfig => _content.CentralConfig;
+		public string CloudProvider => _content.CloudProvider;
 		public string DbgDescription { get; }
 		public IReadOnlyList<WildcardMatcher> DisableMetrics => _content.DisableMetrics;
 		public string Environment => _content.Environment;

--- a/src/Elastic.Apm/Config/EnvironmentConfigurationReader.cs
+++ b/src/Elastic.Apm/Config/EnvironmentConfigurationReader.cs
@@ -35,6 +35,8 @@ namespace Elastic.Apm.Config
 
 		public bool CentralConfig => ParseCentralConfig(Read(ConfigConsts.EnvVarNames.CentralConfig));
 
+		public string CloudProvider => ParseCloudProvider(Read(ConfigConsts.EnvVarNames.CloudProvider));
+
 		public string DbgDescription => Origin;
 		public IReadOnlyList<WildcardMatcher> DisableMetrics => ParseDisableMetrics(Read(ConfigConsts.EnvVarNames.DisableMetrics));
 

--- a/src/Elastic.Apm/Config/IConfigurationReader.cs
+++ b/src/Elastic.Apm/Config/IConfigurationReader.cs
@@ -26,6 +26,13 @@ namespace Elastic.Apm.Config
 		bool CentralConfig { get; }
 
 		/// <summary>
+		/// Specify which cloud provider should be assumed for metadata collection. By default, the agent will attempt to detect the cloud
+		/// provider or, if that fails, will use trial and error to collect the metadata. Valid options are "aws", "gcp", and "azure".
+		/// If this config value is set to "False", no cloud metadata will be collected.
+		/// </summary>
+		string CloudProvider { get; }
+
+		/// <summary>
 		/// Disables the collection of certain metrics. If the name of a metric matches any of the wildcard expressions, it will
 		/// not be collected
 		/// </summary>

--- a/test/Elastic.Apm.AspNetCore.Tests/AspNetCoreDiagnosticListenerTest.cs
+++ b/test/Elastic.Apm.AspNetCore.Tests/AspNetCoreDiagnosticListenerTest.cs
@@ -39,6 +39,7 @@ namespace Elastic.Apm.AspNetCore.Tests
 		{
 			using (var agent = new ApmAgent(new TestAgentComponents()))
 			{
+
 				var capturedPayload = agent.PayloadSender as MockPayloadSender;
 				var client = Helper.GetClient(agent, _factory, useOnlyDiagnosticSource);
 
@@ -53,20 +54,23 @@ namespace Elastic.Apm.AspNetCore.Tests
 
 				capturedPayload.Should().NotBeNull();
 
-				capturedPayload.Transactions.Should().ContainSingle();
+				if (capturedPayload != null)
+				{
+					capturedPayload.Transactions.Should().ContainSingle();
 
-				capturedPayload.Errors.Should().ContainSingle();
+					capturedPayload.Errors.Should().ContainSingle();
 
-				var errorException = capturedPayload.FirstError.Exception;
-				errorException.Message.Should().Be("This is a test exception!");
-				errorException.Type.Should().Be(typeof(Exception).FullName);
+					var errorException = capturedPayload.FirstError.Exception;
+					errorException.Message.Should().Be("This is a test exception!");
+					errorException.Type.Should().Be(typeof(Exception).FullName);
 
-				var context = capturedPayload.FirstError.Context;
-				context.Request.Url.Full.Should().Be("http://localhost/Home/TriggerError");
-				context.Request.Method.Should().Be(HttpMethod.Get.Method);
+					var context = capturedPayload.FirstError.Context;
+					context.Request.Url.Full.Should().Be("http://localhost/Home/TriggerError");
+					context.Request.Method.Should().Be(HttpMethod.Get.Method);
 
-				errorException.Should().NotBeNull();
-				errorException.Handled.Should().BeFalse();
+					errorException.Should().NotBeNull();
+					errorException.Handled.Should().BeFalse();
+				}
 			}
 		}
 

--- a/test/Elastic.Apm.Tests/Cloud/AwsCloudMetadataProviderTests.cs
+++ b/test/Elastic.Apm.Tests/Cloud/AwsCloudMetadataProviderTests.cs
@@ -44,7 +44,7 @@ namespace Elastic.Apm.Tests.Cloud
 			handler.When(AwsCloudMetadataProvider.MetadataUri)
 				.Respond("application/json", JsonConvert.SerializeObject(stubMetadata));
 
-			var provider = new AwsCloudMetadataProvider(handler, new NoopLogger());
+			var provider = new AwsCloudMetadataProvider(new NoopLogger(), handler);
 
 			var metadata = await provider.GetMetadataAsync();
 

--- a/test/Elastic.Apm.Tests/Cloud/AwsCloudMetadataProviderTests.cs
+++ b/test/Elastic.Apm.Tests/Cloud/AwsCloudMetadataProviderTests.cs
@@ -1,0 +1,64 @@
+// Licensed to Elasticsearch B.V under
+// one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System.Threading.Tasks;
+using Elastic.Apm.Cloud;
+using Elastic.Apm.Tests.Mocks;
+using FluentAssertions;
+using Newtonsoft.Json;
+using RichardSzalay.MockHttp;
+using Xunit;
+using MockHttpMessageHandler = RichardSzalay.MockHttp.MockHttpMessageHandler;
+
+namespace Elastic.Apm.Tests.Cloud
+{
+	public class AwsCloudMetadataProviderTests
+	{
+		[Fact]
+		public async Task GetMetadataAsync_Returns_Expected_Cloud_Metadata()
+		{
+			var stubMetadata = new
+			{
+				accountId = "946960629917",
+				architecture = "x86_64",
+				availabilityZone = "us-east-2a",
+				billingProducts = (string)null,
+				devpayProductCodes = (string)null,
+				marketplaceProductCodes = (string)null,
+				imageId = "ami-07c1207a9d40bc3bd",
+				instanceId = "i-0ae894a7c1c4f2a75",
+				instanceType = "t2.medium",
+				kernelId = (string)null,
+				pendingTime = "2020-06-12T17:46:09Z",
+				privateIp = "172.31.0.212",
+				ramdiskId = (string)null,
+				region = "us-east-2",
+				version = "2017-09-30"
+			};
+
+			var handler = new MockHttpMessageHandler();
+			handler.When(AwsCloudMetadataProvider.TokenUri)
+				.Respond("application/json", "aws-token");
+			handler.When(AwsCloudMetadataProvider.MetadataUri)
+				.Respond("application/json", JsonConvert.SerializeObject(stubMetadata));
+
+			var provider = new AwsCloudMetadataProvider(handler, new NoopLogger());
+
+			var metadata = await provider.GetMetadataAsync();
+
+			metadata.Should().NotBeNull();
+			metadata.Account.Should().NotBeNull();
+			metadata.Account.Id.Should().Be(stubMetadata.accountId);
+			metadata.Provider.Should().Be(provider.Provider);
+			metadata.Instance.Should().NotBeNull();
+			metadata.Instance.Id.Should().Be(stubMetadata.instanceId);
+			metadata.Project.Should().BeNull();
+			metadata.AvailabilityZone.Should().Be("us-east-2a");
+			metadata.Region.Should().Be(stubMetadata.region);
+			metadata.Machine.Should().NotBeNull();
+			metadata.Machine.Type.Should().Be(stubMetadata.instanceType);
+		}
+	}
+}

--- a/test/Elastic.Apm.Tests/Cloud/AzureCloudMetadataProviderTests.cs
+++ b/test/Elastic.Apm.Tests/Cloud/AzureCloudMetadataProviderTests.cs
@@ -1,0 +1,56 @@
+// Licensed to Elasticsearch B.V under
+// one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System.Threading.Tasks;
+using Elastic.Apm.Cloud;
+using Elastic.Apm.Tests.Mocks;
+using FluentAssertions;
+using Newtonsoft.Json;
+using RichardSzalay.MockHttp;
+using Xunit;
+using MockHttpMessageHandler = RichardSzalay.MockHttp.MockHttpMessageHandler;
+
+namespace Elastic.Apm.Tests.Cloud
+{
+	public class AzureCloudMetadataProviderTests
+	{
+		[Fact]
+		public async Task GetMetadataAsync_Returns_Expected_Cloud_Metadata()
+		{
+			var stubMetadata = new
+			{
+				location = "westus2",
+				name = "dotnet-agent-test",
+				resourceGroupName = "dotnet-agent-testing",
+				subscriptionId = "7657426d-c4c3-44ac-88a2-3b2cd59e6dba",
+				vmId = "e11ebedc-019d-427f-84dd-56cd4388d3a8",
+				vmScaleSetName = "",
+				vmSize = "Standard_D2s_v3",
+				zone = ""
+			};
+
+			var handler = new MockHttpMessageHandler();
+			handler.When(AzureCloudMetadataProvider.MetadataUri)
+				.Respond("application/json", JsonConvert.SerializeObject(stubMetadata));
+
+			var provider = new AzureCloudMetadataProvider(handler, new NoopLogger());
+
+			var metadata = await provider.GetMetadataAsync();
+
+			metadata.Should().NotBeNull();
+			metadata.Account.Should().NotBeNull();
+			metadata.Account.Id.Should().Be(stubMetadata.subscriptionId);
+			metadata.Provider.Should().Be(provider.Provider);
+			metadata.Instance.Should().NotBeNull();
+			metadata.Instance.Id.Should().Be(stubMetadata.vmId);
+			metadata.Instance.Name.Should().Be(stubMetadata.name);
+			metadata.Project.Should().NotBeNull();
+			metadata.Project.Name.Should().Be(stubMetadata.resourceGroupName);
+			metadata.Region.Should().Be(stubMetadata.location);
+			metadata.Machine.Should().NotBeNull();
+			metadata.Machine.Type.Should().Be(stubMetadata.vmSize);
+		}
+	}
+}

--- a/test/Elastic.Apm.Tests/Cloud/AzureCloudMetadataProviderTests.cs
+++ b/test/Elastic.Apm.Tests/Cloud/AzureCloudMetadataProviderTests.cs
@@ -26,16 +26,15 @@ namespace Elastic.Apm.Tests.Cloud
 				resourceGroupName = "dotnet-agent-testing",
 				subscriptionId = "7657426d-c4c3-44ac-88a2-3b2cd59e6dba",
 				vmId = "e11ebedc-019d-427f-84dd-56cd4388d3a8",
-				vmScaleSetName = "",
 				vmSize = "Standard_D2s_v3",
-				zone = ""
+				zone = "zone-1"
 			};
 
 			var handler = new MockHttpMessageHandler();
 			handler.When(AzureCloudMetadataProvider.MetadataUri)
 				.Respond("application/json", JsonConvert.SerializeObject(stubMetadata));
 
-			var provider = new AzureCloudMetadataProvider(handler, new NoopLogger());
+			var provider = new AzureCloudMetadataProvider(new NoopLogger(), handler);
 
 			var metadata = await provider.GetMetadataAsync();
 
@@ -51,6 +50,43 @@ namespace Elastic.Apm.Tests.Cloud
 			metadata.Region.Should().Be(stubMetadata.location);
 			metadata.Machine.Should().NotBeNull();
 			metadata.Machine.Type.Should().Be(stubMetadata.vmSize);
+			metadata.AvailabilityZone.Should().Be(stubMetadata.zone);
+		}
+
+		[Fact]
+		public async Task GetMetadataAsync_Returns_Expected_Cloud_Metadata_When_No_Zone()
+		{
+			var stubMetadata = new
+			{
+				location = "westus2",
+				name = "dotnet-agent-test",
+				resourceGroupName = "dotnet-agent-testing",
+				subscriptionId = "7657426d-c4c3-44ac-88a2-3b2cd59e6dba",
+				vmId = "e11ebedc-019d-427f-84dd-56cd4388d3a8",
+				vmSize = "Standard_D2s_v3"
+			};
+
+			var handler = new MockHttpMessageHandler();
+			handler.When(AzureCloudMetadataProvider.MetadataUri)
+				.Respond("application/json", JsonConvert.SerializeObject(stubMetadata));
+
+			var provider = new AzureCloudMetadataProvider(new NoopLogger(), handler);
+
+			var metadata = await provider.GetMetadataAsync();
+
+			metadata.Should().NotBeNull();
+			metadata.Account.Should().NotBeNull();
+			metadata.Account.Id.Should().Be(stubMetadata.subscriptionId);
+			metadata.Provider.Should().Be(provider.Provider);
+			metadata.Instance.Should().NotBeNull();
+			metadata.Instance.Id.Should().Be(stubMetadata.vmId);
+			metadata.Instance.Name.Should().Be(stubMetadata.name);
+			metadata.Project.Should().NotBeNull();
+			metadata.Project.Name.Should().Be(stubMetadata.resourceGroupName);
+			metadata.Region.Should().Be(stubMetadata.location);
+			metadata.Machine.Should().NotBeNull();
+			metadata.Machine.Type.Should().Be(stubMetadata.vmSize);
+			metadata.AvailabilityZone.Should().BeNull();
 		}
 	}
 }

--- a/test/Elastic.Apm.Tests/Cloud/CloudMetadataProviderCollectionTests.cs
+++ b/test/Elastic.Apm.Tests/Cloud/CloudMetadataProviderCollectionTests.cs
@@ -1,0 +1,63 @@
+// Licensed to Elasticsearch B.V under
+// one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System.Linq;
+using Elastic.Apm.Cloud;
+using Elastic.Apm.Tests.Mocks;
+using FluentAssertions;
+using Xunit;
+using static Elastic.Apm.Config.ConfigConsts;
+
+namespace Elastic.Apm.Tests.Cloud
+{
+	public class CloudMetadataProviderCollectionTests
+	{
+		[Fact]
+		public void DefaultCloudProvider_Registers_Aws_Gcp_Azure_Providers()
+		{
+			var providers = new CloudMetadataProviderCollection(DefaultValues.CloudProvider, new NoopLogger());
+
+			providers.Count.Should().Be(3);
+			providers.TryGetValue(AwsCloudMetadataProvider.Name, out _).Should().BeTrue();
+			providers.TryGetValue(GcpCloudMetadataProvider.Name, out _).Should().BeTrue();
+			providers.TryGetValue(AzureCloudMetadataProvider.Name, out _).Should().BeTrue();
+			providers.Select(p => p.Provider).Should().Equal("aws", "gcp", "azure");
+		}
+
+		[Fact]
+		public void CloudProvider_False_Should_Not_Register_Any_Providers()
+		{
+			var providers = new CloudMetadataProviderCollection(SupportedValues.CloudProviderFalse, new NoopLogger());
+			providers.Count.Should().Be(0);
+		}
+
+		[Fact]
+		public void CloudProvider_Aws_Should_Register_Aws_Provider()
+		{
+			var providers = new CloudMetadataProviderCollection(SupportedValues.CloudProviderAws, new NoopLogger());
+			providers.Count.Should().Be(1);
+			providers.TryGetValue(SupportedValues.CloudProviderAws, out var provider).Should().BeTrue();
+			provider.Should().BeOfType<AwsCloudMetadataProvider>();
+		}
+
+		[Fact]
+		public void CloudProvider_Gcp_Should_Register_Gcp_Provider()
+		{
+			var providers = new CloudMetadataProviderCollection(SupportedValues.CloudProviderGcp, new NoopLogger());
+			providers.Count.Should().Be(1);
+			providers.TryGetValue(SupportedValues.CloudProviderGcp, out var provider).Should().BeTrue();
+			provider.Should().BeOfType<GcpCloudMetadataProvider>();
+		}
+
+		[Fact]
+		public void CloudProvider_Azure_Should_Register_Azure_Provider()
+		{
+			var providers = new CloudMetadataProviderCollection(SupportedValues.CloudProviderAzure, new NoopLogger());
+			providers.Count.Should().Be(1);
+			providers.TryGetValue(SupportedValues.CloudProviderAzure, out var provider).Should().BeTrue();
+			provider.Should().BeOfType<AzureCloudMetadataProvider>();
+		}
+	}
+}

--- a/test/Elastic.Apm.Tests/Cloud/GcpCloudMetadataProviderTests.cs
+++ b/test/Elastic.Apm.Tests/Cloud/GcpCloudMetadataProviderTests.cs
@@ -35,7 +35,7 @@ namespace Elastic.Apm.Tests.Cloud
 			handler.When(GcpCloudMetadataProvider.MetadataUri)
 				.Respond("application/json", JsonConvert.SerializeObject(stubMetadata));
 
-			var provider = new GcpCloudMetadataProvider(handler, new NoopLogger());
+			var provider = new GcpCloudMetadataProvider(new NoopLogger(), handler);
 
 			var metadata = await provider.GetMetadataAsync();
 

--- a/test/Elastic.Apm.Tests/Cloud/GcpCloudMetadataProviderTests.cs
+++ b/test/Elastic.Apm.Tests/Cloud/GcpCloudMetadataProviderTests.cs
@@ -1,0 +1,56 @@
+// Licensed to Elasticsearch B.V under
+// one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System.Threading.Tasks;
+using Elastic.Apm.Cloud;
+using Elastic.Apm.Tests.Mocks;
+using FluentAssertions;
+using Newtonsoft.Json;
+using RichardSzalay.MockHttp;
+using Xunit;
+using MockHttpMessageHandler = RichardSzalay.MockHttp.MockHttpMessageHandler;
+
+namespace Elastic.Apm.Tests.Cloud
+{
+	public class GcpCloudMetadataProviderTests
+	{
+		[Fact]
+		public async Task GetMetadataAsync_Returns_Expected_Cloud_Metadata()
+		{
+			var stubMetadata = new
+			{
+				instance = new
+				{
+					id = 4306570268266786072,
+					machineType = "projects/513326162531/machineTypes/n1-standard-1",
+					name = "dotnet-agent-test",
+					zone = "projects/513326162531/zones/us-west3-a"
+				},
+				project = new { numericProjectId = 513326162531, projectId = "elastic-apm" }
+			};
+
+			var handler = new MockHttpMessageHandler();
+			handler.When(GcpCloudMetadataProvider.MetadataUri)
+				.Respond("application/json", JsonConvert.SerializeObject(stubMetadata));
+
+			var provider = new GcpCloudMetadataProvider(handler, new NoopLogger());
+
+			var metadata = await provider.GetMetadataAsync();
+
+			metadata.Should().NotBeNull();
+			metadata.Provider.Should().Be(provider.Provider);
+			metadata.Instance.Should().NotBeNull();
+			metadata.Instance.Id.Should().Be(stubMetadata.instance.id.ToString());
+			metadata.Instance.Name.Should().Be(stubMetadata.instance.name);
+			metadata.Project.Should().NotBeNull();
+			metadata.Project.Id.Should().Be(stubMetadata.project.numericProjectId.ToString());
+			metadata.Project.Name.Should().Be(stubMetadata.project.projectId);
+			metadata.AvailabilityZone.Should().Be("us-west3-a");
+			metadata.Region.Should().Be("us-west3");
+			metadata.Machine.Should().NotBeNull();
+			metadata.Machine.Type.Should().Be(stubMetadata.instance.machineType);
+		}
+	}
+}

--- a/test/Elastic.Apm.Tests/ConfigTests.cs
+++ b/test/Elastic.Apm.Tests/ConfigTests.cs
@@ -277,6 +277,31 @@ namespace Elastic.Apm.Tests
 		}
 
 		[Fact]
+		public void DefaultCloudProviderTest()
+		{
+			using var agent = new ApmAgent(new AgentComponents(new NoopLogger(), payloadSender: new MockPayloadSender()));
+			agent.ConfigurationReader.CloudProvider.Should().Be(DefaultValues.CloudProvider);
+		}
+
+		[Fact]
+		public void DefaultCloudProviderEnvironmentTest()
+		{
+			var reader = new EnvironmentConfigurationReader();
+			reader.CloudProvider.Should().Be(DefaultValues.CloudProvider);
+		}
+
+		[Fact]
+		public void SetCloudProviderTest()
+		{
+			foreach (var value in SupportedValues.CloudProviders)
+			{
+				Environment.SetEnvironmentVariable(EnvVarNames.CloudProvider, value);
+				var config = new EnvironmentConfigurationReader();
+				config.CloudProvider.Should().Be(value);
+			}
+		}
+
+		[Fact]
 		public void DefaultTransactionSampleRateTest()
 		{
 			using (var agent = new ApmAgent(new TestAgentComponents()))

--- a/test/Elastic.Apm.Tests/ConstructorTests.cs
+++ b/test/Elastic.Apm.Tests/ConstructorTests.cs
@@ -43,6 +43,7 @@ namespace Elastic.Apm.Tests
 			public List<string> CaptureBodyContentTypes { get; }
 			public bool CaptureHeaders => ConfigConsts.DefaultValues.CaptureHeaders;
 			public bool CentralConfig => ConfigConsts.DefaultValues.CentralConfig;
+			public string CloudProvider => ConfigConsts.DefaultValues.CloudProvider;
 			public string Environment { get; }
 			public string ServiceNodeName { get; }
 			public TimeSpan FlushInterval => TimeSpan.FromMilliseconds(ConfigConsts.DefaultValues.FlushIntervalInMilliseconds);

--- a/test/Elastic.Apm.Tests/Elastic.Apm.Tests.csproj
+++ b/test/Elastic.Apm.Tests/Elastic.Apm.Tests.csproj
@@ -17,6 +17,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Moq" Version="4.12.0" />
+    <PackageReference Include="RichardSzalay.MockHttp" Version="6.0.0" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />

--- a/test/Elastic.Apm.Tests/Mocks/MockConfigSnapshot.cs
+++ b/test/Elastic.Apm.Tests/Mocks/MockConfigSnapshot.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using Elastic.Apm.Config;
 using Elastic.Apm.Helpers;
 using Elastic.Apm.Logging;
+using static Elastic.Apm.Config.ConfigConsts;
 
 namespace Elastic.Apm.Tests.Mocks
 {
@@ -45,6 +46,7 @@ namespace Elastic.Apm.Tests.Mocks
 		private readonly string _verifyServerCert;
 		private readonly string _transactionIgnoreUrls;
 		private readonly string _hostName;
+		private string _cloudProvider;
 
 		public MockConfigSnapshot(IApmLogger logger = null,
 			string logLevel = null,
@@ -61,10 +63,10 @@ namespace Elastic.Apm.Tests.Mocks
 			string transactionSampleRate = null,
 			string transactionMaxSpans = null,
 			string metricsInterval = null,
-			string captureBody = ConfigConsts.SupportedValues.CaptureBodyOff,
+			string captureBody = SupportedValues.CaptureBodyOff,
 			string stackTraceLimit = null,
 			string spanFramesMinDurationInMilliseconds = null,
-			string captureBodyContentTypes = ConfigConsts.DefaultValues.CaptureBodyContentTypes,
+			string captureBodyContentTypes = DefaultValues.CaptureBodyContentTypes,
 			string flushInterval = null,
 			string maxBatchEventCount = null,
 			string maxQueueEventCount = null,
@@ -76,7 +78,9 @@ namespace Elastic.Apm.Tests.Mocks
 			string applicationNamespaces = null,
 			string excludedNamespaces = null,
 			string transactionIgnoreUrls = null,
-			string hostName = null
+			string hostName = null,
+			// false is **not** the default value, but we don't want to query for cloud metadata in all tests
+			string cloudProvider = SupportedValues.CloudProviderFalse
 		) : base(logger, ThisClassName)
 		{
 			_serverUrls = serverUrls;
@@ -109,70 +113,72 @@ namespace Elastic.Apm.Tests.Mocks
 			_excludedNamespaces = excludedNamespaces;
 			_transactionIgnoreUrls = transactionIgnoreUrls;
 			_hostName = hostName;
+			_cloudProvider = cloudProvider;
 		}
 
-		public string ApiKey => ParseApiKey(Kv(ConfigConsts.EnvVarNames.ApiKey, _apiKey, Origin));
+		public string ApiKey => ParseApiKey(Kv(EnvVarNames.ApiKey, _apiKey, Origin));
 
 		public IReadOnlyCollection<string> ApplicationNamespaces =>
-			ParseApplicationNamespaces(new ConfigurationKeyValue(ConfigConsts.EnvVarNames.ApplicationNamespaces, _applicationNamespaces, Origin));
+			ParseApplicationNamespaces(new ConfigurationKeyValue(EnvVarNames.ApplicationNamespaces, _applicationNamespaces, Origin));
 
-		public string CaptureBody => ParseCaptureBody(Kv(ConfigConsts.EnvVarNames.CaptureBody, _captureBody, Origin));
+		public string CaptureBody => ParseCaptureBody(Kv(EnvVarNames.CaptureBody, _captureBody, Origin));
 
 		public List<string> CaptureBodyContentTypes =>
-			ParseCaptureBodyContentTypes(Kv(ConfigConsts.EnvVarNames.CaptureBodyContentTypes, _captureBodyContentTypes, Origin));
+			ParseCaptureBodyContentTypes(Kv(EnvVarNames.CaptureBodyContentTypes, _captureBodyContentTypes, Origin));
 
-		public bool CaptureHeaders => ParseCaptureHeaders(Kv(ConfigConsts.EnvVarNames.CaptureHeaders, _captureHeaders, Origin));
-		public bool CentralConfig => ParseCentralConfig(Kv(ConfigConsts.EnvVarNames.CentralConfig, _centralConfig, Origin));
+		public bool CaptureHeaders => ParseCaptureHeaders(Kv(EnvVarNames.CaptureHeaders, _captureHeaders, Origin));
+		public bool CentralConfig => ParseCentralConfig(Kv(EnvVarNames.CentralConfig, _centralConfig, Origin));
+		public string CloudProvider => ParseCloudProvider(Kv(EnvVarNames.CloudProvider, _cloudProvider, Origin));
 
 		public string DbgDescription => _dbgDescription ?? nameof(MockConfigSnapshot);
 
 		public IReadOnlyList<WildcardMatcher> DisableMetrics =>
-			ParseDisableMetrics(Kv(ConfigConsts.EnvVarNames.DisableMetrics, _disableMetrics, Origin));
+			ParseDisableMetrics(Kv(EnvVarNames.DisableMetrics, _disableMetrics, Origin));
 
-		public string Environment => ParseEnvironment(Kv(ConfigConsts.EnvVarNames.Environment, _environment, Origin));
+		public string Environment => ParseEnvironment(Kv(EnvVarNames.Environment, _environment, Origin));
 
 		public IReadOnlyCollection<string> ExcludedNamespaces =>
-			ParseExcludedNamespaces(new ConfigurationKeyValue(ConfigConsts.EnvVarNames.ExcludedNamespaces, _excludedNamespaces, Origin));
+			ParseExcludedNamespaces(new ConfigurationKeyValue(EnvVarNames.ExcludedNamespaces, _excludedNamespaces, Origin));
 
-		public TimeSpan FlushInterval => ParseFlushInterval(Kv(ConfigConsts.EnvVarNames.FlushInterval, _flushInterval, Origin));
+		public TimeSpan FlushInterval => ParseFlushInterval(Kv(EnvVarNames.FlushInterval, _flushInterval, Origin));
 
 		public IReadOnlyDictionary<string, string> GlobalLabels =>
-			ParseGlobalLabels(Kv(ConfigConsts.EnvVarNames.GlobalLabels, _globalLabels, Origin));
+			ParseGlobalLabels(Kv(EnvVarNames.GlobalLabels, _globalLabels, Origin));
 
-		public string HostName => ParseHostName(Kv(ConfigConsts.EnvVarNames.HostName, _hostName, Origin));
+		public string HostName => ParseHostName(Kv(EnvVarNames.HostName, _hostName, Origin));
 
 		public IReadOnlyList<WildcardMatcher> TransactionIgnoreUrls =>
-			ParseTransactionIgnoreUrls(Kv(ConfigConsts.EnvVarNames.TransactionIgnoreUrls, _transactionIgnoreUrls, Origin));
+			ParseTransactionIgnoreUrls(Kv(EnvVarNames.TransactionIgnoreUrls, _transactionIgnoreUrls, Origin));
 
-		public LogLevel LogLevel => ParseLogLevel(Kv(ConfigConsts.EnvVarNames.LogLevel, _logLevel, Origin));
-		public int MaxBatchEventCount => ParseMaxBatchEventCount(Kv(ConfigConsts.EnvVarNames.MaxBatchEventCount, _maxBatchEventCount, Origin));
-		public int MaxQueueEventCount => ParseMaxQueueEventCount(Kv(ConfigConsts.EnvVarNames.MaxQueueEventCount, _maxQueueEventCount, Origin));
-		public double MetricsIntervalInMilliseconds => ParseMetricsInterval(Kv(ConfigConsts.EnvVarNames.MetricsInterval, _metricsInterval, Origin));
+		public LogLevel LogLevel => ParseLogLevel(Kv(EnvVarNames.LogLevel, _logLevel, Origin));
+		public int MaxBatchEventCount => ParseMaxBatchEventCount(Kv(EnvVarNames.MaxBatchEventCount, _maxBatchEventCount, Origin));
+		public int MaxQueueEventCount => ParseMaxQueueEventCount(Kv(EnvVarNames.MaxQueueEventCount, _maxQueueEventCount, Origin));
+		public double MetricsIntervalInMilliseconds => ParseMetricsInterval(Kv(EnvVarNames.MetricsInterval, _metricsInterval, Origin));
 
 		public IReadOnlyList<WildcardMatcher> SanitizeFieldNames =>
-			ParseSanitizeFieldNames(Kv(ConfigConsts.EnvVarNames.SanitizeFieldNames, _sanitizeFieldNames, Origin));
+			ParseSanitizeFieldNames(Kv(EnvVarNames.SanitizeFieldNames, _sanitizeFieldNames, Origin));
 
-		public string SecretToken => ParseSecretToken(Kv(ConfigConsts.EnvVarNames.SecretToken, _secretToken, Origin));
-		public IReadOnlyList<Uri> ServerUrls => ParseServerUrls(Kv(ConfigConsts.EnvVarNames.ServerUrls, _serverUrls, Origin));
-		public string ServiceName => ParseServiceName(Kv(ConfigConsts.EnvVarNames.ServiceName, _serviceName, Origin));
-		public string ServiceNodeName => ParseServiceNodeName(Kv(ConfigConsts.EnvVarNames.ServiceNodeName, _serviceNodeName, Origin));
-		public string ServiceVersion => ParseServiceVersion(Kv(ConfigConsts.EnvVarNames.ServiceVersion, _serviceVersion, Origin));
+		public string SecretToken => ParseSecretToken(Kv(EnvVarNames.SecretToken, _secretToken, Origin));
+		public IReadOnlyList<Uri> ServerUrls => ParseServerUrls(Kv(EnvVarNames.ServerUrls, _serverUrls, Origin));
+		public string ServiceName => ParseServiceName(Kv(EnvVarNames.ServiceName, _serviceName, Origin));
+		public string ServiceNodeName => ParseServiceNodeName(Kv(EnvVarNames.ServiceNodeName, _serviceNodeName, Origin));
+		public string ServiceVersion => ParseServiceVersion(Kv(EnvVarNames.ServiceVersion, _serviceVersion, Origin));
 
 		public double SpanFramesMinDurationInMilliseconds => ParseSpanFramesMinDurationInMilliseconds(Kv(
-			ConfigConsts.EnvVarNames.SpanFramesMinDuration,
+			EnvVarNames.SpanFramesMinDuration,
 			_spanFramesMinDurationInMilliseconds, Origin));
 
-		public int StackTraceLimit => ParseStackTraceLimit(Kv(ConfigConsts.EnvVarNames.StackTraceLimit, _stackTraceLimit, Origin));
+		public int StackTraceLimit => ParseStackTraceLimit(Kv(EnvVarNames.StackTraceLimit, _stackTraceLimit, Origin));
 
-		public int TransactionMaxSpans => ParseTransactionMaxSpans(Kv(ConfigConsts.EnvVarNames.TransactionMaxSpans, _transactionMaxSpans, Origin));
+		public int TransactionMaxSpans => ParseTransactionMaxSpans(Kv(EnvVarNames.TransactionMaxSpans, _transactionMaxSpans, Origin));
 
 		public double TransactionSampleRate =>
-			ParseTransactionSampleRate(Kv(ConfigConsts.EnvVarNames.TransactionSampleRate, _transactionSampleRate, Origin));
+			ParseTransactionSampleRate(Kv(EnvVarNames.TransactionSampleRate, _transactionSampleRate, Origin));
 
 		public bool UseElasticTraceparentHeader =>
-			ParseUseElasticTraceparentHeader(Kv(ConfigConsts.EnvVarNames.UseElasticTraceparentHeader, _useElasticTraceparentHeader, Origin));
+			ParseUseElasticTraceparentHeader(Kv(EnvVarNames.UseElasticTraceparentHeader, _useElasticTraceparentHeader, Origin));
 
 		public bool VerifyServerCert =>
-			ParseVerifyServerCert(Kv(ConfigConsts.EnvVarNames.VerifyServerCert, _verifyServerCert, Origin));
+			ParseVerifyServerCert(Kv(EnvVarNames.VerifyServerCert, _verifyServerCert, Origin));
 	}
 }


### PR DESCRIPTION
Relates: https://github.com/elastic/apm/issues/256

This commit adds the fetching of cloud metadata to
the agent, to send as part of the agent metadata
when an agent is running in a Cloud provider.

On starting the payload sender's work loop,
the first iteration will asynchronously fetch
the metadata for the cloud provider specified with
the ELASTIC_APM_CLOUD_PROVIDER env var, or the
ElasticApm:CloudProvider app setting. Values
are aws, gcp, azure and false. When false is
specified, no cloud metadata providers are
registered, so there are no attempts to fetch
metadata. The default value of null or ""
will attempt to fetch metadata using all registered
providers.

Closes #918