### PR TITLE
Moving stack trace capturing away from application thread

### DIFF
--- a/src/Elastic.Apm/Filters/SpanStackTraceCapturingFilter.cs
+++ b/src/Elastic.Apm/Filters/SpanStackTraceCapturingFilter.cs
@@ -1,0 +1,58 @@
+// Licensed to Elasticsearch B.V under
+// one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System.Diagnostics;
+using Elastic.Apm.Api;
+using Elastic.Apm.Helpers;
+using Elastic.Apm.Logging;
+using Elastic.Apm.Model;
+using Elastic.Apm.ServerInfo;
+
+namespace Elastic.Apm.Filters
+{
+	/// <summary>
+	/// Stack trace capturing itself happens on the application thread (in order to get the real stack trace).
+	/// This filter turns <see cref="Span.RawStackTrace" /> (which is a plain .NET System.Diagnostics.StackTrace instance) into
+	/// <see cref="Span.StackTrace" /> (which is the representation of the intake API stacktrace model).
+	/// This can be done on a non-application thread right before the span gets sent to the APM Server.
+	/// </summary>
+	internal class SpanStackTraceCapturingFilter
+	{
+		private readonly IApmServerInfo _apmServerInfo;
+		private readonly IApmLogger _logger;
+
+		public SpanStackTraceCapturingFilter(IApmLogger logger, IApmServerInfo apmServerInfo) =>
+			(_logger, _apmServerInfo) = (logger, apmServerInfo);
+
+		public ISpan Filter(ISpan iSpan)
+
+		{
+			if (iSpan is Span span)
+			{
+				if (span.RawStackTrace != null)
+				{
+					StackFrame[] trace;
+					try
+					{
+						// I saw EnhancedStackTrace throwing exceptions in some environments
+						// therefore we try-catch and fall back to a non-demystified call stack.
+						trace = new EnhancedStackTrace(span.RawStackTrace).GetFrames();
+					}
+					catch
+					{
+						trace = span.RawStackTrace.GetFrames();
+					}
+
+					span.StackTrace = StacktraceHelper.GenerateApmStackTrace(trace,
+						_logger,
+						span.ConfigSnapshot, _apmServerInfo, $"Span `{span.Name}'");
+				}
+
+				return span;
+			}
+			return iSpan;
+		}
+	}
+}

--- a/src/Elastic.Apm/Model/Span.cs
+++ b/src/Elastic.Apm/Model/Span.cs
@@ -20,6 +20,7 @@ namespace Elastic.Apm.Model
 {
 	internal class Span : ISpan
 	{
+		private readonly IApmServerInfo _apmServerInfo;
 		private readonly Lazy<SpanContext> _context = new Lazy<SpanContext>();
 		private readonly ICurrentExecutionSegmentsContainer _currentExecutionSegmentsContainer;
 		private readonly Transaction _enclosingTransaction;
@@ -28,22 +29,6 @@ namespace Elastic.Apm.Model
 		private readonly IApmLogger _logger;
 		private readonly Span _parentSpan;
 		private readonly IPayloadSender _payloadSender;
-
-		/// <summary>
-		/// In some cases capturing the stacktrace in <see cref="End" /> results in a stack trace which is not very useful.
-		/// In such cases we capture the stacktrace on span start.
-		/// These are typically async calls - e.g. capturing stacktrace for outgoing HTTP requests in the
-		/// System.Net.Http.HttpRequestOut.Stop
-		/// diagnostic source event produces a stack trace that does not contain the caller method in user code - therefore we
-		/// capture the stacktrace is .Start
-		/// </summary>
-		private readonly StackFrame[] _stackFrames;
-
-		/// <summary>
-		/// Captures the sample rate of the agent when this span was created.
-		/// </summary>
-		[JsonProperty("sample_rate")]
-		internal double SampleRate { get; }
 
 		// This constructor is meant for deserialization
 		[JsonConstructor]
@@ -100,20 +85,14 @@ namespace Elastic.Apm.Model
 				{
 					enclosingTransaction.SpanCount.IncrementStarted();
 
-					if (captureStackTraceOnStart)
-					{
-						var stackTrace = new StackTrace(true);
-						try
-						{
-							// I saw EnhancedStackTrace throwing exceptions in some environments
-							// therefore we try-catch and fall back to a non-demystified call stack.
-							_stackFrames = new EnhancedStackTrace(stackTrace).GetFrames();
-						}
-						catch
-						{
-							_stackFrames = stackTrace.GetFrames();
-						}
-					}
+					// In some cases capturing the stacktrace in End() results in a stack trace which is not very useful.
+					// In such cases we capture the stacktrace on span start.
+					// These are typically async calls - e.g. capturing stacktrace for outgoing HTTP requests in the
+					// System.Net.Http.HttpRequestOut.Stop
+					// diagnostic source event produces a stack trace that does not contain the caller method in user code - therefore we
+					// capture the stacktrace is .Start
+					if (captureStackTraceOnStart && ConfigSnapshot.StackTraceLimit != 0 && ConfigSnapshot.SpanFramesMinDurationInMilliseconds != 0)
+						RawStackTrace = new StackTrace(true);
 				}
 			}
 			else
@@ -127,13 +106,12 @@ namespace Elastic.Apm.Model
 		}
 
 		private bool _isEnded;
