### PR TITLE
Check port is available when creating LocalServer

### DIFF
--- a/test/Elastic.Apm.AspNetCore.Static.Tests/ConfigTests.cs
+++ b/test/Elastic.Apm.AspNetCore.Static.Tests/ConfigTests.cs
@@ -42,7 +42,7 @@ namespace Elastic.Apm.AspNetCore.Static.Tests
 		{
 			var defaultServerUrlConnectionMade = false;
 
-			using var localServer = new LocalServer(context =>
+			using var localServer = LocalServer.Create("http://localhost:8200/", context =>
 			{
 				if (context.Request.HttpMethod != HttpMethod.Post.Method) return;
 
@@ -52,7 +52,8 @@ namespace Elastic.Apm.AspNetCore.Static.Tests
 				// In CI with parallel tests running we could have multiple tests running and some of them may send HTTP post to the default server url
 				// So we only make the test fail, when the request body contains the sample app's url
 				if (body.ToLower().Contains("starttransactionwithagentapi")) defaultServerUrlConnectionMade = true;
-			}, "http://localhost:8200/");
+			});
+
 			var configReader = new MicrosoftExtensionsConfig(new ConfigurationBuilder()
 				.AddJsonFile($"TestConfigs{Path.DirectorySeparatorChar}appsettings_agentdisabled.json")
 				.Build(), new NoopLogger(), "test");

--- a/test/Elastic.Apm.Tests/HttpDiagnosticListenerTests.cs
+++ b/test/Elastic.Apm.Tests/HttpDiagnosticListenerTests.cs
@@ -241,7 +241,7 @@ namespace Elastic.Apm.Tests
 			var (listener, payloadSender, _) = RegisterListenerAndStartTransaction();
 
 			using (listener)
