### PR TITLE
Add SampleRate to spans and transactions

### DIFF
--- a/src/Elastic.Apm/Model/Span.cs
+++ b/src/Elastic.Apm/Model/Span.cs
@@ -19,9 +19,6 @@ namespace Elastic.Apm.Model
 {
 	internal class Span : ISpan
 	{
-		[JsonProperty("sample_rate")]
-		internal readonly double SampleRate;
-
 		private readonly Lazy<SpanContext> _context = new Lazy<SpanContext>();
 		private readonly ICurrentExecutionSegmentsContainer _currentExecutionSegmentsContainer;
 		private readonly Transaction _enclosingTransaction;
@@ -40,6 +37,12 @@ namespace Elastic.Apm.Model
 		/// capture the stacktrace is .Start
 		/// </summary>
 		private readonly StackFrame[] _stackFrames;
+
+		/// <summary>
+		/// Captures the sample rate of the agent when this span was created.
+		/// </summary>
+		[JsonProperty("sample_rate")]
+		internal readonly double SampleRate;
 
 		// This constructor is meant for deserialization
 		[JsonConstructor]

--- a/src/Elastic.Apm/Model/Span.cs
+++ b/src/Elastic.Apm/Model/Span.cs
@@ -42,7 +42,7 @@ namespace Elastic.Apm.Model
 		/// Captures the sample rate of the agent when this span was created.
 		/// </summary>
 		[JsonProperty("sample_rate")]
-		internal readonly double SampleRate;
+		internal double SampleRate { get; }
 
 		// This constructor is meant for deserialization
 		[JsonConstructor]

--- a/src/Elastic.Apm/Model/Transaction.cs
+++ b/src/Elastic.Apm/Model/Transaction.cs
@@ -150,6 +150,8 @@ namespace Elastic.Apm.Model
 			if (IsSampled && _activity != null && !ignoreActivity)
 				_activity.ActivityTraceFlags |= ActivityTraceFlags.Recorded;
 
+			SampleRate = IsSampled ? sampler.Rate : 0;
+
 			SpanCount = new SpanCount();
 			_currentExecutionSegmentsContainer.CurrentTransaction = this;
 
@@ -274,6 +276,9 @@ namespace Elastic.Apm.Model
 		[MaxLength]
 		public string Result { get; set; }
 
+		[JsonProperty("sample_rate")]
+		internal double SampleRate { get; set; }
+
 		internal Service Service;
 
 		[JsonProperty("span_count")]
@@ -291,7 +296,7 @@ namespace Elastic.Apm.Model
 		[MaxLength]
 		public string Type { get; set; }
 
-		///<inheritdoc/>
+		/// <inheritdoc />
 		public void SetService(string serviceName, string serviceVersion)
 		{
 			if (Context.Service == null)
@@ -392,7 +397,9 @@ namespace Elastic.Apm.Model
 			return retVal;
 		}
 
-		public void CaptureException(Exception exception, string culprit = null, bool isHandled = false, string parentId = null, Dictionary<string, Label> labels = null)
+		public void CaptureException(Exception exception, string culprit = null, bool isHandled = false, string parentId = null,
+			Dictionary<string, Label> labels = null
+		)
 			=> ExecutionSegmentCommon.CaptureException(
 				exception,
 				_logger,
@@ -474,7 +481,7 @@ namespace Elastic.Apm.Model
 					? areaString + "/" + controllerString
 					: controllerString;
 
-				count = routeValues.TryGetValue("action", out var action) ? (count + 1) : count;
+				count = routeValues.TryGetValue("action", out var action) ? count + 1 : count;
 				var actionString = action == null ? string.Empty : action.ToString();
 
 				if (!string.IsNullOrEmpty(actionString)) name += "/" + actionString;

--- a/src/Elastic.Apm/Model/Transaction.cs
+++ b/src/Elastic.Apm/Model/Transaction.cs
@@ -276,6 +276,9 @@ namespace Elastic.Apm.Model
 		[MaxLength]
 		public string Result { get; set; }
 
+		/// <summary>
+		/// Captures the sample rate of the agent when this transaction was created.
+		/// </summary>
 		[JsonProperty("sample_rate")]
 		internal double SampleRate { get; set; }
 

--- a/src/Elastic.Apm/Model/Transaction.cs
+++ b/src/Elastic.Apm/Model/Transaction.cs
@@ -280,7 +280,7 @@ namespace Elastic.Apm.Model
 		/// Captures the sample rate of the agent when this transaction was created.
 		/// </summary>
 		[JsonProperty("sample_rate")]
-		internal double SampleRate { get; set; }
+		internal double SampleRate { get; }
 
 		internal Service Service;
 

--- a/src/Elastic.Apm/Sampler.cs
+++ b/src/Elastic.Apm/Sampler.cs
@@ -20,7 +20,8 @@ namespace Elastic.Apm
 	{
 		private readonly long _higherBound;
 		private readonly long _lowerBound;
-		private readonly double _rate;
+
+		public double Rate { get; }
 
 		/// <summary>
 		/// Constructs a new Sampler
@@ -33,8 +34,8 @@ namespace Elastic.Apm
 			if (!IsValidRate(rate))
 				throw new ArgumentOutOfRangeException($"Invalid rate: {rate} - it must be between 0 and 1, inclusive");
 
-			_rate = RoundToPrecision(rate);
-			switch (_rate)
+			Rate = RoundToPrecision(rate);
+			switch (Rate)
 			{
 				case 0:
 					Constant = false;
@@ -47,7 +48,7 @@ namespace Elastic.Apm
 					_lowerBound = long.MinValue;
 					break;
 				default:
-					_higherBound = (long) (long.MaxValue * rate);
+					_higherBound = (long)(long.MaxValue * rate);
 					_lowerBound = -_higherBound;
 					Constant = null;
 					break;
@@ -55,12 +56,14 @@ namespace Elastic.Apm
 		}
 
 		/// <summary>
-		/// Rounds the sampling rate half away from zero to 4 decimal places so that the maximum precision of the sampling rate is `0.0001` (0.01%).
+		/// Rounds the sampling rate half away from zero to 4 decimal places so that the maximum precision of the sampling rate is
+		/// `0.0001` (0.01%).
 		/// Values greater than 0 but less than 0.0001 are rounded to 0.0001
 		/// </summary>
 		/// <param name="rate">The rate</param>
 		/// <returns>The rounded rate</returns>
-		private static double RoundToPrecision(double rate) => rate > 0 && rate < 0.0001 ? 0.0001 : Math.Round(rate, 4, MidpointRounding.AwayFromZero);
+		private static double RoundToPrecision(double rate) =>
+			rate > 0 && rate < 0.0001 ? 0.0001 : Math.Round(rate, 4, MidpointRounding.AwayFromZero);
 
 		internal bool? Constant { get; }
 
@@ -87,7 +90,7 @@ namespace Elastic.Apm
 			if (Constant.HasValue)
 				retVal.Append($"constant: {Constant}");
 			else
-				retVal.Append($"rate: {_rate}");
+				retVal.Append($"rate: {Rate}");
 			retVal.Append(" }");
 			return retVal.ToString();
 		}

--- a/test/Elastic.Apm.Tests/SamplerTests.cs
+++ b/test/Elastic.Apm.Tests/SamplerTests.cs
@@ -157,6 +157,7 @@ namespace Elastic.Apm.Tests
 		{
 			var sampler = new Sampler(rate);
 			sampler.ToString().Should().Be($"Sampler{{ rate: {expectedRate.ToString(CultureInfo.InvariantCulture)} }}");
+			sampler.Rate.Should().Be(expectedRate);
 		}
 
 		[Theory]

--- a/test/Elastic.Apm.Tests/TransactionSamplingTests.cs
+++ b/test/Elastic.Apm.Tests/TransactionSamplingTests.cs
@@ -31,11 +31,13 @@ namespace Elastic.Apm.Tests
 			mockPayloadSender.FirstTransaction.SpanCount.Dropped.Should().Be(0);
 			if (isSampled)
 			{
+				mockPayloadSender.FirstTransaction.SampleRate.Should().Be(1);
 				mockPayloadSender.FirstTransaction.SpanCount.Started.Should().Be(1);
 				mockPayloadSender.Spans.Count.Should().Be(1);
 			}
 			else
 			{
+				mockPayloadSender.FirstTransaction.SampleRate.Should().Be(0);
 				mockPayloadSender.FirstTransaction.SpanCount.Started.Should().Be(0);
 				mockPayloadSender.Spans.Should().BeEmpty();
 			}
@@ -61,6 +63,7 @@ namespace Elastic.Apm.Tests
 			mockPayloadSender.Transactions.Count.Should().Be(1);
 			mockPayloadSender.Spans.Count.Should().Be(0);
 			mockPayloadSender.FirstTransaction.SpanCount.Dropped.Should().Be(1);
+			mockPayloadSender.FirstTransaction.SampleRate.Should().Be(1);
 		}
 
 		[Fact]


### PR DESCRIPTION
Solves #906.

It adds a new field (`sample_rate`) to both `Span` and `Transaction`. I kept those internal.

Spec: [here](https://github.com/elastic/apm/blob/master/specs/agents/tracing-sampling.md).

Opened follow up for propagation: https://github.com/elastic/apm-agent-dotnet/issues/1021. I'd say the propagation part will be left from the current release.