### PR TITLE
Update tests

### DIFF
--- a/test/Elastic.Apm.Tests/ErrorTests.cs
+++ b/test/Elastic.Apm.Tests/ErrorTests.cs
@@ -110,13 +110,13 @@ namespace Elastic.Apm.Tests
 				t.Context.Response = new Response();
 
 				t.CaptureError("Test Error", "Test", new StackTrace().GetFrames());
-
-				mockPayloadSender.FirstError.Context.Request.Should().NotBeNull();
-				mockPayloadSender.FirstError.Context.Request.Headers.Should().BeNull();
-				mockPayloadSender.FirstError.Context.Response.Should().NotBeNull();
-				mockPayloadSender.FirstError.Context.Response.Headers.Should().BeNull();
-				mockPayloadSender.FirstError.Context.InternalLabels.Value.InnerDictionary.Should().BeEmpty();
 			});
+
+			mockPayloadSender.FirstError.Context.Request.Should().NotBeNull();
+			mockPayloadSender.FirstError.Context.Request.Headers.Should().BeNull();
+			mockPayloadSender.FirstError.Context.Response.Should().NotBeNull();
+			mockPayloadSender.FirstError.Context.Response.Headers.Should().BeNull();
+			mockPayloadSender.FirstError.Context.InternalLabels.Value.InnerDictionary.Should().BeEmpty();
 		}
 	}
 }

--- a/test/Elastic.Apm.Tests/HttpDiagnosticListenerTests.cs
+++ b/test/Elastic.Apm.Tests/HttpDiagnosticListenerTests.cs
@@ -757,7 +757,7 @@ namespace Elastic.Apm.Tests
 		[Fact]
 		public async Task HttpCallWithW3CActivityFormar()
 		{
-			Activity.DefaultIdFormat = ActivityIdFormat.Hierarchical;
+			Activity.DefaultIdFormat = ActivityIdFormat.W3C;
 
 			var mockPayloadSender = new MockPayloadSender();
 			using var localServer = new LocalServer();


### PR DESCRIPTION
Minor change on label serialization tests: move serialization after `End()` is called on the events. 

Otherwise we serialize transactions and spans in the middle of the event, which never really happens in a production setup.

Also fixing ActivityIdFormat.W3C in HTTP test.