### PR TITLE
Don't subscribe IDiagnosticsSubscriber in ApmAgentExtensions.Subscribe(...) when agent is disabled

### DIFF
--- a/docs/public-api.asciidoc
+++ b/docs/public-api.asciidoc
@@ -61,6 +61,12 @@ Some examples:
 - `EfCoreDiagnosticsSubscriber`: captures database calls through Entity Framework Core
 - `SqlClientDiagnosticSubscriber`: captures database calls through `SqlClient` 
 
+[NOTE]
+--
+When the agent is configured with <<config-enabled, `Enabled` set to `false`>>, `Elastic.ApmAgent.Subscribe(params IDiagnosticsSubscriber[] subscribers)` will not subscribe the subscribers to
+diagnostic source events.
+--
+
 [float]
 [[api-tracer-api]]
 == Tracer API

--- a/src/Elastic.Apm.SqlClient/SqlClientDiagnosticSubscriber.cs
+++ b/src/Elastic.Apm.SqlClient/SqlClientDiagnosticSubscriber.cs
@@ -9,29 +9,28 @@ using Elastic.Apm.Helpers;
 
 namespace Elastic.Apm.SqlClient
 {
-	public class SqlClientDiagnosticSubscriber : IDiagnosticsSubscriber
+	/// <summary>
+	/// Subscribes to diagnostics events from System.Data.SqlClient and Microsoft.Data.SqlClient
+	/// </summary>
+	public class SqlClientDiagnosticSubscriber : DiagnosticsSubscriberBase
 	{
-		public IDisposable Subscribe(IApmAgent agentComponents)
+		/// <inheritdoc />
+		protected override IDisposable Subscribe(IApmAgent agentComponents, ICompositeDisposable disposable)
 		{
-			var retVal = new CompositeDisposable();
-
-			if (!agentComponents.ConfigurationReader.Enabled)
-				return retVal;
-
 			if (PlatformDetection.IsDotNetCore || PlatformDetection.IsDotNet5)
 			{
 				var initializer = new DiagnosticInitializer(agentComponents.Logger, new[] { new SqlClientDiagnosticListener(agentComponents) });
 
-				retVal.Add(initializer);
+				disposable.Add(initializer);
 
-				retVal.Add(DiagnosticListener
+				disposable.Add(DiagnosticListener
 					.AllListeners
 					.Subscribe(initializer));
 			}
 			else
-				retVal.Add(new SqlEventListener(agentComponents));
+				disposable.Add(new SqlEventListener(agentComponents));
 
-			return retVal;
+			return disposable;
 		}
 	}
 }

--- a/src/Elastic.Apm.SqlClient/SqlClientDiagnosticSubscriber.cs
+++ b/src/Elastic.Apm.SqlClient/SqlClientDiagnosticSubscriber.cs
@@ -12,25 +12,27 @@ namespace Elastic.Apm.SqlClient
 	/// <summary>
 	/// Subscribes to diagnostics events from System.Data.SqlClient and Microsoft.Data.SqlClient
 	/// </summary>
-	public class SqlClientDiagnosticSubscriber : DiagnosticsSubscriberBase
+	public class SqlClientDiagnosticSubscriber : IDiagnosticsSubscriber
 	{
 		/// <inheritdoc />
-		protected override IDisposable Subscribe(IApmAgent agentComponents, ICompositeDisposable disposable)
+		public IDisposable Subscribe(IApmAgent agentComponents)
 		{
+			var retVal = new CompositeDisposable();
+
 			if (PlatformDetection.IsDotNetCore || PlatformDetection.IsDotNet5)
 			{
 				var initializer = new DiagnosticInitializer(agentComponents.Logger, new[] { new SqlClientDiagnosticListener(agentComponents) });
 
-				disposable.Add(initializer);
+				retVal.Add(initializer);
 
-				disposable.Add(DiagnosticListener
+				retVal.Add(DiagnosticListener
 					.AllListeners
 					.Subscribe(initializer));
 			}
 			else
-				disposable.Add(new SqlEventListener(agentComponents));
+				retVal.Add(new SqlEventListener(agentComponents));
 
-			return disposable;
+			return retVal;
 		}
 	}
 }

--- a/src/Elastic.Apm/Agent.cs
+++ b/src/Elastic.Apm/Agent.cs
@@ -224,6 +224,8 @@ namespace Elastic.Apm
 		/// <summary>
 		/// Sets up multiple <see cref="IDiagnosticsSubscriber" />s to start listening to one or more
 		/// <see cref="IDiagnosticListener" />s.
+		/// <para />
+		/// If the agent is not enabled, subscribers are not subscribed.
 		/// </summary>
 		/// <param name="subscribers">
 		/// An array of <see cref="IDiagnosticsSubscriber" /> that will set up <see cref="IDiagnosticListener" /> subscriptions.

--- a/src/Elastic.Apm/ApmAgentExtensions.cs
+++ b/src/Elastic.Apm/ApmAgentExtensions.cs
@@ -27,10 +27,8 @@ namespace Elastic.Apm
 		public static IDisposable Subscribe(this IApmAgent agent, params IDiagnosticsSubscriber[] subscribers)
 		{
 			var subs = subscribers ?? Array.Empty<IDiagnosticsSubscriber>();
-			
-			var retVal = subs.Aggregate(
-				(ICompositeDisposable)new CompositeDisposable(), 
-				(d, s) => d.Add(s.Subscribe(agent)));
+
+			var retVal = subs.Aggregate(new CompositeDisposable(), (d, s) => d.Add(s.Subscribe(agent)));
 
 			if (agent is ApmAgent apmAgent)
 				apmAgent.Disposables.Add(retVal);
@@ -40,28 +38,21 @@ namespace Elastic.Apm
 	}
 
 	/// <summary>
-	/// A collection of <see cref="IDisposable"/> instances 
+	/// A collection of <see cref="IDisposable"/> instances
 	/// </summary>
-	public interface ICompositeDisposable : IDisposable
-	{
-		/// <summary>
-		/// Adds an instance of <see cref="IDisposable"/> to the collection
-		/// </summary>
-		/// <param name="disposable">A disposable</param>
-		/// <returns>This instance of <see cref="ICompositeDisposable"/></returns>
-		ICompositeDisposable Add(IDisposable disposable);
-	}
-
-	/// <inheritdoc />
-	internal class CompositeDisposable : ICompositeDisposable
+	internal class CompositeDisposable : IDisposable
 	{
 		private readonly List<IDisposable> _disposables = new List<IDisposable>();
 		private readonly object _lock = new object();
 
 		private bool _isDisposed;
 
-		/// <inheritdoc />
-		public ICompositeDisposable Add(IDisposable disposable)
+		/// <summary>
+		/// Adds an instance of <see cref="IDisposable"/> to the collection
+		/// </summary>
+		/// <param name="disposable">A disposable</param>
+		/// <returns>This instance of <see cref="CompositeDisposable"/></returns>
+		public CompositeDisposable Add(IDisposable disposable)
 		{
 			if (_isDisposed) throw new ObjectDisposedException(nameof(CompositeDisposable));
 

--- a/src/Elastic.Apm/ApmAgentExtensions.cs
+++ b/src/Elastic.Apm/ApmAgentExtensions.cs
@@ -12,8 +12,10 @@ namespace Elastic.Apm
 	public static class ApmAgentExtensions
 	{
 		/// <summary>
-		/// Sets up multiple <see cref="IDiagnosticsSubscriber" />'s to start listening to one or more
-		/// <see cref="IDiagnosticListener" />'s
+		/// Sets up multiple <see cref="IDiagnosticsSubscriber" />s to start listening to one or more
+		/// <see cref="IDiagnosticListener" />s.
+		/// <para />
+		/// If the agent is not enabled, subscribers are not subscribed.
 		/// </summary>
 		/// <param name="agent">The agent to report diagnostics over</param>
 		/// <param name="subscribers">
@@ -21,19 +23,22 @@ namespace Elastic.Apm
 		/// <see cref="IDiagnosticListener" /> subscriptions
 		/// </param>
 		/// <returns>
-		/// A disposable referencing all the subscriptions, disposing this is not necessary for clean up, only to
-		/// unsubscribe if desired.
+		/// A disposable referencing all the subscriptions. Disposing this is not necessary for clean up, only to unsubscribe if
+		/// desired.
 		/// </returns>
 		public static IDisposable Subscribe(this IApmAgent agent, params IDiagnosticsSubscriber[] subscribers)
 		{
-			var subs = subscribers ?? Array.Empty<IDiagnosticsSubscriber>();
+			var disposable = new CompositeDisposable();
+			if (!agent.ConfigurationReader.Enabled || subscribers is null || subscribers.Length == 0)
+				return disposable;
 
-			var retVal = subs.Aggregate(new CompositeDisposable(), (d, s) => d.Add(s.Subscribe(agent)));
+			foreach (var subscriber in subscribers)
+				disposable.Add(subscriber.Subscribe(agent));
 
 			if (agent is ApmAgent apmAgent)
-				apmAgent.Disposables.Add(retVal);
+				apmAgent.Disposables.Add(disposable);
 
-			return retVal;
+			return disposable;
 		}
 	}
 

--- a/src/Elastic.Apm/DiagnosticSource/HttpDiagnosticsSubscriber.cs
+++ b/src/Elastic.Apm/DiagnosticSource/HttpDiagnosticsSubscriber.cs
@@ -13,28 +13,23 @@ namespace Elastic.Apm.DiagnosticSource
 	/// Activates the <see cref="HttpDiagnosticListener" /> which enables
 	/// capturing outgoing web requests created by <see cref="System.Net.Http.HttpClient" />.
 	/// </summary>
-	public class HttpDiagnosticsSubscriber : IDiagnosticsSubscriber
+	public class HttpDiagnosticsSubscriber : DiagnosticsSubscriberBase
 	{
 		/// <summary>
 		/// Start listening for HttpClient diagnostic source events.
 		/// </summary>
-		public IDisposable Subscribe(IApmAgent agent)
+		protected override IDisposable Subscribe(IApmAgent agent, ICompositeDisposable disposable)
 		{
-			var retVal = new CompositeDisposable();
-
-			if (!agent.ConfigurationReader.Enabled)
-				return retVal;
-
 			var logger = agent.Logger.Scoped(nameof(HttpDiagnosticsSubscriber));
 
 			var initializer = new DiagnosticInitializer(agent.Logger, new[] { HttpDiagnosticListener.New(agent) });
-			retVal.Add(initializer);
+			disposable.Add(initializer);
 
-			retVal.Add(DiagnosticListener
+			disposable.Add(DiagnosticListener
 				.AllListeners
 				.Subscribe(initializer));
 
-			return retVal;
+			return disposable;
 		}
 	}
 }

--- a/src/Elastic.Apm/DiagnosticSource/HttpDiagnosticsSubscriber.cs
+++ b/src/Elastic.Apm/DiagnosticSource/HttpDiagnosticsSubscriber.cs
@@ -13,23 +13,23 @@ namespace Elastic.Apm.DiagnosticSource
 	/// Activates the <see cref="HttpDiagnosticListener" /> which enables
 	/// capturing outgoing web requests created by <see cref="System.Net.Http.HttpClient" />.
 	/// </summary>
-	public class HttpDiagnosticsSubscriber : DiagnosticsSubscriberBase
+	public class HttpDiagnosticsSubscriber : IDiagnosticsSubscriber
 	{
 		/// <summary>
 		/// Start listening for HttpClient diagnostic source events.
 		/// </summary>
-		protected override IDisposable Subscribe(IApmAgent agent, ICompositeDisposable disposable)
+		public IDisposable Subscribe(IApmAgent agent)
 		{
-			var logger = agent.Logger.Scoped(nameof(HttpDiagnosticsSubscriber));
+			var retVal = new CompositeDisposable();
 
 			var initializer = new DiagnosticInitializer(agent.Logger, new[] { HttpDiagnosticListener.New(agent) });
-			disposable.Add(initializer);
+			retVal.Add(initializer);
 
-			disposable.Add(DiagnosticListener
+			retVal.Add(DiagnosticListener
 				.AllListeners
 				.Subscribe(initializer));
 
-			return disposable;
+			return retVal;
 		}
 	}
 }

--- a/src/Elastic.Apm/DiagnosticSource/IDiagnosticsSubscriber.cs
+++ b/src/Elastic.Apm/DiagnosticSource/IDiagnosticsSubscriber.cs
@@ -15,32 +15,4 @@ namespace Elastic.Apm.DiagnosticSource
 		/// <returns>A disposable</returns>
 		IDisposable Subscribe(IApmAgent components);
 	}
-
-	/// <summary>
-	/// A base diagnostic subscriber that subscribes to diagnostic
-	/// listeners only if the agent is enabled
-	/// </summary>
-	public abstract class DiagnosticsSubscriberBase : IDiagnosticsSubscriber
-	{
-		/// <summary>
-		/// Subscribes to diagnostic listeners only if the agent is enabled
-		/// </summary>
-		/// <param name="components">The agent components</param>
-		/// <returns>A disposable</returns>
-		public IDisposable Subscribe(IApmAgent components)
-		{
-			var disposable = new CompositeDisposable();
-			return components.ConfigurationReader.Enabled
-				? Subscribe(components, disposable)
-				: disposable;
-		}
-
-		/// <summary>
-		/// Subscribes to diagnostic listeners
-		/// </summary>
-		/// <param name="components">The agent components</param>
-		/// <param name="disposable">A disposable to which other disposables can be added</param>
-		/// <returns>A disposable</returns>
-		protected abstract IDisposable Subscribe(IApmAgent components, ICompositeDisposable disposable);
-	}
 }

--- a/src/Elastic.Apm/DiagnosticSource/IDiagnosticsSubscriber.cs
+++ b/src/Elastic.Apm/DiagnosticSource/IDiagnosticsSubscriber.cs
@@ -8,6 +8,39 @@ namespace Elastic.Apm.DiagnosticSource
 {
 	public interface IDiagnosticsSubscriber
 	{
+		/// <summary>
+		/// Subscribes to diagnostic listeners
+		/// </summary>
+		/// <param name="components">The agent components</param>
+		/// <returns>A disposable</returns>
 		IDisposable Subscribe(IApmAgent components);
+	}
+
+	/// <summary>
+	/// A base diagnostic subscriber that subscribes to diagnostic
+	/// listeners only if the agent is enabled
+	/// </summary>
+	public abstract class DiagnosticsSubscriberBase : IDiagnosticsSubscriber
+	{
+		/// <summary>
+		/// Subscribes to diagnostic listeners only if the agent is enabled
+		/// </summary>
+		/// <param name="components">The agent components</param>
+		/// <returns>A disposable</returns>
+		public IDisposable Subscribe(IApmAgent components)
+		{
+			var disposable = new CompositeDisposable();
+			return components.ConfigurationReader.Enabled
+				? Subscribe(components, disposable)
+				: disposable;
+		}
+
+		/// <summary>
+		/// Subscribes to diagnostic listeners
+		/// </summary>
+		/// <param name="components">The agent components</param>
+		/// <param name="disposable">A disposable to which other disposables can be added</param>
+		/// <returns>A disposable</returns>
+		protected abstract IDisposable Subscribe(IApmAgent components, ICompositeDisposable disposable);
 	}
 }


### PR DESCRIPTION
This commit subscribes `IDiagnosticsSubscriber`
in `ApmAgentExtensions.Subscribe(...)` **only** if the agent is
enabled. This extension method is the root for the 
subscribers subscribing to diagnostic events, and
performing the check here removes the need to perform the
check to see if the agent is enabled in each subscriber implementation.

Closes #1018