### PR TITLE
Update Specification attributes for MockApmServer

### DIFF
--- a/test/Elastic.Apm.Tests.MockApmServer/ErrorDto.cs
+++ b/test/Elastic.Apm.Tests.MockApmServer/ErrorDto.cs
@@ -12,7 +12,7 @@ using Newtonsoft.Json;
 
 namespace Elastic.Apm.Tests.MockApmServer
 {
-	[Specification("docs/spec/errors/error.json")]
+	[Specification("docs/spec/v2/error.json")]
 	internal class ErrorDto : ITimestampedDto
 	{
 		public ContextDto Context { get; set; }

--- a/test/Elastic.Apm.Tests.MockApmServer/MetadataDto.cs
+++ b/test/Elastic.Apm.Tests.MockApmServer/MetadataDto.cs
@@ -13,7 +13,7 @@ using Elastic.Apm.Helpers;
 
 namespace Elastic.Apm.Tests.MockApmServer
 {
-	[Specification("docs/spec/metadata.json")]
+	[Specification("docs/spec/v2/metadata.json")]
 	internal class MetadataDto : IDto
 	{
 		public Service Service { get; set; }

--- a/test/Elastic.Apm.Tests.MockApmServer/MetricSetDto.cs
+++ b/test/Elastic.Apm.Tests.MockApmServer/MetricSetDto.cs
@@ -13,7 +13,7 @@ using Elastic.Apm.Helpers;
 
 namespace Elastic.Apm.Tests.MockApmServer
 {
-	[Specification("docs/spec/metricsets/metricset.json")]
+	[Specification("docs/spec/v2/metricset.json")]
 	internal class MetricSetDto : ITimestampedDto
 	{
 		public Dictionary<string, MetricSampleDto> Samples { get; set; }

--- a/test/Elastic.Apm.Tests.MockApmServer/SpanDto.cs
+++ b/test/Elastic.Apm.Tests.MockApmServer/SpanDto.cs
@@ -13,7 +13,7 @@ using Newtonsoft.Json;
 
 namespace Elastic.Apm.Tests.MockApmServer
 {
-	[Specification("docs/spec/spans/span.json")]
+	[Specification("docs/spec/v2/span.json")]
 	internal class SpanDto : ITimedDto
 	{
 		public string Action { get; set; }

--- a/test/Elastic.Apm.Tests.MockApmServer/TransactionDto.cs
+++ b/test/Elastic.Apm.Tests.MockApmServer/TransactionDto.cs
@@ -12,7 +12,7 @@ using Newtonsoft.Json;
 
 namespace Elastic.Apm.Tests.MockApmServer
 {
-	[Specification("docs/spec/transactions/transaction.json")]
+	[Specification("docs/spec/v2/transaction.json")]
 	internal class TransactionDto : ITimedDto
 	{
 		public ContextDto Context { get; set; }


### PR DESCRIPTION
This commit updates the paths used in Specification attributes for DTOs used by MockApmServer.