### PR TITLE
Add SourceLink and XML documentation to all packages

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -9,17 +9,25 @@
     <Authors>Elastic and contributors</Authors>
     <Copyright>2020 Elasticsearch BV</Copyright>
     <PackageProjectUrl>https://github.com/elastic/apm-agent-dotnet</PackageProjectUrl>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <PackageIcon>nuget-icon.png</PackageIcon>
+    <!-- Include .pdb in package -->
+    <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
+    <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
   <ItemGroup>
+    <!-- Include the icon referenced by <PackageIcon> in the package -->
     <None Include="$(SolutionRoot)/build/nuget-icon.png">
       <Pack>True</Pack>
       <PackagePath>.</PackagePath>
     </None>
+    <!-- Include the license referenced by <PackageLicenseFile> in the package -->
     <None Include="$(SolutionRoot)/LICENSE">
       <Pack>True</Pack>
       <PackagePath>.</PackagePath>
     </None>
+    <!-- Configure SourceLink for packages -->
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
   </ItemGroup>
 </Project>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -14,6 +14,10 @@
     <PackageIcon>nuget-icon.png</PackageIcon>
     <!-- Include .pdb in package -->
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
+    <!-- Generate documentation files for each package -->
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <!-- don't warn on missing XML documentation -->
+    <NoWarn>$(NoWarn);1591</NoWarn>
     <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
   <ItemGroup>

