### PR TITLE
Update log level based on central configuration and support "off" configuration

### DIFF
--- a/src/Elastic.Apm/Config/AbstractConfigurationReader.cs
+++ b/src/Elastic.Apm/Config/AbstractConfigurationReader.cs
@@ -72,7 +72,9 @@ namespace Elastic.Apm.Config
 					case "warning": return LogLevel.Warning;
 					case "error": return LogLevel.Error;
 					case "critical": return LogLevel.Critical;
-					case "none": return LogLevel.None;
+					case "off":
+					case "none":
+						return LogLevel.None;
 					default: return null;
 				}
 			}

--- a/src/Elastic.Apm/Logging/ConsoleLogger.cs
+++ b/src/Elastic.Apm/Logging/ConsoleLogger.cs
@@ -7,7 +7,7 @@ using System.IO;
 
 namespace Elastic.Apm.Logging
 {
-	internal class ConsoleLogger : IApmLogger
+	internal class ConsoleLogger : IApmLogger, ILogLevelSwitchable
 	{
 		private static readonly object SyncRoot = new object();
 		internal static readonly LogLevel DefaultLogLevel = LogLevel.Error;
@@ -17,14 +17,16 @@ namespace Elastic.Apm.Logging
 
 		public ConsoleLogger(LogLevel level, TextWriter standardOut = null, TextWriter errorOut = null)
 		{
-			Level = level;
+			LogLevelSwitch = new LogLevelSwitch(level);
 			_standardOut = standardOut ?? Console.Out;
 			_errorOut = errorOut ?? Console.Error;
 		}
 
 		public static ConsoleLogger Instance { get; } = new ConsoleLogger(DefaultLogLevel);
 
-		private LogLevel Level { get; }
+		public LogLevelSwitch LogLevelSwitch { get; }
+
+		private LogLevel Level => LogLevelSwitch.Level;
 
 		public static ConsoleLogger LoggerOrDefault(LogLevel? level)
 		{

--- a/src/Elastic.Apm/Logging/IApmLogger.cs
+++ b/src/Elastic.Apm/Logging/IApmLogger.cs
@@ -6,10 +6,36 @@ using System;
 
 namespace Elastic.Apm.Logging
 {
+	/// <summary>
+	/// Performs logging for the Elastic APM agent
+	/// </summary>
 	public interface IApmLogger
 	{
+		/// <summary>
+		/// Checks if the given log level is enabled
+		/// </summary>
+		/// <param name="level">the log level</param>
+		/// <returns><c>true</c> if the log level is enabled, <c>false</c> otherwise.</returns>
 		bool IsEnabled(LogLevel level);
 
+		/// <summary>Writes a log entry.</summary>
+		/// <param name="level">Entry will be written on this level.</param>
+		/// <param name="state">The entry to be written. Can be also an object.</param>
+		/// <param name="e">The exception related to this entry.</param>
+		/// <param name="formatter">Function to create a <see cref="T:System.String" />
+		/// message of the <paramref name="state" /> and <paramref name="e" />.</param>
+		/// <typeparam name="TState">The type of the object to be written.</typeparam>
 		void Log<TState>(LogLevel level, TState state, Exception e, Func<TState, Exception, string> formatter);
+	}
+
+	/// <summary>
+	/// Has a log level that can be dynamically changed at runtime
+	/// </summary>
+	public interface ILogLevelSwitchable
+	{
+		/// <summary>
+		/// A switch to dynamically control the log level at runtime
+		/// </summary>
+		LogLevelSwitch LogLevelSwitch { get; }
 	}
 }

--- a/src/Elastic.Apm/Logging/LogLevelSwitch.cs
+++ b/src/Elastic.Apm/Logging/LogLevelSwitch.cs
@@ -1,0 +1,26 @@
+// Licensed to Elasticsearch B.V under
+// one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+namespace Elastic.Apm.Logging
+{
+	/// <summary>
+	/// Dynamically controls the log level
+	/// </summary>
+	public class LogLevelSwitch
+	{
+		private volatile LogLevel _level;
+
+		public LogLevelSwitch(LogLevel level) => _level = level;
+
+		/// <summary>
+		/// Gets or sets the current log level
+		/// </summary>
+		public LogLevel Level
+		{
+			get => _level;
+			set => _level = value;
+		}
+	}
+}

--- a/test/Elastic.Apm.AspNetCore.Tests/TransactionNameTests.cs
+++ b/test/Elastic.Apm.AspNetCore.Tests/TransactionNameTests.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Threading.Tasks;
 using Elastic.Apm.Extensions.Hosting;
+using Elastic.Apm.Logging;
 using Elastic.Apm.Tests.Mocks;
 using Elastic.Apm.Tests.TestHelpers;
 using FluentAssertions;
@@ -33,14 +34,14 @@ namespace Elastic.Apm.AspNetCore.Tests
 
 			var logger = new LineWriterToLoggerAdaptor(new XunitOutputToLineWriterAdaptor(testOutputHelper))
 			{
-				Level = Logging.LogLevel.Trace
+				LogLevelSwitch = { Level = LogLevel.Trace }
 			};
 
 			_agent = new ApmAgent(new TestAgentComponents(payloadSender: _payloadSender,
 				logger: logger,
 				// _agent needs to share CurrentExecutionSegmentsContainer with Agent.Instance
 				// because the sample application used by the tests (SampleAspNetCoreApp) uses Agent.Instance.Tracer.CurrentTransaction/CurrentSpan
-				currentExecutionSegmentsContainer: Agent.Instance.TracerInternal.CurrentExecutionSegmentsContainer));;
+				currentExecutionSegmentsContainer: Agent.Instance.TracerInternal.CurrentExecutionSegmentsContainer));
 			HostBuilderExtensions.UpdateServiceInformation(_agent.Service);
 		}
 

