### PR TITLE
Read request body only up to maximum length

### DIFF
--- a/sample/SampleAspNetCoreApp/Controllers/HomeController.cs
+++ b/sample/SampleAspNetCoreApp/Controllers/HomeController.cs
@@ -166,8 +166,21 @@ namespace SampleAspNetCoreApp.Controllers
 
 		[HttpPost]
 		[DisableRequestSizeLimit]
+		public async Task<long> Stream()
+		{
+			using var stream = new MemoryStream();
+			await Request.Body.CopyToAsync(stream);
+			return stream.Length;
+		}
+
+		[HttpPost]
+		[DisableRequestSizeLimit]
 		[RequestFormLimits(ValueLengthLimit = int.MaxValue, MultipartBodyLengthLimit = int.MaxValue)]
 		public long File(IFormFile file) => file.Length;
+
+		[HttpPost]
+		[DisableRequestSizeLimit]
+		public long Form(IFormCollection form) => form.Count;
 
 		public IActionResult TransactionWithCustomName()
 		{

--- a/src/Elastic.Apm.AspNetCore/Extensions/RequestExtentions.cs
+++ b/src/Elastic.Apm.AspNetCore/Extensions/RequestExtentions.cs
@@ -3,20 +3,22 @@
 // See the LICENSE file in the project root for more information
 
 using System;
+using System.Buffers;
 using System.IO;
 using System.Text;
 using Elastic.Apm.Config;
 using Elastic.Apm.Helpers;
 using Elastic.Apm.Logging;
 using Microsoft.AspNetCore.Http;
+using static Elastic.Apm.AspNetCore.Consts;
 
 namespace Elastic.Apm.AspNetCore.Extensions
 {
 	internal static class HttpRequestExtensions
 	{
 		/// <summary>
-		/// Extracts the request body using measure to prevent the 'read once' problem (cannot read after the body ha been already
-		/// read).
+		/// Extracts the request body, up to a specified maximum length.
+		/// The request body that is read is buffered.
 		/// </summary>
 		/// <param name="request"></param>
 		/// <param name="logger"></param>
@@ -24,6 +26,7 @@ namespace Elastic.Apm.AspNetCore.Extensions
 		public static string ExtractRequestBody(this HttpRequest request, IApmLogger logger, IConfigSnapshot configSnapshot)
 		{
 			string body = null;
+			var longerThanMaxLength = false;
 
 			try
 			{
@@ -35,13 +38,12 @@ namespace Elastic.Apm.AspNetCore.Extensions
 					if (form != null && form.Count > 0)
 					{
 						var sb = new StringBuilder();
-
 						foreach (var item in form)
 						{
 							sb.Append(item.Key);
 							sb.Append("=");
 
-							if(WildcardMatcher.IsAnyMatch(configSnapshot.SanitizeFieldNames, item.Key))
+							if (WildcardMatcher.IsAnyMatch(configSnapshot.SanitizeFieldNames, item.Key))
 								sb.Append(Elastic.Apm.Consts.Redacted);
 							else
 								sb.Append(item.Value);
@@ -49,26 +51,66 @@ namespace Elastic.Apm.AspNetCore.Extensions
 							itemProcessed++;
 							if (itemProcessed != form.Count)
 								sb.Append("&");
+
+							// perf: check length once per iteration and truncate at the end, rather than each append
+							if (sb.Length > RequestBodyMaxLength)
+							{
+								longerThanMaxLength = true;
+								break;
+							}
 						}
 
-						body = sb.ToString();
+						body = sb.ToString(0, Math.Min(sb.Length, RequestBodyMaxLength));
 					}
 				}
 				else
 				{
 					request.EnableBuffering();
-					request.Body.Position = 0;
+					var requestBody = request.Body;
+					requestBody.Position = 0;
+					var arrayPool = ArrayPool<char>.Shared;
+					var capacity = 512;
+					var buffer = arrayPool.Rent(capacity);
+					var totalRead = 0;
+					int read;
 
-					using (var reader = new StreamReader(request.Body,
-						Encoding.UTF8,
-						false,
-						1024 * 2,
-						true))
-						body = reader.ReadToEnd();
+					// requestBody.Length is 0 on initial buffering - length relates to how much has been read and buffered.
+					// Read to just beyond request body max length so that we can determine if truncation will occur
+					try
+					{
+						// TODO: can we assume utf-8 encoding?
+						using var reader = new StreamReader(requestBody, Encoding.UTF8, false, buffer.Length, true);
+						while ((read = reader.Read(buffer, 0, capacity)) != 0)
+						{
+							totalRead += read;
+							if (totalRead > RequestBodyMaxLength)
+							{
+								longerThanMaxLength = true;
+								break;
+							}
+						}
+					}
+					finally
+					{
+						arrayPool.Return(buffer);
+					}
 
-					// Truncate the body to the first 2kb if it's longer
-					if (body.Length > Consts.RequestBodyMaxLength) body = body.Substring(0, Consts.RequestBodyMaxLength);
-					request.Body.Position = 0;
+					requestBody.Position = 0;
+					capacity = Math.Min(totalRead, RequestBodyMaxLength);
+					buffer = arrayPool.Rent(capacity);
+
+					try
+					{
+						using var reader = new StreamReader(requestBody, Encoding.UTF8, false, RequestBodyMaxLength, true);
+						read = reader.ReadBlock(buffer, 0, capacity);
+						body = new string(buffer, 0, read);
+					}
+					finally
+					{
+						arrayPool.Return(buffer);
+					}
+
+					requestBody.Position = 0;
 				}
 			}
 			catch (IOException ioException)
@@ -79,6 +121,10 @@ namespace Elastic.Apm.AspNetCore.Extensions
 			{
 				logger.Error()?.LogException(e, "Error reading request body");
 			}
+
+			if (longerThanMaxLength)
+				logger.Debug()?.Log("truncated body to max length {MaxLength}", RequestBodyMaxLength);
+
 			return body;
 		}
 	}


### PR DESCRIPTION
This commit optimizes the capturing of the request body
to stop reading when the maximum request body length
has been reached.