### PR TITLE
Introduce ServerUrl and deprecate ServerUrls

### DIFF
--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -484,7 +484,7 @@ NOTE: This option requires APM Server 7.2 or later. It will have no effect on ol
 
 The URL for your APM Server. The URL must be fully qualified, including protocol (`http` or `https`) and port.
 
-IMPORTANT: Use of `ServerUrls` is deprecated. Use `ServerUrl`
+IMPORTANT: Use of `ServerUrls` is deprecated. Use `ServerUrl`.
 
 [float]
 [[config-secret-token]]

--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -76,7 +76,7 @@ Here is a sample `appsettings.json` configuration file for a typical ASP.NET Cor
   "AllowedHosts": "*",
   "ElasticApm": <2>
     {
-      "ServerUrls":  "http://myapmserver:8200",
+      "ServerUrl":  "http://myapmserver:8200",
       "SecretToken":  "apm-server-secret-token",
       "TransactionSampleRate": 1.0
     }
@@ -100,7 +100,7 @@ In this case, you can set the agent's log level with <<config-log-level,`Elastic
   "ElasticApm":
     {
       "LogLevel":  "Debug",
-      "ServerUrls":  "http://myapmserver:8200",
+      "ServerUrl":  "http://myapmserver:8200",
       "SecretToken":  "apm-server-secret-token",
       "TransactionSampleRate": 1.0
     }
@@ -134,7 +134,7 @@ Below is a sample `Web.config` configuration file for a ASP.NET application.
     <!-- ... -->
     <appSettings>
         <!-- ... -->
-        <add key="ElasticApm:ServerUrls" value="https://my-apm-server:8200" />
+        <add key="ElasticApm:ServerUrl" value="https://my-apm-server:8200" />
         <add key="ElasticApm:SecretToken" value="apm-server-secret-token" />
         <!-- ... -->
     </appSettings>
@@ -467,13 +467,13 @@ NOTE: This option requires APM Server 7.2 or later. It will have no effect on ol
 === Reporter configuration options
 
 [float]
-[[config-server-urls]]
-==== `ServerUrls`
+[[config-server-url]]
+==== `ServerUrl`
 
 [options="header"]
 |============
 | Environment variable name | IConfiguration or Web.config key
-| `ELASTIC_APM_SERVER_URLS` | `ElasticApm:ServerUrls`
+| `ELASTIC_APM_SERVER_URL` | `ElasticApm:ServerUrl`
 |============
 
 [options="header"]
@@ -484,7 +484,7 @@ NOTE: This option requires APM Server 7.2 or later. It will have no effect on ol
 
 The URL for your APM Server. The URL must be fully qualified, including protocol (`http` or `https`) and port.
 
-NOTE: Providing multiple URLs is not supported by the agent yet. If multiple URLs are provided only the first one will be used.
+IMPORTANT: Use of `ServerUrls` is deprecated. Use `ServerUrl`
 
 [float]
 [[config-secret-token]]
@@ -1016,7 +1016,7 @@ you must instead set the `LogLevel` for the internal APM logger under the `Loggi
 | <<config-recording,`Recording`>> | Yes | Core
 | <<config-sanitize-field-names,`SanitizeFieldNames`>> | No | Core
 | <<config-secret-token,`SecretToken`>> | No | Reporter
-| <<config-server-urls,`ServerUrls`>> | No | Reporter
+| <<config-server-url,`ServerUrl`>> | No | Reporter
 | <<config-service-name,`ServiceName`>> | No | Core
 | <<config-service-node-name, `ServiceNodeName`>> | No | Core
 | <<config-service-version,`ServiceVersion`>> | No | Core

--- a/docs/public-api.asciidoc
+++ b/docs/public-api.asciidoc
@@ -20,7 +20,7 @@ The API does not require explicit Agent initialization—agent initialization is
 [[implicit-initialization]]
 === Implicit agent initialization
 
-If you don't explicitly initialize the agent, it will be started with a default component setup. This means the Agent will read <<configuration,configuration settings>> from environment variables. If you don't set an environment variable, the Agent will use the default value. For example, the `ServerUrls` default is `http://localhost:8200`.
+If you don't explicitly initialize the agent, it will be started with a default component setup. This means the Agent will read <<configuration,configuration settings>> from environment variables. If you don't set an environment variable, the Agent will use the default value. For example, the `ServerUrl` default is `http://localhost:8200`.
 
 This implicit initialization of the agent happens on the first call on the `Elastic.Apm.Agent` class.
 