--- a/test/Elastic.Apm.Tests/BackendCommTests/CentralConfig/CentralConfigFetcherTests.cs
+++ b/test/Elastic.Apm.Tests/BackendCommTests/CentralConfig/CentralConfigFetcherTests.cs
@@ -36,7 +36,7 @@ namespace Elastic.Apm.Tests.BackendCommTests.CentralConfig
 		public CentralConfigFetcherTests(ITestOutputHelper xUnitOutputHelper) : base(xUnitOutputHelper) { }
 
 		[Fact]
-		public void Should_Not_Update_Logger_That_Is_ILogLevelSwitchable()
+		public void Should_Update_Logger_That_Is_ILogLevelSwitchable()
 		{
 			var testLogger = new ConsoleLogger(LogLevel.Trace);
 

--- a/test/Elastic.Apm.Tests/BackendCommTests/CentralConfig/CentralConfigFetcherTests.cs
+++ b/test/Elastic.Apm.Tests/BackendCommTests/CentralConfig/CentralConfigFetcherTests.cs
@@ -2,18 +2,30 @@
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
 
+using System;
+using System.IO;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text;
 using System.Threading;
 using Elastic.Apm.Api;
+using Elastic.Apm.BackendComm;
 using Elastic.Apm.BackendComm.CentralConfig;
+using Elastic.Apm.Cloud;
 using Elastic.Apm.Config;
 using Elastic.Apm.Helpers;
+using Elastic.Apm.Logging;
 using Elastic.Apm.Report;
 using Elastic.Apm.Tests.Mocks;
 using Elastic.Apm.Tests.TestHelpers;
 using FluentAssertions;
 using FluentAssertions.Extensions;
+using Newtonsoft.Json;
+using RichardSzalay.MockHttp;
 using Xunit;
 using Xunit.Abstractions;
+using MockHttpMessageHandler = RichardSzalay.MockHttp.MockHttpMessageHandler;
 
 // ReSharper disable ImplicitlyCapturedClosure
 
@@ -22,6 +34,101 @@ namespace Elastic.Apm.Tests.BackendCommTests.CentralConfig
 	public class CentralConfigFetcherTests : LoggingTestBase
 	{
 		public CentralConfigFetcherTests(ITestOutputHelper xUnitOutputHelper) : base(xUnitOutputHelper) { }
+
+		[Fact]
+		public void Should_Not_Update_Logger_That_Is_ILogLevelSwitchable()
+		{
+			var testLogger = new ConsoleLogger(LogLevel.Trace);
+
+			var environmentConfigurationReader = new EnvironmentConfigurationReader();
+			var configSnapshotFromReader = new ConfigSnapshotFromReader(environmentConfigurationReader, "local");
+			var configStore = new ConfigStore(configSnapshotFromReader, testLogger);
+			var service = Service.GetDefaultService(environmentConfigurationReader, testLogger);
+
+			var waitHandle = new ManualResetEvent(false);
+			var handler = new MockHttpMessageHandler();
+			var configUrl = BackendCommUtils.ApmServerEndpoints
+				.BuildGetConfigAbsoluteUrl(environmentConfigurationReader.ServerUrl, service);
+
+			handler.When(configUrl.AbsoluteUri)
+				.Respond(_ =>
+				{
+					waitHandle.Set();
+					return new HttpResponseMessage(HttpStatusCode.OK)
+					{
+						Headers = { ETag = new EntityTagHeaderValue("\"etag\"") },
+						Content = new StringContent("{ \"log_level\": \"error\" }", Encoding.UTF8)
+					};
+				});
+
+			var centralConfigFetcher = new CentralConfigFetcher(testLogger, configStore, service, handler);
+
+			using (var agent = new ApmAgent(new TestAgentComponents(testLogger,
+				centralConfigFetcher: centralConfigFetcher,
+				payloadSender: new NoopPayloadSender())))
+			{
+				centralConfigFetcher.IsRunning.Should().BeTrue();
+				waitHandle.WaitOne();
+				Thread.Sleep(TimeSpan.FromSeconds(1));
+			}
+
+			testLogger.LogLevelSwitch.Level.Should().Be(LogLevel.Error);
+		}
+
+		/// <summary>
+		/// logger that has a log level switch but does not implement <see cref="ILogLevelSwitchable"/>
+		/// </summary>
+		private class UnswitchableLogger: IApmLogger
+		{
+			public LogLevelSwitch LogLevelSwitch { get; }
+
+			public UnswitchableLogger(LogLevelSwitch logLevelSwitch) => LogLevelSwitch = logLevelSwitch;
+
+			public bool IsEnabled(LogLevel level) => LogLevelSwitch.Level <= level;
+
+			public void Log<TState>(LogLevel level, TState state, Exception e, Func<TState, Exception, string> formatter)
+			{
+			}
+		}
+
+		[Fact]
+		public void Should_Not_Update_Logger_That_Is_Not_ILogLevelSwitchable()
+		{
+			var testLogger = new UnswitchableLogger(new LogLevelSwitch(LogLevel.Trace));
+
+			var environmentConfigurationReader = new EnvironmentConfigurationReader();
+			var configSnapshotFromReader = new ConfigSnapshotFromReader(environmentConfigurationReader, "local");
+			var configStore = new ConfigStore(configSnapshotFromReader, testLogger);
+			var service = Service.GetDefaultService(environmentConfigurationReader, testLogger);
+
+			var waitHandle = new ManualResetEvent(false);
+			var handler = new MockHttpMessageHandler();
+			var configUrl = BackendCommUtils.ApmServerEndpoints
+				.BuildGetConfigAbsoluteUrl(environmentConfigurationReader.ServerUrl, service);
+
+			handler.When(configUrl.AbsoluteUri)
+				.Respond(_ =>
+				{
+					waitHandle.Set();
+					return new HttpResponseMessage(HttpStatusCode.OK)
+					{
+						Headers = { ETag = new EntityTagHeaderValue("\"etag\"") },
+						Content = new StringContent("{ \"log_level\": \"error\" }", Encoding.UTF8)
+					};
+				});
+
+			var centralConfigFetcher = new CentralConfigFetcher(testLogger, configStore, service, handler);
+			using (var agent = new ApmAgent(new TestAgentComponents(testLogger,
+				centralConfigFetcher: centralConfigFetcher,
+				payloadSender: new NoopPayloadSender())))
+			{
+				centralConfigFetcher.IsRunning.Should().BeTrue();
+				waitHandle.WaitOne();
+				Thread.Sleep(TimeSpan.FromSeconds(1));
+			}
+
+			testLogger.LogLevelSwitch.Level.Should().Be(LogLevel.Trace);
+		}
 
 		[Fact]
 		public void Dispose_stops_the_thread()

--- a/test/Elastic.Apm.Tests/LoggerTests.cs
+++ b/test/Elastic.Apm.Tests/LoggerTests.cs
@@ -61,6 +61,22 @@ namespace Elastic.Apm.Tests
 			logger.Lines[3].Should().EndWith("[Debug] - Debug log");
 		}
 
+		[Fact]
+		public void LogLevelSwitch_Should_Switch_LogLevel()
+		{
+			var logger = LogWithLevel(LogLevel.Warning);
+
+			logger.Lines.Count.Should().Be(2);
+			logger.Lines[0].Should().EndWith("[Error] - Error log");
+			logger.Lines[1].Should().EndWith("[Warning] - Warning log");
+
+			logger.LogLevelSwitch.Level = LogLevel.Error;
+			LogWithLevel(logger, LogLevel.Warning);
+
+			logger.Lines.Should().HaveCount(3);
+			logger.Lines[2].Should().EndWith("[Error] - Error log");
+		}
+
 		/// <summary>
 		/// Logs a message with exception by using <see cref="LoggingExtensions.MaybeLogger.LogException" />.
 		/// Makes sure that both the message and the exception is printed.
@@ -403,6 +419,17 @@ namespace Elastic.Apm.Tests
 		private static TestLogger LogWithLevel(LogLevel logLevel)
 		{
 			var logger = new TestLogger(logLevel);
+
+			logger.Error()?.Log("Error log");
+			logger.Warning()?.Log("Warning log");
+			logger.Info()?.Log("Info log");
+			logger.Debug()?.Log("Debug log");
+			return logger;
+		}
+
+		private static TestLogger LogWithLevel(TestLogger logger, LogLevel logLevel)
+		{
+			logger ??= new TestLogger(logLevel);
 
 			logger.Error()?.Log("Error log");
 			logger.Warning()?.Log("Warning log");

--- a/test/Elastic.Apm.Tests/TestHelpers/LineWriterToLoggerAdaptor.cs
+++ b/test/Elastic.Apm.Tests/TestHelpers/LineWriterToLoggerAdaptor.cs
@@ -7,19 +7,17 @@ using Elastic.Apm.Logging;
 
 namespace Elastic.Apm.Tests.TestHelpers
 {
-	public class LineWriterToLoggerAdaptor : IApmLogger
+	public class LineWriterToLoggerAdaptor : IApmLogger, ILogLevelSwitchable
 	{
 		private readonly ILineWriter _lineWriter;
 
 		public LineWriterToLoggerAdaptor(ILineWriter lineWriter, LogLevel level = LogLevel.Information)
 		{
-			Level = level;
+			LogLevelSwitch = new LogLevelSwitch(level);
 			_lineWriter = lineWriter;
 		}
 
-		public LogLevel Level { get; set; }
-
-		public bool IsEnabled(LogLevel level) => Level <= level;
+		public bool IsEnabled(LogLevel level) => LogLevelSwitch.Level <= level;
 
 		public void Log<TState>(LogLevel level, TState state, Exception e, Func<TState, Exception, string> formatter)
 		{
@@ -34,5 +32,7 @@ namespace Elastic.Apm.Tests.TestHelpers
 			if (IsEnabled(level))
 				_lineWriter.WriteLine(fullMessage);
 		}
+
+		public LogLevelSwitch LogLevelSwitch { get; }
 	}
 }

--- a/test/Elastic.Apm.Tests/TestHelpers/LoggingTestBase.cs
+++ b/test/Elastic.Apm.Tests/TestHelpers/LoggingTestBase.cs
@@ -49,24 +49,23 @@ namespace Elastic.Apm.Tests.TestHelpers
 
 			_loggerForStartFinish = new LineWriterToLoggerAdaptor(new SplittingLineWriter(writerForStartFinish), config.LogLevel);
 
-			LogTestStartFinish( /* isStart: */ true);
+			LogProgress("Starting test: {UnitTestDisplayName}...");
 
 			LoggerBase = new LineWriterToLoggerAdaptor(new SplittingLineWriter(lineWriters.ToArray()), config.LogLevel);
 		}
 
 		protected string TestDisplayName => CurrentXunitTest?.DisplayName;
 
-		public virtual void Dispose() => LogTestStartFinish( /* isStart: */ false);
+		public virtual void Dispose() => LogProgress("Finished test: {UnitTestDisplayName}");
 
-		private void LogTestStartFinish(bool isStart)
+		private void LogProgress(string message)
 		{
-			var originalLogLevel = _loggerForStartFinish.Level;
-			_loggerForStartFinish.Level = LogLevel.Information;
+			var originalLogLevel = _loggerForStartFinish.LogLevelSwitch.Level;
+			_loggerForStartFinish.LogLevelSwitch.Level = LogLevel.Information;
 			_loggerForStartFinish.Scoped(ThisClassName)
 				.Info()
-				?.Log(
-					isStart ? "Starting test: {UnitTestDisplayName}..." : "Finished test: {UnitTestDisplayName}", TestDisplayName);
-			_loggerForStartFinish.Level = originalLogLevel;
+				?.Log(message, TestDisplayName);
+			_loggerForStartFinish.LogLevelSwitch.Level = originalLogLevel;
 		}
 
 		internal static ITest GetCurrentXunitTest(ITestOutputHelper xUnitOutputHelper)


### PR DESCRIPTION
This PR allows updating the log level of the configured `IApmLogger` at runtime, based on the log level received from central configuration, and also supports the "off" central configuration log level.

An `ILogLevelSwitchable` interface is introduced that can be implemented by an `IApmLogger` to allow the log level to be updated by central configuration.

`ConsoleLogger` implements `ILogLevelSwitchable` but `NetCoreLogger` does not. The ability to change the log level of `NetCoreLogger` at runtime is controlled by the provider used with Microsoft.Extensions.Logging.

Closes #970