### PR TITLE
Make transaction_ignore_urls central config compatible

### DIFF
--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -411,6 +411,8 @@ the latest {apm-app-ref}/agent-configuration.html[APM Agent configuration].
 [[config-sanitize-field-names]]
 ==== `SanitizeFieldNames` (added[1.2])
 
+<<dynamic-configuration, image:./images/dynamic-config.svg[] >>
+
 Sometimes it is necessary to sanitize, i.e., remove, sensitive data sent to Elastic APM.
 This config accepts a list of wildcard patterns of field names which should be sanitized.
 These apply for example to HTTP headers and `application/x-www-form-urlencoded` data.
@@ -808,6 +810,8 @@ NOTE: Setting this to `false` reduces memory allocations, network bandwidth and 
 [[config-transaction-ignore-urls]]
 ==== `TransactionIgnoreUrls` (performance)
 
+<<dynamic-configuration, image:./images/dynamic-config.svg[] >>
+
 [options="header"]
 |============
 | Environment variable name             | IConfiguration or Web.config key
@@ -1014,7 +1018,7 @@ you must instead set the `LogLevel` for the internal APM logger under the `Loggi
 | <<config-max-queue-event-count,`MaxQueueEventCount`>> | No | Reporter
 | <<config-metrics-interval,`MetricsInterval`>> | No | Reporter
 | <<config-recording,`Recording`>> | Yes | Core
-| <<config-sanitize-field-names,`SanitizeFieldNames`>> | No | Core
+| <<config-sanitize-field-names,`SanitizeFieldNames`>> | Yes | Core
 | <<config-secret-token,`SecretToken`>> | No | Reporter
 | <<config-server-url,`ServerUrl`>> | No | Reporter
 | <<config-service-name,`ServiceName`>> | No | Core
@@ -1022,7 +1026,7 @@ you must instead set the `LogLevel` for the internal APM logger under the `Loggi
 | <<config-service-version,`ServiceVersion`>> | No | Core
 | <<config-span-frames-min-duration,`SpanFramesMinDuration`>> | No | Stacktrace, Performance
 | <<config-stack-trace-limit,`StackTraceLimit`>> | No | Stacktrace, Performance
-| <<config-transaction-ignore-urls,`TransactionIgnoreUrls`>>  | No | HTTP, Performance
+| <<config-transaction-ignore-urls,`TransactionIgnoreUrls`>>  | Yes | HTTP, Performance
 | <<config-transaction-max-spans,`TransactionMaxSpans`>>  | Yes | Core, Performance
 | <<config-transaction-sample-rate,`TransactionSampleRate`>> | Yes | Core, Performance
 | <<config-use-elastic-apm-traceparent-header,`UseElasticTraceparentHeader`>> | No | HTTP

