### PR TITLE
Remove IConfigSnapshot parameter from CollectRequestBody

### DIFF
--- a/src/Elastic.Apm.AspNetCore/ApmMiddleware.cs
+++ b/src/Elastic.Apm.AspNetCore/ApmMiddleware.cs
@@ -66,7 +66,7 @@ namespace Elastic.Apm.AspNetCore
 				if (transaction != null && transaction.IsContextCreated && context?.Response.StatusCode >= 400
 					&& transaction.Context?.Request?.Body is string body
 					&& (string.IsNullOrEmpty(body) || body == Apm.Consts.Redacted))
-					transaction.CollectRequestBody(true, context.Request, _logger, transaction.ConfigSnapshot);
+					transaction.CollectRequestBody(true, context.Request, _logger);
 
 				if(transaction != null)
 					WebRequestTransactionCreator.StopTransaction(transaction, context, _logger);
@@ -79,7 +79,7 @@ namespace Elastic.Apm.AspNetCore
 		{
 			transaction?.CaptureException(e);
 			if (context != null)
-				transaction?.CollectRequestBody(true, context.Request, _logger, transaction.ConfigSnapshot);
+				transaction?.CollectRequestBody(true, context.Request, _logger);
 			return false;
 		}
 	}

--- a/src/Elastic.Apm.AspNetCore/DiagnosticListener/AspNetCoreDiagnosticListener.cs
+++ b/src/Elastic.Apm.AspNetCore/DiagnosticListener/AspNetCoreDiagnosticListener.cs
@@ -76,8 +76,7 @@ namespace Elastic.Apm.AspNetCore.DiagnosticListener
 
 					if (iDiagnosticsTransaction is Transaction diagnosticsTransaction)
 					{
-						diagnosticsTransaction.CollectRequestBody(true, httpContextDiagnosticsUnhandledException.Request, _logger,
-							diagnosticsTransaction.ConfigSnapshot);
+						diagnosticsTransaction.CollectRequestBody(true, httpContextDiagnosticsUnhandledException.Request, _logger);
 						diagnosticsTransaction.CaptureException(diagnosticsException);
 					}
 
@@ -89,8 +88,7 @@ namespace Elastic.Apm.AspNetCore.DiagnosticListener
 
 					if (iCurrentTransaction is Transaction currentTransaction)
 					{
-						currentTransaction.CollectRequestBody(true, httpContextUnhandledException.Request, _logger,
-							currentTransaction.ConfigSnapshot);
+						currentTransaction.CollectRequestBody(true, httpContextUnhandledException.Request, _logger);
 						currentTransaction.CaptureException(exception);
 					}
 					break;

--- a/src/Elastic.Apm.AspNetCore/DiagnosticListener/AspNetCoreErrorDiagnosticListener.cs
+++ b/src/Elastic.Apm.AspNetCore/DiagnosticListener/AspNetCoreErrorDiagnosticListener.cs
@@ -34,7 +34,7 @@ namespace Elastic.Apm.AspNetCore.DiagnosticListener
 				kv.Value.GetType().GetTypeInfo().GetDeclaredProperty("httpContext")?.GetValue(kv.Value) as DefaultHttpContext;
 
 			var transaction = _agent.Tracer.CurrentTransaction as Transaction;
-			transaction?.CollectRequestBody(true, httpContextUnhandledException?.Request, _agent.Logger, transaction.ConfigSnapshot);
+			transaction?.CollectRequestBody(true, httpContextUnhandledException?.Request, _agent.Logger);
 			transaction?.CaptureException(exception, "ASP.NET Core Unhandled Exception",
 				kv.Key == "Microsoft.AspNetCore.Diagnostics.HandledException");
 		}

--- a/src/Elastic.Apm.AspNetCore/Extensions/TransactionExtensions.cs
+++ b/src/Elastic.Apm.AspNetCore/Extensions/TransactionExtensions.cs
@@ -20,13 +20,7 @@ namespace Elastic.Apm.AspNetCore.Extensions
 		/// <param name="isForError">Is request body being captured for error (otherwise it's for transaction)</param>
 		/// <param name="httpRequest">Current http request</param>
 		/// <param name="logger">Logger object</param>