-		private readonly IApmServerInfo _apmServerInfo;
 
 		[MaxLength]
 		public string Action { get; set; }
 
 		[JsonIgnore]
-		private IConfigSnapshot ConfigSnapshot => _enclosingTransaction.ConfigSnapshot;
+		internal IConfigSnapshot ConfigSnapshot => _enclosingTransaction.ConfigSnapshot;
 
 		/// <summary>
 		/// Any other arbitrary data captured by the agent, optionally provided by the user.
@@ -185,6 +163,20 @@ namespace Elastic.Apm.Model
 		[MaxLength]
 		[JsonProperty("parent_id")]
 		public string ParentId { get; set; }
+
+		/// <summary>
+		/// This holds the raw stack trace that was captured when the span either started or ended (depending on the parameter
+		/// passed to the .ctor)
+		/// This will be turned into an elastic stack trace and sent to APM Server in the <see cref="StackTrace" /> property
+		/// </summary>
+		[JsonIgnore]
+		internal StackTrace RawStackTrace;
+
+		/// <summary>
+		/// Captures the sample rate of the agent when this span was created.
+		/// </summary>
+		[JsonProperty("sample_rate")]
+		internal double SampleRate { get; }
 
 		[JsonIgnore]
 		internal bool ShouldBeSentToApmServer => IsSampled && !_isDropped;
@@ -298,38 +290,40 @@ namespace Elastic.Apm.Model
 
 				// Spans are sent only for sampled transactions so it's only worth capturing stack trace for sampled spans
 				// ReSharper disable once CompareOfFloatsByEqualityOperator
-				if (ConfigSnapshot.StackTraceLimit != 0 && ConfigSnapshot.SpanFramesMinDurationInMilliseconds != 0)
-				{
-					if (Duration >= ConfigSnapshot.SpanFramesMinDurationInMilliseconds
-						|| ConfigSnapshot.SpanFramesMinDurationInMilliseconds < 0)
-					{
-						if (_stackFrames == null)
-						{
-							StackFrame[] trace;
-							var stackTrace = new StackTrace(true);
-							try
-							{
-								// I saw EnhancedStackTrace throwing exceptions in some environments
-								// therefore we try-catch and fall back to a non-demystified call stack.
-								trace = new EnhancedStackTrace(stackTrace).GetFrames();
-							}
-							catch
-							{
-								trace = stackTrace.GetFrames();
-							}
+				if (ConfigSnapshot.StackTraceLimit != 0 && ConfigSnapshot.SpanFramesMinDurationInMilliseconds != 0 && RawStackTrace == null
+					&& (Duration >= ConfigSnapshot.SpanFramesMinDurationInMilliseconds
+						|| ConfigSnapshot.SpanFramesMinDurationInMilliseconds < 0))
+					RawStackTrace = new StackTrace(true);
 
-							StackTrace = StacktraceHelper.GenerateApmStackTrace(trace,
-								_logger,
-								ConfigSnapshot, _apmServerInfo, $"Span `{Name}'");
-						}
-						else
-						{
-							StackTrace = StacktraceHelper.GenerateApmStackTrace(_stackFrames,
-								_logger,
-								ConfigSnapshot, _apmServerInfo, $"Span `{Name}'");
-						}
-					}
-				}
+				// if (Duration >= ConfigSnapshot.SpanFramesMinDurationInMilliseconds
+				// 	|| ConfigSnapshot.SpanFramesMinDurationInMilliseconds < 0)
+				// {
+				// 	if (StackFrames == null)
+				// 	{
+				// 		StackFrame[] trace;
+				// 		var stackTrace = new StackTrace(true);
+				// 		try
+				// 		{
+				// 			// I saw EnhancedStackTrace throwing exceptions in some environments
+				// 			// therefore we try-catch and fall back to a non-demystified call stack.
+				// 			trace = new EnhancedStackTrace(stackTrace).GetFrames();
+				// 		}
+				// 		catch
+				// 		{
+				// 			trace = stackTrace.GetFrames();
+				// 		}
+				//
+				// 		StackTrace = StacktraceHelper.GenerateApmStackTrace(trace,
+				// 			_logger,
+				// 			ConfigSnapshot, _apmServerInfo, $"Span `{Name}'");
+				// 	}
+				// 	else
+				// 	{
+				// 		StackTrace = StacktraceHelper.GenerateApmStackTrace(StackFrames,
+				// 			_logger,
+				// 			ConfigSnapshot, _apmServerInfo, $"Span `{Name}'");
+				// 	}
+				// }
 
 				_payloadSender.QueueSpan(this);
 			}

