### PR TITLE
Fix cloud metadata

### DIFF
--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -688,7 +688,9 @@ This option supports the wildcard `*`, which matches zero or more characters. Ex
 
 Allows you to specify which cloud provider should be assumed for metadata collection. By default, the agent will attempt to detect the cloud provider and, if that fails, use trial and error to collect the metadata.
 
-Valid options are `"aws"`, `"gcp"`, `"azure"`, and `"false"`. If this config value is set to `"false"`, no cloud metadata will be collected.
+Valid options are `"auto"`, `"aws"`, `"gcp"`, `"azure"`, and `"none"`. If this config value is set to `"none"`, no cloud metadata will be collected. If set to any of
+`"aws"`, `"gcp"`, or `"azure"`, attempts to collect metadata will only be performed 
+from the chosen provider.
 
 [options="header"]
 |============
@@ -699,7 +701,7 @@ Valid options are `"aws"`, `"gcp"`, `"azure"`, and `"false"`. If this config val
 [options="header"]
 |============
 | Default | Type
-| `null`  | String
+| `auto`  | String
 |============
 
 [[config-http]]

--- a/sample/AspNetFullFrameworkSampleApp/Web.config
+++ b/sample/AspNetFullFrameworkSampleApp/Web.config
@@ -17,7 +17,7 @@
 		<add key="ClientValidationEnabled" value="true"/>
 		<add key="UnobtrusiveJavaScriptEnabled" value="true"/>
 		<add key="ElasticApm:MaxQueueEventCount" value="9128"/>
-		<add key="ElasticApm:CloudProvider" value="false"/>
+		<add key="ElasticApm:CloudProvider" value="none"/>
 	</appSettings>
 	<system.web>
 		<compilation debug="true" targetFramework="4.6.1"/>

--- a/sample/GrpcServiceSample/appsettings.json
+++ b/sample/GrpcServiceSample/appsettings.json
@@ -13,6 +13,6 @@
     }
   },
   "ElasticApm": {
-    "CloudProvider": "false"
+    "CloudProvider": "none"
   }
 }

--- a/sample/SampleAspNetCoreApp/appsettings.json
+++ b/sample/SampleAspNetCoreApp/appsettings.json
@@ -11,6 +11,6 @@
     "TransactionSampleRate": 1.0,
     "CaptureBody": "all",
     "CaptureBodyContentTypes": "application/x-www-form-urlencoded*, text/*, application/json*, application/xml*",
-    "CloudProvider": "false"
+    "CloudProvider": "none"
   }
 }

--- a/sample/WebApiSample/appsettings.json
+++ b/sample/WebApiSample/appsettings.json
@@ -10,6 +10,6 @@
     "ServerUrls": "http://localhost:8200",
     "CaptureBody": "all",
     "CaptureBodyContentTypes": "application/x-www-form-urlencoded*, text/*, application/json*, application/xml*",
-    "CloudProvider": "false"
+    "CloudProvider": "none"
   }
 }

--- a/src/Elastic.Apm/Cloud/AwsCloudMetadataProvider.cs
+++ b/src/Elastic.Apm/Cloud/AwsCloudMetadataProvider.cs
@@ -56,7 +56,7 @@ namespace Elastic.Apm.Cloud
 				}
 
 				JObject metadata;
-				using (var requestMessage = new HttpRequestMessage(HttpMethod.Put, MetadataUri))
+				using (var requestMessage = new HttpRequestMessage(HttpMethod.Get, MetadataUri))
 				{
 					requestMessage.Headers.Add("X-aws-ec2-metadata-token", awsToken);
 					var responseMessage = await client.SendAsync(requestMessage).ConfigureAwait(false);

--- a/src/Elastic.Apm/Cloud/CloudMetadataProviderCollection.cs
+++ b/src/Elastic.Apm/Cloud/CloudMetadataProviderCollection.cs
@@ -31,8 +31,9 @@ namespace Elastic.Apm.Cloud
 				case SupportedValues.CloudProviderAzure:
 					Add(new AzureCloudMetadataProvider(logger));
 					break;
-				case SupportedValues.CloudProviderFalse:
+				case SupportedValues.CloudProviderNone:
 					break;
+				case SupportedValues.CloudProviderAuto:
 				case "":
 				case null:
 					// keyed collection is ordered

--- a/src/Elastic.Apm/Cloud/GcpCloudMetadataProvider.cs
+++ b/src/Elastic.Apm/Cloud/GcpCloudMetadataProvider.cs
@@ -61,12 +61,16 @@ namespace Elastic.Apm.Cloud
 					metadata = serializer.Deserialize<JObject>(jsonReader);
 				}
 
-				var availabilityZone = Path.GetFileName(metadata["instance"]["zone"].Value<string>());
+				var zoneParts = metadata["instance"]["zone"].Value<string>().Split('/');
+				var availabilityZone = zoneParts[zoneParts.Length - 1];
 
 				var lastHyphen = availabilityZone.LastIndexOf('-');
 				var region = lastHyphen > -1
 					? availabilityZone.Substring(0, lastHyphen)
 					: availabilityZone;