-		/// <param name="configSnapshot">
-		/// The config snapshot of the current transaction. This is for reading the sanitization
-		/// settings.
-		/// </param>
-		internal static void CollectRequestBody(this Transaction transaction, bool isForError, HttpRequest httpRequest, IApmLogger logger,
-			IConfigSnapshot configSnapshot
-		)
+		internal static void CollectRequestBody(this Transaction transaction, bool isForError, HttpRequest httpRequest, IApmLogger logger)
 		{
 			if (!transaction.IsSampled) return;
 
@@ -41,7 +35,7 @@ namespace Elastic.Apm.AspNetCore.Extensions
 				&& !ReferenceEquals(transaction.Context.Request.Body, Apm.Consts.Redacted)) return;
 
 			if (transaction.IsCaptureRequestBodyEnabled(isForError) && IsCaptureRequestBodyEnabledForContentType(transaction, httpRequest, logger))
-				body = httpRequest.ExtractRequestBody(logger, configSnapshot);
+				body = httpRequest.ExtractRequestBody(logger, transaction.ConfigSnapshot);
 
 			// According to the documentation - the default value of 'body' is '[Redacted]'
 			transaction.Context.Request.Body = body ?? Apm.Consts.Redacted;

--- a/src/Elastic.Apm.AspNetCore/WebRequestTransactionCreator.cs
+++ b/src/Elastic.Apm.AspNetCore/WebRequestTransactionCreator.cs
@@ -108,7 +108,7 @@ namespace Elastic.Apm.AspNetCore
 					Headers = GetHeaders(context.Request.Headers, transaction.ConfigSnapshot)
 				};
 
-				transaction.CollectRequestBody(false, context.Request, logger, transaction.ConfigSnapshot);
+				transaction.CollectRequestBody(false, context.Request, logger);
 			}
 			catch (Exception ex)
 			{
@@ -243,13 +243,13 @@ namespace Elastic.Apm.AspNetCore
 		/// <returns>default if it's not a grpc call, otherwise the Grpc method name and result as a tuple </returns>
 		private static (string methodname, string result) CollectGrpcInfo()
 		{
-			var parentActivty = Activity.Current.Parent;
+			var parentActivity = Activity.Current?.Parent;
 			(string methodname, string result) grpcCallInfo = default;
 
-			if (parentActivty != null)
+			if (parentActivity != null)
 			{
-				var grpcMethodName = parentActivty.Tags.Where(n => n.Key == "grpc.method").FirstOrDefault().Value;
-				var grpcStatusCode = parentActivty.Tags.Where(n => n.Key == "grpc.status_code").FirstOrDefault().Value;
+				var grpcMethodName = parentActivity.Tags.FirstOrDefault(n => n.Key == "grpc.method").Value;
+				var grpcStatusCode = parentActivity.Tags.FirstOrDefault(n => n.Key == "grpc.status_code").Value;
 
 				if (!string.IsNullOrEmpty(grpcMethodName) && !string.IsNullOrEmpty(grpcStatusCode))
 					grpcCallInfo = (grpcMethodName, grpcStatusCode);


### PR DESCRIPTION
Just a nit from when I looked at the code during [this discussion](https://github.com/elastic/apm-agent-dotnet/pull/1082#discussion_r543376989).

We had this method:

```
internal static void CollectRequestBody(this Transaction transaction, bool isForError, HttpRequest httpRequest, IApmLogger logger, IConfigSnapshot configSnapshot)
```

The 1. parameter is a `Transaction`, the last one is an `IConfigSnapshot`. The last parameter is unnecessary, we can just use the `Transaction.ConfigSnapshot` property.

This PR removed the `IConfigSnapshot` parameter and adapts caller code.