--- a/src/Elastic.Apm/Api/Request.cs
+++ b/src/Elastic.Apm/Api/Request.cs
@@ -7,6 +7,7 @@ using Elastic.Apm.Api.Constraints;
 using System.Linq;
 using Elastic.Apm.Helpers;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
 
 namespace Elastic.Apm.Api
 {

--- a/src/Elastic.Apm/BackendComm/CentralConfig/CentralConfigFetcher.cs
+++ b/src/Elastic.Apm/BackendComm/CentralConfig/CentralConfigFetcher.cs
@@ -283,7 +283,7 @@ namespace Elastic.Apm.BackendComm.CentralConfig
 				_centralConfig.SpanFramesMinDurationInMilliseconds ?? _wrapped.SpanFramesMinDurationInMilliseconds;
 
 			public int StackTraceLimit => _centralConfig.StackTraceLimit ?? _wrapped.StackTraceLimit;
-			public IReadOnlyList<WildcardMatcher> TransactionIgnoreUrls => _wrapped.TransactionIgnoreUrls;
+			public IReadOnlyList<WildcardMatcher> TransactionIgnoreUrls => _centralConfig.TransactionIgnoreUrls ?? _wrapped.TransactionIgnoreUrls;
 
 			public int TransactionMaxSpans => _centralConfig.TransactionMaxSpans ?? _wrapped.TransactionMaxSpans;
 

--- a/src/Elastic.Apm/BackendComm/CentralConfig/CentralConfigReader.cs
+++ b/src/Elastic.Apm/BackendComm/CentralConfig/CentralConfigReader.cs
@@ -45,6 +45,8 @@ namespace Elastic.Apm.BackendComm.CentralConfig
 
 		internal int? StackTraceLimit { get; private set; }
 
+		internal IReadOnlyList<WildcardMatcher> TransactionIgnoreUrls { get; private set; }
+
 		internal int? TransactionMaxSpans { get; private set; }
 
 		internal double? TransactionSampleRate { get; private set; }
@@ -67,6 +69,8 @@ namespace Elastic.Apm.BackendComm.CentralConfig
 			Recording = GetSimpleConfigurationValue(CentralConfigResponseParser.CentralConfigPayload.Recording, ParseRecording);
 			SanitizeFieldNames =
 				GetConfigurationValue(CentralConfigResponseParser.CentralConfigPayload.SanitizeFieldNames, ParseSanitizeFieldNames);
+			TransactionIgnoreUrls =
+				GetConfigurationValue(CentralConfigResponseParser.CentralConfigPayload.TransactionIgnoreUrls, ParseTransactionIgnoreUrls);
 		}
 
 		private ConfigurationKeyValue BuildKv(string key, string value) =>

--- a/src/Elastic.Apm/BackendComm/CentralConfig/CentralConfigResponseParser.cs
+++ b/src/Elastic.Apm/BackendComm/CentralConfig/CentralConfigResponseParser.cs
@@ -163,7 +163,14 @@ namespace Elastic.Apm.BackendComm.CentralConfig
 
 			public CentralConfigPayload(IDictionary<string, string> keyValues) => _keyValues = keyValues;
 
-			public string this[string key] => _keyValues.ContainsKey(key) ? _keyValues[key] : null;
+			public string this[string key]
+			{
+				get
+				{
+					_keyValues.TryGetValue(key, out var val);
+					return val;
+				}
+			}
 
 			[JsonIgnore]
 			public IEnumerable<KeyValuePair<string, string>> UnknownKeys => _keyValues.Where(x => !SupportedOptions.Contains(x.Key));

--- a/src/Elastic.Apm/BackendComm/CentralConfig/CentralConfigResponseParser.cs
+++ b/src/Elastic.Apm/BackendComm/CentralConfig/CentralConfigResponseParser.cs
@@ -1,4 +1,5 @@
-// Licensed to Elasticsearch B.V under one or more agreements.
+// Licensed to Elasticsearch B.V under
+// one or more agreements.
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
 
