### PR TITLE
Add diff build target

### DIFF
--- a/ElasticApmAgent.sln
+++ b/ElasticApmAgent.sln
@@ -50,6 +50,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "files", "files", "{B406113B
 		RELEASING.md = RELEASING.md
 		build.bat = build.bat
 		build.sh = build.sh
+		dotnet-tools.json = dotnet-tools.json
 	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Elastic.Apm.PerfTests", "test\Elastic.Apm.PerfTests\Elastic.Apm.PerfTests.csproj", "{F069CE99-F418-4BC2-9E44-8F03497D8DA8}"

--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ These are the main folders within the repository:
   * `Elastic.Apm.Tests.MockApmServer`: Implementation of APM Server mock used for agent-as-component tests (for example in `Elastic.Apm.AspNetFullFramework.Tests`).
 * `docs`: This folder contains the official documentation.
 * `sample`: Sample applications that are monitored by the APM .NET Agent. These are also very useful for development: you can start one of these applications and debug the agent through them.
+* `.build`: Contains files used when building the solution, and [a project to perform
+common build tasks](build/README.md).
 * `.ci`: This folder contains all the scripts used to build, test and release the agent within the CI.
 
 ## License

--- a/build/README.md
+++ b/build/README.md
@@ -1,0 +1,64 @@
+# Build automation
+
+The `./build/scripts` directory contains a small F# project that uses
+[Bullseye](https://github.com/adamralph/bullseye) and [System.CommandLine](https://github.com/dotnet/command-line-api)
+to define a set of build targets for performing common tasks.
+
+The project root contains `build.bat` and `build.sh` that make it simple to run
+the scripts project, passing arguments through to invocation. 
+
+The following examples assume running in cmd or PowerShell on Windows.
+To run in a Unix shell like Bash, change `.\build.bat` to `./build.sh`.
+
+Usage and command line arguments can be listed with `--help`
+
+```
+.\build.bat --help
+```
+
+To list the supported targets
+
+```
+.\build.bat --list-targets
+```
+
+To see the dependencies of a specific target
+
+```
+.\build.bat <target> --list-dependencies
+```
+
+## Build all projects
+
+```
+.\build.bat
+```
+
+All build output can be found in `./build/output`, with each project in a directory named after the project.
+
+## Build ElasticApmAgent_\<version\>.zip file
+
+```
+.\build.bat agent-zip
+```
+
+Builds a versioned zip file containing all the assemblies needed to auto instrument an application using [`DOTNET_STARTUP_HOOKS`](https://github.com/dotnet/runtime/blob/master/docs/design/features/host-startup-hook.md).
+
+
+
+## Diff built assemblies
+
+To diff locally built assemblies against the latest relevant released version on Nuget
+
+```
+.\build.bat diff
+```
+
+This will use the `netstandard2.0` TFM by default, but a TFM can be supplied with 
+`--framework` argument.
+
+To run for only certain assemblies, pass the nuget package ids with `--packageids` arguments
+
+```
+build.bat diff --packageids Elastic.Apm --packageids Elastic.SqlClient
+```

--- a/build/scripts/Tooling.fs
+++ b/build/scripts/Tooling.fs
@@ -60,3 +60,10 @@ module Tooling =
         member this.Exec arguments = this.ExecWithTimeout arguments timeout
 
     let DotNet = BuildTooling(None, "dotnet")
+    
+    let private restoreDotnetTools = lazy(DotNet.Exec ["tool"; "restore"])
+    
+    let Diff args =
+        restoreDotnetTools.Force()    
+        let args = args |> String.concat " "
+        DotNet.Exec ["assembly-differ"; args]

--- a/dotnet-tools.json
+++ b/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "assembly-differ": {
+      "version": "0.13.0",
+      "commands": [
+        "assembly-differ"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
This commit adds the ability to diff built assemblies against
the previously released version on Nuget. If there are changes,
an XML file containing the diffs is emitted in ./build/output
with a name matching the assembly name.

To run the diff command for all assemblies

```
build.bat diff
```

This will use the netstandard2.0 TFM by default, but a TFM
can be supplied with `--framework`.

To run for only certain assemblies

```
build.bat diff --packageids Elastic.Apm --packageids Elastic.Apm.SqlClient
```

Closes #1079