### PR TITLE
AllowSynchronousIO when capturing request body

### DIFF
--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -717,9 +717,24 @@ For transactions that are HTTP requests, the agent can optionally capture the re
 If the request has a body and this setting is disabled, the body will be shown as [REDACTED].
 This option is case-insensitive.
 
-WARNING: Request bodies often contain sensitive values like passwords, credit card numbers, etc.
+[IMPORTANT]
+====
+To allow capturing request bodies, the agent sets `AllowSynchronousIO` to `true` on a per
+request basis in ASP.NET Core, since capturing can occur in synchronous code paths. 
+
+https://docs.microsoft.com/en-us/aspnet/core/migration/22-to-30?#allowsynchronousio-disabled[With ASP.NET Core 3.0 onwards, `AllowSynchronousIO` is `false` by default] 
+because a large number of blocking synchronous I/O operations can lead to thread pool starvation, 
+which makes the application unresponsive. If your application becomes unresponsive with this 
+feature enabled, consider disabling capturing.
+====
+
+[WARNING]
+====
+Request bodies often contain sensitive values like passwords, credit card numbers, etc.
 If your service handles data like this, we advise to only enable this feature with care.
-Turning on body capturing can also significantly increase the overhead in terms of heap usage, network utilization, and Elasticsearch index size.
+Turning on body capturing can also significantly increase the overhead in terms of heap usage, 
+network utilization, and Elasticsearch index size.
+====
 
 Possible options are `off`, `errors`, `transactions` and `all`:
 

