### PR TITLE
docs: add ifeval for 7.10 release

### DIFF
--- a/docs/log-correlation.asciidoc
+++ b/docs/log-correlation.asciidoc
@@ -6,7 +6,6 @@ endif::[]
 [[log-correlation]]
 == Log correlation
 
-
 The Elastic APM .NET agent provides integrations for popular logging frameworks, which take care of
 injecting trace ID fields into your application's log records. Currently supported logging frameworks are:
 
@@ -20,7 +19,12 @@ If your favorite logging framework is not already supported, there are two other
 
 Regardless of how you integrate APM with logging, you can use {filebeat-ref}[Filebeat] to
 send your logs to Elasticsearch, in order to correlate your traces and logs and link from
+ifeval::["{branch}"=="7.9"]
 APM to the {apm-app-ref}/xpack-logs.html[Logs app].
+endif::[]
+ifeval::["{branch}"!="7.9"]
+APM to the {observability-guide}/monitor-logs.html[Logs app].
+endif::[]
 
 [[serilog]]
 === Serilog
@@ -67,7 +71,7 @@ With this setup the application will send all the logs automatically to Elastics
 [[nlog]]
 === NLog
 
-For NLog, we offer two https://github.com/NLog/NLog/wiki/Layout-Renderers[LayoutRenderers] that inject the current trace and transaction id into logs. 
+For NLog, we offer two https://github.com/NLog/NLog/wiki/Layout-Renderers[LayoutRenderers] that inject the current trace and transaction id into logs.
 
 In order to use them, you need to add the https://www.nuget.org/packages/Elastic.Apm.NLog[Elastic.Apm.NLog] NuGet package to your application and load it in the `<extensions>` section of your NLog config file:
 
@@ -109,7 +113,7 @@ For correlating structured logs with traces, the following fields should be adde
 
  - `trace.id`
  - `transaction.id`
- 
+
 Given a transaction object, you can obtain its trace id by using the `Transaction.TraceId` property and its transaction id by using the `Transaction.Id` property.
 
 You can also use the <<api-current-transaction, Elastic.Apm.Agent.Tracer.CurrentTransaction>> property anywhere in the code to access the currently active transaction.


### PR DESCRIPTION
## Summary

This PR fixes a documentation link that will break when `7.10` becomes the `current` stack version. It conditionally changes the link location of the Logs app docs based on the stack version defined in github.com/elastic/docs ([here](https://github.com/elastic/docs/blob/master/shared/versions/stack/current.asciidoc)).

```asciidoc
ifeval::["{branch}"=="7.9"]
APM to the {apm-app-ref}/xpack-logs.html[Logs app].
endif::[]
ifeval::["{branch}"!="7.9"]
APM to the {observability-guide}/monitor-logs.html[Logs app].
endif::[]
```

Admittedly, this isn't pretty, but it's the cleanest way to ensure this link continues to work for users who click it before and after the `7.10` release.

Tested by building locally with `:branch:` overridden to `7.9`, `7.10`, and `master`.

## Target

**This PR will need to be backported to `1.x`.**

## Related issue

* https://github.com/elastic/observability-docs/issues/215
* https://github.com/elastic/docs/pull/1994

## Follow-ups

After the release of `7.10`, I will backport a fix that removes the conditional code.