### PR TITLE
Add GetLabel method

### DIFF
--- a/docs/public-api.asciidoc
+++ b/docs/public-api.asciidoc
@@ -282,6 +282,19 @@ transaction.SetLabel("intSample", 42);
 * `String|Number|bool value`: The tag value
 
 [float]
+[[api-transaction-get-label]]
+==== `Label GetLabel(string key)` added[1.8.0,Number and boolean labels require APM Server 6.7+]
+
+Returns the label which was added in the <<api-transaction-set-label, SetLabel>> method. If the key does not exist, the method returns `null`.
+
+
+[source,csharp]
+----
+var myLabel = transaction.GetLabel("foo");
+Console.WriteLine(myLabel.Value);
+----
+
+[float]
 [[api-transaction-tags]]
 ==== `Dictionary<string,string> Labels`
 
@@ -566,6 +579,20 @@ span.SetLabel("intSample", 42);
 
 * `String key`:   The tag key
 * `String|Number|bool value`: The tag value
+
+
+[float]
+[[api-span-get-label]]
+==== `Label GetLabel(string key)` added[1.8.0,Number and boolean labels require APM Server 6.7+]
+
+Returns the label which was added in the <<api-span-set-label, SetLabel>> method. If the key does not exist, the method returns `null`.
+
+
+[source,csharp]
+----
+var myLabel = span.GetLabel("foo");
+Console.WriteLine(myLabel.Value);
+----
 
 [float]
 [[api-span-tags]]

--- a/docs/public-api.asciidoc
+++ b/docs/public-api.asciidoc
@@ -282,17 +282,17 @@ transaction.SetLabel("intSample", 42);
 * `String|Number|bool value`: The tag value
 
 [float]
-[[api-transaction-get-label]]
-==== `Label GetLabel(string key)` added[1.8.0,Number and boolean labels require APM Server 6.7+]
+[[api-transaction-try-get-label]]
+==== `T GetLabel<T>(string key, out T value)` added[1.7.1,Number and boolean labels require APM Server 6.7+]
 
-Returns the transaction's label. If the `key` does not exist, this method returns `null`.
+Returns the transaction's label in the `value` out parameter. If the `key` does not exist, this method returns false.
 Labels can be added with the <<api-transaction-set-label, SetLabel>> method.
 
 
 [source,csharp]
 ----
-var myLabel = transaction.GetLabel("foo");
-Console.WriteLine(myLabel.Value);
+if(transaction.TryGetLabel<int>("foo", our var myLabel))
+    Console.WriteLine(myLabel);
 ----
 
 [float]
@@ -583,17 +583,17 @@ span.SetLabel("intSample", 42);
 
 
 [float]
-[[api-span-get-label]]
-==== `Label GetLabel(string key)` added[1.8.0,Number and boolean labels require APM Server 6.7+]
+[[api-span-try-get-label]]
+==== `T GetLabel<T>(string key, out T value)` added[1.7.1,Number and boolean labels require APM Server 6.7+]
 
-Returns the span's label. If the `key` does not exist, this method returns `null`.
+Returns the span's label in the `value` out parameter. If the `key` does not exist, this method returns false.
 Labels can be added with the <<api-span-set-label, SetLabel>> method.
 
 
 [source,csharp]
 ----
-var myLabel = span.GetLabel("foo");
-Console.WriteLine(myLabel.Value);
+if(span.TryGetLabel<bool>("foo", out var myLabel))
+    Console.WriteLine(myLabel);
 ----
 
 [float]

--- a/docs/public-api.asciidoc
+++ b/docs/public-api.asciidoc
@@ -285,7 +285,8 @@ transaction.SetLabel("intSample", 42);
 [[api-transaction-get-label]]
 ==== `Label GetLabel(string key)` added[1.8.0,Number and boolean labels require APM Server 6.7+]
 
-Returns the label which was added in the <<api-transaction-set-label, SetLabel>> method. If the key does not exist, the method returns `null`.
+Returns the transaction's label. If the `key` does not exist, this method returns `null`.
+Labels can be added with the <<api-transaction-set-label, SetLabel>> method.
 
 
 [source,csharp]
@@ -585,7 +586,8 @@ span.SetLabel("intSample", 42);
 [[api-span-get-label]]
 ==== `Label GetLabel(string key)` added[1.8.0,Number and boolean labels require APM Server 6.7+]
 
-Returns the label which was added in the <<api-span-set-label, SetLabel>> method. If the key does not exist, the method returns `null`.
+Returns the span's label. If the `key` does not exist, this method returns `null`.
+Labels can be added with the <<api-span-set-label, SetLabel>> method.
 
 
 [source,csharp]