--- a/sample/AspNetFullFrameworkSampleApp/Global.asax.cs
+++ b/sample/AspNetFullFrameworkSampleApp/Global.asax.cs
@@ -57,7 +57,7 @@ namespace AspNetFullFrameworkSampleApp
 				var responseHeaders = httpContext?.Response?.Headers;
 				if (responseHeaders == null) return;
 
-				AddHeaderIfNotPresent(responseHeaders, Consts.ElasticApmServerUrlsResponseHeaderName, string.Join(", ", Agent.Config.ServerUrls));
+				AddHeaderIfNotPresent(responseHeaders, Consts.ElasticApmServerUrlsResponseHeaderName, Agent.Config.ServerUrl.ToString());
 				AddHeaderIfNotPresent(responseHeaders, Consts.ProcessIdResponseHeaderName, Process.GetCurrentProcess().Id.ToString());
 			});
 

--- a/src/Elastic.Apm/BackendComm/BackendCommUtils.cs
+++ b/src/Elastic.Apm/BackendComm/BackendCommUtils.cs
@@ -130,7 +130,7 @@ namespace Elastic.Apm.BackendComm
 		{
 			var logger = loggerArg.Scoped(ThisClassName);
 
-			var serverUrlBase = config.ServerUrls.First();
+			var serverUrlBase = config.ServerUrl;
 			ConfigServicePoint(serverUrlBase, loggerArg);
 
 			logger.Debug()

--- a/src/Elastic.Apm/BackendComm/CentralConfig/CentralConfigFetcher.cs
+++ b/src/Elastic.Apm/BackendComm/CentralConfig/CentralConfigFetcher.cs
@@ -69,7 +69,7 @@ namespace Elastic.Apm.BackendComm.CentralConfig
 
 			_agentTimer = agentTimer ?? new AgentTimer();
 
-			_getConfigAbsoluteUrl = BackendCommUtils.ApmServerEndpoints.BuildGetConfigAbsoluteUrl(initialConfigSnapshot.ServerUrls.First(), service);
+			_getConfigAbsoluteUrl = BackendCommUtils.ApmServerEndpoints.BuildGetConfigAbsoluteUrl(initialConfigSnapshot.ServerUrl, service);
 			_logger.Debug()
 				?.Log("Combined absolute URL for APM Server get central configuration endpoint: `{Url}'. Service: {Service}."
 					, _getConfigAbsoluteUrl, service);
@@ -269,7 +269,10 @@ namespace Elastic.Apm.BackendComm.CentralConfig
 
 			public string SecretToken => _wrapped.SecretToken;
 
+			[Obsolete("Use ServerUrl")]
 			public IReadOnlyList<Uri> ServerUrls => _wrapped.ServerUrls;
+
+			public Uri ServerUrl => _wrapped.ServerUrl;
 
 			public string ServiceName => _wrapped.ServiceName;
 			public string ServiceNodeName => _wrapped.ServiceNodeName;

--- a/src/Elastic.Apm/Config/AbstractConfigurationReader.cs
+++ b/src/Elastic.Apm/Config/AbstractConfigurationReader.cs
@@ -213,7 +213,20 @@ namespace Elastic.Apm.Config
 		private IReadOnlyList<Uri> ParseServerUrlsImpl(ConfigurationKeyValue kv)
 		{
 			var list = new List<Uri>();
-			if (kv == null || string.IsNullOrEmpty(kv.Value)) return LogAndReturnDefault().AsReadOnly();
+			if (kv == null || string.IsNullOrEmpty(kv.Value))
+				return LogAndReturnDefault().AsReadOnly();
+
+			switch (kv.Key)
+			{
+				case EnvVarNames.ServerUrls:
+					_logger?.Info()?.Log(
+						"{ServerUrls} is deprecated. Use {ServerUrl}", EnvVarNames.ServerUrls, EnvVarNames.ServerUrl);
+					break;
+				case KeyNames.ServerUrls:
+					_logger?.Info()?.Log(
+						"{ServerUrls} is deprecated. Use {ServerUrl}", KeyNames.ServerUrls, KeyNames.ServerUrl);
+					break;
+			}
 
 			var uriStrings = kv.Value.Split(',');
 			foreach (var u in uriStrings)

--- a/src/Elastic.Apm/Config/ConfigConsts.cs
+++ b/src/Elastic.Apm/Config/ConfigConsts.cs
@@ -129,6 +129,7 @@ namespace Elastic.Apm.Config
 			public const string SanitizeFieldNames = Prefix + "SANITIZE_FIELD_NAMES";
 			public const string SecretToken = Prefix + "SECRET_TOKEN";
 			public const string ServerUrls = Prefix + "SERVER_URLS";
+			public const string ServerUrl = Prefix + "SERVER_URL";
 			public const string ServiceName = Prefix + "SERVICE_NAME";
 			public const string ServiceNodeName = Prefix + "SERVICE_NODE_NAME";
 			public const string ServiceVersion = Prefix + "SERVICE_VERSION";
@@ -168,6 +169,7 @@ namespace Elastic.Apm.Config
 			public const string SanitizeFieldNames = Prefix + nameof(SanitizeFieldNames);
 			public const string SecretToken = Prefix + nameof(SecretToken);
 			public const string ServerUrls = Prefix + nameof(ServerUrls);
+			public const string ServerUrl = Prefix + nameof(ServerUrl);
 			public const string ServiceName = Prefix + nameof(ServiceName);
 			public const string ServiceNodeName = Prefix + nameof(ServiceNodeName);
 			public const string ServiceVersion = Prefix + nameof(ServiceVersion);

--- a/src/Elastic.Apm/Config/ConfigSnapshotFromReader.cs
+++ b/src/Elastic.Apm/Config/ConfigSnapshotFromReader.cs
@@ -42,7 +42,9 @@ namespace Elastic.Apm.Config
 		public bool Recording => _content.Recording;
 		public IReadOnlyList<WildcardMatcher> SanitizeFieldNames => _content.SanitizeFieldNames;
 		public string SecretToken => _content.SecretToken;
+		[Obsolete("Use ServerUrl")]
 		public IReadOnlyList<Uri> ServerUrls => _content.ServerUrls;
+		public Uri ServerUrl => _content.ServerUrl;
 		public string ServiceName => _content.ServiceName;
 		public string ServiceNodeName => _content.ServiceNodeName;
 		public string ServiceVersion => _content.ServiceVersion;

--- a/src/Elastic.Apm/Config/EnvironmentConfigurationReader.cs
+++ b/src/Elastic.Apm/Config/EnvironmentConfigurationReader.cs
@@ -68,7 +68,35 @@ namespace Elastic.Apm.Config
 
 		public string SecretToken => ParseSecretToken(Read(ConfigConsts.EnvVarNames.SecretToken));
 
-		public IReadOnlyList<Uri> ServerUrls => ParseServerUrls(Read(ConfigConsts.EnvVarNames.ServerUrls));
+		/// <inheritdoc />
+		[Obsolete("Use ServerUrl")]
+		public IReadOnlyList<Uri> ServerUrls
+		{
+			get
+			{
+				// Use ServerUrl if there's no value for ServerUrls so that usage of ServerUrls
+				// outside of the agent will work with ServerUrl
+				var configurationKeyValue = Read(ConfigConsts.EnvVarNames.ServerUrls);
+				return ParseServerUrls(!string.IsNullOrEmpty(configurationKeyValue.Value)
+					? configurationKeyValue
+					: Read(ConfigConsts.EnvVarNames.ServerUrl));
+			}
+		}
+
+		/// <inheritdoc />
+		public Uri ServerUrl
+		{
+			get
+			{
+				// Fallback to using the first ServerUrls in the event ServerUrl is not specified
+				var configurationKeyValue = Read(ConfigConsts.EnvVarNames.ServerUrl);
+				return !string.IsNullOrEmpty(configurationKeyValue.Value)
+					? ParseServerUrl(configurationKeyValue)
+#pragma warning disable 618
+					: ServerUrls[0];
+#pragma warning restore 618
+			}
+		}
 
 		public string ServiceName => ParseServiceName(Read(ConfigConsts.EnvVarNames.ServiceName));
 

--- a/src/Elastic.Apm/Config/IConfigurationReader.cs
+++ b/src/Elastic.Apm/Config/IConfigurationReader.cs
@@ -140,26 +140,37 @@ namespace Elastic.Apm.Config
 
 		/// <summary>
 		/// Whether the agent is recording.
-		/// When set to <c>true</c>. the agent instruments and capture requests, tracks errors, and 
-		/// collects and sends metrics. 
-		/// When set to <c>false</c>, the agent does not collect data or communicate with the APM server, except to 
-		/// fetch central configuration. 
-		/// Recording can be changed during the lifetime of the application.		
+		/// When set to <c>true</c>. the agent instruments and capture requests, tracks errors, and
+		/// collects and sends metrics.
+		/// When set to <c>false</c>, the agent does not collect data or communicate with the APM server, except to
+		/// fetch central configuration.
+		/// Recording can be changed during the lifetime of the application.
 		/// </summary>
 		/// <remarks>
-		/// As this is a reversible switch, agent threads are not terminated when inactivated, but they will be mostly 
+		/// As this is a reversible switch, agent threads are not terminated when inactivated, but they will be mostly
 		/// idle in this state, so the overhead should be negligible.
 		/// </remarks>
 		public bool Recording { get; }
 
-		// <summary>
-		// Sometimes it is necessary to sanitize the data sent to Elastic APM, e.g. remove sensitive data.
-		// Configure a list of wildcard patterns of field names which should be sanitized.
-		// These apply for example to HTTP headers and application/x-www-form-urlencoded data.
-		// </summary>
+		/// <summary>
+		/// Sometimes it is necessary to sanitize the data sent to Elastic APM, e.g. remove sensitive data.
+		/// Configure a list of wildcard patterns of field names which should be sanitized.
+		/// These apply for example to HTTP headers and application/x-www-form-urlencoded data.
+		/// </summary>
 		IReadOnlyList<WildcardMatcher> SanitizeFieldNames { get; }
 		string SecretToken { get; }
+
+		/// <summary>
+		/// The URLs for APM server.
+		/// </summary>
+		[Obsolete("Use ServerUrl")]
 		IReadOnlyList<Uri> ServerUrls { get; }
+
+		/// <summary>
+		/// The URL for APM server
+		/// </summary>
+		Uri ServerUrl { get; }
+
 		string ServiceName { get; }
 
 		string ServiceNodeName { get; }

--- a/src/Elastic.Apm/DiagnosticListeners/HttpDiagnosticListenerImplBase.cs
+++ b/src/Elastic.Apm/DiagnosticListeners/HttpDiagnosticListenerImplBase.cs
@@ -251,6 +251,6 @@ namespace Elastic.Apm.DiagnosticListeners
 		/// </summary>
 		/// <returns><c>true</c>, if request should not be captured, <c>false</c> otherwise.</returns>
 		/// <param name="requestUri">Request URI. It cannot be null</param>
-		private bool IsRequestFilteredOut(Uri requestUri) => _agent.ConfigurationReader.ServerUrls.Any(n => n.IsBaseOf(requestUri));
+		private bool IsRequestFilteredOut(Uri requestUri) => _agent.ConfigurationReader.ServerUrl.IsBaseOf(requestUri);
 	}
 }

