### PR TITLE
Fix compile warnings

### DIFF
--- a/sample/StackExchangeRedisSample/StackExchangeRedisSample.csproj
+++ b/sample/StackExchangeRedisSample/StackExchangeRedisSample.csproj
@@ -7,6 +7,8 @@
 
     <ItemGroup>
       <PackageReference Include="StackExchange.Redis" Version="2.0.495" />
+      <!-- Strong name any assemblies that aren't i.e. DotNet.Testcontainers -->
+      <PackageReference Include="StrongNamer" Version="0.2.5" />
       <PackageReference Include="DotNet.Testcontainers" Version="1.4.0" />
     </ItemGroup>
   

--- a/test/Elastic.Apm.Grpc.Tests/Elastic.Apm.Grpc.Tests.csproj
+++ b/test/Elastic.Apm.Grpc.Tests/Elastic.Apm.Grpc.Tests.csproj
@@ -24,30 +24,31 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="Grpc.AspNetCore" Version="2.27.0" />
   </ItemGroup>
   <!--<ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1' ">
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="3.1.0" />
   </ItemGroup>-->
-
-
+  
   <ItemGroup>
-    <ProjectReference Include="..\..\sample\GrpcServiceSample\GrpcServiceSample.csproj" />
     <ProjectReference Include="..\..\src\Elastic.Apm.GrpcClient\Elastic.Apm.GrpcClient.csproj" />
     <ProjectReference Include="..\..\src\Elastic.Apm\Elastic.Apm.csproj" />
     <ProjectReference Include="..\Elastic.Apm.Tests\Elastic.Apm.Tests.csproj" />
+    <ProjectReference Include="..\..\src\Elastic.Apm.NetCoreAll\Elastic.Apm.NetCoreAll.csproj" />
   </ItemGroup>
-
-
+  
   <ItemGroup>
-    <Protobuf Include="..\..\sample\GrpcServiceSample\Protos\greet.proto" GrpcServices="Client">
+    <Protobuf Include="..\..\sample\GrpcServiceSample\Protos\greet.proto" GrpcServices="Both">
       <Link>Protos\greet.proto</Link>
     </Protobuf>
   </ItemGroup>
   <ItemGroup>
-    <Content Update="TestConfigs\appsettings_valid.json">
+    <Content Include="..\..\sample\GrpcServiceSample\appsettings.Development.json">
+      <Link>appsettings.Development.json</Link>
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
-    <Content Update="TestConfigs\appsettings_invalid.json">
+    <Content Include="..\..\sample\GrpcServiceSample\appsettings.json">
+      <Link>appsettings.json</Link>
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
   </ItemGroup>

--- a/test/Elastic.Apm.Grpc.Tests/SampleAppHostBuilder.cs
+++ b/test/Elastic.Apm.Grpc.Tests/SampleAppHostBuilder.cs
@@ -1,5 +1,5 @@
 ﻿using Elastic.Apm.AspNetCore;
-using GrpcServiceSample;
+using Elastic.Apm.Grpc.Tests.Services;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
@@ -8,6 +8,34 @@ using Microsoft.Extensions.Hosting;
 
 namespace Elastic.Apm.Grpc.Tests
 {
+	public class Startup
+	{
+		// This method gets called by the runtime. Use this method to add services to the container.
+		// For more information on how to configure your application, visit https://go.microsoft.com/fwlink/?LinkID=398940
+		public void ConfigureServices(IServiceCollection services)
+			=> services.AddGrpc();
+
+		// This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
+		public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
+		{
+			if (env.IsDevelopment()) app.UseDeveloperExceptionPage();
+
+			app.UseRouting();
+
+			app.UseEndpoints(endpoints =>
+			{
+				endpoints.MapGrpcService<GreeterService>();
+
+				endpoints.MapGet("/",
+					async context =>
+					{
+						await context.Response.WriteAsync(
+							"Communication with gRPC endpoints must be made through a gRPC client. To learn how to create a client, visit: https://go.microsoft.com/fwlink/?linkid=2086909");
+					});
+			});
+		}
+	}
+
 	public class SampleAppHostBuilder
 	{
 		public static int SampleAppPort = 5866;

--- a/test/Elastic.Apm.Grpc.Tests/Services/GreeterService.cs
+++ b/test/Elastic.Apm.Grpc.Tests/Services/GreeterService.cs
@@ -1,0 +1,25 @@
+// Licensed to Elasticsearch B.V under
+// one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System;
+using System.Threading.Tasks;
+using Grpc.Core;
+using GrpcServiceSample;
+using Microsoft.Extensions.Logging;
+
+namespace Elastic.Apm.Grpc.Tests.Services
+{
+	public class GreeterService : Greeter.GreeterBase
+	{
+		private readonly ILogger<GreeterService> _logger;
+
+		public GreeterService(ILogger<GreeterService> logger) => _logger = logger;
+
+		public override Task<HelloReply> SayHello(HelloRequest request, ServerCallContext context) =>
+			Task.FromResult(new HelloReply { Message = "Hello " + request.Name });
+
+		public override Task<HelloReply> ThrowAnException(HelloRequest request, ServerCallContext context) => throw new Exception("Test Exception");
+	}
+}

--- a/test/Elastic.Apm.StackExchange.Redis.Tests/Elastic.Apm.StackExchange.Redis.Tests.csproj
+++ b/test/Elastic.Apm.StackExchange.Redis.Tests/Elastic.Apm.StackExchange.Redis.Tests.csproj
@@ -15,7 +15,8 @@
     <PackageReference Include="StackExchange.Redis" Version="2.0.495" />
     <PackageReference Include="Proc" Version="0.6.2" />
     <PackageReference Include="DotNet.Testcontainers" Version="1.4.0" />
-
+    <!-- Strong name any assemblies that aren't i.e. DotNet.Testcontainers -->
+    <PackageReference Include="StrongNamer" Version="0.2.5" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
This PR fixes the compile warnings

- strong name DotNet.Testcontainers reference
- remove reference to Grpc sample app in Grpc tests, and implements components needed to run Grpc service in the test project