### PR TITLE
Add SqlClient diagnostic listeners for .NET 5.0

### DIFF
--- a/src/Elastic.Apm.SqlClient/SqlClientDiagnosticSubscriber.cs
+++ b/src/Elastic.Apm.SqlClient/SqlClientDiagnosticSubscriber.cs
@@ -18,7 +18,7 @@ namespace Elastic.Apm.SqlClient
 			if (!agentComponents.ConfigurationReader.Enabled)
 				return retVal;
 
-			if (PlatformDetection.IsDotNetCore)
+			if (PlatformDetection.IsDotNetCore || PlatformDetection.IsDotNet5)
 			{
 				var initializer = new DiagnosticInitializer(agentComponents.Logger, new[] { new SqlClientDiagnosticListener(agentComponents) });
 


### PR DESCRIPTION
This commit adds SqlClientDiagnosticListener
for .NET 5.0, when .NET 5.0 is the detected
platform. This follows the same branch as
.NET Core.

Fixes #1025