--- a/src/Elastic.Apm/Report/PayloadSenderV2.cs
+++ b/src/Elastic.Apm/Report/PayloadSenderV2.cs
@@ -72,7 +72,7 @@ namespace Elastic.Apm.Report
 			_payloadItemSerializer = new PayloadItemSerializer(config);
 			_configSnapshot = config;
 
-			_intakeV2EventsAbsoluteUrl = BackendCommUtils.ApmServerEndpoints.BuildIntakeV2EventsAbsoluteUrl(config.ServerUrls.First());
+			_intakeV2EventsAbsoluteUrl = BackendCommUtils.ApmServerEndpoints.BuildIntakeV2EventsAbsoluteUrl(config.ServerUrl);
 
 			System = system;
 

--- a/src/Elastic.Apm/ServerInfo/ApmServerInfoProvider.cs
+++ b/src/Elastic.Apm/ServerInfo/ApmServerInfoProvider.cs
@@ -23,7 +23,7 @@ namespace Elastic.Apm.ServerInfo
 		{
 			try
 			{
-				using var requestMessage = new HttpRequestMessage(HttpMethod.Get, configSnapshot.ServerUrls[0]);
+				using var requestMessage = new HttpRequestMessage(HttpMethod.Get, configSnapshot.ServerUrl);
 				requestMessage.Headers.Add("Metadata", "true");
 
 				var responseMessage = await httpClient.SendAsync(requestMessage).ConfigureAwait(false);

--- a/test/Elastic.Apm.AspNetCore.Tests/MicrosoftExtensionsConfigTests.cs
+++ b/test/Elastic.Apm.AspNetCore.Tests/MicrosoftExtensionsConfigTests.cs
@@ -40,7 +40,10 @@ namespace Elastic.Apm.AspNetCore.Tests
 			var config = new MicrosoftExtensionsConfig(GetConfig($"TestConfigs{Path.DirectorySeparatorChar}appsettings_valid.json"),
 				new NoopLogger(), "test");
 			config.LogLevel.Should().Be(LogLevel.Debug);
+#pragma warning disable 618
 			config.ServerUrls[0].Should().Be(new Uri("http://myServerFromTheConfigFile:8080"));
+#pragma warning restore 618
+			config.ServerUrl.Should().Be(new Uri("http://myServerFromTheConfigFile:8080"));
 			config.ServiceName.Should().Be("My_Test_Application");
 			config.ServiceNodeName.Should().Be("Instance1");
 			config.ServiceVersion.Should().Be("2.1.0.5");
@@ -137,7 +140,10 @@ namespace Elastic.Apm.AspNetCore.Tests
 
 			var config = new MicrosoftExtensionsConfig(configBuilder, new NoopLogger(), "test");
 			config.LogLevel.Should().Be(LogLevel.Debug);
+#pragma warning disable 618
 			config.ServerUrls[0].Should().Be(new Uri(serverUrl));
+#pragma warning restore 618
+			config.ServerUrl.Should().Be(new Uri(serverUrl));
 			config.ServiceName.Should().Be(serviceName);
 			config.ServiceNodeName.Should().Be(serviceNodeName);
 			config.ServiceVersion.Should().Be(serviceVersion);
@@ -158,8 +164,14 @@ namespace Elastic.Apm.AspNetCore.Tests
 			var testLogger = new TestLogger();
 			var config = new MicrosoftExtensionsConfig(GetConfig($"TestConfigs{Path.DirectorySeparatorChar}appsettings_invalid.json"), testLogger,
 				"test");
+#pragma warning disable 618
 			var serverUrl = config.ServerUrls.FirstOrDefault();
+#pragma warning restore 618
 			serverUrl.Should().NotBeNull();
+
+			serverUrl = config.ServerUrl;
+			serverUrl.Should().NotBeNull();
+
 			testLogger.Lines.Should().NotBeEmpty();
 		}
 

--- a/test/Elastic.Apm.Tests/ConfigTests.cs
+++ b/test/Elastic.Apm.Tests/ConfigTests.cs
@@ -62,7 +62,7 @@ namespace Elastic.Apm.Tests
 		}
 
 		[Fact]
