### PR TITLE
Fix nullref in MetricsCollector with custom IConfigurationReader

### DIFF
--- a/src/Elastic.Apm/Helpers/WildcardMatcher.cs
+++ b/src/Elastic.Apm/Helpers/WildcardMatcher.cs
@@ -68,6 +68,7 @@ namespace Elastic.Apm.Helpers
 			{
 				if (!matcher.StartsWith(Wildcard) && !matcher.EndsWith(Wildcard))
 					return new VerbatimMatcher(split[0], ignoreCase);
+
 				return new SimpleWildcardMatcher(split[0], matcher.StartsWith(Wildcard), matcher.EndsWith(Wildcard), ignoreCase);
 			}
 
@@ -110,7 +111,9 @@ namespace Elastic.Apm.Helpers
 		/// <returns>The first matching <see cref="WildcardMatcher" />, or <code>null</code> if none match.</returns>
 		internal static WildcardMatcher AnyMatch(IReadOnlyCollection<WildcardMatcher> matchers, string firstPart, string secondPart)
 		{
-			for (var i = 0; i < matchers?.Count; i++)
+			if (matchers is null) return null;
+
+			for (var i = 0; i < matchers.Count; i++)
 			{
 				if (matchers.ElementAt(i).Matches(firstPart, secondPart))
 					return matchers.ElementAt(i);

--- a/src/Elastic.Apm/Helpers/WildcardMatcher.cs
+++ b/src/Elastic.Apm/Helpers/WildcardMatcher.cs
@@ -110,7 +110,7 @@ namespace Elastic.Apm.Helpers
 		/// <returns>The first matching <see cref="WildcardMatcher" />, or <code>null</code> if none match.</returns>
 		internal static WildcardMatcher AnyMatch(IReadOnlyCollection<WildcardMatcher> matchers, string firstPart, string secondPart)
 		{
-			for (var i = 0; i < matchers.Count; i++)
+			for (var i = 0; i < matchers?.Count; i++)
 			{
 				if (matchers.ElementAt(i).Matches(firstPart, secondPart))
 					return matchers.ElementAt(i);

--- a/src/Elastic.Apm/Metrics/MetricsCollector.cs
+++ b/src/Elastic.Apm/Metrics/MetricsCollector.cs
@@ -46,73 +46,83 @@ namespace Elastic.Apm.Metrics
 
 		public MetricsCollector(IApmLogger logger, IPayloadSender payloadSender, IConfigSnapshotProvider configSnapshotProvider)
 		{
-			_logger = logger.Scoped(nameof(MetricsCollector));
-			_payloadSender = payloadSender;
-			_configSnapshotProvider = configSnapshotProvider;
-
-			var currentConfigSnapshot = configSnapshotProvider.CurrentSnapshot;
-
-			var interval = currentConfigSnapshot.MetricsIntervalInMilliseconds;
-
-			// ReSharper disable once CompareOfFloatsByEqualityOperator
-			if (interval == 0)
+			try
 			{
-				_logger.Info()?.Log("Collecting metrics is disabled - the agent won't collect metrics");
-				return;
+				_logger = logger.Scoped(nameof(MetricsCollector));
+				_payloadSender = payloadSender;
+				_configSnapshotProvider = configSnapshotProvider;
+
+				var currentConfigSnapshot = configSnapshotProvider.CurrentSnapshot;
+
+				var interval = currentConfigSnapshot.MetricsIntervalInMilliseconds;
+
+				// ReSharper disable once CompareOfFloatsByEqualityOperator
+				if (interval == 0)
+				{
+					_logger.Info()?.Log("Collecting metrics is disabled - the agent won't collect metrics");
+					return;
+				}
+
+				MetricsProviders = new List<IMetricsProvider>();
+
+				if (!WildcardMatcher.IsAnyMatch(currentConfigSnapshot.DisableMetrics, ProcessTotalCpuTimeProvider.ProcessCpuTotalPct))
+					MetricsProviders.Add(new ProcessTotalCpuTimeProvider(_logger));
+				if (!WildcardMatcher.IsAnyMatch(currentConfigSnapshot.DisableMetrics, SystemTotalCpuProvider.SystemCpuTotalPct))
+					MetricsProviders.Add(new SystemTotalCpuProvider(_logger));
+
+				var collectProcessWorkingSet = !WildcardMatcher.IsAnyMatch(currentConfigSnapshot.DisableMetrics,
+					ProcessWorkingSetAndVirtualMemoryProvider.ProcessWorkingSetMemory);
+				var collectProcessVirtualMemory = !WildcardMatcher.IsAnyMatch(currentConfigSnapshot.DisableMetrics,
+					ProcessWorkingSetAndVirtualMemoryProvider.ProcessVirtualMemory);
+				if (collectProcessVirtualMemory || collectProcessWorkingSet)
+					MetricsProviders.Add(new ProcessWorkingSetAndVirtualMemoryProvider(collectProcessVirtualMemory, collectProcessWorkingSet));
+
+				var collectTotalMemory = !WildcardMatcher.IsAnyMatch(currentConfigSnapshot.DisableMetrics,
+					FreeAndTotalMemoryProvider.TotalMemory);
+				var collectFreeMemory = !WildcardMatcher.IsAnyMatch(currentConfigSnapshot.DisableMetrics,
+					FreeAndTotalMemoryProvider.FreeMemory);
+				if (collectFreeMemory || collectTotalMemory)
+					MetricsProviders.Add(new FreeAndTotalMemoryProvider(collectFreeMemory, collectTotalMemory));
+
+				var collectGcCount = !WildcardMatcher.IsAnyMatch(currentConfigSnapshot.DisableMetrics,
+					GcMetricsProvider.GcCountName);
+				var collectGen0Size = !WildcardMatcher.IsAnyMatch(currentConfigSnapshot.DisableMetrics,
+					GcMetricsProvider.GcGen0SizeName);
+				var collectGen1Size = !WildcardMatcher.IsAnyMatch(currentConfigSnapshot.DisableMetrics,
+					GcMetricsProvider.GcGen1SizeName);
+				var collectGen2Size = !WildcardMatcher.IsAnyMatch(currentConfigSnapshot.DisableMetrics,
+					GcMetricsProvider.GcGen2SizeName);
+				var collectGen3Size = !WildcardMatcher.IsAnyMatch(currentConfigSnapshot.DisableMetrics,
+					GcMetricsProvider.GcGen3SizeName);
+				if (collectGcCount || collectGen0Size || collectGen1Size || collectGen2Size || collectGen3Size)
+				{
+					MetricsProviders.Add(new GcMetricsProvider(_logger, collectGcCount, collectGen0Size, collectGen1Size, collectGen2Size,
+						collectGen3Size));
+				}
+
+				var collectCgroupMemLimitBytes = !WildcardMatcher.IsAnyMatch(currentConfigSnapshot.DisableMetrics,
+					CgroupMetricsProvider.SystemProcessCgroupMemoryMemLimitBytes);
+				var collectCgroupMemUsageBytes = !WildcardMatcher.IsAnyMatch(currentConfigSnapshot.DisableMetrics,
+					CgroupMetricsProvider.SystemProcessCgroupMemoryMemUsageBytes);
+				var collectCgroupStatsInactiveFileBytes = !WildcardMatcher.IsAnyMatch(currentConfigSnapshot.DisableMetrics,
+					CgroupMetricsProvider.SystemProcessCgroupMemoryStatsInactiveFileBytes);
+				if (collectCgroupMemLimitBytes || collectCgroupMemUsageBytes || collectCgroupStatsInactiveFileBytes)
+				{
+					MetricsProviders.Add(
+						new CgroupMetricsProvider(_logger, collectCgroupMemLimitBytes, collectCgroupMemUsageBytes,
+							collectCgroupStatsInactiveFileBytes));
+				}
+
+				_logger.Info()?.Log("Collecting metrics in {interval} milliseconds interval", interval);
+				_timer = new Timer(interval);
+				_timer.Elapsed += (sender, args) => { CollectAllMetrics(); };
 			}
-
-			MetricsProviders = new List<IMetricsProvider>();
-
-			if (!WildcardMatcher.IsAnyMatch(currentConfigSnapshot.DisableMetrics, ProcessTotalCpuTimeProvider.ProcessCpuTotalPct))
-				MetricsProviders.Add(new ProcessTotalCpuTimeProvider(_logger));
-			if (!WildcardMatcher.IsAnyMatch(currentConfigSnapshot.DisableMetrics, SystemTotalCpuProvider.SystemCpuTotalPct))
-				MetricsProviders.Add(new SystemTotalCpuProvider(_logger));
-
-			var collectProcessWorkingSet = !WildcardMatcher.IsAnyMatch(currentConfigSnapshot.DisableMetrics,
-				ProcessWorkingSetAndVirtualMemoryProvider.ProcessWorkingSetMemory);
-			var collectProcessVirtualMemory = !WildcardMatcher.IsAnyMatch(currentConfigSnapshot.DisableMetrics,
-				ProcessWorkingSetAndVirtualMemoryProvider.ProcessVirtualMemory);
-			if (collectProcessVirtualMemory || collectProcessWorkingSet)
-				MetricsProviders.Add(new ProcessWorkingSetAndVirtualMemoryProvider(collectProcessVirtualMemory, collectProcessWorkingSet));
-
-			var collectTotalMemory = !WildcardMatcher.IsAnyMatch(currentConfigSnapshot.DisableMetrics,
-				FreeAndTotalMemoryProvider.TotalMemory);
-			var collectFreeMemory = !WildcardMatcher.IsAnyMatch(currentConfigSnapshot.DisableMetrics,
-				FreeAndTotalMemoryProvider.FreeMemory);
-			if (collectFreeMemory || collectTotalMemory)
-				MetricsProviders.Add(new FreeAndTotalMemoryProvider(collectFreeMemory, collectTotalMemory));
-
-			var collectGcCount = !WildcardMatcher.IsAnyMatch(currentConfigSnapshot.DisableMetrics,
-				GcMetricsProvider.GcCountName);
-			var collectGen0Size = !WildcardMatcher.IsAnyMatch(currentConfigSnapshot.DisableMetrics,
-				GcMetricsProvider.GcGen0SizeName);
-			var collectGen1Size = !WildcardMatcher.IsAnyMatch(currentConfigSnapshot.DisableMetrics,
-				GcMetricsProvider.GcGen1SizeName);
-			var collectGen2Size = !WildcardMatcher.IsAnyMatch(currentConfigSnapshot.DisableMetrics,
-				GcMetricsProvider.GcGen2SizeName);
-			var collectGen3Size = !WildcardMatcher.IsAnyMatch(currentConfigSnapshot.DisableMetrics,
-				GcMetricsProvider.GcGen3SizeName);
-			if (collectGcCount || collectGen0Size || collectGen1Size || collectGen2Size || collectGen3Size)
+			catch (Exception e)
 			{
-				MetricsProviders.Add(new GcMetricsProvider(_logger, collectGcCount, collectGen0Size, collectGen1Size, collectGen2Size,
-					collectGen3Size));
+				_logger.Warning()?.LogException(e, "MetricsCollector initialization failed - the agent won't collect metrics");
+				_timer?.Stop();
+				_timer = null;
 			}
-
-			var collectCgroupMemLimitBytes = !WildcardMatcher.IsAnyMatch(currentConfigSnapshot.DisableMetrics,
-				CgroupMetricsProvider.SystemProcessCgroupMemoryMemLimitBytes);
-			var collectCgroupMemUsageBytes = !WildcardMatcher.IsAnyMatch(currentConfigSnapshot.DisableMetrics,
-				CgroupMetricsProvider.SystemProcessCgroupMemoryMemUsageBytes);
-			var collectCgroupStatsInactiveFileBytes = !WildcardMatcher.IsAnyMatch(currentConfigSnapshot.DisableMetrics,
-				CgroupMetricsProvider.SystemProcessCgroupMemoryStatsInactiveFileBytes);
-			if (collectCgroupMemLimitBytes || collectCgroupMemUsageBytes || collectCgroupStatsInactiveFileBytes)
-			{
-				MetricsProviders.Add(
-					new CgroupMetricsProvider(_logger, collectCgroupMemLimitBytes, collectCgroupMemUsageBytes, collectCgroupStatsInactiveFileBytes));
-			}
-
-			_logger.Info()?.Log("Collecting metrics in {interval} milliseconds interval", interval);
-			_timer = new Timer(interval);
-			_timer.Elapsed += (sender, args) => { CollectAllMetrics(); };
 		}
 
 		public void StartCollecting() => _timer?.Start();

--- a/test/Elastic.Apm.Tests/MetricsTests.cs
+++ b/test/Elastic.Apm.Tests/MetricsTests.cs
@@ -1,4 +1,5 @@
-// Licensed to Elasticsearch B.V under one or more agreements.
+// Licensed to Elasticsearch B.V under
+// one or more agreements.
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
 
@@ -331,6 +332,21 @@ namespace Elastic.Apm.Tests
 				gcMetricsProvider.IsMetricAlreadyCaptured.Should().BeTrue();
 #endif
 			}
+		}
+
+		/// <summary>
+		/// Makes sure that <see cref="MetricsCollector" /> does not throw an exception when <see cref="IConfigurationReader" />
+		/// returns <code>null</code> for <see cref="IConfigurationReader.DisableMetrics"/>.
+		/// From https://discuss.elastic.co/t/elastic-apm-object-reference-not-set-to-an-instance-of-an-object
+		/// </summary>
+		[Fact]
+		public void MetricsCollectorWithNoopConfigReader()
+		{
+			var noopConfigReader = new Mock<IConfigurationReader>();
+			noopConfigReader.SetupGet(n => n.MetricsIntervalInMilliseconds).Returns(1);
+
+			var _ = new MetricsCollector(new NoopLogger(), new NoopPayloadSender(),
+				new ConfigStore(new ConfigSnapshotFromReader(noopConfigReader.Object, ""), new NoopLogger()));
 		}
 
 		internal class MetricsProviderWithException : IMetricsProvider

--- a/test/Elastic.Apm.Tests/WildcardMatcherTests.cs
+++ b/test/Elastic.Apm.Tests/WildcardMatcherTests.cs
@@ -1,4 +1,5 @@
-// Licensed to Elasticsearch B.V under one or more agreements.
+// Licensed to Elasticsearch B.V under
+// one or more agreements.
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
 
@@ -421,5 +422,8 @@ namespace Elastic.Apm.Tests
 			WildcardMatcher.ValueOf("foobar*").Matches("baz").Should().BeFalse();
 			WildcardMatcher.ValueOf("*foobar*").Matches("baz").Should().BeFalse();
 		}
+
+		[Fact]
+		public void IsAnyMatchWithNullShouldNotThrow() => WildcardMatcher.IsAnyMatch(null, "abc");
 	}
 }


### PR DESCRIPTION
From [discuss](https://discuss.elastic.co/t/elastic-apm-object-reference-not-set-to-an-instance-of-an-object).

With a custom `IConfigurationReader` where the `IConfigurationReader.DisabledMetrics` property returns `null`, the `MetricsCollector` `.ctor` throws an exception.

This PR fixes that.