### PR TITLE
Expose creating agent components for ASP.NET Full Framework

### DIFF
--- a/docs/setup.asciidoc
+++ b/docs/setup.asciidoc
@@ -241,6 +241,36 @@ as shown in the following example:
 
 You can also configure the agent using `web.config` as described at <<configuration-on-asp-net>>.
 
+The `ElasticApmModule` instantiates the APM agent on first initialization. There are some scenarios however where
+you might want to control agent instantiatiation, such as configuring filters in application start. The
+`ElasticApmModule` exposes a `CreateAgentComponents()` method that returns agent components configured to work with
+ASP.NET Full Framework, that can then be used to instantiate the agent.
+
+For example, one might wish to add transaction filters to the agent in application start
+
+[source, c#]
+----
+public class MvcApplication : HttpApplication
+{
+    protected void Application_Start()
+    {
+        // other application startup e.g. RouteConfig, etc.
+
+        // set up agent with components
+        var agentComponents = ElasticApmModule.CreateAgentComponents();
+        Agent.Setup(agentComponents);
+
+        // add transaction filter
+        Agent.AddFilter((ITransaction t) =>
+        {
+            t.SetLabel("foo", "bar");
+            return t;
+        });
+    }
+}
+----
+
+Now, the `ElasticApmModule` will use the already instantiated APM agent instance upon initialization.
 
 [[setup-ef6]]
 === Entity Framework 6

--- a/src/Elastic.Apm.AspNetFullFramework/AgentDependencies.cs
+++ b/src/Elastic.Apm.AspNetFullFramework/AgentDependencies.cs
@@ -6,8 +6,14 @@ using Elastic.Apm.Logging;
 
 namespace Elastic.Apm.AspNetFullFramework
 {
+	/// <summary>
+	/// Dependencies to initialize the APM agent with
+	/// </summary>
 	public static class AgentDependencies
 	{
+		/// <summary>
+		/// The logger
+		/// </summary>
 		public static IApmLogger Logger { get; set; }
 	}
 }

--- a/src/Elastic.Apm.AspNetFullFramework/AspNetVersion.cs
+++ b/src/Elastic.Apm.AspNetFullFramework/AspNetVersion.cs
@@ -1,0 +1,72 @@
+// Licensed to Elasticsearch B.V under
+// one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System;
+using System.Reflection;
+using System.Web;
+using Elastic.Apm.Logging;
+
+namespace Elastic.Apm.AspNetFullFramework
+{
+	internal static class AspNetVersion
+	{
+		/// <summary>
+		/// Gets the ASP.NET engine version
+		/// </summary>
+		/// <param name="logger">The logger</param>
+		/// <returns>the engine version, or N/A if it cannot be found</returns>
+		public static string GetEngineVersion(IApmLogger logger)
+		{
+			var aspNetVersion = "N/A";
+			try
+			{
+				// We would like to report the same ASP.NET version as the one printed at the bottom of the error page
+				// (see https://github.com/microsoft/referencesource/blob/master/System.Web/ErrorFormatter.cs#L431)
+				// It is stored in VersionInfo.EngineVersion
+				// (see https://github.com/microsoft/referencesource/blob/3b1eaf5203992df69de44c783a3eda37d3d4cd10/System.Web/Util/versioninfo.cs#L91)
+				// which is unfortunately an internal property of an internal class in System.Web assembly so we use reflection to get it
+				const string versionInfoTypeName = "System.Web.Util.VersionInfo";
+				var versionInfoType = typeof(HttpRuntime).Assembly.GetType(versionInfoTypeName);
+				if (versionInfoType == null)
+				{
+					logger.Error()
+						?.Log("Type {TypeName} was not found in assembly {AssemblyFullName} - {AspNetVersion} will be used as ASP.NET version",
+							versionInfoTypeName, typeof(HttpRuntime).Assembly.FullName, aspNetVersion);
+					return aspNetVersion;
+				}
+
+				const string engineVersionPropertyName = "EngineVersion";
+				var engineVersionProperty = versionInfoType.GetProperty(engineVersionPropertyName,
+					BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static);
+				if (engineVersionProperty == null)
+				{
+					logger.Error()
+						?.Log("Property {PropertyName} was not found in type {TypeName} - {AspNetVersion} will be used as ASP.NET version",
+							engineVersionPropertyName, versionInfoType.FullName, aspNetVersion);
+					return aspNetVersion;
+				}
+
+				var engineVersionPropertyValue = (string)engineVersionProperty.GetValue(null);
+				if (engineVersionPropertyValue == null)
+				{
+					logger.Error()
+						?.Log("Property {PropertyName} (in type {TypeName}) is of type {TypeName} and not a string as expected" +
+							" - {AspNetVersion} will be used as ASP.NET version",
+							engineVersionPropertyName, versionInfoType.FullName, engineVersionPropertyName.GetType().FullName, aspNetVersion);
+					return aspNetVersion;
+				}
+
+				aspNetVersion = engineVersionPropertyValue;
+			}
+			catch (Exception ex)
+			{
+				logger.Error()?.LogException(ex, "Failed to obtain ASP.NET version - {AspNetVersion} will be used as ASP.NET version", aspNetVersion);
+			}
+
+			logger.Debug()?.Log("Found ASP.NET version: {AspNetVersion}", aspNetVersion);
+			return aspNetVersion;
+		}
+	}
+}

--- a/src/Elastic.Apm.AspNetFullFramework/ElasticApmModule.cs
+++ b/src/Elastic.Apm.AspNetFullFramework/ElasticApmModule.cs
@@ -409,8 +409,8 @@ namespace Elastic.Apm.AspNetFullFramework
 				{
 					BuildLogger()
 						.Scoped(dbgInstanceName)
-						.Error()
-						?.LogException(ex, "The Elastic APM agent was already initialized before call to"
+						.Info()
+						?.Log("The Elastic APM agent was already initialized before call to"
 							+ $" {nameof(ElasticApmModule)}.{nameof(Init)} - {nameof(ElasticApmModule)} will use existing instance");
 				}
 				else

--- a/src/Elastic.Apm.AspNetFullFramework/ElasticApmModule.cs
+++ b/src/Elastic.Apm.AspNetFullFramework/ElasticApmModule.cs
@@ -6,7 +6,6 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.Linq;
-using System.Reflection;
 using System.Security.Claims;
 using System.Web;
 using Elastic.Apm.Api;
@@ -19,6 +18,9 @@ using Elastic.Apm.Model;
 
 namespace Elastic.Apm.AspNetFullFramework
 {
+	/// <summary>
+	/// Captures each request in an APM transaction
+	/// </summary>
 	public class ElasticApmModule : IHttpModule
 	{
 		private static bool _isCaptureHeadersEnabled;
@@ -29,9 +31,13 @@ namespace Elastic.Apm.AspNetFullFramework
 		private HttpApplication _application;
 		private IApmLogger _logger;
 
-		// ReSharper disable once ImpureMethodCallOnReadonlyValueField
-		public ElasticApmModule() => _dbgInstanceName = DbgInstanceNameGenerator.Generate($"{nameof(ElasticApmModule)}.#");
+		public ElasticApmModule() =>
+			// ReSharper disable once ImpureMethodCallOnReadonlyValueField
+			_dbgInstanceName = DbgInstanceNameGenerator.Generate($"{nameof(ElasticApmModule)}.#");
 
+		public void Dispose() => _application = null;
+
+		/// <inheritdoc />
 		public void Init(HttpApplication application)
 		{
 			try
@@ -47,6 +53,13 @@ namespace Elastic.Apm.AspNetFullFramework
 				);
 			}
 		}
+
+		/// <summary>
+		/// Creates a new instance of <see cref="AgentComponents"/> configured
+		/// to use with ASP.NET Full Framework.
+		/// </summary>
+		/// <returns>a new instance of <see cref="AgentComponents"/></returns>
+		public static AgentComponents CreateAgentComponents() => CreateAgentComponents($"{nameof(ElasticApmModule)}.#0");
 
 		private void InitImpl(HttpApplication application)
 		{
@@ -68,8 +81,6 @@ namespace Elastic.Apm.AspNetFullFramework
 			_application.BeginRequest += OnBeginRequest;
 			_application.EndRequest += OnEndRequest;
 		}
-
-		public void Dispose() => _application = null;
 
 		private void OnBeginRequest(object sender, EventArgs e)
 		{
@@ -352,58 +363,6 @@ namespace Elastic.Apm.AspNetFullFramework
 			_logger.Debug()?.Log("Captured user - {CapturedUser}", transaction.Context.User);
 		}
 
-		private static string FindAspNetVersion(IApmLogger logger)
-		{
-			var aspNetVersion = "N/A";
-			try
-			{
-				// We would like to report the same ASP.NET version as the one printed at the bottom of the error page
-				// (see https://github.com/microsoft/referencesource/blob/master/System.Web/ErrorFormatter.cs#L431)
-				// It is stored in VersionInfo.EngineVersion
-				// (see https://github.com/microsoft/referencesource/blob/3b1eaf5203992df69de44c783a3eda37d3d4cd10/System.Web/Util/versioninfo.cs#L91)
-				// which is unfortunately an internal property of an internal class in System.Web assembly so we use reflection to get it
-				const string versionInfoTypeName = "System.Web.Util.VersionInfo";
-				var versionInfoType = typeof(HttpRuntime).Assembly.GetType(versionInfoTypeName);
-				if (versionInfoType == null)
-				{
-					logger.Error()
-						?.Log("Type {TypeName} was not found in assembly {AssemblyFullName} - {AspNetVersion} will be used as ASP.NET version",
-							versionInfoTypeName, typeof(HttpRuntime).Assembly.FullName, aspNetVersion);
-					return aspNetVersion;
-				}
-
-				const string engineVersionPropertyName = "EngineVersion";
-				var engineVersionProperty = versionInfoType.GetProperty(engineVersionPropertyName,
-					BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static);
-				if (engineVersionProperty == null)
-				{
-					logger.Error()
-						?.Log("Property {PropertyName} was not found in type {TypeName} - {AspNetVersion} will be used as ASP.NET version",
-							engineVersionPropertyName, versionInfoType.FullName, aspNetVersion);
-					return aspNetVersion;
-				}
-
-				var engineVersionPropertyValue = (string)engineVersionProperty.GetValue(null);
-				if (engineVersionPropertyValue == null)
-				{
-					logger.Error()
-						?.Log("Property {PropertyName} (in type {TypeName}) is of type {TypeName} and not a string as expected" +
-							" - {AspNetVersion} will be used as ASP.NET version",
-							engineVersionPropertyName, versionInfoType.FullName, engineVersionPropertyName.GetType().FullName, aspNetVersion);
-					return aspNetVersion;
-				}
-
-				aspNetVersion = engineVersionPropertyValue;
-			}
-			catch (Exception ex)
-			{
-				logger.Error()?.LogException(ex, "Failed to obtain ASP.NET version - {AspNetVersion} will be used as ASP.NET version", aspNetVersion);
-			}
-
-			logger.Debug()?.Log("Found ASP.NET version: {AspNetVersion}", aspNetVersion);
-			return aspNetVersion;
-		}
-
 		private static bool InitOnceForAllInstancesUnderLock(string dbgInstanceName) =>
 			InitOnceHelper.IfNotInited?.Init(() =>
 			{
@@ -419,24 +378,15 @@ namespace Elastic.Apm.AspNetFullFramework
 
 		private static IApmLogger BuildLogger() => AgentDependencies.Logger ?? ConsoleLogger.Instance;
 
-		private static AgentComponents BuildAgentComponents(string dbgInstanceName)
+		private static AgentComponents CreateAgentComponents(string dbgInstanceName)
 		{
 			var rootLogger = BuildLogger();
-			var scopedLogger = rootLogger.Scoped(dbgInstanceName);
 
 			var reader = ConfigHelper.CreateReader(rootLogger) ?? new FullFrameworkConfigReader(rootLogger);
+			var agentComponents = new FullFrameworkAgentComponents(rootLogger, reader);
 
-			var agentComponents = new AgentComponents(
-				rootLogger,
-				reader,
-				null,
-				null,
-				new HttpContextCurrentExecutionSegmentsContainer(),
-				null,
-				null);
-
-			var aspNetVersion = FindAspNetVersion(scopedLogger);
-
+			var scopedLogger = rootLogger.Scoped(dbgInstanceName);
+			var aspNetVersion = AspNetVersion.GetEngineVersion(scopedLogger);
 			agentComponents.Service.Framework = new Framework { Name = "ASP.NET", Version = aspNetVersion };
 			agentComponents.Service.Language = new Language { Name = "C#" }; //TODO
 
@@ -445,7 +395,7 @@ namespace Elastic.Apm.AspNetFullFramework
 
 		private static void SafeAgentSetup(string dbgInstanceName)
 		{
-			var agentComponents = BuildAgentComponents(dbgInstanceName);
+			var agentComponents = CreateAgentComponents(dbgInstanceName);
 			try
 			{
 				if (!agentComponents.ConfigurationReader.Enabled)
@@ -455,12 +405,24 @@ namespace Elastic.Apm.AspNetFullFramework
 			}
 			catch (Agent.InstanceAlreadyCreatedException ex)
 			{
-				BuildLogger().Scoped(dbgInstanceName)
-					.Error()
-					?.LogException(ex, "The Elastic APM agent was already initialized before call to"
-						+ $" {nameof(ElasticApmModule)}.{nameof(Init)} - {nameof(ElasticApmModule)} will use existing instance"
-						+ " even though it might lead to unexpected behavior"
-						+ " (for example agent using incorrect configuration source such as environment variables instead of Web.config).");
+				if (Agent.Components is FullFrameworkAgentComponents)
+				{
+					BuildLogger()
+						.Scoped(dbgInstanceName)
+						.Error()
+						?.LogException(ex, "The Elastic APM agent was already initialized before call to"
+							+ $" {nameof(ElasticApmModule)}.{nameof(Init)} - {nameof(ElasticApmModule)} will use existing instance");
+				}
+				else
+				{
+					BuildLogger()
+						.Scoped(dbgInstanceName)
+						.Error()
+						?.LogException(ex, "The Elastic APM agent was already initialized before call to"
+							+ $" {nameof(ElasticApmModule)}.{nameof(Init)} - {nameof(ElasticApmModule)} will use existing instance"
+							+ " even though it might lead to unexpected behavior"
+							+ " (for example agent using incorrect configuration source such as environment variables instead of Web.config).");
+				}
 
 				agentComponents.Dispose();
 			}

--- a/src/Elastic.Apm.AspNetFullFramework/FullFrameworkAgentComponents.cs
+++ b/src/Elastic.Apm.AspNetFullFramework/FullFrameworkAgentComponents.cs
@@ -1,0 +1,29 @@
+// Licensed to Elasticsearch B.V under
+// one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using Elastic.Apm.Config;
+using Elastic.Apm.Logging;
+
+namespace Elastic.Apm.AspNetFullFramework
+{
+	/// <summary>
+	/// Agent components for ASP.NET Full Framework
+	/// </summary>
+	internal class FullFrameworkAgentComponents : AgentComponents
+	{
+		public FullFrameworkAgentComponents(
+			IApmLogger logger,
+			IConfigurationReader configurationReader) : base(
+				logger,
+				configurationReader,
+				null,
+				null,
+				new HttpContextCurrentExecutionSegmentsContainer(),
+				null,
+				null)
+		{
+		}
+	}
+}


### PR DESCRIPTION
This commit exposes a CreateAgentComponents method on
ElasticApmModule that allows a user to create agent components
for ASP.NET Full Framework and set up the APM agent, before
the ElasticApmModule Init() runs. This is useful in scenarios
where a user wishes to capture transactions/spans or setup filters at application
start.

The CreateAgentComponents returns a derived FullFrameworkAgentComponents
type that SafeAgentSetup method uses to determine whether an already initialized
agent is likely to lead to unexpected behaviour e.g. agent component implementations
not designed to work with ASP.NET Full Framework.

An example usage of CreateAgentComponents is

    public class MvcApplication : HttpApplication
    {
        protected void Application_Start()
        {
            // other application startup e.g. RouteConfig, etc.

            // configure agent filter on startup
            var agentComponents = ElasticApmModule.CreateAgentComponents();
            Agent.Setup(agentComponents);
            Agent.AddFilter((ITransaction t) =>
            {
                t.SetLabel("foo", "bar");
                return t;
            });
        }
    }

Fixes #1098
Fixes #1045