-			using (var localServer = new LocalServer())
+			using (var localServer = LocalServer.Create())
 			{
 				var httpClient = new HttpClient();
 				var res = await httpClient.GetAsync(localServer.Uri);
@@ -268,7 +268,7 @@ namespace Elastic.Apm.Tests
 			var (listener, payloadSender, _) = RegisterListenerAndStartTransaction();
 
 			using (listener)
-			using (var localServer = new LocalServer())
+			using (var localServer = LocalServer.Create())
 			{
 				var uri = new Uri(localServer.Uri);
 
@@ -302,7 +302,7 @@ namespace Elastic.Apm.Tests
 			var (listener, payloadSender, _) = RegisterListenerAndStartTransaction();
 
 			using (listener)
-			using (var localServer = new LocalServer(ctx => { ctx.Response.StatusCode = 500; }))
+			using (var localServer = LocalServer.Create(ctx => { ctx.Response.StatusCode = 500; }))
 			{
 				var httpClient = new HttpClient();
 				var res = await httpClient.PostAsync(localServer.Uri, new StringContent("foo"));
@@ -378,7 +378,7 @@ namespace Elastic.Apm.Tests
 			var (listener, payloadSender, _) = RegisterListenerAndStartTransaction();
 
 			using (listener)
-			using (var localServer = new LocalServer())
+			using (var localServer = LocalServer.Create())
 			{
 				var httpClient = new HttpClient();
 				var res = await httpClient.GetAsync(localServer.Uri);
@@ -400,7 +400,7 @@ namespace Elastic.Apm.Tests
 			var (listener, payloadSender, _) = RegisterListenerAndStartTransaction();
 
 			using (listener)
-			using (var localServer = new LocalServer())
+			using (var localServer = LocalServer.Create())
 			{
 				var httpClient = new HttpClient();
 				var res = await httpClient.GetAsync(localServer.Uri);
@@ -421,7 +421,7 @@ namespace Elastic.Apm.Tests
 			var (listener, payloadSender, _) = RegisterListenerAndStartTransaction();
 
 			using (listener)
-			using (var localServer = new LocalServer(ctx =>
+			using (var localServer = LocalServer.Create(ctx =>
 			{
 				ctx.Response.StatusCode = 200;
 				Thread.Sleep(5); //Make sure duration is really > 0
@@ -449,7 +449,7 @@ namespace Elastic.Apm.Tests
 			var (listener, payloadSender, _) = RegisterListenerAndStartTransaction();
 
 			using (listener)
-			using (var localServer = new LocalServer())
+			using (var localServer = LocalServer.Create())
 			{
 				var httpClient = new HttpClient();
 				var res = await httpClient.GetAsync(localServer.Uri);
@@ -474,7 +474,7 @@ namespace Elastic.Apm.Tests
 			var (listener, payloadSender, agent) = RegisterListenerAndStartTransaction();
 
 			using (listener)
-			using (var localServer = new LocalServer())
+			using (var localServer = LocalServer.Create())
 			{
 				{
 					var httpClient = new HttpClient();
@@ -523,7 +523,7 @@ namespace Elastic.Apm.Tests
 			var mockPayloadSender = new MockPayloadSender();
 			var agent = new ApmAgent(new TestAgentComponents(payloadSender: mockPayloadSender));
 
-			using (var localServer = new LocalServer())
+			using (var localServer = LocalServer.Create())
 			{
 				await agent.Tracer.CaptureTransaction("TestTransaction", "TestType", async t =>
 				{
@@ -559,7 +559,7 @@ namespace Elastic.Apm.Tests
 			agent.Subscribe(new HttpDiagnosticsSubscriber());
 			StartTransaction(agent);
 
-			using (var localServer = new LocalServer())
+			using (var localServer = LocalServer.Create())
 			using (var httpClient = new HttpClient())
 			{
 				var uriBuilder = new UriBuilder(localServer.Uri) { UserName = "TestUser289421", Password = "Password973243" };
@@ -589,7 +589,7 @@ namespace Elastic.Apm.Tests
 
 			var spans = payloadSender.Spans;
 
-			using (var localServer = new LocalServer())
+			using (var localServer = LocalServer.Create())
 			using (var httpClient = new HttpClient())
 			{
 				spans.Should().BeEmpty();
@@ -624,7 +624,7 @@ namespace Elastic.Apm.Tests
 			var agent = new ApmAgent(new TestAgentComponents(payloadSender: mockPayloadSender));
 			var subscriber = new HttpDiagnosticsSubscriber();
 
-			using (var localServer = new LocalServer())
+			using (var localServer = LocalServer.Create())
 			using (agent.Subscribe(subscriber))
 			{
 				var url = localServer.Uri;
@@ -662,7 +662,7 @@ namespace Elastic.Apm.Tests
 			var agent = new ApmAgent(new TestAgentComponents(payloadSender: mockPayloadSender));
 			var subscriber = new HttpDiagnosticsSubscriber();
 
-			using (var localServer = new LocalServer())
+			using (var localServer = LocalServer.Create())
 			{
 				var url = localServer.Uri;
 				using (agent.Subscribe(subscriber)) //subscribe
@@ -741,7 +741,7 @@ namespace Elastic.Apm.Tests
 
 			try
 			{
-				using var localServer = new LocalServer();
+				using var localServer = LocalServer.Create();
 				var httpClient = new HttpClient();
 				await httpClient.GetAsync(localServer.Uri);
 			}
@@ -760,7 +760,7 @@ namespace Elastic.Apm.Tests
 			Activity.DefaultIdFormat = ActivityIdFormat.W3C;
 
 			var mockPayloadSender = new MockPayloadSender();
-			using var localServer = new LocalServer();
+			using var localServer = LocalServer.Create();
 			using var agent = new ApmAgent(new TestAgentComponents(payloadSender: mockPayloadSender));
 			agent.Subscribe(new HttpDiagnosticsSubscriber());
 			await agent.Tracer.CaptureTransaction("Test", "Test", async () =>

--- a/test/Elastic.Apm.Tests/LoggerTests.cs
+++ b/test/Elastic.Apm.Tests/LoggerTests.cs
@@ -358,15 +358,16 @@ namespace Elastic.Apm.Tests
 			var userName = "abc";
 			var pw = "def";
 			var inMemoryLogger = new InMemoryBlockingLogger(LogLevel.Error);
-			var port = new Random(DateTime.UtcNow.Millisecond).Next(8100, 65535);
-			var configReader = new MockConfigSnapshot(serverUrls: $"http://{userName}:{pw}@localhost:{port}", maxBatchEventCount: "0",
+
+			using var localServer = LocalServer.Create(httpListenerContext => { httpListenerContext.Response.StatusCode = 500; });
+
+			var uri = new Uri(localServer.Uri);
+
+			var configReader = new MockConfigSnapshot(serverUrls: $"http://{userName}:{pw}@{uri.Authority}", maxBatchEventCount: "0",
 				flushInterval: "0");
 
 			using var payloadSender = new PayloadSenderV2(inMemoryLogger, configReader,
 				Service.GetDefaultService(configReader, inMemoryLogger), new Api.System(), MockApmServerInfo.Version710);
-
-			using var localServer = new LocalServer(httpListenerContext => { httpListenerContext.Response.StatusCode = 500; },
-				$"http://localhost:{port}/");
 
 			using var agent = new ApmAgent(new AgentComponents(payloadSender: payloadSender));
 
@@ -374,7 +375,7 @@ namespace Elastic.Apm.Tests
 
 			inMemoryLogger.Lines.Should().HaveCount(1);
 			inMemoryLogger.Lines.Should().NotContain(n => n.Contains($"{userName}:{pw}"));
-			inMemoryLogger.Lines.Should().Contain(n => n.Contains($"http://[REDACTED]:[REDACTED]@localhost:{port}"));
+			inMemoryLogger.Lines.Should().Contain(n => n.Contains($"http://[REDACTED]:[REDACTED]@{uri.Authority}"));
 		}
 
 		/// <summary>

--- a/test/Elastic.Apm.Tests/Mocks/LocalServer.cs
+++ b/test/Elastic.Apm.Tests/Mocks/LocalServer.cs
@@ -3,23 +3,28 @@
 // See the LICENSE file in the project root for more information
 
 using System;
+using System.Linq;
 using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
+using Xunit.Sdk;
 
 namespace Elastic.Apm.Tests.Mocks
 {
 	public class LocalServer : IDisposable
 	{
-		private readonly HttpListener _httpListener = new HttpListener();
+		private const int MinPort = 49215;
+		private const int MaxPort = 65535;
+
+		private readonly HttpListener _httpListener;
 		private readonly Task _task;
 		private readonly CancellationTokenSource _tokenSource;
+		private long _seenRequests;
 
-		public LocalServer(Action<HttpListenerContext> testAction = null, string uri = "http://localhost:8082/")
+		private LocalServer(HttpListener httpListener, Action<HttpListenerContext> testAction = null)
 		{
-			Uri = uri;
-			_httpListener.Prefixes.Add(Uri);
-			_httpListener.Start();
+			_httpListener = httpListener;
+			Uri = _httpListener.Prefixes.First();
 			_tokenSource = new CancellationTokenSource();
 			_task = Task.Run(() =>
 			{
@@ -38,7 +43,45 @@ namespace Elastic.Apm.Tests.Mocks
 			}, _tokenSource.Token);
 		}
 
-		private long _seenRequests;
+		public static LocalServer Create() => Create(null);
+
+		public static LocalServer Create(Action<HttpListenerContext> testAction)
+		{
+			for (var i = MinPort; i < MaxPort; i++)
+			{
+				if (TryCreate($"http://localhost:{i}/", testAction, out var server))
+					return server;
+			}
+
+			throw new XunitException("could not create LocalServer");
+		}
+
+		public static LocalServer Create(string uri, Action<HttpListenerContext> testAction)
+		{
+			if (TryCreate(uri, testAction, out var server))
+				return server;
+
+			throw new XunitException($"could not create LocalServer listening on {uri}");
+		}
+
+		public static bool TryCreate(string uri, Action<HttpListenerContext> testAction, out LocalServer server)
+		{
+			var httpListener = new HttpListener();
+			httpListener.Prefixes.Add(uri);
+			try
+			{
+				httpListener.Start();
+			}
+			catch
+			{
+				server = null;
+				return false;
+			}
+
+			server = new LocalServer(httpListener, testAction);
+			return true;
+		}
+
 		public long SeenRequests => _seenRequests;
 
 		public string Uri { get; }
@@ -49,6 +92,9 @@ namespace Elastic.Apm.Tests.Mocks
 			((IDisposable)_httpListener).Dispose();
 			_tokenSource.Cancel();
 			_tokenSource.Dispose();
+
+			if (_task.IsCompleted || _task.IsFaulted || _task.IsCanceled)
+				_task.Dispose();
 		}
 	}
 }


### PR DESCRIPTION
This commit adds static methods to create a LocalServer,
checking that a HttpListener can be started to listen on a
specific port as part of creation, and optionally looping through
ports until the listener can be started.