### PR TITLE
Fix GrpcClientDiagnosticListener memory issue

### DIFF
--- a/src/Elastic.Apm.GrpcClient/GrpcClientDiagnosticListener.cs
+++ b/src/Elastic.Apm.GrpcClient/GrpcClientDiagnosticListener.cs
@@ -15,7 +15,7 @@ namespace Elastic.Apm.GrpcClient
 	public class GrpcClientDiagnosticListener : IDiagnosticListener
 	{
 		private readonly IApmAgent _agent;
-		private readonly ConcurrentDictionary<HttpRequestMessage, ISpan> _processingRequests = new ConcurrentDictionary<HttpRequestMessage, ISpan>();
+		internal readonly ConcurrentDictionary<HttpRequestMessage, ISpan> ProcessingRequests = new ConcurrentDictionary<HttpRequestMessage, ISpan>();
 
 		public GrpcClientDiagnosticListener(IApmAgent apmAgent) => _agent = apmAgent;
 
@@ -47,7 +47,7 @@ namespace Elastic.Apm.GrpcClient
 
 						_agent?.Logger.Trace()?.Log("Starting span for gRPC call, method:{methodName}", grpcMethodName);
 						var newSpan = currentTransaction.StartSpan(grpcMethodName, ApiConstants.TypeExternal, ApiConstants.SubTypeGrpc);
-						_processingRequests.TryAdd(requestObject, newSpan);
+						ProcessingRequests.TryAdd(requestObject, newSpan);
 					}
 				}
 			}
@@ -57,7 +57,7 @@ namespace Elastic.Apm.GrpcClient
 
 				if (requestObject == null) return;
 
-				if (!_processingRequests.TryGetValue(requestObject, out var span)) return;
+				if (!ProcessingRequests.TryRemove(requestObject, out var span)) return;
 
 				_agent?.Logger.Trace()?.Log("Ending span for gRPC call, span:{span}", span);
 

