### PR TITLE
Add Microsoft.NET.Sdk.Razor package reference for ASP.NET Core 2.2

### DIFF
--- a/.ci/windows/msbuild.bat
+++ b/.ci/windows/msbuild.bat
@@ -5,7 +5,4 @@ echo "Prepare context for VsDevCmd.bat"
 call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Professional\Common7\Tools\VsDevCmd.bat"
 nuget restore -verbosity detailed -NonInteractive
 
-rem TODO: Workaround for https://github.com/dotnet/sdk/issues/14497
-set DOTNET_HOST_PATH=dotnet
-
 msbuild

--- a/sample/SampleAspNetCoreApp/SampleAspNetCoreApp.csproj
+++ b/sample/SampleAspNetCoreApp/SampleAspNetCoreApp.csproj
@@ -12,6 +12,7 @@
   <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.2' ">
     <PackageReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="2.2.6" />
+    <PackageReference Include="Microsoft.NET.Sdk.Razor" Version="2.2.0" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.0' ">
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="3.0.0" />


### PR DESCRIPTION
This commit adds a reference to Microsoft.NET.Sdk.Razor package reference for ASP.NET Core 2.2. This is to fix a known bug in the .NET 5.0 SDK where the build target RazorTagHelper fails when DOTNET_HOST_PATH is not set.