--- a/src/Elastic.Apm/Model/Span.cs
+++ b/src/Elastic.Apm/Model/Span.cs
@@ -295,36 +295,6 @@ namespace Elastic.Apm.Model
 						|| ConfigSnapshot.SpanFramesMinDurationInMilliseconds < 0))
 					RawStackTrace = new StackTrace(true);
 
-				// if (Duration >= ConfigSnapshot.SpanFramesMinDurationInMilliseconds
-				// 	|| ConfigSnapshot.SpanFramesMinDurationInMilliseconds < 0)
-				// {
-				// 	if (StackFrames == null)
-				// 	{
-				// 		StackFrame[] trace;
-				// 		var stackTrace = new StackTrace(true);
-				// 		try
-				// 		{
-				// 			// I saw EnhancedStackTrace throwing exceptions in some environments
-				// 			// therefore we try-catch and fall back to a non-demystified call stack.
-				// 			trace = new EnhancedStackTrace(stackTrace).GetFrames();
-				// 		}
-				// 		catch
-				// 		{
-				// 			trace = stackTrace.GetFrames();
-				// 		}
-				//
-				// 		StackTrace = StacktraceHelper.GenerateApmStackTrace(trace,
-				// 			_logger,
-				// 			ConfigSnapshot, _apmServerInfo, $"Span `{Name}'");
-				// 	}
-				// 	else
-				// 	{
-				// 		StackTrace = StacktraceHelper.GenerateApmStackTrace(StackFrames,
-				// 			_logger,
-				// 			ConfigSnapshot, _apmServerInfo, $"Span `{Name}'");
-				// 	}
-				// }
-
 				_payloadSender.QueueSpan(this);
 			}
 

--- a/src/Elastic.Apm/Model/Span.cs
+++ b/src/Elastic.Apm/Model/Span.cs
@@ -169,7 +169,6 @@ namespace Elastic.Apm.Model
 		/// passed to the .ctor)
 		/// This will be turned into an elastic stack trace and sent to APM Server in the <see cref="StackTrace" /> property
 		/// </summary>
-		[JsonIgnore]
 		internal StackTrace RawStackTrace;
 
 		/// <summary>

--- a/src/Elastic.Apm/Report/PayloadSenderV2.cs
+++ b/src/Elastic.Apm/Report/PayloadSenderV2.cs
@@ -108,6 +108,8 @@ namespace Elastic.Apm.Report
 
 			_eventQueue = new BatchBlock<object>(config.MaxBatchEventCount);
 			TransactionFilters.Add(new TransactionIgnoreUrlsFilter(config).Filter);
+			// with this stack trace demystification and conversion to the intake API model happens on a non-application thread:
+			SpanFilters.Add(new SpanStackTraceCapturingFilter(_logger, apmServerInfo).Filter);
 			StartWorkLoop();
 		}
 

--- a/src/Elastic.Apm/Report/PayloadSenderV2.cs
+++ b/src/Elastic.Apm/Report/PayloadSenderV2.cs
@@ -108,7 +108,7 @@ namespace Elastic.Apm.Report
 
 			_eventQueue = new BatchBlock<object>(config.MaxBatchEventCount);
 			TransactionFilters.Add(new TransactionIgnoreUrlsFilter(config).Filter);