-		public void ServerUrlsInvalidUrlTest()
+		public void ServerUrls_Should_Use_Default_Value_When_Invalid_Url()
 		{
 			var serverUrl = "InvalidUrl";
 			var agent = new ApmAgent(new TestAgentComponents(config: new MockConfigSnapshot(serverUrls: serverUrl)));
@@ -79,7 +79,7 @@ namespace Elastic.Apm.Tests
 		}
 
 		[Fact]
-		public void ServerUrlInvalidUrlLogTest()
+		public void ServerUrls_Should_Log_Error_When_Invalid_Url()
 		{
 			var serverUrl = "InvalidUrl";
 			var logger = new TestLogger();
@@ -97,6 +97,22 @@ namespace Elastic.Apm.Tests
 					EnvVarNames.ServerUrls,
 					serverUrl
 				);
+		}
+
+		[Fact]
+		public void ServerUrls_Should_Log_Info_Deprecated()
+		{
+			var serverUrl = DefaultValues.ServerUri.ToString();
+			var logger = new TestLogger(LogLevel.Information);
+			var agent = new ApmAgent(new TestAgentComponents(logger, new MockConfigSnapshot(logger, serverUrls: serverUrl)));
+			agent.ConfigurationReader.ServerUrls[0].Should().Be(DefaultValues.ServerUri);
+			agent.ConfigurationReader.ServerUrl.Should().Be(DefaultValues.ServerUri);
+
+			logger.Lines.Should().NotBeEmpty();
+			// ReSharper disable once UseIndexFromEndExpression
+			logger.Lines[logger.Lines.Count - 1]
+				.Should()
+				.Contain($"{EnvVarNames.ServerUrls} is deprecated. Use {EnvVarNames.ServerUrl}");
 		}
 
 		[Fact]