--- a/src/Elastic.Apm/Api/IExecutionSegment.cs
+++ b/src/Elastic.Apm/Api/IExecutionSegment.cs
@@ -249,6 +249,13 @@ namespace Elastic.Apm.Api
 		/// </summary>
 		void End();
 
+		/// <summary>
+		/// Returns the value of a label.
+		/// </summary>
+		/// <param name="key">The key of the label that you would like to read</param>
+		/// <returns>A <see cref="Label" /> instance if they key exists, <code>null</code> otherwise</returns>
+		Label GetLabel(string key);
+
 
 		/// <summary>
 		/// Labels are used to add indexed information to transactions, spans, and errors. Indexed means the data is searchable and

--- a/src/Elastic.Apm/Api/IExecutionSegment.cs
+++ b/src/Elastic.Apm/Api/IExecutionSegment.cs
@@ -250,14 +250,6 @@ namespace Elastic.Apm.Api
 		void End();
 
 		/// <summary>
-		/// Returns the value of a label.
-		/// </summary>
-		/// <param name="key">The key of the label that you would like to read</param>
-		/// <typeparam name="T">The type of the value for the given label. If the type does not match this method returns <code>default(T)</code></typeparam>
-		/// <returns>The value of the label if the key exists, <code>default(T)</code> otherwise.</returns>
-		T GetLabel<T>(string key);
-
-		/// <summary>
 		/// Labels are used to add indexed information to transactions, spans, and errors. Indexed means the data is searchable and
 		/// aggregatable in Elasticsearch. Multiple labels can be defined with different key-value pairs.
 		/// Note: Values added through this method won't be visible through <see cref="Labels" />.
@@ -334,5 +326,17 @@ namespace Elastic.Apm.Api
 		/// <param name="action">The action of the span.</param>
 		/// <returns>Returns the newly created and active span.</returns>
 		ISpan StartSpan(string name, string type, string subType = null, string action = null);
+
+		/// <summary>
+		/// Returns the value of a label.
+		/// </summary>
+		/// <typeparam name="T">The type of the value for the label that you would like to read.</typeparam>
+		/// <param name="key">The key of the label that you would like to read.</param>
+		/// <param name="value">The out parameter to receive the value of the label.</param>
+		/// <returns>
+		/// <code>true</code> if the label was witten into <paramref name="value" />, <code>false</code> otherwise, which
+		/// can be because the label does not exit or <typeparamref name="T" /> does not match the type of the given label.
+		/// </returns>
+		bool TryGetLabel<T>(string key, out T value);
 	}
 }

--- a/src/Elastic.Apm/Api/IExecutionSegment.cs
+++ b/src/Elastic.Apm/Api/IExecutionSegment.cs
@@ -253,9 +253,9 @@ namespace Elastic.Apm.Api
 		/// Returns the value of a label.
 		/// </summary>
 		/// <param name="key">The key of the label that you would like to read</param>
-		/// <returns>A <see cref="Label" /> instance if they key exists, <code>null</code> otherwise</returns>
-		Label GetLabel(string key);
-
+		/// <typeparam name="T">The type of the value for the given label. If the type does not match this method returns <code>default(T)</code></typeparam>
+		/// <returns>The value of the label if the key exists, <code>default(T)</code> otherwise.</returns>
+		T GetLabel<T>(string key);
 
 		/// <summary>
 		/// Labels are used to add indexed information to transactions, spans, and errors. Indexed means the data is searchable and

--- a/src/Elastic.Apm/Model/NoopSpan.cs
+++ b/src/Elastic.Apm/Model/NoopSpan.cs
@@ -112,6 +112,8 @@ namespace Elastic.Apm.Model
 
 		public void SetLabel(string key, decimal value) { }
 
+		public Label GetLabel(string key) => null;
+
 		public ISpan StartSpan(string name, string type, string subType = null, string action = null) =>
 			new NoopSpan(name, type, subType, action, _currentExecutionSegmentsContainer, Id, TraceId, this);
 	}

--- a/src/Elastic.Apm/Model/NoopSpan.cs
+++ b/src/Elastic.Apm/Model/NoopSpan.cs
@@ -112,7 +112,7 @@ namespace Elastic.Apm.Model
 
 		public void SetLabel(string key, decimal value) { }
 
-		public Label GetLabel(string key) => null;
+		public T GetLabel<T>(string key) => default;
 
 		public ISpan StartSpan(string name, string type, string subType = null, string action = null) =>
 			new NoopSpan(name, type, subType, action, _currentExecutionSegmentsContainer, Id, TraceId, this);

