### PR TITLE
Fetch APM server version only when not null

### DIFF
--- a/src/Elastic.Apm/Report/PayloadSenderV2.cs
+++ b/src/Elastic.Apm/Report/PayloadSenderV2.cs
@@ -181,7 +181,7 @@ namespace Elastic.Apm.Report
 				_getCloudMetadata = true;
 			}
 
-			if (!_getApmServerVersion)
+			if (!_getApmServerVersion && _apmServerInfo?.Version is null)
 			{
 				await ApmServerInfoProvider.FillApmServerInfo(_apmServerInfo, _logger, _configSnapshot, HttpClientInstance).ConfigureAwait(false);
 				_getApmServerVersion = true;

--- a/test/Elastic.Apm.Tests/BackendCommTests/CentralConfig/CentralConfigFetcherTests.cs
+++ b/test/Elastic.Apm.Tests/BackendCommTests/CentralConfig/CentralConfigFetcherTests.cs
@@ -33,7 +33,7 @@ namespace Elastic.Apm.Tests.BackendCommTests.CentralConfig
 			using (var agent = new ApmAgent(new TestAgentComponents(LoggerBase,
 				centralConfigFetcher: new CentralConfigFetcher(LoggerBase, configStore, service),
 				payloadSender: new PayloadSenderV2(LoggerBase, configSnapshotFromReader, service,
-					new SystemInfoHelper(LoggerBase).ParseSystemInfo(null), new MockApmServerInfo()))))
+					new SystemInfoHelper(LoggerBase).ParseSystemInfo(null), MockApmServerInfo.Version710))))
 			{
 				lastCentralConfigFetcher = (CentralConfigFetcher)agent.CentralConfigFetcher;
 				lastCentralConfigFetcher.IsRunning.Should().BeTrue();
@@ -63,7 +63,7 @@ namespace Elastic.Apm.Tests.BackendCommTests.CentralConfig
 				using (agents[i] = new ApmAgent(new TestAgentComponents(LoggerBase,
 					centralConfigFetcher: new CentralConfigFetcher(LoggerBase, configStore, service),
 					payloadSender: new PayloadSenderV2(LoggerBase, configSnapshotFromReader, service,
-						new SystemInfoHelper(LoggerBase).ParseSystemInfo(null), new MockApmServerInfo()))))
+						new SystemInfoHelper(LoggerBase).ParseSystemInfo(null), MockApmServerInfo.Version710))))
 				{
 					((CentralConfigFetcher)agents[i].CentralConfigFetcher).IsRunning.Should().BeTrue();
 					((PayloadSenderV2)agents[i].PayloadSender).IsRunning.Should().BeTrue();

--- a/test/Elastic.Apm.Tests/BackendCommTests/PayloadSenderTests.cs
+++ b/test/Elastic.Apm.Tests/BackendCommTests/PayloadSenderTests.cs
@@ -65,7 +65,7 @@ namespace Elastic.Apm.Tests.BackendCommTests
 			var noopLogger = new NoopLogger();
 			var mockConfig = new MockConfigSnapshot(_logger, secretToken: secretToken, maxBatchEventCount: "1");
 			var payloadSender = new PayloadSenderV2(_logger, mockConfig,
-				Service.GetDefaultService(mockConfig, noopLogger), new Api.System(), new MockApmServerInfo(), handler, /* dbgName: */ TestDisplayName);
+				Service.GetDefaultService(mockConfig, noopLogger), new Api.System(), MockApmServerInfo.Version710, handler, /* dbgName: */ TestDisplayName);
 
 			// Act
 			using (var agent = new ApmAgent(new TestAgentComponents(LoggerBase, mockConfig, payloadSender)))
@@ -100,7 +100,7 @@ namespace Elastic.Apm.Tests.BackendCommTests
 			var noopLogger = new NoopLogger();
 			var mockConfig = new MockConfigSnapshot(_logger, secretToken: secretToken, apiKey: apiKey, maxBatchEventCount: "1");
 			var payloadSender = new PayloadSenderV2(_logger, mockConfig,
-				Service.GetDefaultService(mockConfig, noopLogger), new Api.System(), new MockApmServerInfo(), handler, /* dbgName: */ TestDisplayName);
+				Service.GetDefaultService(mockConfig, noopLogger), new Api.System(), MockApmServerInfo.Version710, handler, /* dbgName: */ TestDisplayName);
 
 			// Act
 			using (var agent = new ApmAgent(new TestAgentComponents(LoggerBase, mockConfig, payloadSender)))