--- a/test/Elastic.Apm.Tests/ConstructorTests.cs
+++ b/test/Elastic.Apm.Tests/ConstructorTests.cs
@@ -59,6 +59,7 @@ namespace Elastic.Apm.Tests
 			public string SecretToken { get; }
 			public string ApiKey { get; }
 			public IReadOnlyList<Uri> ServerUrls => new List<Uri> { ConfigConsts.DefaultValues.ServerUri };
+			public Uri ServerUrl => ConfigConsts.DefaultValues.ServerUri;
 			public string ServiceName { get; }
 			public string ServiceVersion { get; }
 			public IReadOnlyList<WildcardMatcher> DisableMetrics => ConfigConsts.DefaultValues.DisableMetrics;

--- a/test/Elastic.Apm.Tests/Mocks/MockConfigSnapshot.cs
+++ b/test/Elastic.Apm.Tests/Mocks/MockConfigSnapshot.cs
@@ -17,11 +17,11 @@ namespace Elastic.Apm.Tests.Mocks
 		private const string ThisClassName = nameof(MockConfigSnapshot);
 		private readonly string _apiKey;
 		private readonly string _applicationNamespaces;
-
 		private readonly string _captureBody;
 		private readonly string _captureBodyContentTypes;
 		private readonly string _captureHeaders;
 		private readonly string _centralConfig;
