### PR TITLE
Round sampling precision to four decimal places

### DIFF
--- a/src/Elastic.Apm/Sampler.cs
+++ b/src/Elastic.Apm/Sampler.cs
@@ -30,9 +30,10 @@ namespace Elastic.Apm
 		/// <returns>The same value as the given rate</returns>
 		internal Sampler(double rate)
 		{
-			if (!IsValidRate(rate)) throw new ArgumentOutOfRangeException($"Invalid rate: {rate} - it must be between 0 and 1 (including both)");
+			if (!IsValidRate(rate))
+				throw new ArgumentOutOfRangeException($"Invalid rate: {rate} - it must be between 0 and 1, inclusive");
 
-			_rate = rate;
+			_rate = RoundToPrecision(rate);
 			switch (_rate)
 			{
 				case 0:
@@ -52,6 +53,14 @@ namespace Elastic.Apm
 					break;
 			}
 		}
+
+		/// <summary>
+		/// Rounds the sampling rate half away from zero to 4 decimal places so that the maximum precision of the sampling rate is `0.0001` (0.01%).
+		/// Values greater than 0 but less than 0.0001 are rounded to 0.0001
+		/// </summary>
+		/// <param name="rate">The rate</param>
+		/// <returns>The rounded rate</returns>
+		private static double RoundToPrecision(double rate) => rate < 0.0001 ? 0.0001 : Math.Round(rate, 4, MidpointRounding.AwayFromZero);
 
 		internal bool? Constant { get; }
 
@@ -74,9 +83,7 @@ namespace Elastic.Apm
 
 		public override string ToString()
 		{
-			var retVal = new StringBuilder();
-			retVal.Append(nameof(Sampler));
-			retVal.Append("{ ");
+			var retVal = new StringBuilder(nameof(Sampler)).Append("{ ");
 			if (Constant.HasValue)
 				retVal.Append($"constant: {Constant}");
 			else

--- a/src/Elastic.Apm/Sampler.cs
+++ b/src/Elastic.Apm/Sampler.cs
@@ -60,7 +60,7 @@ namespace Elastic.Apm
 		/// </summary>
 		/// <param name="rate">The rate</param>
 		/// <returns>The rounded rate</returns>
-		private static double RoundToPrecision(double rate) => rate < 0.0001 ? 0.0001 : Math.Round(rate, 4, MidpointRounding.AwayFromZero);
+		private static double RoundToPrecision(double rate) => rate > 0 && rate < 0.0001 ? 0.0001 : Math.Round(rate, 4, MidpointRounding.AwayFromZero);
 
 		internal bool? Constant { get; }
 

--- a/test/Elastic.Apm.Tests/SamplerTests.cs
+++ b/test/Elastic.Apm.Tests/SamplerTests.cs
@@ -20,13 +20,13 @@ namespace Elastic.Apm.Tests
 		public static TheoryData RateVariantsToTest => new TheoryData<double>
 		{
 			0,
-			0.000000001,
-			0.00123,
+			0.0001,
+			0.0123,
 			0.3,
 			0.5,
 			0.75,
 			0.789,
-			0.999999999,
+			0.9999,
 			1
 		};
 

--- a/test/Elastic.Apm.Tests/SamplerTests.cs
+++ b/test/Elastic.Apm.Tests/SamplerTests.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Diagnostics;
+using System.Globalization;
 using Elastic.Apm.Helpers;
 using Elastic.Apm.Model;
 using Elastic.Apm.Tests.Mocks;
@@ -104,6 +105,19 @@ namespace Elastic.Apm.Tests
 			RandomGenerator.GenerateRandomBytes(randomBytes);
 			var firstIsSampled = sampler.DecideIfToSample(randomBytes);
 			10.Repeat(() => sampler.DecideIfToSample(randomBytes).Should().Be(firstIsSampled));
+		}
+
+		[Theory]
+		[InlineData(0.0001, 0.0001)]
+		[InlineData(0.00001, 0.0001)]
+		[InlineData(0.000001, 0.0001)]
+		[InlineData(0.55554, 0.5555)]
+		[InlineData(0.55555, 0.5556)]
+		[InlineData(0.55556, 0.5556)]
+		public void Rate_Precision_Should_Be_Rounded_To_Four_Decimal_Places(double rate, double expectedRate)
+		{
+			var sampler = new Sampler(rate);
+			sampler.ToString().Should().Be($"Sampler{{ rate: {expectedRate.ToString(CultureInfo.InvariantCulture)} }}");
 		}
 
 		[Theory]


### PR DESCRIPTION
This commit updates the sampler to round the sample
rate to four decimal places in line with the agent
spec for tracing sampling.

Closes #955