--- a/src/Elastic.Apm.GrpcClient/GrpcClientDiagnosticSubscriber.cs
+++ b/src/Elastic.Apm.GrpcClient/GrpcClientDiagnosticSubscriber.cs
@@ -16,7 +16,7 @@ namespace Elastic.Apm.GrpcClient
 {
 	public class GrpcClientDiagnosticSubscriber : IDiagnosticsSubscriber
 	{
-		internal GrpcClientDiagnosticListener GrpcClientDiagnosticListener { get; private set; }
+		internal GrpcClientDiagnosticListener Listener { get; private set; }
 
 		public IDisposable Subscribe(IApmAgent agent)
 		{
@@ -25,8 +25,8 @@ namespace Elastic.Apm.GrpcClient
 			if (!agent.ConfigurationReader.Enabled)
 				return retVal;
 
-			GrpcClientDiagnosticListener = new GrpcClientDiagnosticListener(agent as ApmAgent);
-			var subscriber = new DiagnosticInitializer(agent.Logger, new[] { GrpcClientDiagnosticListener });
+			Listener = new GrpcClientDiagnosticListener(agent as ApmAgent);
+			var subscriber = new DiagnosticInitializer(agent.Logger, new[] { Listener });
 			retVal.Add(subscriber);
 
 			retVal.Add(DiagnosticListener

--- a/src/Elastic.Apm.GrpcClient/GrpcClientDiagnosticSubscriber.cs
+++ b/src/Elastic.Apm.GrpcClient/GrpcClientDiagnosticSubscriber.cs
@@ -1,11 +1,23 @@
-﻿using System;
+﻿// Licensed to Elasticsearch B.V under
+// one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System;
 using System.Diagnostics;
+using System.Runtime.CompilerServices;
 using Elastic.Apm.DiagnosticSource;
+
+[assembly:
+	InternalsVisibleTo(
+		"Elastic.Apm.Grpc.Tests, PublicKey=002400000480000094000000060200000024000052534131000400000100010051df3e4d8341d66c6dfbf35b2fda3627d08073156ed98eef81122b94e86ef2e44e7980202d21826e367db9f494c265666ae30869fb4cd1a434d171f6b634aa67fa8ca5b9076d55dc3baa203d3a23b9c1296c9f45d06a45cf89520bef98325958b066d8c626db76dd60d0508af877580accdd0e9f88e46b6421bf09a33de53fe1")]
 
 namespace Elastic.Apm.GrpcClient
 {
 	public class GrpcClientDiagnosticSubscriber : IDiagnosticsSubscriber
 	{
+		internal GrpcClientDiagnosticListener GrpcClientDiagnosticListener { get; private set; }
+
 		public IDisposable Subscribe(IApmAgent agent)
 		{
 			var retVal = new CompositeDisposable();
@@ -13,7 +25,8 @@ namespace Elastic.Apm.GrpcClient
 			if (!agent.ConfigurationReader.Enabled)
 				return retVal;
 
-			var subscriber = new DiagnosticInitializer(agent.Logger, new[] { new GrpcClientDiagnosticListener(agent as ApmAgent) });
+			GrpcClientDiagnosticListener = new GrpcClientDiagnosticListener(agent as ApmAgent);
+			var subscriber = new DiagnosticInitializer(agent.Logger, new[] { GrpcClientDiagnosticListener });
 			retVal.Add(subscriber);
 
 			retVal.Add(DiagnosticListener

--- a/test/Elastic.Apm.Grpc.Tests/GrpcTests.cs
+++ b/test/Elastic.Apm.Grpc.Tests/GrpcTests.cs
@@ -46,7 +46,8 @@ namespace Elastic.Apm.Grpc.Tests
 			else
 				sampleAppHost = new SampleAppHostBuilder().BuildHostWithMiddleware(apmAgent);
 
-			apmAgent.Subscribe(new GrpcClientDiagnosticSubscriber(), new HttpDiagnosticsSubscriber());
+			var grpcClientDiagnosticSubscriber = new GrpcClientDiagnosticSubscriber();
+			apmAgent.Subscribe(grpcClientDiagnosticSubscriber, new HttpDiagnosticsSubscriber());
 
 			await sampleAppHost.StartAsync();
 
@@ -83,6 +84,8 @@ namespace Elastic.Apm.Grpc.Tests
 					&& span.Context.Destination.Service.Resource == $"localhost:{SampleAppHostBuilder.SampleAppPort}"
 				);
 
+			grpcClientDiagnosticSubscriber.GrpcClientDiagnosticListener.ProcessingRequests.Should().BeEmpty();
+
 			await sampleAppHost.StopAsync();
 			sampleAppHost.Dispose();
 		}
@@ -100,11 +103,11 @@ namespace Elastic.Apm.Grpc.Tests
 		{
 			var payloadSender = new MockPayloadSender();
 			using var apmAgent = new ApmAgent(new TestAgentComponents(payloadSender: payloadSender));
-
+			var grpcClientDiagnosticSubscriber = new GrpcClientDiagnosticSubscriber();
 			using var sampleAppHost = withDiagnosticSource
 				? new SampleAppHostBuilder().BuildHost()
 				: new SampleAppHostBuilder().BuildHostWithMiddleware(apmAgent);
-			apmAgent.Subscribe(new AspNetCoreDiagnosticSubscriber(), new GrpcClientDiagnosticSubscriber(), new HttpDiagnosticsSubscriber());
+			apmAgent.Subscribe(new AspNetCoreDiagnosticSubscriber(), grpcClientDiagnosticSubscriber, new HttpDiagnosticsSubscriber());
 
 			await sampleAppHost.StartAsync();
 
@@ -145,6 +148,8 @@ namespace Elastic.Apm.Grpc.Tests
 					&& span.Context.Destination.Service.Name == SampleAppHostBuilder.SampleAppUrl
 					&& span.Context.Destination.Service.Resource == $"localhost:{SampleAppHostBuilder.SampleAppPort}"
 				);
+
+			grpcClientDiagnosticSubscriber.GrpcClientDiagnosticListener.ProcessingRequests.Should().BeEmpty();
 
 			await sampleAppHost.StopAsync();
 		}

--- a/test/Elastic.Apm.Grpc.Tests/GrpcTests.cs
+++ b/test/Elastic.Apm.Grpc.Tests/GrpcTests.cs
@@ -84,7 +84,7 @@ namespace Elastic.Apm.Grpc.Tests
 					&& span.Context.Destination.Service.Resource == $"localhost:{SampleAppHostBuilder.SampleAppPort}"
 				);
 
-			grpcClientDiagnosticSubscriber.GrpcClientDiagnosticListener.ProcessingRequests.Should().BeEmpty();
+			grpcClientDiagnosticSubscriber.Listener.ProcessingRequests.Should().BeEmpty();
 
 			await sampleAppHost.StopAsync();
 			sampleAppHost.Dispose();
@@ -149,7 +149,7 @@ namespace Elastic.Apm.Grpc.Tests
 					&& span.Context.Destination.Service.Resource == $"localhost:{SampleAppHostBuilder.SampleAppPort}"
 				);
 
-			grpcClientDiagnosticSubscriber.GrpcClientDiagnosticListener.ProcessingRequests.Should().BeEmpty();
+			grpcClientDiagnosticSubscriber.Listener.ProcessingRequests.Should().BeEmpty();
 
 			await sampleAppHost.StopAsync();
 		}


### PR DESCRIPTION
Fixes https://github.com/elastic/apm-agent-dotnet/issues/1116

### The bug
In the `GrpcClientDiagnosticListener` we never removed processed requests from the `ProcessingRequests` dictionary.

### The fix
Now we remove items on `Stop` events. 