+		private readonly string _cloudProvider;
 		private readonly string _dbgDescription;
 		private readonly string _disableMetrics;
 		private readonly string _enabled;
@@ -37,6 +37,7 @@ namespace Elastic.Apm.Tests.Mocks
 		private readonly string _recording;
 		private readonly string _sanitizeFieldNames;
 		private readonly string _secretToken;
+		private readonly string _serverUrl;
 		private readonly string _serverUrls;
 		private readonly string _serviceName;
 		private readonly string _serviceNodeName;
@@ -83,7 +84,8 @@ namespace Elastic.Apm.Tests.Mocks
 			// none is **not** the default value, but we don't want to query for cloud metadata in all tests
 			string cloudProvider = SupportedValues.CloudProviderNone,
 			string enabled = null,
-			string recording = null
+			string recording = null,
+			string serverUrl = null
 		) : base(logger, ThisClassName)
 		{
 			_serverUrls = serverUrls;
@@ -119,9 +121,8 @@ namespace Elastic.Apm.Tests.Mocks
 			_cloudProvider = cloudProvider;
 			_enabled = enabled;
 			_recording = recording;
+			_serverUrl = serverUrl;
 		}
-
-		private readonly string _cloudProvider;
 
 		public string ApiKey => ParseApiKey(Kv(EnvVarNames.ApiKey, _apiKey, Origin));
 
@@ -166,7 +167,24 @@ namespace Elastic.Apm.Tests.Mocks
 			ParseSanitizeFieldNames(Kv(EnvVarNames.SanitizeFieldNames, _sanitizeFieldNames, Origin));
 
 		public string SecretToken => ParseSecretToken(Kv(EnvVarNames.SecretToken, _secretToken, Origin));
-		public IReadOnlyList<Uri> ServerUrls => ParseServerUrls(Kv(EnvVarNames.ServerUrls, _serverUrls, Origin));
+
+		[Obsolete("Use ServerUrl")]
+		public IReadOnlyList<Uri> ServerUrls => ParseServerUrls(_serverUrls != null
+			? Kv(EnvVarNames.ServerUrls, _serverUrls, Origin)
+			: Kv(EnvVarNames.ServerUrl, _serverUrl, Origin));
+
+		public Uri ServerUrl
+		{
+			get
+			{
+				return _serverUrl != null
+					? ParseServerUrl(Kv(EnvVarNames.ServerUrl, _serverUrl, Origin))
+#pragma warning disable 618
+					: ServerUrls[0];
+#pragma warning restore 618
+			}
+		}
+
 		public string ServiceName => ParseServiceName(Kv(EnvVarNames.ServiceName, _serviceName, Origin));
 		public string ServiceNodeName => ParseServiceNodeName(Kv(EnvVarNames.ServiceNodeName, _serviceNodeName, Origin));
 		public string ServiceVersion => ParseServiceVersion(Kv(EnvVarNames.ServiceVersion, _serviceVersion, Origin));


### PR DESCRIPTION
This commit consolidates ServerUrl and ServerUrls options
by

- introducing ServerUrl configuration value
- deprecating ServerUrls with ObsoleteAttribute

ServerUrl uses the ServerUrl environment or setting key value,
falling back to ServerUrls[0] when not specified, allowing
the usage of ServerUrls to continue to work.

ServerUrls uses the ServerUrls environment or setting key value
if specified, falling back to ServerUrl environment or setting key value
when not specified, allowing exitsing usage of ServerUrls outside of the
agent API to work with ServerUrl.

Closes #1035