+
+				var machineTypeParts = metadata["instance"]["machineType"].Value<string>().Split('/');
+				var machineType = machineTypeParts[machineTypeParts.Length - 1];
 
 				return new Api.Cloud
 				{
@@ -82,7 +86,7 @@ namespace Elastic.Apm.Cloud
 						Name = metadata["project"]["projectId"].Value<string>()
 					},
 					AvailabilityZone = availabilityZone,
-					Machine = new CloudMachine { Type = metadata["instance"]["machineType"].Value<string>() },
+					Machine = new CloudMachine { Type = machineType },
 					Provider = Provider,
 					Region = region
 				};

--- a/src/Elastic.Apm/Config/ConfigConsts.cs
+++ b/src/Elastic.Apm/Config/ConfigConsts.cs
@@ -23,7 +23,7 @@ namespace Elastic.Apm.Config
 			public const string CaptureBodyContentTypes = "application/x-www-form-urlencoded*, text/*, application/json*, application/xml*";
 			public const bool CaptureHeaders = true;
 			public const bool CentralConfig = true;
-			public const string CloudProvider = "";
+			public const string CloudProvider = SupportedValues.CloudProviderAuto;
 			public const int FlushIntervalInMilliseconds = 10_000; // 10 seconds
 			public const int MaxBatchEventCount = 10;
 			public const int MaxQueueEventCount = 1000;
@@ -194,11 +194,12 @@ namespace Elastic.Apm.Config
 			public const string CloudProviderAws = AwsCloudMetadataProvider.Name;
 			public const string CloudProviderAzure = AzureCloudMetadataProvider.Name;
 			public const string CloudProviderGcp = GcpCloudMetadataProvider.Name;
-			public const string CloudProviderFalse = "false";
+			public const string CloudProviderNone = "none";
+			public const string CloudProviderAuto = "auto";
 
 			public static readonly HashSet<string> CloudProviders = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
 			{
-				CloudProviderAws, CloudProviderAzure, CloudProviderGcp, CloudProviderFalse
+				CloudProviderAuto, CloudProviderAws, CloudProviderAzure, CloudProviderGcp, CloudProviderNone
 			};
 		}
 	}

--- a/test/Elastic.Apm.Tests/Cloud/CloudMetadataProviderCollectionTests.cs
+++ b/test/Elastic.Apm.Tests/Cloud/CloudMetadataProviderCollectionTests.cs
@@ -27,9 +27,9 @@ namespace Elastic.Apm.Tests.Cloud
 		}
 
 		[Fact]
-		public void CloudProvider_False_Should_Not_Register_Any_Providers()
+		public void CloudProvider_None_Should_Not_Register_Any_Providers()
 		{
-			var providers = new CloudMetadataProviderCollection(SupportedValues.CloudProviderFalse, new NoopLogger());
+			var providers = new CloudMetadataProviderCollection(SupportedValues.CloudProviderNone, new NoopLogger());
 			providers.Count.Should().Be(0);
 		}
 

--- a/test/Elastic.Apm.Tests/Cloud/GcpCloudMetadataProviderTests.cs
+++ b/test/Elastic.Apm.Tests/Cloud/GcpCloudMetadataProviderTests.cs
@@ -50,7 +50,7 @@ namespace Elastic.Apm.Tests.Cloud
 			metadata.AvailabilityZone.Should().Be("us-west3-a");
 			metadata.Region.Should().Be("us-west3");
 			metadata.Machine.Should().NotBeNull();
-			metadata.Machine.Type.Should().Be(stubMetadata.instance.machineType);
+			metadata.Machine.Type.Should().Be("n1-standard-1");
 		}
 	}
 }

--- a/test/Elastic.Apm.Tests/Mocks/MockConfigSnapshot.cs
+++ b/test/Elastic.Apm.Tests/Mocks/MockConfigSnapshot.cs
@@ -80,8 +80,8 @@ namespace Elastic.Apm.Tests.Mocks
 			string excludedNamespaces = null,
 			string transactionIgnoreUrls = null,
 			string hostName = null,
-			// false is **not** the default value, but we don't want to query for cloud metadata in all tests
-			string cloudProvider = SupportedValues.CloudProviderFalse,
+			// none is **not** the default value, but we don't want to query for cloud metadata in all tests
+			string cloudProvider = SupportedValues.CloudProviderNone,
 			string enabled = null,
 			string recording = null
 		) : base(logger, ThisClassName)


### PR DESCRIPTION
This commit fixes a few bugs with cloud
metadata:

- AWS instance metadata should be a GET
- Default cloud provider value should be `"auto"`
- Disable cloud provider value should be `"none"`
- Correct machine type parsing in GCP provider