### PR TITLE
[DOCS] Fixes link typo in  Get started section

### DIFF
--- a/docs/setup.asciidoc
+++ b/docs/setup.asciidoc
@@ -13,7 +13,7 @@ On .NET Core the agent also supports auto instrumentation without any code chang
 * <<setup-asp-dot-net>>
 * <<setup-ef6>>
 * <<setup-sqlclient>>
-* <<setup-stackexhange-redis>>
+* <<setup-stackexchange-redis>>
 * <<setup-general>>
 
 [float]


### PR DESCRIPTION
## Overview

This PR fixes a typo on a link in the Get started section that breaks the docs build process.