### PR TITLE
MockApmServer: Add SampleRate to SpanDto and TransactionDto

### DIFF
--- a/test/Elastic.Apm.Tests.MockApmServer/SpanDto.cs
+++ b/test/Elastic.Apm.Tests.MockApmServer/SpanDto.cs
@@ -26,6 +26,9 @@ namespace Elastic.Apm.Tests.MockApmServer
 		[JsonProperty("parent_id")]
 		public string ParentId { get; set; }
 
+		[JsonProperty("sample_rate")]
+		public string SampleRate { get; set; }
+
 		[JsonProperty("stacktrace")]
 		public List<CapturedStackFrame> StackTrace { get; set; }
 

--- a/test/Elastic.Apm.Tests.MockApmServer/TransactionDto.cs
+++ b/test/Elastic.Apm.Tests.MockApmServer/TransactionDto.cs
@@ -30,6 +30,9 @@ namespace Elastic.Apm.Tests.MockApmServer
 
 		public string Result { get; set; }
 
+		[JsonProperty("sample_rate")]
+		public string SampleRate { get; set; }
+
 		[JsonProperty("span_count")]
 		public SpanCountDto SpanCount { get; set; }
 


### PR DESCRIPTION
IIS Tests were failing due to this - yet another reason to generate these based on json schema.


Logs from failing tests for reference (this should  be fixed by this PR):

```
[2020-11-11 17:32:34.631 +01:00][Error] - {IntakeV2EventsController#4FD3B2} Failed to parse payload line as JSON. Error: Could not find member 'sample_rate' on object of type 'TransactionDto'. Path 'transaction.sample_rate', line 1, position 573., line: `{"transaction": {"context":{"request":{"http_version":"1.1","method":"GET","socket":{"encrypted":false,"remote_address":"::1"},"url":{"full":"http://localhost/Elastic.Apm.AspNetFullFramework.Tests.SampleApp/","hostname":"localhost","pathname":"/Elastic.Apm.AspNetFullFramework.Tests.SampleApp/","protocol":"HTTP","raw":"http://localhost/Elastic.Apm.AspNetFullFramework.Tests.SampleApp/"}},"response":{"finished":true,"status_code":200}},"duration":3540.14,"id":"0e6f03ef8287666f","sampled":true,"name":"GET Home/Index","outcome":"success","result":"HTTP 2xx","sample_rate":1.0,"span_count":{"dropped":0,"started":0},"timestamp":1605112350855117,"trace_id":"13491b7ed3654ae34fc6c1f9b27770d1","type":"request"}}'
[2020-11-11 17:32:44.596 +01:00][Error] - {AspNetFullFramework.Tests.TestsBase} Reached max number of attempts to verify payload - Rethrowing the last exception...
+-> Exception: Xunit.Sdk.XunitException: Expected receivedData.Transactions.Count to be 1, but found 0.
   at FluentAssertions.Execution.XUnit2TestFramework.Throw(String message) in C:\projects\fluentassertions-vf06b\Src\FluentAssertions\Execution\XUnit2TestFramework.cs:line 32
   at FluentAssertions.Execution.AssertionScope.FailWith(Func`1 failReasonFunc) in C:\projects\fluentassertions-vf06b\Src\FluentAssertions\Execution\AssertionScope.cs:line 181
   at FluentAssertions.Numeric.NumericAssertions`1.Be(T expected, String because, Object[] becauseArgs) in C:\projects\fluentassertions-vf06b\Src\FluentAssertions\Numeric\NumericAssertions.cs:line 50
   at Elastic.Apm.AspNetFullFramework.Tests.TestsBase.VerifyReceivedDataSharedConstraints(SampleAppUrlPathData sampleAppUrlPathData, ReceivedData receivedData) in C:\repos\GregKalapos_apm-agent-dotnet\test\Elastic.Apm.AspNetFullFramework.Tests\TestsBase.cs:line 510
   at Elastic.Apm.AspNetFullFramework.Tests.TestsBase.<>c__DisplayClass32_0.<WaitAndVerifyReceivedDataSharedConstraints>b__0(ReceivedData receivedData) in C:\repos\GregKalapos_apm-agent-dotnet\test\Elastic.Apm.AspNetFullFramework.Tests\TestsBase.cs:line 503
   at Elastic.Apm.AspNetFullFramework.Tests.TestsBase.WaitAndCustomVerifyReceivedData(Action`1 verifyAction, Boolean shouldGatherDiagnostics) in C:\repos\GregKalapos_apm-agent-dotnet\test\Elastic.Apm.AspNetFullFramework.Tests\TestsBase.cs:line 358
[2020-11-11 17:32:44.798 +01:00][Error] - {IntakeV2EventsController#33C71FB} Failed to parse payload line as JSON. Error: Could not find member 'sample_rate' on object of type 'TransactionDto'. Path 'transaction.sample_rate', line 1, position 613., line: `{"transaction": {"context":{"request":{"http_version":"1.1","method":"GET","socket":{"encrypted":false,"remote_address":"::1"},"url":{"full":"http://localhost/Elastic.Apm.AspNetFullFramework.Tests.SampleApp/Diagnostics","hostname":"localhost","pathname":"/Elastic.Apm.AspNetFullFramework.Tests.SampleApp/Diagnostics","protocol":"HTTP","raw":"http://localhost/Elastic.Apm.AspNetFullFramework.Tests.SampleApp/Diagnostics"}},"response":{"finished":true,"status_code":500}},"duration":130.783,"id":"8715ce2e961e25ff","sampled":true,"name":"GET Diagnostics/Index","outcome":"failure","result":"HTTP 5xx","sample_rate":1.0,"span_count":{"dropped":0,"started":0},"timestamp":1605112364603749,"trace_id":"b8cc541bd3830d4a0b3f4f95546be08a","type":"request"}}'
```