--- a/src/Elastic.Apm.AspNetCore/Extensions/ListExtensions.cs
+++ b/src/Elastic.Apm.AspNetCore/Extensions/ListExtensions.cs
@@ -9,13 +9,11 @@ namespace Elastic.Apm.AspNetCore.Extensions
 	internal static class ListExtensions
 	{
 		/// <summary>
-		/// Similar to List
-		/// <T>
-		/// .Contains but matches the string using a 'like' operator instead
-		/// of an exact match
+		/// Similar to <see cref="List{T}.Contains"/> but matches the string using
+		/// a 'like' operator instead of an exact match
 		/// </summary>
-		/// <param name="list"></param>
-		/// <param name="matchedString"></param>
+		/// <param name="list">The list in which to find the match</param>
+		/// <param name="matchedString">The string to match</param>
 		/// <returns></returns>
 		public static bool ContainsLike(this List<string> list, string matchedString)
 		{

--- a/src/Elastic.Apm.AspNetCore/Extensions/RequestExtentions.cs
+++ b/src/Elastic.Apm.AspNetCore/Extensions/RequestExtentions.cs
@@ -21,8 +21,9 @@ namespace Elastic.Apm.AspNetCore.Extensions
 		/// Extracts the request body, up to a specified maximum length.
 		/// The request body that is read is buffered.
 		/// </summary>
-		/// <param name="request"></param>
-		/// <param name="logger"></param>
+		/// <param name="request">The request</param>
+		/// <param name="logger">The logger</param>
+		/// <param name="configSnapshot">The configuration snapshot</param>
 		/// <returns></returns>
 		public static string ExtractRequestBody(this HttpRequest request, IApmLogger logger, IConfigSnapshot configSnapshot)
 		{

--- a/src/Elastic.Apm/Agent.cs
+++ b/src/Elastic.Apm/Agent.cs
@@ -147,24 +147,20 @@ namespace Elastic.Apm
 		public static bool IsConfigured => _isConfigured;
 
 		/// <summary>
-		/// The entry point for manual instrumentation. The <see cref="Tracer" /> property returns the tracer,
-		/// which you access to the currently active transaction and span and it also enables you to manually start
-		/// a transaction.
+		/// The entry point for manual instrumentation. Gets an <see cref="ITracer"/> from
+		/// which the currently active transaction and span can be accessed, and enables starting
+		/// or capturing a new transaction.
 		/// </summary>
 		public static ITracer Tracer => Instance.Tracer;
 
 		/// <summary>
 		/// Adds a filter which gets called before each transaction gets sent to APM Server.
-		/// In the
-		/// <param name="filter"></param>
-		/// you have access to the <see cref="ITransaction" /> instance which gets sent to APM Server
-		/// and you can modify it. With the return value of the
-		/// <param name="filter"></param>
-		/// you can also control if the <see cref="ITransaction" /> should be sent to the server or not.
-		/// If the
-		/// <param name="filter"></param>
-		/// returns a non-null <see cref="ITransaction" /> instance then it will be sent to the APM Server -
-		/// if it returns <code>null</code>, the event will be dropped and won't be sent to the APM server.
+		/// In the <paramref name="filter" />, you have access to the <see cref="ITransaction" />
+		/// instance which gets sent to APM Server and you can modify it. With the return value of the
+		/// <paramref name="filter" />, you can also control if the <see cref="ITransaction" />
+		/// should be sent to the server or not. If the <paramref name="filter" />
+		/// returns a non-null <see cref="ITransaction" /> instance then it will be sent to the APM Server,
+		/// and if it returns <code>null</code>, the event will be dropped and won't be sent to the APM server.
 		/// </summary>
 		/// <param name="filter">
 		/// The filter that can process the <see cref="ITransaction" /> and decide if it should be sent to APM
@@ -178,15 +174,11 @@ namespace Elastic.Apm
 
 		/// <summary>
 		/// Adds a filter which gets called before each span gets sent to APM Server.
-		/// In the
-		/// <param name="filter"></param>
-		/// you have access to the <see cref="ISpan" /> instance which gets sent to APM Server
-		/// and you can modify it. With the return value of the
-		/// <param name="filter"></param>
-		/// you can also control if the <see cref="ISpan" /> should be sent to the server or not.
-		/// If the
-		/// <param name="filter"></param>
-		/// returns a non-null <see cref="ISpan" /> instance then it will be sent to the APM Server -
+		/// In the <paramref name="filter" />, you have access to the <see cref="ISpan" />
+		/// instance which gets sent to APM Server and you can modify it. With the return value of the
+		/// <paramref name="filter" />, you can also control if the <see cref="ISpan" />
+		/// should be sent to the server or not. If the <paramref name="filter" />
+		/// returns a non-null <see cref="ISpan" /> instance then it will be sent to the APM Server, and
 		/// if it returns <code>null</code>, the event will be dropped and won't be sent to the APM server.
 		/// </summary>
 		/// <param name="filter">
@@ -201,15 +193,11 @@ namespace Elastic.Apm
 
 		/// <summary>
 		/// Adds a filter which gets called before each error gets sent to APM Server.
-		/// In the
-		/// <param name="filter"></param>
-		/// you have access to the <see cref="IError" /> instance which gets sent to APM Server
-		/// and you can modify it. With the return value of the
-		/// <param name="filter"></param>
-		/// you can also control if the <see cref="IError" /> should be sent to the server or not.
-		/// If the
-		/// <param name="filter"></param>
-		/// returns a non-null <see cref="IError" /> instance then it will be sent to the APM Server -
+		/// In the <paramref name="filter" />, you have access to the <see cref="IError" />
+		/// instance which gets sent to APM Server and you can modify it. With the return value of the
+		/// <paramref name="filter" /> you can also control if the <see cref="IError" />
+		/// should be sent to the server or not. If the <paramref name="filter" />
+		/// returns a non-null <see cref="IError" /> instance then it will be sent to the APM Server, and
 		/// if it returns <code>null</code>, the event will be dropped and won't be sent to the APM server.
 		/// </summary>
 		/// <param name="filter">

--- a/src/Elastic.Apm/Api/DistributedTracingData.cs
+++ b/src/Elastic.Apm/Api/DistributedTracingData.cs
@@ -49,9 +49,7 @@ namespace Elastic.Apm.Api
 		/// </summary>
 		/// <param name="serialized">should be a return value from a call to <see cref="SerializeToString" />.</param>
 		/// <returns>
-		/// Instance deserialized from
-		/// <param name="serialized" />
-		/// .
+		/// Instance deserialized from <paramref name="serialized" />.
 		/// </returns>
 		public static DistributedTracingData TryDeserializeFromString(string serialized) => TraceContext.TryExtractTracingData(serialized);
 

--- a/src/Elastic.Apm/Api/Http.cs
+++ b/src/Elastic.Apm/Api/Http.cs
@@ -44,10 +44,8 @@ namespace Elastic.Apm.Api
 
 		/// <summary>
 		/// Sets the <see cref="Url" /> string property directly with a <see cref="Uri" /> instance.
-		/// The advantage of using this method is that the sanitization of the
-		/// <param name="uri"></param>
-		/// is
-		/// allocation free in case there is nothing to sanitize in the <paramref name="uri" />.
+		/// The advantage of using this method is that the sanitization of the <paramref name="uri" />
+		/// is allocation free in case there is nothing to sanitize in the <paramref name="uri" />.
 		/// </summary>
 		/// <param name="uri"></param>
 		internal void SetUrl(Uri uri)
@@ -113,7 +111,7 @@ namespace Elastic.Apm.Api
 		/// <param name="uriString">The Uri to sanitize.</param>
 		/// <param name="result">
 		/// The result, which is the sanitized string. If no sanitization was needed
-		/// (because there was no username& password in the URL) then this contains the <paramref name="result" /> parameter.
+		/// (because there was no username and password in the URL) then this contains the <paramref name="result" /> parameter.
 		/// </param>
 		/// <returns></returns>
 		internal static bool Sanitize(string uriString, out string result) =>

--- a/src/Elastic.Apm/Api/IExecutionSegment.cs
+++ b/src/Elastic.Apm/Api/IExecutionSegment.cs
@@ -12,7 +12,7 @@ namespace Elastic.Apm.Api
 {
 	/// <summary>
 	/// A base interface that encapsulates basic functionality of a piece of work that the agent can measure (e.g.
-	/// <see cref="ISpan" /> and <see cref="ITracer" />)
+	/// <see cref="ISpan" /> and <see cref="ITransaction" />)
 	/// </summary>
 	public interface IExecutionSegment
 	{
@@ -147,9 +147,7 @@ namespace Elastic.Apm.Api
 		/// <param name="action">The action of the span.</param>
 		/// <typeparam name="T">The return type of the code that you want to capture as span.</typeparam>
 		/// <returns>
-		/// The result of the
-		/// <param name="func"></param>
-		/// .
+		/// The result of the <paramref name="func" />.
 		/// </returns>
 		T CaptureSpan<T>(string name, string type, Func<ISpan, T> func, string subType = null, string action = null);
 
@@ -169,9 +167,7 @@ namespace Elastic.Apm.Api
 		/// <param name="action">The action of the span.</param>
 		/// <typeparam name="T">The return type of the code that you want to capture as span.</typeparam>
 		/// <returns>
-		/// The result of the
-		/// <param name="func"></param>
-		/// .
+		/// The result of the <paramref name="func" />.
 		/// </returns>
 		T CaptureSpan<T>(string name, string type, Func<T> func, string subType = null, string action = null);
 

--- a/src/Elastic.Apm/Api/ITracer.cs
+++ b/src/Elastic.Apm/Api/ITracer.cs
@@ -11,13 +11,13 @@ namespace Elastic.Apm.Api
 	public interface ITracer
 	{
 		/// <summary>
-		/// Returns the currently active span.
+		/// Gets the currently active span.
 		/// Returns <c>null</c> if there's no currently active span.
 		/// </summary>
 		ISpan CurrentSpan { get; }
 
 		/// <summary>
-		/// Returns the currently active transaction.
+		/// Gets the currently active transaction.
 		/// Returns <c>null</c> if there's no currently active transaction.
 		/// </summary>
 		ITransaction CurrentTransaction { get; }
@@ -36,7 +36,7 @@ namespace Elastic.Apm.Api
 		/// In case of a distributed trace, you can pass distributed tracing data to the API. By doing so, the new transaction will
 		/// be
 		/// automatically part of a distributed trace.
-		/// Use <see cref="ISpan.OutgoingDistributedTracingData" /> to obtain distributed tracing data on the caller side.
+		/// Use <see cref="IExecutionSegment.OutgoingDistributedTracingData" /> to obtain distributed tracing data on the caller side.
 		/// </param>
 		void CaptureTransaction(string name, string type, Action<ITransaction> action, DistributedTracingData distributedTracingData = null);
 
@@ -54,7 +54,7 @@ namespace Elastic.Apm.Api
 		/// In case of a distributed trace, you can pass distributed tracing data to the API. By doing so, the new transaction will
 		/// be
 		/// automatically part of a distributed trace.
-		/// Use <see cref="ISpan.OutgoingDistributedTracingData" /> to obtain distributed tracing data on the caller side.
+		/// Use <see cref="IExecutionSegment.OutgoingDistributedTracingData" /> to obtain distributed tracing data on the caller side.
 		/// </param>
 		void CaptureTransaction(string name, string type, Action action, DistributedTracingData distributedTracingData = null);
 
@@ -73,12 +73,10 @@ namespace Elastic.Apm.Api
 		/// In case of a distributed trace, you can pass distributed tracing data to the API. By doing so, the new transaction will
 		/// be
 		/// automatically part of a distributed trace.
-		/// Use <see cref="ISpan.OutgoingDistributedTracingData" /> to obtain distributed tracing data on the caller side.
+		/// Use <see cref="IExecutionSegment.OutgoingDistributedTracingData" /> to obtain distributed tracing data on the caller side.
 		/// </param>
 		/// <returns>
-		/// The result of the
-		/// <param name="func"></param>
-		/// .
+		/// The result of the <paramref name="func" />.
 		/// </returns>
 		T CaptureTransaction<T>(string name, string type, Func<ITransaction, T> func, DistributedTracingData distributedTracingData = null);
 
@@ -93,17 +91,15 @@ namespace Elastic.Apm.Api
 		/// transaction.
 		/// </param>
 		/// <typeparam name="T">The return type of the code that you want to capture as transaction.</typeparam>
-		/// <returns>
-		/// The result of the
-		/// <param name="func"></param>
-		/// .
-		/// </returns>
 		/// <param name="distributedTracingData">
 		/// In case of a distributed trace, you can pass distributed tracing data to the API. By doing so, the new transaction will
 		/// be
 		/// automatically part of a distributed trace.
-		/// Use <see cref="ISpan.OutgoingDistributedTracingData" /> to obtain distributed tracing data on the caller side.
+		/// Use <see cref="IExecutionSegment.OutgoingDistributedTracingData" /> to obtain distributed tracing data on the caller side.
 		/// </param>
+		/// <returns>
+		/// The result of the <paramref name="func" />.
+		/// </returns>
 		T CaptureTransaction<T>(string name, string type, Func<T> func, DistributedTracingData distributedTracingData = null);
 
 		/// <summary>
@@ -120,9 +116,9 @@ namespace Elastic.Apm.Api
 		/// In case of a distributed trace, you can pass distributed tracing data to the API. By doing so, the new transaction will
 		/// be
 		/// automatically part of a distributed trace.
-		/// Use <see cref="ISpan.OutgoingDistributedTracingData" /> to obtain distributed tracing data on the caller side.
+		/// Use <see cref="IExecutionSegment.OutgoingDistributedTracingData" /> to obtain distributed tracing data on the caller side.
 		/// </param>
-		/// <returns>The <see cref="Task" /> that you can await on.</returns>
+		/// <returns>A <see cref="Task" /> that can be awaited</returns>
 		Task CaptureTransaction(string name, string type, Func<Task> func, DistributedTracingData distributedTracingData = null);
 
 		/// <summary>
@@ -139,9 +135,9 @@ namespace Elastic.Apm.Api
 		/// In case of a distributed trace, you can pass distributed tracing data to the API. By doing so, the new transaction will
 		/// be
 		/// automatically part of a distributed trace.
-		/// Use <see cref="ISpan.OutgoingDistributedTracingData" /> to obtain distributed tracing data on the caller side.
+		/// Use <see cref="IExecutionSegment.OutgoingDistributedTracingData" /> to obtain distributed tracing data on the caller side.
 		/// </param>
-		/// <returns>The <see cref="Task" /> that you can await on.</returns>
+		/// <returns>A <see cref="Task" /> that can be awaited</returns>
 		Task CaptureTransaction(string name, string type, Func<ITransaction, Task> func, DistributedTracingData distributedTracingData = null);
 
 		/// <summary>
@@ -159,9 +155,9 @@ namespace Elastic.Apm.Api
 		/// In case of a distributed trace, you can pass distributed tracing data to the API. By doing so, the new transaction will
 		/// be
 		/// automatically part of a distributed trace.
-		/// Use <see cref="ISpan.OutgoingDistributedTracingData" /> to obtain distributed tracing data on the caller side.
+		/// Use <see cref="IExecutionSegment.OutgoingDistributedTracingData" /> to obtain distributed tracing data on the caller side.
 		/// </param>
-		/// <returns>The <see cref="Task{T}" /> that you can await on.</returns>
+		/// <returns>A <see cref="Task{T}" /> that can be awaited</returns>
 		Task<T> CaptureTransaction<T>(string name, string type, Func<Task<T>> func, DistributedTracingData distributedTracingData = null);
 
 		/// <summary>
@@ -180,9 +176,9 @@ namespace Elastic.Apm.Api
 		/// In case of a distributed trace, you can pass distributed tracing data to the API. By doing so, the new transaction will
 		/// be
 		/// automatically part of a distributed trace.
-		/// Use <see cref="ISpan.OutgoingDistributedTracingData" /> to obtain distributed tracing data on the caller side.
+		/// Use <see cref="IExecutionSegment.OutgoingDistributedTracingData" /> to obtain distributed tracing data on the caller side.
 		/// </param>
-		/// <returns>The <see cref="Task{T}" /> that you can await on.</returns>
+		/// <returns>A <see cref="Task{T}" /> that can be awaited.</returns>
 		Task<T> CaptureTransaction<T>(string name, string type, Func<ITransaction, Task<T>> func, DistributedTracingData distributedTracingData = null
 		);
 
@@ -195,11 +191,11 @@ namespace Elastic.Apm.Api
 		/// In case of a distributed trace, you can pass distributed tracing data to the API. By doing so, the new transaction will
 		/// be
 		/// automatically part of a distributed trace.
-		/// Use <see cref="ISpan.OutgoingDistributedTracingData" /> to obtain distributed tracing data on the caller side.
+		/// Use <see cref="IExecutionSegment.OutgoingDistributedTracingData" /> to obtain distributed tracing data on the caller side.
 		/// </param>
-		/// <param name="tyignoreActivitype">
-		/// The agent by default does a best effort to keep <see cref="Activity.TraceId"/> in sync with the trace id which is used in Elasitc APM.
-		/// By setting <paramref name="ignoreActivity"/> to false you can turn off this functionality. </param>
+		/// <param name="ignoreActivity">
+		/// The agent by default does a best effort to keep <see cref="Activity.TraceId"/> in sync with the trace id used in Elastic APM.
+		/// By setting <paramref name="ignoreActivity"/> to <c>false</c> you can turn off this functionality. </param>
 		/// <returns>The transaction that is created based on the parameters. This transaction is already active.</returns>
 		ITransaction StartTransaction(string name, string type, DistributedTracingData distributedTracingData = null, bool ignoreActivity = false);
 	}

--- a/src/Elastic.Apm/DistributedTracing/TraceContext.cs
+++ b/src/Elastic.Apm/DistributedTracing/TraceContext.cs
@@ -131,7 +131,7 @@ namespace Elastic.Apm.DistributedTracing
 		/// Validates the tracestate value
 		/// </summary>
 		/// <param name="traceState">The value to validate</param>
-		/// <returns>The <see cref="traceState" /> if the value is a valid trace state, <code>null</code> otherwise</returns>
+		/// <returns>The <paramref name="traceState"/> if the value is a valid trace state, <code>null</code> otherwise</returns>
 		private static string ValidateTracestate(string traceState)
 		{
 			if (string.IsNullOrEmpty(traceState))

--- a/src/Elastic.Apm/Helpers/TimeExtensions.cs
+++ b/src/Elastic.Apm/Helpers/TimeExtensions.cs
@@ -79,9 +79,8 @@ namespace Elastic.Apm.Helpers
 		/// <summary>
 		/// Converts time duration to "9d 8h 7m 6s" (seconds resolution) string representation.
 		/// If time duration has non-integer number of seconds the fractional part is truncated.
-		/// If time duration is [0, 1s) range it is converted to "
-		/// <1s".
-		/// If time duration is (-1s, 0] range it is converted to ">-1s".
+		/// If time duration is [0, 1s) range it is converted to "&lt;1s".
+		/// If time duration is (-1s, 0] range it is converted to "&gt;-1s".
 		/// </summary>
 		internal static string ToHmsInSeconds(this TimeSpan timeSpan)
 		{

--- a/src/Elastic.Apm/Metrics/MetricsProvider/FreeAndTotalMemoryProvider.cs
+++ b/src/Elastic.Apm/Metrics/MetricsProvider/FreeAndTotalMemoryProvider.cs
@@ -13,7 +13,7 @@ namespace Elastic.Apm.Metrics.MetricsProvider
 {
 	/// <summary>
 	/// Returns total and free system memory.
-	/// Currently Windows & Linux -only, no macOS support at the moment.
+	/// Currently Windows and Linux only, no macOS support at the moment.
 	/// </summary>
 	internal class FreeAndTotalMemoryProvider : IMetricsProvider
 	{


### PR DESCRIPTION
This PR adds SourceLink and XML documentation to all packages.

Portable PDBs are included in nuget packages because symbol packages (.snupkg) are less interoperable.

Fix XML documentation warnings