### PR TITLE
HostBuilderExtensions.UseElasticApm: subscribe to `subscribers` params

### DIFF
--- a/src/Elastic.Apm.Extensions.Hosting/Elastic.Apm.Extensions.Hosting.csproj
+++ b/src/Elastic.Apm.Extensions.Hosting/Elastic.Apm.Extensions.Hosting.csproj
@@ -2,23 +2,25 @@
 
   <PropertyGroup>
     <PackageId>Elastic.Apm.Extensions.Hosting</PackageId>
-    <Description>Elastic APM .NET Agent. This package offers integration with Microsoft.Extensions.Hosting.IHostBuilder for agent registration </Description>
+    <Description>Elastic APM .NET Agent. This package offers integration with Microsoft.Extensions.Hosting.IHostBuilder for agent registration</Description>
     <PackageTags>apm, monitoring, elastic, elasticapm, analytics, netcore</PackageTags>
     <TargetFrameworks>netstandard2.0;netcoreapp3.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\Elastic.Apm\Elastic.Apm.csproj" />
+    <ProjectReference Include="..\Elastic.Apm\Elastic.Apm.csproj"/>
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
-    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="2.1.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.1.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="2.1.0"/>
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.1.0"/>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection " Version="2.1.0"/>
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.0' ">
-    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="3.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="3.0.0"/>
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.0.0"/>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection " Version="3.0.0"/>
   </ItemGroup>
 
 </Project>

--- a/src/Elastic.Apm.Extensions.Hosting/HostBuilderExtensions.cs
+++ b/src/Elastic.Apm.Extensions.Hosting/HostBuilderExtensions.cs
@@ -55,11 +55,8 @@ namespace Elastic.Apm.Extensions.Hosting
 				services.AddSingleton<IApmAgent, ApmAgent>(sp =>
 				{
 					if (Agent.IsConfigured) return Agent.Instance;
-
-					var components = sp.GetService<AgentComponents>();
-					var newAgentInstance = new ApmAgent(components);
-					Agent.Setup(components);
-					return newAgentInstance;
+					Agent.Setup(sp.GetService<AgentComponents>());
+					return Agent.Instance;
 				});
 
 				services.AddSingleton(sp => sp.GetRequiredService<IApmAgent>().Tracer);

--- a/src/Elastic.Apm.Extensions.Hosting/HostBuilderExtensions.cs
+++ b/src/Elastic.Apm.Extensions.Hosting/HostBuilderExtensions.cs
@@ -28,12 +28,11 @@ namespace Elastic.Apm.Extensions.Hosting
 			builder.ConfigureServices((ctx, services) =>
 			{
 				//If the static agent doesn't exist, we create one here. If there is already 1 agent created, we reuse it.
-
 				if (!Agent.IsConfigured)
 				{
 					services.AddSingleton<IApmLogger, NetCoreLogger>();
 					services.AddSingleton<IConfigurationReader>(sp =>
-					new MicrosoftExtensionsConfig(ctx.Configuration, sp.GetService<IApmLogger>(), ctx.HostingEnvironment.EnvironmentName));
+						new MicrosoftExtensionsConfig(ctx.Configuration, sp.GetService<IApmLogger>(), ctx.HostingEnvironment.EnvironmentName));
 				}
 				else
 				{
@@ -57,15 +56,22 @@ namespace Elastic.Apm.Extensions.Hosting
 				{
 					if (Agent.IsConfigured) return Agent.Instance;
 
-					var apmAgent = new ApmAgent(sp.GetService<AgentComponents>());
+					var newAgentInstance = new ApmAgent(sp.GetService<AgentComponents>());
 					Agent.Setup(sp.GetService<AgentComponents>());
-					return apmAgent;
+					return newAgentInstance;
 				});
 
-				if(Agent.IsConfigured && Agent.Config.Enabled)
-					if (subscribers != null && subscribers.Any() && Agent.IsConfigured) Agent.Subscribe(subscribers);
-
 				services.AddSingleton(sp => sp.GetRequiredService<IApmAgent>().Tracer);
+
+				var serviceProvider = services.BuildServiceProvider();
+				var agent = serviceProvider.GetService<IApmAgent>();
+
+				if (!(agent is ApmAgent apmAgent)) return;
+
+				if (!Agent.IsConfigured || !apmAgent.ConfigurationReader.Enabled) return;
+
+				if (subscribers != null && subscribers.Any() && Agent.IsConfigured)
+					apmAgent.Subscribe(subscribers);
 			});
 
 			return builder;

--- a/src/Elastic.Apm.Extensions.Hosting/HostBuilderExtensions.cs
+++ b/src/Elastic.Apm.Extensions.Hosting/HostBuilderExtensions.cs
@@ -56,8 +56,9 @@ namespace Elastic.Apm.Extensions.Hosting
 				{
 					if (Agent.IsConfigured) return Agent.Instance;
 
-					var newAgentInstance = new ApmAgent(sp.GetService<AgentComponents>());
-					Agent.Setup(sp.GetService<AgentComponents>());
+					var components = sp.GetService<AgentComponents>();
+					var newAgentInstance = new ApmAgent(components);
+					Agent.Setup(components);
 					return newAgentInstance;
 				});
 

