### PR TITLE
fix doc markup

### DIFF
--- a/docs/public-api.asciidoc
+++ b/docs/public-api.asciidoc
@@ -564,7 +564,7 @@ finally
 
 [float]
 [[api-span-set-label]]
-==== `void SetLabel(string key, T value) added[1.7.0,Number and boolean labels require APM Server 6.7]
+==== `void SetLabel(string key, T value)` added[1.7.0,Number and boolean labels require APM Server 6.7]
 
 A flat mapping of user-defined labels with string, number or boolean values.
 


### PR DESCRIPTION
Just noticed this while browsing the docs:
https://www.elastic.co/guide/en/apm/agent/dotnet/current/public-api.html#api-span-set-label

I think this was a typo from commit 2c433d31c45444e026081721e9c4190dadc383b8