--- a/src/Elastic.Apm/Model/NoopSpan.cs
+++ b/src/Elastic.Apm/Model/NoopSpan.cs
@@ -112,9 +112,13 @@ namespace Elastic.Apm.Model
 
 		public void SetLabel(string key, decimal value) { }
 
-		public T GetLabel<T>(string key) => default;
-
 		public ISpan StartSpan(string name, string type, string subType = null, string action = null) =>
 			new NoopSpan(name, type, subType, action, _currentExecutionSegmentsContainer, Id, TraceId, this);
+
+		public bool TryGetLabel<T>(string key, out T value)
+		{
+			value = default;
+			return false;
+		}
 	}
 }

--- a/src/Elastic.Apm/Model/NoopTransaction.cs
+++ b/src/Elastic.Apm/Model/NoopTransaction.cs
@@ -93,7 +93,10 @@ namespace Elastic.Apm.Model
 
 		public void SetLabel(string key, decimal value) { }
 
-		public ISpan StartSpan(string name, string type, string subType = null, string action = null) => new NoopSpan(name, type, subType, action, _currentExecutionSegmentsContainer);
+		public Label GetLabel(string key) => null;
+
+		public ISpan StartSpan(string name, string type, string subType = null, string action = null) =>
+			new NoopSpan(name, type, subType, action, _currentExecutionSegmentsContainer);
 
 		public string EnsureParentId() => string.Empty;
 

--- a/src/Elastic.Apm/Model/NoopTransaction.cs
+++ b/src/Elastic.Apm/Model/NoopTransaction.cs
@@ -93,7 +93,7 @@ namespace Elastic.Apm.Model
 
 		public void SetLabel(string key, decimal value) { }
 
-		public Label GetLabel(string key) => null;
+		public T GetLabel<T>(string key) => default;
 
 		public ISpan StartSpan(string name, string type, string subType = null, string action = null) =>
 			new NoopSpan(name, type, subType, action, _currentExecutionSegmentsContainer);

--- a/src/Elastic.Apm/Model/NoopTransaction.cs
+++ b/src/Elastic.Apm/Model/NoopTransaction.cs
@@ -93,13 +93,17 @@ namespace Elastic.Apm.Model
 
 		public void SetLabel(string key, decimal value) { }
 
-		public T GetLabel<T>(string key) => default;
-
 		public ISpan StartSpan(string name, string type, string subType = null, string action = null) =>
 			new NoopSpan(name, type, subType, action, _currentExecutionSegmentsContainer);
 
 		public string EnsureParentId() => string.Empty;
 
 		public void SetService(string serviceName, string serviceVersion) { }
+
+		public bool TryGetLabel<T>(string key, out T value)
+		{
+			value = default;
+			return false;
+		}
 	}
 }

--- a/src/Elastic.Apm/Model/Span.cs
+++ b/src/Elastic.Apm/Model/Span.cs
@@ -223,9 +223,14 @@ namespace Elastic.Apm.Model
 			{ nameof(IsSampled), IsSampled }
 		}.ToString();
 
-		public Label GetLabel(string key) => Context.InternalLabels.Value.InnerDictionary.ContainsKey(key)
-			? Context.InternalLabels.Value.InnerDictionary[key]
-			: null;
+		public T GetLabel<T>(string key)
+		{
+			if (Context.InternalLabels.Value.InnerDictionary.TryGetValue(key, out var label))
+				if (label?.Value is T t) return t;
+
+			return default;
+		}
+
 
 		public ISpan StartSpan(string name, string type, string subType = null, string action = null)
 		{

--- a/src/Elastic.Apm/Model/Span.cs
+++ b/src/Elastic.Apm/Model/Span.cs
@@ -223,12 +223,19 @@ namespace Elastic.Apm.Model
 			{ nameof(IsSampled), IsSampled }
 		}.ToString();
 
-		public T GetLabel<T>(string key)
+		public bool TryGetLabel<T>(string key, out T value)
 		{
 			if (Context.InternalLabels.Value.InnerDictionary.TryGetValue(key, out var label))
-				if (label?.Value is T t) return t;
+			{
+				if (label?.Value is T t)
+				{
+					value = t;
+					return true;
+				}
+			}
 
-			return default;
+			value = default;
+			return false;
 		}
 
 

--- a/src/Elastic.Apm/Model/Span.cs
+++ b/src/Elastic.Apm/Model/Span.cs
@@ -223,6 +223,10 @@ namespace Elastic.Apm.Model
 			{ nameof(IsSampled), IsSampled }
 		}.ToString();
 