@@ -131,7 +131,7 @@ namespace Elastic.Apm.Tests.BackendCommTests
 			var logger = new NoopLogger();
 			var service = Service.GetDefaultService(new MockConfigSnapshot(logger), logger);
 			var payloadSender = new PayloadSenderV2(logger, new MockConfigSnapshot(logger, flushInterval: "1s"),
-				service, new Api.System(), new MockApmServerInfo(), handler, /* dbgName: */ TestDisplayName);
+				service, new Api.System(), MockApmServerInfo.Version710, handler, /* dbgName: */ TestDisplayName);
 
 			using (var agent = new ApmAgent(new TestAgentComponents(LoggerBase, payloadSender: payloadSender)))
 			{
@@ -212,7 +212,7 @@ namespace Elastic.Apm.Tests.BackendCommTests
 
 			var configurationReader = args.BuildConfig(_logger);
 			var service = Service.GetDefaultService(configurationReader, _logger);
-			var payloadSender = new PayloadSenderV2(_logger, configurationReader, service, new Api.System(), new MockApmServerInfo(), handler, /* dbgName: */ TestDisplayName);
+			var payloadSender = new PayloadSenderV2(_logger, configurationReader, service, new Api.System(), MockApmServerInfo.Version710, handler, /* dbgName: */ TestDisplayName);
 
 			using (var agent = new ApmAgent(new TestAgentComponents(_logger, payloadSender: payloadSender)))
 			{
@@ -259,7 +259,7 @@ namespace Elastic.Apm.Tests.BackendCommTests
 
 			var configurationReader = args.BuildConfig(_logger);
 			var service = Service.GetDefaultService(configurationReader, _logger);
-			var payloadSender = new PayloadSenderV2(_logger, configurationReader, service, new Api.System(), new MockApmServerInfo(), handler, /* dbgName: */ TestDisplayName);
+			var payloadSender = new PayloadSenderV2(_logger, configurationReader, service, new Api.System(), MockApmServerInfo.Version710, handler, /* dbgName: */ TestDisplayName);
 
 			using (var agent = new ApmAgent(new TestAgentComponents(_logger, payloadSender: payloadSender)))
 			{
@@ -307,7 +307,7 @@ namespace Elastic.Apm.Tests.BackendCommTests
 
 			var configurationReader = args.BuildConfig(_logger);
 			var service = Service.GetDefaultService(configurationReader, _logger);
-			var payloadSender = new PayloadSenderV2(_logger, configurationReader, service, new Api.System(), new MockApmServerInfo(), handler
+			var payloadSender = new PayloadSenderV2(_logger, configurationReader, service, new Api.System(), MockApmServerInfo.Version710, handler
 				, /* dbgName: */ TestDisplayName);
 
 			using (var agent = new ApmAgent(new TestAgentComponents(_logger, payloadSender: payloadSender)))
@@ -363,7 +363,7 @@ namespace Elastic.Apm.Tests.BackendCommTests
 
 			var configurationReader = args.BuildConfig(_logger);
 			var service = Service.GetDefaultService(configurationReader, _logger);
-			var payloadSender = new PayloadSenderV2(_logger, configurationReader, service, new Api.System(), new MockApmServerInfo(), handler, /* dbgName: */ TestDisplayName);
+			var payloadSender = new PayloadSenderV2(_logger, configurationReader, service, new Api.System(), MockApmServerInfo.Version710, handler, /* dbgName: */ TestDisplayName);
 
 			using (var agent = new ApmAgent(new TestAgentComponents(_logger, payloadSender: payloadSender)))
 			{
@@ -419,7 +419,7 @@ namespace Elastic.Apm.Tests.BackendCommTests
 			var configReader = new MockConfigSnapshot(_logger);
 			var mockHttpMessageHandler = new MockHttpMessageHandler((r, c) => Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)));
 			var service = Service.GetDefaultService(configReader, _logger);
-			var payloadSender = new PayloadSenderV2(_logger, configReader, service, new Api.System(), new MockApmServerInfo(), mockHttpMessageHandler
+			var payloadSender = new PayloadSenderV2(_logger, configReader, service, new Api.System(), MockApmServerInfo.Version710, mockHttpMessageHandler
 				, /* dbgName: */ TestDisplayName);
 
 			payloadSender.IsRunning.Should().BeTrue();

--- a/test/Elastic.Apm.Tests/FilterTests.cs
+++ b/test/Elastic.Apm.Tests/FilterTests.cs
@@ -189,7 +189,7 @@ namespace Elastic.Apm.Tests
 			});
 
 			var payloadSender = new PayloadSenderV2(_logger, mockConfig,
-				Service.GetDefaultService(mockConfig, _logger), new Api.System(),new MockApmServerInfo(), handler);
+				Service.GetDefaultService(mockConfig, _logger), new Api.System(),MockApmServerInfo.Version710, handler);
 
 			registerFilters(payloadSender);
 

--- a/test/Elastic.Apm.Tests/LoggerTests.cs
+++ b/test/Elastic.Apm.Tests/LoggerTests.cs
@@ -336,7 +336,7 @@ namespace Elastic.Apm.Tests
 				flushInterval: "0");
 
 			using var payloadSender = new PayloadSenderV2(inMemoryLogger, configReader,
-				Service.GetDefaultService(configReader, inMemoryLogger), new Api.System(), new MockApmServerInfo());
+				Service.GetDefaultService(configReader, inMemoryLogger), new Api.System(), MockApmServerInfo.Version710);
 
 			using var agent = new ApmAgent(new AgentComponents(payloadSender: payloadSender));
 