--- a/test/Elastic.Apm.Extensions.Hosting.Tests/HostBuilderExtensionTests.cs
+++ b/test/Elastic.Apm.Extensions.Hosting.Tests/HostBuilderExtensionTests.cs
@@ -1,4 +1,7 @@
-﻿using System.Threading.Tasks;
+﻿using System;
+using System.Threading.Tasks;
+using Elastic.Apm.DiagnosticSource;
+using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using SampleConsoleNetCoreApp;
@@ -24,9 +27,49 @@ namespace Elastic.Apm.Extensions.Hosting.Tests
 			await Task.WhenAll(hostBuilder1.StopAsync(), hostBuilder2.StopAsync());
 		}
 
+		/// <summary>
+		/// Makes sure that <see cref="Agent.IsConfigured" /> is <code>true</code> after the agent is enabled through
+		/// <see cref="HostBuilderExtensions.UseElasticApm" />.
+		/// </summary>
+		[Fact]
+		public void IsAgentInitializedAfterUseElasticApm()
+		{
+			var _ = CreateHostBuilder().Build();
+			Agent.IsConfigured.Should().BeTrue();
+		}
+
+		/// <summary>
+		/// Makes sure that agent enables the <see cref="IDiagnosticsSubscriber" /> passed into
+		/// <see cref="HostBuilderExtensions.UseElasticApm" />.
+		/// </summary>
+		[Fact]
+		public void DiagnosticSubscriberWithUseElasticApm()
+		{
+			var fakeSubscriber = new FakeSubscriber();
+			fakeSubscriber.IsSubscribed.Should().BeFalse();
+
+			Host.CreateDefaultBuilder()
+				.ConfigureServices((context, services) => { services.AddHostedService<HostedService>(); })
+				.UseElasticApm(fakeSubscriber)
+				.Build();
+
+			fakeSubscriber.IsSubscribed.Should().BeTrue();
+		}
+
 		private static IHostBuilder CreateHostBuilder() =>
-				Host.CreateDefaultBuilder()
-					.ConfigureServices((context, services) => { services.AddHostedService<HostedService>(); })
-					.UseElasticApm();
+			Host.CreateDefaultBuilder()
+				.ConfigureServices((context, services) => { services.AddHostedService<HostedService>(); })
+				.UseElasticApm();
+
+		public class FakeSubscriber : IDiagnosticsSubscriber
+		{
+			public bool IsSubscribed { get; set; }
+
+			public IDisposable Subscribe(IApmAgent components)
+			{
+				IsSubscribed = true;
+				return null;
+			}
+		}
 	}
 }

--- a/test/Elastic.Apm.Extensions.Hosting.Tests/HostBuilderExtensionTests.cs
+++ b/test/Elastic.Apm.Extensions.Hosting.Tests/HostBuilderExtensionTests.cs
@@ -56,6 +56,33 @@ namespace Elastic.Apm.Extensions.Hosting.Tests
 			fakeSubscriber.IsSubscribed.Should().BeTrue();
 		}
 
+		/// <summary>
+		/// Sets `enabled=false` and makes sure that <see cref="HostBuilderExtensions.UseElasticApm" /> does not turn on diagnostic
+		/// listeners.
+		/// </summary>
+		[Fact]
+		public void DiagnosticSubscriberWithUseElasticApmAgentDisabled()
+		{
+			var fakeSubscriber = new FakeSubscriber();
+			fakeSubscriber.IsSubscribed.Should().BeFalse();
+
+			Environment.SetEnvironmentVariable("ELASTIC_APM_ENABLED", "false");
+
+			try
+			{
+				Host.CreateDefaultBuilder()
+					.ConfigureServices((context, services) => { services.AddHostedService<HostedService>(); })
+					.UseElasticApm(fakeSubscriber)
+					.Build();
+
+				fakeSubscriber.IsSubscribed.Should().BeFalse();
+			}
+			finally
+			{
+				Environment.SetEnvironmentVariable("ELASTIC_APM_ENABLED", null);
+			}
+		}
+
 		private static IHostBuilder CreateHostBuilder() =>
 			Host.CreateDefaultBuilder()
 				.ConfigureServices((context, services) => { services.AddHostedService<HostedService>(); })


### PR DESCRIPTION
Fixes #1059

In `Elastic.Apm.Extensions.Hosting.HostBuilderExtensions.UseElasticApm(this IHostBuilder builder, params IDiagnosticsSubscriber[] subscribers)` the `params IDiagnosticsSubscriber[] subscribers` were never activated. This was because of the following wrong check:

```
if(Agent.IsConfigured && Agent.Config.Enabled)
  if (subscribers != null && subscribers.Any() && Agent.IsConfigured) Agent.Subscribe(subscribers);
```

Problem here was that `Agent.IsConfigured` remained false until `IApmAgent` got resolved first  - but that always runs after the check.

Proposed fix: we force the resolution directly within the `UseElasticApm` method:

```
var serviceProvider = services.BuildServiceProvider();
var agent = serviceProvider.GetService<IApmAgent>();
```

And do a similar check after that.

I feel doing "lazy agent loading" here makes no sense, the agent should be immediately enabled, otherwise it would e.g. not collect metrics, plus there is no guarantee that a user forces to resolve `IApmAgent`.