-			// with this stack trace demystification and conversion to the intake API model happens on a non-application thread:
+			// with this, stack trace demystification and conversion to the intake API model happens on a non-application thread:
 			SpanFilters.Add(new SpanStackTraceCapturingFilter(_logger, apmServerInfo).Filter);
 			StartWorkLoop();
 		}

--- a/test/Elastic.Apm.Tests/Mocks/MockPayloadSender.cs
+++ b/test/Elastic.Apm.Tests/Mocks/MockPayloadSender.cs
@@ -8,19 +8,27 @@ using System.Linq;
 using System.Threading.Tasks;
 using System.Timers;
 using Elastic.Apm.Api;
+using Elastic.Apm.Filters;
+using Elastic.Apm.Logging;
 using Elastic.Apm.Metrics;
 using Elastic.Apm.Model;
 using Elastic.Apm.Report;
+using Elastic.Apm.ServerInfo;
 
 namespace Elastic.Apm.Tests.Mocks
 {
 	internal class MockPayloadSender : IPayloadSender
 	{
+		internal readonly List<Func<ISpan, ISpan>> SpanFilters = new List<Func<ISpan, ISpan>>();
 		private readonly List<IError> _errors = new List<IError>();
 		private readonly object _lock = new object();
 		private readonly List<IMetricSet> _metrics = new List<IMetricSet>();
 		private readonly List<ISpan> _spans = new List<ISpan>();
 		private readonly List<ITransaction> _transactions = new List<ITransaction>();
+
+		public MockPayloadSender(IApmLogger logger = null)
+			=> SpanFilters.Add(
+				new SpanStackTraceCapturingFilter(logger ?? new NoopLogger(), new MockApmServerInfo(new ElasticVersion(7, 10, 0, null))).Filter);
 
 		private TaskCompletionSource<ITransaction> _transactionTaskCompletionSource = new TaskCompletionSource<ITransaction>();
 
@@ -28,7 +36,7 @@ namespace Elastic.Apm.Tests.Mocks
 
 		public Error FirstError => _errors.First() as Error;
 
-		internal void ResetTransactionTaskCompletionSource() => _transactionTaskCompletionSource = new TaskCompletionSource<ITransaction>();
+		public MetricSet FirstMetric => _metrics.First() as MetricSet;
 
 		/// <summary>
 		/// The 1. Span on the 1. Transaction
@@ -36,11 +44,9 @@ namespace Elastic.Apm.Tests.Mocks
 		public Span FirstSpan => _spans.First() as Span;
 
 		public Transaction FirstTransaction =>
-			 Transactions.First() as Transaction;
+			Transactions.First() as Transaction;
 
 		public IReadOnlyList<IMetricSet> Metrics => CreateImmutableSnapshot(_metrics);
-
-		public MetricSet FirstMetric => _metrics.First() as MetricSet;
 
 		public IReadOnlyList<ISpan> Spans => CreateImmutableSnapshot(_spans);
 
@@ -51,11 +57,7 @@ namespace Elastic.Apm.Tests.Mocks
 		{
 			get
 			{
-
-				var timer = new Timer
-				{
-					Interval = 1000
-				};
+				var timer = new Timer { Interval = 1000 };
 
 				timer.Enabled = true;
 				timer.Start();
@@ -82,6 +84,8 @@ namespace Elastic.Apm.Tests.Mocks
 			}
 		}
 
+		internal void ResetTransactionTaskCompletionSource() => _transactionTaskCompletionSource = new TaskCompletionSource<ITransaction>();
+
 		public void QueueError(IError error) => _errors.Add(error);
 
 		public virtual void QueueTransaction(ITransaction transaction)
@@ -92,8 +96,11 @@ namespace Elastic.Apm.Tests.Mocks
 
 		public void QueueSpan(ISpan span)
 		{
-			lock(_lock)
+			lock (_lock)
+			{
+				foreach (var filter in SpanFilters) span = filter(span);
 				_spans.Add(span);
+			}
 		}
 
 		public void QueueMetrics(IMetricSet metricSet) => _metrics.Add(metricSet);

--- a/test/Elastic.Apm.Tests/Mocks/MockPayloadSender.cs
+++ b/test/Elastic.Apm.Tests/Mocks/MockPayloadSender.cs
@@ -19,7 +19,7 @@ namespace Elastic.Apm.Tests.Mocks
 {
 	internal class MockPayloadSender : IPayloadSender
 	{
-		internal readonly List<Func<ISpan, ISpan>> SpanFilters = new List<Func<ISpan, ISpan>>();
+		private readonly List<Func<ISpan, ISpan>> _spanFilters = new List<Func<ISpan, ISpan>>();
 		private readonly List<IError> _errors = new List<IError>();
 		private readonly object _lock = new object();
 		private readonly List<IMetricSet> _metrics = new List<IMetricSet>();
@@ -27,7 +27,7 @@ namespace Elastic.Apm.Tests.Mocks
 		private readonly List<ITransaction> _transactions = new List<ITransaction>();
 
 		public MockPayloadSender(IApmLogger logger = null)
-			=> SpanFilters.Add(
+			=> _spanFilters.Add(
 				new SpanStackTraceCapturingFilter(logger ?? new NoopLogger(), new MockApmServerInfo(new ElasticVersion(7, 10, 0, null))).Filter);
 
 		private TaskCompletionSource<ITransaction> _transactionTaskCompletionSource = new TaskCompletionSource<ITransaction>();
@@ -98,7 +98,7 @@ namespace Elastic.Apm.Tests.Mocks
 		{
 			lock (_lock)
 			{
-				foreach (var filter in SpanFilters) span = filter(span);
+				foreach (var filter in _spanFilters) span = filter(span);
 				_spans.Add(span);
 			}
 		}

--- a/test/Elastic.Apm.Tests/StackTraceTests.cs
+++ b/test/Elastic.Apm.Tests/StackTraceTests.cs
@@ -201,7 +201,8 @@ namespace Elastic.Apm.Tests
 
 			var payloadSender = new MockPayloadSender();
 
-			using (var agent = new ApmAgent(new TestAgentComponents(payloadSender: payloadSender, apmServerInfo: new MockApmServerInfo(new ElasticVersion(7, 5, 0, null)))))
+			using (var agent = new ApmAgent(new TestAgentComponents(payloadSender: payloadSender,
+				apmServerInfo: new MockApmServerInfo(new ElasticVersion(7, 5, 0, null)))))
 				Assert.Throws<Exception>(() => { agent.Tracer.CaptureTransaction("TestTransaction", "Test", () => { testClass.JustThrow(); }); });
 
 			payloadSender.Errors.First().Should().NotBeNull();
@@ -518,7 +519,6 @@ namespace Elastic.Apm.Tests
 
 			assertAction(payloadSender);
 		}
-
 
 		private void TestMethod() => InnerTestMethod(() => throw new Exception("TestException"));
 


### PR DESCRIPTION
Addresses https://github.com/elastic/apm-agent-dotnet/issues/1039

`new StackTrace(true)` still happens on the app thread, but the demystification and the conversion to our internal stack trace model happens right before serialization on the payloadsender thread.

Benchmarks (I worked with [this benchmark](https://github.com/elastic/apm-agent-dotnet/blob/2182be81af478390111061e3edee280c4cafa3b9/test/Elastic.Apm.PerfTests/AspNetCorePerf/AspNetCoreLoadTestWithAgent.cs))

Current master:

```
|                             Method |     Mean |    Error |   StdDev |   Median |
|----------------------------------- |---------:|---------:|---------:|---------:|
| WebRequestWithDbCallsAndCustomSpan | 31.96 ms | 3.569 ms | 10.52 ms | 24.93 ms |
```

With this PR:

```
|                             Method |     Mean |     Error |    StdDev |   Median |
|----------------------------------- |---------:|----------:|----------:|---------:|
| WebRequestWithDbCallsAndCustomSpan | 8.325 ms | 0.2154 ms | 0.6214 ms | 8.126 ms |
```

So from the throughput perspective of the monitored app this seems like an improvement.

Potential issues: 
- With this we moved more work to the `PayloadSenderV2` (or to be precise to the thread that handles every span after `.End()` is called on it)
- If people do `apm.Tracer.CurrentSpan` then the `StackTrace` property will be `null` on it, which wasn't the case previously (although to be fair the story there wasn't very nice, because in some cases it was filled when the span was ended (that's the default) and in other cases (e.g. HTTP and DB spans) it was filled when the span started). On the positive side, if people use filters, then at that point the property will be already filled. 