@@ -363,7 +363,7 @@ namespace Elastic.Apm.Tests
 				flushInterval: "0");
 
 			using var payloadSender = new PayloadSenderV2(inMemoryLogger, configReader,
-				Service.GetDefaultService(configReader, inMemoryLogger), new Api.System(), new MockApmServerInfo());
+				Service.GetDefaultService(configReader, inMemoryLogger), new Api.System(), MockApmServerInfo.Version710);
 
 			using var localServer = new LocalServer(httpListenerContext => { httpListenerContext.Response.StatusCode = 500; },
 				$"http://localhost:{port}/");

--- a/test/Elastic.Apm.Tests/Mocks/MockApmServerInfo.cs
+++ b/test/Elastic.Apm.Tests/Mocks/MockApmServerInfo.cs
@@ -9,8 +9,7 @@ namespace Elastic.Apm.Tests.Mocks
 {
 	internal class MockApmServerInfo : IApmServerInfo
 	{
-		public MockApmServerInfo()
-			=> Version = new ElasticVersion(7, 10, 0, null);
+		public static MockApmServerInfo Version710 { get; } = new MockApmServerInfo(new ElasticVersion(7, 10, 0, null));
 
 		public MockApmServerInfo(ElasticVersion version) => Version = version;
 

--- a/test/Elastic.Apm.Tests/Mocks/TestAgentComponents.cs
+++ b/test/Elastic.Apm.Tests/Mocks/TestAgentComponents.cs
@@ -28,7 +28,7 @@ namespace Elastic.Apm.Tests.Mocks
 			new FakeMetricsCollector(),
 			currentExecutionSegmentsContainer,
 			centralConfigFetcher ?? new NoopCentralConfigFetcher(),
-			apmServerInfo ?? new MockApmServerInfo()
+			apmServerInfo ?? MockApmServerInfo.Version710
 		)
 		{ }
 	}

--- a/test/Elastic.Apm.Tests/SamplerTests.cs
+++ b/test/Elastic.Apm.Tests/SamplerTests.cs
@@ -116,7 +116,7 @@ namespace Elastic.Apm.Tests
 				Activity.Current = null;
 
 				var transaction = new Transaction(noopLogger, "test transaction name", "test transaction type", sampler,
-					/* distributedTracingData: */ null, noopPayloadSender, configurationReader, currentExecutionSegmentsContainer, new MockApmServerInfo());
+					/* distributedTracingData: */ null, noopPayloadSender, configurationReader, currentExecutionSegmentsContainer, MockApmServerInfo.Version710);
 				if (transaction.IsSampled) ++sampledCount;
 
 				// ReSharper disable once InvertIf

--- a/test/Elastic.Apm.Tests/SerializationTests.cs
+++ b/test/Elastic.Apm.Tests/SerializationTests.cs
@@ -268,13 +268,13 @@ namespace Elastic.Apm.Tests
 			var agent = new TestAgentComponents();
 			// Create a transaction that is sampled (because the sampler is constant sampling-everything sampler
 			var sampledTransaction = new Transaction(agent.Logger, "dummy_name", "dumm_type", new Sampler(1.0), /* distributedTracingData: */ null,
-				agent.PayloadSender, new MockConfigSnapshot(new NoopLogger()), agent.TracerInternal.CurrentExecutionSegmentsContainer, new MockApmServerInfo());
+				agent.PayloadSender, new MockConfigSnapshot(new NoopLogger()), agent.TracerInternal.CurrentExecutionSegmentsContainer, MockApmServerInfo.Version710);
 			sampledTransaction.Context.Request = new Request("GET",
 				new Url { Full = "https://elastic.co", Raw = "https://elastic.co", HostName = "elastic.co", Protocol = "HTTP" });
 
 			// Create a transaction that is not sampled (because the sampler is constant not-sampling-anything sampler
 			var nonSampledTransaction = new Transaction(agent.Logger, "dummy_name", "dumm_type", new Sampler(0.0), /* distributedTracingData: */ null,
-				agent.PayloadSender, new MockConfigSnapshot(new NoopLogger()), agent.TracerInternal.CurrentExecutionSegmentsContainer, new MockApmServerInfo());
+				agent.PayloadSender, new MockConfigSnapshot(new NoopLogger()), agent.TracerInternal.CurrentExecutionSegmentsContainer, MockApmServerInfo.Version710);
 			nonSampledTransaction.Context.Request = sampledTransaction.Context.Request;
 
 			var serializedSampledTransaction = SerializePayloadItem(sampledTransaction);


### PR DESCRIPTION
This commit updates the PayloadSender workloop to only fetch APM server info on the first iteration when the version is not null.

Tests pass an APM server info with a version so the call should not be made.