### PR TITLE
only package projects explicitly marked <IsPackable>true</IsPackable>

### DIFF
--- a/build/scripts/scripts.fsproj
+++ b/build/scripts/scripts.fsproj
@@ -3,6 +3,7 @@
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <OutputType>Exe</OutputType>
     <NoWarn>$(NoWarn);NU1701</NoWarn>
+    <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Paths.fs" />

--- a/sample/Directory.Build.props
+++ b/sample/Directory.Build.props
@@ -2,5 +2,9 @@
   <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
   <PropertyGroup>
     <AssemblyOriginatorKeyFile>$(SolutionRoot)/build/sampleapps.snk</AssemblyOriginatorKeyFile>
+    <IsPackable>false</IsPackable>
+    <!-- Suppress warnings when a proj is marked <IsPackable>false</IsPackable> 
+         but dotnet pack expects to pack it e.g. Microsoft.NET.Sdk.Web test and sample projects. -->
+    <WarnOnPackingNonPackableProject>false</WarnOnPackingNonPackableProject>
   </PropertyGroup>
 </Project>

--- a/sample/HttpListenerSample/HttpListenerSample.csproj
+++ b/sample/HttpListenerSample/HttpListenerSample.csproj
@@ -4,7 +4,6 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp2.1</TargetFramework>
     <LangVersion>7.1</LangVersion>
-    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Elastic.Apm.AspNetCore/Elastic.Apm.AspNetCore.csproj
+++ b/src/Elastic.Apm.AspNetCore/Elastic.Apm.AspNetCore.csproj
@@ -6,6 +6,7 @@
     <Description>Elastic APM for ASP.NET Core. This package contains auto instrumentation for ASP.NET Core. See: https://github.com/elastic/apm-agent-dotnet/tree/master/docs</Description>
     <PackageTags>apm, monitoring, elastic, elasticapm, analytics, aspnetcore</PackageTags>
     <TargetFrameworks>netstandard2.0;netcoreapp3.0</TargetFrameworks>
+    <IsPackable>true</IsPackable>
   </PropertyGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
     <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.1.0" />

--- a/src/Elastic.Apm.AspNetFullFramework/Elastic.Apm.AspNetFullFramework.csproj
+++ b/src/Elastic.Apm.AspNetFullFramework/Elastic.Apm.AspNetFullFramework.csproj
@@ -6,6 +6,7 @@
     <PackageId>Elastic.Apm.AspNetFullFramework</PackageId>
     <Description>Elastic APM for ASP.NET Full Framework. This package contains auto instrumentation for ASP.NET Full Framework. See: https://github.com/elastic/apm-agent-dotnet/tree/master/docs</Description>
     <PackageTags>apm, monitoring, elastic, elasticapm, analytics, aspnet</PackageTags>
+    <IsPackable>true</IsPackable>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/src/Elastic.Apm.Elasticsearch/Elastic.Apm.Elasticsearch.csproj
+++ b/src/Elastic.Apm.Elasticsearch/Elastic.Apm.Elasticsearch.csproj
@@ -7,6 +7,7 @@
     <PackageProjectUrl>https://github.com/elastic/apm-agent-dotnet</PackageProjectUrl>
     <Description>Elastic APM for the Elasticsearch .NET clients. See: https://github.com/elastic/apm-agent-dotnet/tree/master/docs</Description>
     <PackageTags>apm, monitoring, elastic, elasticapm, analytics, elasticsearch, NEST</PackageTags>
+    <IsPackable>true</IsPackable>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Elasticsearch.Net" Version="7.6.0" />

--- a/src/Elastic.Apm.EntityFramework6/Elastic.Apm.EntityFramework6.csproj
+++ b/src/Elastic.Apm.EntityFramework6/Elastic.Apm.EntityFramework6.csproj
@@ -6,6 +6,7 @@
     <PackageId>Elastic.Apm.EntityFramework6</PackageId>
     <Description>Elastic APM for Entity Framework 6. This package contains auto instrumentation for Entity Framework 6. See: https://github.com/elastic/apm-agent-dotnet/tree/master/docs</Description>
     <PackageTags>apm, monitoring, elastic, elasticapm, analytics, entiryframework6, ef6</PackageTags>
+    <IsPackable>true</IsPackable>
   </PropertyGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net461' ">
     <PackageReference Include="EntityFramework" Version="6.2.0">

--- a/src/Elastic.Apm.EntityFrameworkCore/Elastic.Apm.EntityFrameworkCore.csproj
+++ b/src/Elastic.Apm.EntityFrameworkCore/Elastic.Apm.EntityFrameworkCore.csproj
@@ -6,6 +6,7 @@
     <PackageId>Elastic.Apm.EntityFrameworkCore</PackageId>
     <Description>Elastic APM for Entity Framework Core. This package contains auto instrumentation for Entity Framework Core. See: https://github.com/elastic/apm-agent-dotnet/tree/master/docs</Description>
     <PackageTags>apm, monitoring, elastic, elasticapm, analytics, entiryframeworkcore, efcore</PackageTags>