+		public Label GetLabel(string key) => Context.InternalLabels.Value.InnerDictionary.ContainsKey(key)
+			? Context.InternalLabels.Value.InnerDictionary[key]
+			: null;
+
 		public ISpan StartSpan(string name, string type, string subType = null, string action = null)
 		{
 			if (ConfigSnapshot.Enabled && ConfigSnapshot.Recording)

--- a/src/Elastic.Apm/Model/Transaction.cs
+++ b/src/Elastic.Apm/Model/Transaction.cs
@@ -384,7 +384,7 @@ namespace Elastic.Apm.Model
 
 		public Label GetLabel(string key) => _context.Value.InternalLabels.Value.InnerDictionary.ContainsKey(key)
 			? _context.Value.InternalLabels.Value.InnerDictionary[key]
-			: null
+			: null;
 
 		public ISpan StartSpan(string name, string type, string subType = null, string action = null)
 		{

--- a/src/Elastic.Apm/Model/Transaction.cs
+++ b/src/Elastic.Apm/Model/Transaction.cs
@@ -22,12 +22,12 @@ namespace Elastic.Apm.Model
 	internal class Transaction : ITransaction
 	{
 		private static readonly string ApmTransactionActivityName = "ElasticApm.Transaction";
+		private readonly IApmServerInfo _apmServerInfo;
 		private readonly Lazy<Context> _context = new Lazy<Context>();
 		private readonly ICurrentExecutionSegmentsContainer _currentExecutionSegmentsContainer;
 
 		private readonly IApmLogger _logger;
 		private readonly IPayloadSender _sender;
-		private readonly IApmServerInfo _apmServerInfo;
 
 		private readonly string _traceState;
 
@@ -381,6 +381,10 @@ namespace Elastic.Apm.Model
 			_sender.QueueTransaction(this);
 			_currentExecutionSegmentsContainer.CurrentTransaction = null;
 		}
+
+		public Label GetLabel(string key) => _context.Value.InternalLabels.Value.InnerDictionary.ContainsKey(key)
+			? _context.Value.InternalLabels.Value.InnerDictionary[key]
+			: null
 
 		public ISpan StartSpan(string name, string type, string subType = null, string action = null)
 		{

--- a/src/Elastic.Apm/Model/Transaction.cs
+++ b/src/Elastic.Apm/Model/Transaction.cs
@@ -382,12 +382,19 @@ namespace Elastic.Apm.Model
 			_currentExecutionSegmentsContainer.CurrentTransaction = null;
 		}
 
-		public T GetLabel<T>(string key)
+		public bool TryGetLabel<T>(string key, out T value)
 		{
 			if (Context.InternalLabels.Value.InnerDictionary.TryGetValue(key, out var label))
-				if (label?.Value is T t) return t;
+			{
+				if (label?.Value is T t)
+				{
+					value = t;
+					return true;
+				}
+			}
 
-			return default;
+			value = default;
+			return false;
 		}
 
 		public ISpan StartSpan(string name, string type, string subType = null, string action = null)

--- a/src/Elastic.Apm/Model/Transaction.cs
+++ b/src/Elastic.Apm/Model/Transaction.cs
@@ -382,9 +382,13 @@ namespace Elastic.Apm.Model
 			_currentExecutionSegmentsContainer.CurrentTransaction = null;
 		}
 
-		public Label GetLabel(string key) => _context.Value.InternalLabels.Value.InnerDictionary.ContainsKey(key)
-			? _context.Value.InternalLabels.Value.InnerDictionary[key]
-			: null;
+		public T GetLabel<T>(string key)
+		{
+			if (Context.InternalLabels.Value.InnerDictionary.TryGetValue(key, out var label))
+				if (label?.Value is T t) return t;
+
+			return default;
+		}
 
 		public ISpan StartSpan(string name, string type, string subType = null, string action = null)
 		{

--- a/test/Elastic.Apm.Tests/HttpDiagnosticListenerTests.cs
+++ b/test/Elastic.Apm.Tests/HttpDiagnosticListenerTests.cs
@@ -770,7 +770,7 @@ namespace Elastic.Apm.Tests
 				{
 					await httpClient.GetAsync(localServer.Uri);
 				}
-				catch (Exception e)
+				catch
 				{
 					//ignore - we don't care about the result
 				}

--- a/test/Elastic.Apm.Tests/LabelTests.cs
+++ b/test/Elastic.Apm.Tests/LabelTests.cs
@@ -268,18 +268,23 @@ namespace Elastic.Apm.Tests
 					s.SetLabel("fooS", 43);
 					s.SetLabel("barS", true);
 
-					s.GetLabel<int>("fooS").Should().Be(43);
-					s.GetLabel<bool>("barS").Should().Be(true);
+					s.TryGetLabel<int>("fooS", out var fooSValue).Should().BeTrue();
+					fooSValue.Should().Be(43);
+					s.TryGetLabel<bool>("barS", out var barSValue).Should().BeTrue();
+					barSValue.Should().BeTrue();
 				});
 
