### PR TITLE
Add git info to benchmarks

### DIFF
--- a/test/Elastic.Apm.PerfTests/Helpers/GitInfo.cs
+++ b/test/Elastic.Apm.PerfTests/Helpers/GitInfo.cs
@@ -13,6 +13,8 @@ namespace Elastic.Apm.PerfTests.Helpers
 	/// </summary>
 	public class GitInfo : IDisposable
 	{
+		private readonly Process _gitProcess;
+
 		public GitInfo()
 		{
 			var processInfo = new ProcessStartInfo
@@ -41,8 +43,6 @@ namespace Elastic.Apm.PerfTests.Helpers
 			_gitProcess.WaitForExit();
 			return output;
 		}
-
-		private readonly Process _gitProcess;
 
 		public void Dispose() => _gitProcess?.Dispose();
 	}

--- a/test/Elastic.Apm.PerfTests/Helpers/GitInfo.cs
+++ b/test/Elastic.Apm.PerfTests/Helpers/GitInfo.cs
@@ -1,0 +1,49 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+
+namespace Elastic.Apm.PerfTests.Helpers
+{
+	/// <summary>
+	/// A helper class to get git related info about the git repo where the benchmark is running.
+	/// </summary>
+	public class GitInfo : IDisposable
+	{
+		public GitInfo()
+		{
+			var processInfo = new ProcessStartInfo
+			{
+				UseShellExecute = false,
+				RedirectStandardOutput = true,
+				CreateNoWindow = true,
+				FileName = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "git.exe" : "git",
+				WorkingDirectory = Environment.CurrentDirectory
+			};
+
+			_gitProcess = new Process();
+			_gitProcess.StartInfo = processInfo;
+		}
+
+		public string BranchName => RunCommand("rev-parse --abbrev-ref HEAD");
+
+		public string CommitHash => RunCommand("rev-parse HEAD");
+
+
+		private string RunCommand(string args)
+		{
+			_gitProcess.StartInfo.Arguments = args;
+			_gitProcess.Start();
+			var output = _gitProcess.StandardOutput.ReadToEnd().Trim();
+			_gitProcess.WaitForExit();
+			return output;
+		}
+
+		private readonly Process _gitProcess;
+
+		public void Dispose() => _gitProcess?.Dispose();
+	}
+}

--- a/test/Elastic.Apm.PerfTests/Program.cs
+++ b/test/Elastic.Apm.PerfTests/Program.cs
@@ -3,8 +3,11 @@
 // See the LICENSE file in the project root for more information
 
 using System;
+using System.Diagnostics;
+using System.IO;
 using BenchmarkDotNet.Configs;
 using BenchmarkDotNet.Running;
+using Elastic.Apm.PerfTests.Helpers;
 using Elastic.CommonSchema.BenchmarkDotNetExporter;
 
 namespace Elastic.Apm.PerfTests
@@ -13,6 +16,7 @@ namespace Elastic.Apm.PerfTests
 	{
 		public static void Main(string[] args)
 		{
+
 			var esUrl = Environment.GetEnvironmentVariable("ES_URL");
 			var esPassword = Environment.GetEnvironmentVariable("ES_PASS");
 			var esUser = Environment.GetEnvironmentVariable("ES_USER");
@@ -29,6 +33,20 @@ namespace Elastic.Apm.PerfTests
 				Console.WriteLine(
 					"Setting ElasticsearchBenchmarkExporterOptions to export data to http://localhost:9200 - to change this set following environment variables: ES_URL, ES_PASS, ES_USER");
 				options = new ElasticsearchBenchmarkExporterOptions("http://localhost:9200");
+			}
+
+			using (var gitInfo = new GitInfo())
+			{
+				try
+				{
+					options.GitBranch = gitInfo.BranchName;
+					options.GitCommitSha = gitInfo.CommitHash;
+				}
+				catch (Exception e)
+				{
+					Console.WriteLine("Failed reading git info");
+					Console.WriteLine(e);
+				}
 			}
 
 			var exporter = new ElasticsearchBenchmarkExporter(options);


### PR DESCRIPTION
This PR adds git commit sha and branch name to our benchmarks.

Mostly inspired by recent performance issues we had.

### The broader idea

Currently we only run benchmarks when PRs are merged to `master` and we report that to observability-benchmarks cluster. That helps us to find perf issues after merge (which is not ideal).

With this PR benchmark data will always have git info (branch and last commit SHA). Once merged we could turn on running benchmarks on every PR - we could still plot only `master` on the observability-benchmarks cluster but we'll have data for every CI run (including PR branches). With that we can compare the PRs benchmark value with the last master value and put the info into the PR, which I think will help us to avoid perf. issues later.