+    <IsPackable>true</IsPackable>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="2.0.0">

--- a/src/Elastic.Apm.Extensions.Hosting/Elastic.Apm.Extensions.Hosting.csproj
+++ b/src/Elastic.Apm.Extensions.Hosting/Elastic.Apm.Extensions.Hosting.csproj
@@ -5,6 +5,7 @@
     <Description>Elastic APM .NET Agent. This package offers integration with Microsoft.Extensions.Hosting.IHostBuilder for agent registration</Description>
     <PackageTags>apm, monitoring, elastic, elasticapm, analytics, netcore</PackageTags>
     <TargetFrameworks>netstandard2.0;netcoreapp3.0</TargetFrameworks>
+    <IsPackable>true</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Elastic.Apm.GrpcClient/Elastic.Apm.GrpcClient.csproj
+++ b/src/Elastic.Apm.GrpcClient/Elastic.Apm.GrpcClient.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
+    <IsPackable>true</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Elastic.Apm.NetCoreAll/Elastic.Apm.NetCoreAll.csproj
+++ b/src/Elastic.Apm.NetCoreAll/Elastic.Apm.NetCoreAll.csproj
@@ -5,6 +5,7 @@
     <PackageId>Elastic.Apm.NetCoreAll</PackageId>
     <Description>Elastic APM .NET agent. This is a convenient package that automatically pulls in ASP.NET Core, and Entity Framework Core auto instrumentation with the Elastic APM .NET Agent. If your application uses the Microsoft.AspNetCore.All package the easiest way to reference the Elastic APM project is to use this package. If you only need specific functionalities (e.g. EF Core monitoring, or ASP.NET Core without EF Core monitoring, etc) you can reference specific Elastic.Apm packages. See: https://github.com/elastic/apm-agent-dotnet/tree/master/docs</Description>
     <PackageTags>apm, monitoring, elastic, elasticapm, analytics, aspnetcore, entiryframeworkcore, efcore</PackageTags>
+    <IsPackable>true</IsPackable>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Elastic.Apm.AspNetCore\Elastic.Apm.AspNetCore.csproj" />

--- a/src/Elastic.Apm.SqlClient/Elastic.Apm.SqlClient.csproj
+++ b/src/Elastic.Apm.SqlClient/Elastic.Apm.SqlClient.csproj
@@ -6,6 +6,7 @@
     <Description>Elastic APM for System.Data.SqlClient and Microsoft.Data.SqlClient. This package contains auto instrumentation for SqlClient. See: https://github.com/elastic/apm-agent-dotnet/tree/master/docs</Description>
     <PackageTags>apm, monitoring, elastic, elasticapm, analytics, sqlclient</PackageTags>
     <TargetFrameworks>net461;netstandard2.0</TargetFrameworks>
+    <IsPackable>true</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Elastic.Apm/Elastic.Apm.csproj
+++ b/src/Elastic.Apm/Elastic.Apm.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
+    <IsPackable>true</IsPackable>
   </PropertyGroup>
   <PropertyGroup>
     <RootNamespace>Elastic.Apm</RootNamespace>

--- a/src/ElasticApmStartupHook/ElasticApmStartupHook.csproj
+++ b/src/ElasticApmStartupHook/ElasticApmStartupHook.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp2.2</TargetFramework>
     <AssemblyName>ElasticApmAgentStartupHook</AssemblyName>
+    <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Elastic.Apm.AspNetCore\Elastic.Apm.AspNetCore.csproj" />

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -3,6 +3,9 @@
   <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
   <PropertyGroup>
     <IsPackable>false</IsPackable>
+    <!-- Suppress warnings when a proj is marked <IsPackable>false</IsPackable> 
+     but dotnet pack expects to pack it e.g. Microsoft.NET.Sdk.Web test and sample projects. -->
+    <WarnOnPackingNonPackableProject>false</WarnOnPackingNonPackableProject>
     <!-- Always generate debug symbols this allows fluent symbols exception messages to include variable names -->
     <DebugSymbols>True</DebugSymbols>
   </PropertyGroup>


### PR DESCRIPTION
This commit only packages projects
explicitly marked as <IsPackable>true</IsPackable>.
Each project in ./src is explicltly marked, and projects
in ./test and ./sample inherit <IsPackable>false</IsPackable>
from Directory.Build.props.

This allows build[.bat/.sh] pack to package just
the releasable artifacts.