-				t.GetLabel<int>("fooT").Should().Be(42);
-				t.GetLabel<bool>("barT").Should().Be(false);
+				t.TryGetLabel<int>("fooT", out var fooTValue).Should().BeTrue();
+				fooTValue.Should().Be(42);
+				t.TryGetLabel<bool>("barT", out var barTValue).Should().BeTrue();
+				barTValue.Should().BeFalse();
 			});
 		}
 
 		/// <summary>
-		/// Utilizes <see cref="IExecutionSegment.GetLabel{T}" /> with mismatched types.
-		/// If the type parameter does not match the type of the given label, <see cref="IExecutionSegment.GetLabel{T}" /> returns
+		/// Utilizes <see cref="IExecutionSegment.TryGetLabel{T}" /> with mismatched types.
+		/// If the type parameter does not match the type of the given label, <see cref="IExecutionSegment.TryGetLabel{T}" />
+		/// returns
 		/// <code>default</code>.
 		/// </summary>
 		[Fact]
@@ -294,17 +299,20 @@ namespace Elastic.Apm.Tests
 				t.SetLabel("boolLabel", true);
 				t.SetLabel("stringLabel", "foo");
 
-				t.GetLabel<string>("intLabel").Should().BeNull();
-				t.GetLabel<bool>("intLabel").Should().BeFalse();
-				t.GetLabel<int>("intLabel").Should().Be(42);
+				t.TryGetLabel<string>("intLabel", out _).Should().BeFalse();
+				t.TryGetLabel<bool>("intLabel", out _).Should().BeFalse();
+				t.TryGetLabel<int>("intLabel", out var intVal).Should().BeTrue();
+				intVal.Should().Be(42);
 
-				t.GetLabel<string>("boolLabel").Should().BeNull();
-				t.GetLabel<bool>("boolLabel").Should().BeTrue();
-				t.GetLabel<int>("boolLabel").Should().Be(0);
+				t.TryGetLabel<string>("boolLabel", out _).Should().BeFalse();
+				t.TryGetLabel<bool>("boolLabel", out var boolVal).Should().BeTrue();
+				boolVal.Should().BeTrue();
+				t.TryGetLabel<int>("boolLabel", out _).Should().BeFalse();
 
-				t.GetLabel<string>("stringLabel").Should().Be("foo");
-				t.GetLabel<bool>("stringLabel").Should().BeFalse();
-				t.GetLabel<int>("stringLabel").Should().Be(0);
+				t.TryGetLabel<string>("stringLabel", out var strVal).Should().BeTrue();
+				strVal.Should().Be("foo");
+				t.TryGetLabel<bool>("stringLabel", out _).Should().BeFalse();
+				t.TryGetLabel<int>("stringLabel", out _).Should().BeFalse();
 			});
 		}
 
@@ -321,11 +329,13 @@ namespace Elastic.Apm.Tests
 
 			t.Labels["oldApi"] = "43";
 
-			t.GetLabel<int>("foo").Should().Be(42);
-			t.GetLabel<bool>("bar").Should().Be(false);
+			t.TryGetLabel<int>("foo", out var fooVal).Should().BeTrue();
+			fooVal.Should().Be(42);
+			t.TryGetLabel<bool>("bar", out var barVal).Should().BeTrue();
+			barVal.Should().BeFalse();
 
 			// values from the Labels dictionary aren't visible through the new API
-			t.GetLabel<string>("oldApi").Should().BeNull();
+			t.TryGetLabel<string>("oldApi", out _).Should().BeFalse();
 
 			t.End();
 


### PR DESCRIPTION
Addresses https://github.com/elastic/apm-agent-dotnet/issues/1033 

In release `1.7.0` we marked the `Labels` property as obsolete and added the `SetLabel()` method with multiple overloads to support `string`, `bool`, and numbers.

This PR adds a method to read back the values from the agent. Since the `Labels` property supported both writing and reading back the value, we decided to not break users who rely on the reading use case in the future - therefore we agreed we offer a way to read values also with the new API.

Here is how it works (same on span) (updated version):

```
transaction.SetLabel("intLabel", 42);
var myLabelValue = transaction.GetLabel<int>("intLabel"); //myLabelValue is an `int`
Console.WriteLine(myLabelValue);
```


TODO:
- [x] Given the API is still up for discussion, make sure the `docs/public-api.asciidoc` documents the final version.