@@ -15,9 +16,8 @@ namespace Elastic.Apm.BackendComm.CentralConfig
 {
 	internal class CentralConfigResponseParser : ICentralConfigResponseParser
 	{
-		private readonly IApmLogger _logger;
-
 		internal static readonly TimeSpan WaitTimeIfNoCacheControlMaxAge = TimeSpan.FromMinutes(5);
+		private readonly IApmLogger _logger;
 
 		internal CentralConfigResponseParser(IApmLogger logger) => _logger = logger?.Scoped(nameof(CentralConfigResponseParser));
 
@@ -136,30 +136,37 @@ namespace Elastic.Apm.BackendComm.CentralConfig
 		{
 			internal const string CaptureBodyContentTypesKey = "capture_body_content_types";
 			internal const string CaptureBodyKey = "capture_body";
-			internal const string TransactionMaxSpansKey = "transaction_max_spans";
-			internal const string TransactionSampleRateKey = "transaction_sample_rate";
 
 			internal const string CaptureHeadersKey = "capture_headers";
 			internal const string LogLevelKey = "log_level";
-			internal const string SpanFramesMinDurationKey = "span_frames_min_duration";
-			internal const string StackTraceLimitKey = "stack_trace_limit";
 			internal const string Recording = "recording";
 			internal const string SanitizeFieldNames = "sanitize_field_names";
+			internal const string SpanFramesMinDurationKey = "span_frames_min_duration";
+			internal const string StackTraceLimitKey = "stack_trace_limit";
+			internal const string TransactionIgnoreUrls = "transaction_ignore_urls";
+			internal const string TransactionMaxSpansKey = "transaction_max_spans";
+			internal const string TransactionSampleRateKey = "transaction_sample_rate";
 
 			internal static readonly ISet<string> SupportedOptions = new HashSet<string>
 			{
-				CaptureBodyKey, CaptureBodyContentTypesKey, TransactionMaxSpansKey, TransactionSampleRateKey,
-				CaptureHeadersKey, LogLevelKey, SpanFramesMinDurationKey, StackTraceLimitKey
+				CaptureBodyKey,
+				CaptureBodyContentTypesKey,
+				TransactionMaxSpansKey,
+				TransactionSampleRateKey,
+				CaptureHeadersKey,
+				LogLevelKey,
+				SpanFramesMinDurationKey,
+				StackTraceLimitKey
 			};
 
 			private readonly IDictionary<string, string> _keyValues;
 
 			public CentralConfigPayload(IDictionary<string, string> keyValues) => _keyValues = keyValues;
 
+			public string this[string key] => _keyValues.ContainsKey(key) ? _keyValues[key] : null;
+
 			[JsonIgnore]
 			public IEnumerable<KeyValuePair<string, string>> UnknownKeys => _keyValues.Where(x => !SupportedOptions.Contains(x.Key));
-
-			public string this[string key] => _keyValues.ContainsKey(key) ? _keyValues[key] : null;
 		}
 	}
 }

--- a/src/Elastic.Apm/Report/PayloadSenderV2.cs
+++ b/src/Elastic.Apm/Report/PayloadSenderV2.cs
@@ -116,7 +116,7 @@ namespace Elastic.Apm.Report
 			IConfigSnapshot configSnapshot, IApmServerInfo apmServerInfo, IApmLogger logger
 		)
 		{
-			transactionFilters.Add(new TransactionIgnoreUrlsFilter(configSnapshot).Filter);
+			transactionFilters.Add(new TransactionIgnoreUrlsFilter().Filter);
 			transactionFilters.Add(new HeaderDictionarySanitizerFilter().Filter);
 			// with this, stack trace demystification and conversion to the intake API model happens on a non-application thread:
 			spanFilters.Add(new SpanStackTraceCapturingFilter(logger, apmServerInfo).Filter);

--- a/test/Elastic.Apm.Tests/Mocks/MockPayloadSenderWithFilters.cs
+++ b/test/Elastic.Apm.Tests/Mocks/MockPayloadSenderWithFilters.cs
@@ -14,7 +14,7 @@ namespace Elastic.Apm.Tests.Mocks
 	{
 		private readonly List<Func<ITransaction, ITransaction>> _transactionFilters = new List<Func<ITransaction, ITransaction>>();
 
-		public MockPayloadSenderWithFilters() => _transactionFilters.Add(new TransactionIgnoreUrlsFilter(new MockConfigSnapshot()).Filter);
+		public MockPayloadSenderWithFilters() => _transactionFilters.Add(new TransactionIgnoreUrlsFilter().Filter);
 
 		public override void QueueTransaction(ITransaction transaction)
 		{


### PR DESCRIPTION
Solves https://github.com/elastic/apm-agent-dotnet/issues/1086

This is based on https://github.com/elastic/apm-agent-dotnet/pull/1082 - Same approach.

We could review https://github.com/elastic/apm-agent-dotnet/pull/1082 first and merge and then review this.