### PR TITLE
Add assembly redirect for System.Runtime.CompilerServices.Unsafe

### DIFF
--- a/sample/AspNetFullFrameworkSampleApp/Web.config
+++ b/sample/AspNetFullFrameworkSampleApp/Web.config
@@ -134,6 +134,10 @@
 				<bindingRedirect oldVersion="0.0.0.0-4.3.0.0" newVersion="4.3.0.0"/>
 			</dependentAssembly>
 			<dependentAssembly>
+				<assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
+				<bindingRedirect oldVersion="0.0.0.0-5.0.0.0" newVersion="5.0.0.0" />
+			</dependentAssembly>
+			<dependentAssembly>
 				<assemblyIdentity name="System.Runtime.Serialization.Xml" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
 				<bindingRedirect oldVersion="0.0.0.0-4.1.3.0" newVersion="4.1.3.0"/>
 			</dependentAssembly>


### PR DESCRIPTION
This commit adds a System.Runtime.CompilerServices.Unsafe
assembyl redirect to AspNetFullFrameworkSampleApp, to
get rid of the build warning.