### PR TITLE
Adapt GcMetricsProvider to work on .NET5

### DIFF
--- a/src/Elastic.Apm/Metrics/MetricsProvider/GcMetricsProvider.cs
+++ b/src/Elastic.Apm/Metrics/MetricsProvider/GcMetricsProvider.cs
@@ -115,7 +115,7 @@ namespace Elastic.Apm.Metrics.MetricsProvider
 				}
 			}
 
-			if (PlatformDetection.IsDotNetCore)
+			if (PlatformDetection.IsDotNetCore || PlatformDetection.IsDotNet5)
 				_eventListener = new GcEventListener(this, logger);
 		}
 
@@ -141,7 +141,7 @@ namespace Elastic.Apm.Metrics.MetricsProvider
 		{
 			if (_gcCount != 0 || _gen0Size != 0 || _gen2Size != 0 || _gen3Size != 0)
 			{
-				var retVal = new List<MetricSample>();
+				var retVal = new List<MetricSample>(5);
 
 				if (_collectGcCount)
 					retVal.Add(new MetricSample(GcCountName, _gcCount));

--- a/test/Elastic.Apm.Tests/ConfigTests.cs
+++ b/test/Elastic.Apm.Tests/ConfigTests.cs
@@ -226,7 +226,7 @@ namespace Elastic.Apm.Tests
 			var payloadSender = new MockPayloadSender();
 			using (var agent = new ApmAgent(new TestAgentComponents(payloadSender: payloadSender, config: new EnvironmentConfigurationReader())))
 			{
-#if !NETCOREAPP3_0 && !NETCOREAPP3_1
+#if !NETCOREAPP3_0 && !NETCOREAPP3_1 && !NET5_0
 				agent.ConfigurationReader.ServerUrls.First().Should().NotBe(serverUrlsWithSpace);
 #endif
 				agent.ConfigurationReader.ServerUrls.First().Should().Be("http://myServer:1234");

--- a/test/Elastic.Apm.Tests/MetricsTests.cs
+++ b/test/Elastic.Apm.Tests/MetricsTests.cs
@@ -319,7 +319,7 @@ namespace Elastic.Apm.Tests
 					}
 				}
 
-				if (PlatformDetection.IsDotNetCore)
+				if (PlatformDetection.IsDotNetCore || PlatformDetection.IsDotNet5)
 				{
 					if (!logger.Lines.Where(n => n.Contains("OnEventWritten with GC")).Any())
 					{


### PR DESCRIPTION
This contains @russcam's findings from  #1006.


#1006 may take a bit longer, so merging this in separately to make sure this is included in the next release.