--- a/src/Elastic.Apm.AspNetCore/Extensions/RequestExtentions.cs
+++ b/src/Elastic.Apm.AspNetCore/Extensions/RequestExtentions.cs
@@ -9,6 +9,7 @@ using Elastic.Apm.Config;
 using Elastic.Apm.Helpers;
 using Elastic.Apm.Logging;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Features;
 
 namespace Elastic.Apm.AspNetCore.Extensions
 {
@@ -56,6 +57,12 @@ namespace Elastic.Apm.AspNetCore.Extensions
 				}
 				else
 				{
+					// allow synchronous reading of the request stream, which is false by default from 3.0 onwards.
+					// Reading must be synchronous as it can happen within a synchronous diagnostic listener method
+					var bodyControlFeature = request.HttpContext.Features.Get<IHttpBodyControlFeature>();
+					if (bodyControlFeature != null)
+						bodyControlFeature.AllowSynchronousIO = true;
+
 					request.EnableBuffering();
 					request.Body.Position = 0;
 

--- a/test/Elastic.Apm.AspNetCore.Tests/AspNetCoreBasicTests.cs
+++ b/test/Elastic.Apm.AspNetCore.Tests/AspNetCoreBasicTests.cs
@@ -244,8 +244,8 @@ namespace Elastic.Apm.AspNetCore.Tests
 
 			_agent.Service.Framework.Name.Should().Be("ASP.NET Core");
 
-			var aspNetCoreMajorMinorVersion = Assembly.Load("Microsoft.AspNetCore").GetName().Version.ToString(2);
-			_agent.Service.Framework.Version.Should().StartWith(aspNetCoreMajorMinorVersion);
+			var aspNetCoreVersion = Assembly.Load("Microsoft.AspNetCore").GetName().Version.ToString();
+			_agent.Service.Framework.Version.Should().Be(aspNetCoreVersion);
 
 			_agent.Service.Runtime.Name.Should().Be(Runtime.DotNetCoreName);
 			_agent.Service.Runtime.Version.Should().Be(Directory.GetParent(typeof(object).Assembly.Location).Name);

--- a/test/Elastic.Apm.AspNetCore.Tests/AspNetCoreBasicTests.cs
+++ b/test/Elastic.Apm.AspNetCore.Tests/AspNetCoreBasicTests.cs
@@ -244,8 +244,8 @@ namespace Elastic.Apm.AspNetCore.Tests
 
 			_agent.Service.Framework.Name.Should().Be("ASP.NET Core");
 
-			var aspNetCoreVersion = Assembly.Load("Microsoft.AspNetCore").GetName().Version.ToString();
-			_agent.Service.Framework.Version.Should().Be(aspNetCoreVersion);
+			var aspNetCoreMajorMinorVersion = Assembly.Load("Microsoft.AspNetCore").GetName().Version.ToString(2);
+			_agent.Service.Framework.Version.Should().StartWith(aspNetCoreMajorMinorVersion);
 
 			_agent.Service.Runtime.Name.Should().Be(Runtime.DotNetCoreName);
 			_agent.Service.Runtime.Version.Should().Be(Directory.GetParent(typeof(object).Assembly.Location).Name);

--- a/test/Elastic.Apm.AspNetCore.Tests/BodyCapturingTests.cs
+++ b/test/Elastic.Apm.AspNetCore.Tests/BodyCapturingTests.cs
@@ -350,7 +350,7 @@ namespace Elastic.Apm.AspNetCore.Tests
 				_taskForSampleApp = Program.CreateWebHostBuilder(null)
 					.ConfigureServices(services =>
 						{
-							services.Configure<KestrelServerOptions>(options => { options.AllowSynchronousIO = true; });
+							services.Configure<KestrelServerOptions>(options => {  });
 							Startup.ConfigureServicesExceptMvc(services);
 
 							services.AddMvc()

--- a/test/Elastic.Apm.AspNetCore.Tests/Helper.cs
+++ b/test/Elastic.Apm.AspNetCore.Tests/Helper.cs
@@ -32,13 +32,13 @@ namespace Elastic.Apm.AspNetCore.Tests
 					{
 						if (useOnlyDiagnosticSource)
 						{
-							var subs = new List<IDiagnosticsSubscriber>()
+							var subs = new IDiagnosticsSubscriber[]
 							{
 								new AspNetCoreDiagnosticSubscriber(),
 								new HttpDiagnosticsSubscriber(),
 								new EfCoreDiagnosticsSubscriber()
 							};
-							agent.Subscribe(subs.ToArray());
+							agent.Subscribe(subs);
 						}
 						else
 						{
@@ -56,9 +56,7 @@ namespace Elastic.Apm.AspNetCore.Tests
 
 					n.ConfigureServices(ConfigureServices);
 				});
-#if !NETCOREAPP2_1 && !NETCOREAPP2_2
-			builder.Server.AllowSynchronousIO = true;
-#endif
+
 			return builder.CreateClient();
 		}
 
@@ -71,13 +69,13 @@ namespace Elastic.Apm.AspNetCore.Tests
 					  {
 						  if (useOnlyDiagnosticSource)
 						  {
-							  var subs = new List<IDiagnosticsSubscriber>()
-							{
-								new HttpDiagnosticsSubscriber(),
-								new EfCoreDiagnosticsSubscriber(),
-								new AspNetCoreDiagnosticSubscriber()
-							};
-							  agent.Subscribe(subs.ToArray());
+							  var subs = new IDiagnosticsSubscriber[]
+							  {
+								  new HttpDiagnosticsSubscriber(),
+								  new EfCoreDiagnosticsSubscriber(),
+								  new AspNetCoreDiagnosticSubscriber()
+							  };
+							  agent.Subscribe(subs);
 						  }
 						  else
 						  {
@@ -89,9 +87,7 @@ namespace Elastic.Apm.AspNetCore.Tests
 
 					  n.ConfigureServices(ConfigureServices);
 				  });
-#if !NETCOREAPP2_1 && !NETCOREAPP2_2
-			builder.Server.AllowSynchronousIO = true;
-#endif
+
 			return builder.CreateClient();
 		}
 


### PR DESCRIPTION
This commit allows synchronous IO for a given request
when capturing the request body.

From ASP.NET Core 3.0 onwards, synchronous reading or writing
of request streams is disabled by default, throwing
an exception when attempting to do so. See

https://docs.microsoft.com/en-us/aspnet/core/migration/22-to-30?view=aspnetcore-5.0&tabs=visual-studio#allowsynchronousio-disabled

Capturing of the request body by the agent is a synchronous
operation because it may happen in the the synchronous
flow of a diagnostic listener.

Consideration was made to using GetAwaiter().GetResult()
which would effectively be sync over async, but using the
http body control feature is preferred as it is a framework feature
designed for this purpose.

Fixes #1044.