### PR TITLE
Handling exceptions in the agent

### DIFF
--- a/docs/troubleshooting.asciidoc
+++ b/docs/troubleshooting.asciidoc
@@ -99,10 +99,16 @@ Agent.Setup(new AgentComponents(logger: new ApmLoggerBridge()));
 ----
 
 [float]
+[[double-agent-initialization-log]]
+=== Following error appears in logs: `The singleton APM agent has already been instantiated and can no longer be configured.`
+
+See "<<double-agent-initialization>>".
+
+[float]
 [[double-agent-initialization]]
 === An `InstanceAlreadyCreatedException` exception is thrown
 
-In the early stage of a monitored process, the Agent might throw an `InstanceAlreadyCreatedException` exception with the following message: "The singleton APM agent has already been instantiated and can no longer be configured." This happens when you attempt to initialize the Agent multiple times, which is prohibited. Allowing multiple Agent instances per process would open up problems, like capturing events and metrics multiple times for each instance, or having multiple background threads for event serialization and transfer to the APM Server.
+In the early stage of a monitored process, the Agent might throw an `InstanceAlreadyCreatedException` exception with the following message: "The singleton APM agent has already been instantiated and can no longer be configured.", or an error log appears with the same message. This happens when you attempt to initialize the Agent multiple times, which is prohibited. Allowing multiple Agent instances per process would open up problems, like capturing events and metrics multiple times for each instance, or having multiple background threads for event serialization and transfer to the APM Server.
 
 TIP: Take a look at the initialization section of the <<public-api,Public Agent API>> for more information on how agent initialization works.
 

--- a/src/Elastic.Apm.AspNetCore/WebRequestTransactionCreator.cs
+++ b/src/Elastic.Apm.AspNetCore/WebRequestTransactionCreator.cs
@@ -22,11 +22,11 @@ namespace Elastic.Apm.AspNetCore
 	/// </summary>
 	internal static class WebRequestTransactionCreator
 	{
-		internal static ITransaction StartTransactionAsync(HttpContext context, IApmLogger logger, Tracer tracer, IConfigSnapshot configSnapshot)
+		internal static ITransaction StartTransactionAsync(HttpContext context, IApmLogger logger, ITracer tracer, IConfigSnapshot configSnapshot)
 		{
 			try
 			{
-				if (WildcardMatcher.IsAnyMatch(configSnapshot.TransactionIgnoreUrls, context.Request.Path))
+				if (WildcardMatcher.IsAnyMatch(configSnapshot?.TransactionIgnoreUrls, context.Request.Path))
 				{
 					logger.Debug()?.Log("Request ignored based on TransactionIgnoreUrls, url: {urlPath}", context.Request.Path);
 					return null;

--- a/src/Elastic.Apm.AspNetFullFramework/ElasticApmModule.cs
+++ b/src/Elastic.Apm.AspNetFullFramework/ElasticApmModule.cs
@@ -403,29 +403,6 @@ namespace Elastic.Apm.AspNetFullFramework
 
 				Agent.Setup(agentComponents);
 			}
-			catch (Agent.InstanceAlreadyCreatedException ex)
-			{
-				if (Agent.Components is FullFrameworkAgentComponents)
-				{
-					BuildLogger()
-						.Scoped(dbgInstanceName)
-						.Info()
-						?.Log("The Elastic APM agent was already initialized before call to"
-							+ $" {nameof(ElasticApmModule)}.{nameof(Init)} - {nameof(ElasticApmModule)} will use existing instance");
-				}
-				else
-				{
-					BuildLogger()
-						.Scoped(dbgInstanceName)
-						.Error()
-						?.LogException(ex, "The Elastic APM agent was already initialized before call to"
-							+ $" {nameof(ElasticApmModule)}.{nameof(Init)} - {nameof(ElasticApmModule)} will use existing instance"
-							+ " even though it might lead to unexpected behavior"
-							+ " (for example agent using incorrect configuration source such as environment variables instead of Web.config).");
-				}
-
-				agentComponents.Dispose();
-			}
 		}
 	}
 }

--- a/src/Elastic.Apm.AspNetFullFramework/ElasticApmModule.cs
+++ b/src/Elastic.Apm.AspNetFullFramework/ElasticApmModule.cs
@@ -167,7 +167,8 @@ namespace Elastic.Apm.AspNetFullFramework
 				{
 					_logger.Debug()
 						?.Log("Incoming request doesn't have {TraceParentHeaderName} header - " +
-							"it means request doesn't have incoming distributed tracing data", DistributedTracing.TraceContext.TraceParentHeaderNamePrefixed);
+							"it means request doesn't have incoming distributed tracing data",
+							DistributedTracing.TraceContext.TraceParentHeaderNamePrefixed);
 					return null;
 				}
 			}
@@ -292,8 +293,10 @@ namespace Elastic.Apm.AspNetFullFramework
 					else
 					{
 						// dealing with a 404 HttpException that came from System.Web.Mvc
-						_logger?.Trace()?
-							.Log("Route data found but a HttpException with 404 status code was thrown from System.Web.Mvc - setting transaction name to 'unknown route");
+						_logger?.Trace()
+							?
+							.Log(
+								"Route data found but a HttpException with 404 status code was thrown from System.Web.Mvc - setting transaction name to 'unknown route");
 						transaction.Name = $"{context.Request.HttpMethod} unknown route";
 					}
 				}
@@ -332,9 +335,7 @@ namespace Elastic.Apm.AspNetFullFramework
 		private static void FillSampledTransactionContextResponse(HttpResponse response, ITransaction transaction) =>
 			transaction.Context.Response = new Response
 			{
-				Finished = true,
-				StatusCode = response.StatusCode,
-				Headers = _isCaptureHeadersEnabled ? ConvertHeaders(response.Headers) : null
+				Finished = true, StatusCode = response.StatusCode, Headers = _isCaptureHeadersEnabled ? ConvertHeaders(response.Headers) : null
 			};
 
 		private void FillSampledTransactionContextUser(HttpContext context, ITransaction transaction)
@@ -396,13 +397,10 @@ namespace Elastic.Apm.AspNetFullFramework
 		private static void SafeAgentSetup(string dbgInstanceName)
 		{
 			var agentComponents = CreateAgentComponents(dbgInstanceName);
-			try
-			{
-				if (!agentComponents.ConfigurationReader.Enabled)
-					return;
+			if (!agentComponents.ConfigurationReader.Enabled)
+				return;
 
-				Agent.Setup(agentComponents);
-			}
+			Agent.Setup(agentComponents);
 		}
 	}
 }

--- a/src/Elastic.Apm.Elasticsearch/AuditDiagnosticsListener.cs
+++ b/src/Elastic.Apm.Elasticsearch/AuditDiagnosticsListener.cs
@@ -1,3 +1,8 @@
+// Licensed to Elasticsearch B.V under
+// one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
 using Elastic.Apm.Logging;
 using Elasticsearch.Net;
 using Elasticsearch.Net.Diagnostics;
@@ -6,8 +11,10 @@ namespace Elastic.Apm.Elasticsearch
 {
 	public class AuditDiagnosticsListener : ElasticsearchDiagnosticsListenerBase
 	{
-		public AuditDiagnosticsListener(IApmAgent agent) : base(agent, DiagnosticSources.AuditTrailEvents.SourceName) =>
+		public AuditDiagnosticsListener(IApmAgent agent) : base(agent) =>
 			Observer = new AuditDiagnosticObserver(a => OnAudit(a.Key, a.Value));
+
+		public override string Name => DiagnosticSources.AuditTrailEvents.SourceName;
 
 		private void OnAudit(string @event, Audit audit)
 		{
@@ -21,6 +28,5 @@ namespace Elastic.Apm.Elasticsearch
 				span.End();
 			}
 		}
-
 	}
 }

--- a/src/Elastic.Apm.Elasticsearch/ElasticsearchDiagnosticsSubscriber.cs
+++ b/src/Elastic.Apm.Elasticsearch/ElasticsearchDiagnosticsSubscriber.cs
@@ -1,4 +1,8 @@
-﻿using System;
+﻿// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System;
 using System.Diagnostics;
 using Elastic.Apm.DiagnosticSource;
 

--- a/src/Elastic.Apm.Elasticsearch/HttpConnectionDiagnosticsListener.cs
+++ b/src/Elastic.Apm.Elasticsearch/HttpConnectionDiagnosticsListener.cs
@@ -1,5 +1,7 @@
-using System;
-using System.Diagnostics;
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
 using Elastic.Apm.Api;
 using Elastic.Apm.Logging;
 using Elasticsearch.Net;
@@ -9,11 +11,13 @@ namespace Elastic.Apm.Elasticsearch
 {
 	public class HttpConnectionDiagnosticsListener : ElasticsearchDiagnosticsListenerBase
 	{
-		public HttpConnectionDiagnosticsListener(IApmAgent agent) : base(agent, DiagnosticSources.HttpConnection.SourceName) =>
+		public HttpConnectionDiagnosticsListener(IApmAgent agent) : base(agent) =>
 			Observer = new HttpConnectionDiagnosticObserver(
 				a => OnRequestData(a.Key, a.Value),
 				a => OnResult(a.Key, a.Value)
 			);
+
+		public override string Name => DiagnosticSources.HttpConnection.SourceName;
 
 		private void OnResult(string @event, int? statusCode)
 		{

--- a/src/Elastic.Apm.Elasticsearch/RequestPipelineDiagnosticsListener.cs
+++ b/src/Elastic.Apm.Elasticsearch/RequestPipelineDiagnosticsListener.cs
@@ -1,3 +1,8 @@
+// Licensed to Elasticsearch B.V under
+// one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
 using System;
 using System.Diagnostics;
 using System.IO;
@@ -19,11 +24,13 @@ namespace Elastic.Apm.Elasticsearch
 		private const string SniffStart = nameof(DiagnosticSources.RequestPipeline.Sniff) + StartSuffix;
 		private const string SniffStop = nameof(DiagnosticSources.RequestPipeline.Sniff) + StopSuffix;
 
-		public RequestPipelineDiagnosticsListener(IApmAgent agent) : base(agent, DiagnosticSources.RequestPipeline.SourceName) =>
+		public RequestPipelineDiagnosticsListener(IApmAgent agent) : base(agent) =>
 			Observer = new RequestPipelineDiagnosticObserver(
 				a => OnRequestData(a.Key, a.Value),
 				a => OnResult(a.Key, a.Value)
 			);
+
+		public override string Name => DiagnosticSources.RequestPipeline.SourceName;
 
 		private void OnResult(string @event, IApiCallDetails response)
 		{

--- a/src/Elastic.Apm.Elasticsearch/SerializerDiagnosticsListener .cs
+++ b/src/Elastic.Apm.Elasticsearch/SerializerDiagnosticsListener .cs
@@ -1,3 +1,7 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
 using Elastic.Apm.Logging;
 using Elasticsearch.Net;
 using Elasticsearch.Net.Diagnostics;
@@ -6,8 +10,10 @@ namespace Elastic.Apm.Elasticsearch
 {
 	public class SerializerDiagnosticsListener : ElasticsearchDiagnosticsListenerBase
 	{
-		public SerializerDiagnosticsListener(IApmAgent agent) : base(agent, DiagnosticSources.Serializer.SourceName) =>
+		public SerializerDiagnosticsListener(IApmAgent agent) : base(agent) =>
 			Observer = new SerializerDiagnosticObserver(a => OnSerializer(a.Key, a.Value));
+
+		public override string Name => DiagnosticSources.Serializer.SourceName;
 
 		private void OnSerializer(string @event, SerializerRegistrationInformation serializerInfo)
 		{

--- a/src/Elastic.Apm.EntityFrameworkCore/EfCoreDiagnosticListener.cs
+++ b/src/Elastic.Apm.EntityFrameworkCore/EfCoreDiagnosticListener.cs
@@ -6,29 +6,24 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using Elastic.Apm.Api;
-using Elastic.Apm.DiagnosticSource;
+using Elastic.Apm.DiagnosticListeners;
 using Elastic.Apm.Model;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 
 namespace Elastic.Apm.EntityFrameworkCore
 {
-	internal class EfCoreDiagnosticListener : IDiagnosticListener
+	internal class EfCoreDiagnosticListener : DiagnosticListenerBase
 	{
-		private readonly ApmAgent _agent;
 		private readonly ConcurrentDictionary<Guid, ISpan> _spans = new ConcurrentDictionary<Guid, ISpan>();
 
-		public EfCoreDiagnosticListener(IApmAgent agent) => _agent = (ApmAgent)agent;
+		public EfCoreDiagnosticListener(IApmAgent agent) : base(agent) { }
 
-		public string Name => "Microsoft.EntityFrameworkCore";
+		public override string Name => "Microsoft.EntityFrameworkCore";
 
-		public void OnCompleted() { }
-
-		public void OnError(Exception error) { }
-
-		public void OnNext(KeyValuePair<string, object> kv)
+		protected override void HandleOnNext(KeyValuePair<string, object> kv)
 		{
 			// check for competing instrumentation
-			if (_agent.TracerInternal.CurrentSpan is Span currentSpan)
+			if ((ApmAgent as ApmAgent)?.TracerInternal.CurrentSpan is Span currentSpan)
 			{
 				if (currentSpan.InstrumentationFlag == InstrumentationFlag.SqlClient)
 					return;
@@ -36,10 +31,10 @@ namespace Elastic.Apm.EntityFrameworkCore
 
 			switch (kv.Key)
 			{
-				case { } k when k == RelationalEventId.CommandExecuting.Name && _agent.Tracer.CurrentTransaction != null:
+				case { } k when k == RelationalEventId.CommandExecuting.Name && ApmAgent.Tracer.CurrentTransaction != null:
 					if (kv.Value is CommandEventData commandEventData)
 					{
-						var newSpan = _agent.TracerInternal.DbSpanCommon.StartSpan(_agent, commandEventData.Command, InstrumentationFlag.EfCore,
+						var newSpan = (ApmAgent as ApmAgent)?.TracerInternal.DbSpanCommon.StartSpan(ApmAgent, commandEventData.Command, InstrumentationFlag.EfCore,
 							captureStackTraceOnStart: true);
 						_spans.TryAdd(commandEventData.CommandId, newSpan);
 					}
@@ -49,7 +44,7 @@ namespace Elastic.Apm.EntityFrameworkCore
 					{
 						if (_spans.TryRemove(commandExecutedEventData.CommandId, out var span))
 						{
-							_agent.TracerInternal.DbSpanCommon.EndSpan(span, commandExecutedEventData.Command, Outcome.Success,
+							(ApmAgent as ApmAgent)?.TracerInternal.DbSpanCommon.EndSpan(span, commandExecutedEventData.Command, Outcome.Success,
 								commandExecutedEventData.Duration);
 						}
 					}
@@ -60,7 +55,7 @@ namespace Elastic.Apm.EntityFrameworkCore
 						if (_spans.TryRemove(commandErrorEventData.CommandId, out var span))
 						{
 							span.CaptureException(commandErrorEventData.Exception);
-							_agent.TracerInternal.DbSpanCommon.EndSpan(span, commandErrorEventData.Command, Outcome.Failure,
+							(ApmAgent as ApmAgent)?.TracerInternal.DbSpanCommon.EndSpan(span, commandErrorEventData.Command, Outcome.Failure,
 								commandErrorEventData.Duration);
 						}
 					}

--- a/src/Elastic.Apm.GrpcClient/GrpcClientDiagnosticListener.cs
+++ b/src/Elastic.Apm.GrpcClient/GrpcClientDiagnosticListener.cs
@@ -1,4 +1,8 @@
-﻿using System;
+﻿// Licensed to Elasticsearch B.V under
+// one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -6,28 +10,23 @@ using System.Linq;
 using System.Net.Http;
 using System.Reflection;
 using Elastic.Apm.Api;
-using Elastic.Apm.DiagnosticSource;
+using Elastic.Apm.DiagnosticListeners;
 using Elastic.Apm.Helpers;
 using Elastic.Apm.Logging;
 
 namespace Elastic.Apm.GrpcClient
 {
-	public class GrpcClientDiagnosticListener : IDiagnosticListener
+	public class GrpcClientDiagnosticListener : DiagnosticListenerBase
 	{
-		private readonly IApmAgent _agent;
 		internal readonly ConcurrentDictionary<HttpRequestMessage, ISpan> ProcessingRequests = new ConcurrentDictionary<HttpRequestMessage, ISpan>();
 
-		public GrpcClientDiagnosticListener(IApmAgent apmAgent) => _agent = apmAgent;
+		public GrpcClientDiagnosticListener(IApmAgent apmAgent) : base(apmAgent) { }
 
-		public string Name => "Grpc.Net.Client";
+		public override string Name => "Grpc.Net.Client";
 
-		public void OnCompleted() { }
-
-		public void OnError(Exception error) { }
-
-		public void OnNext(KeyValuePair<string, object> kv)
+		protected override void HandleOnNext(KeyValuePair<string, object> kv)
 		{
-			_agent?.Logger.Trace()
+			Logger.Trace()
 				?.Log("{currentClassName} received diagnosticsource event: {eventKey}", nameof(GrpcClientDiagnosticListener), kv.Key);
 
 			var currentActivity = Activity.Current;
@@ -36,16 +35,16 @@ namespace Elastic.Apm.GrpcClient
 				var requestObject = kv.Value.GetType().GetTypeInfo().GetDeclaredProperty("Request")?.GetValue(kv.Value) as HttpRequestMessage;
 				if (requestObject != null)
 				{
-					var currentTransaction = _agent?.Tracer.CurrentTransaction;
+					var currentTransaction = ApmAgent?.Tracer.CurrentTransaction;
 
 					if (currentTransaction != null)
 					{
-						var grpcMethodName = currentActivity?.Tags?.FirstOrDefault(n => n.Key == "grpc.method").Value;
+						var grpcMethodName = currentActivity?.Tags.FirstOrDefault(n => n.Key == "grpc.method").Value;
 
 						if (string.IsNullOrEmpty(grpcMethodName))
 							grpcMethodName = "unknown";
 
-						_agent?.Logger.Trace()?.Log("Starting span for gRPC call, method:{methodName}", grpcMethodName);
+						Logger.Trace()?.Log("Starting span for gRPC call, method:{methodName}", grpcMethodName);
 						var newSpan = currentTransaction.StartSpan(grpcMethodName, ApiConstants.TypeExternal, ApiConstants.SubTypeGrpc);
 						ProcessingRequests.TryAdd(requestObject, newSpan);
 					}
@@ -59,13 +58,13 @@ namespace Elastic.Apm.GrpcClient
 
 				if (!ProcessingRequests.TryRemove(requestObject, out var span)) return;
 
-				_agent?.Logger.Trace()?.Log("Ending span for gRPC call, span:{span}", span);
+				Logger.Trace()?.Log("Ending span for gRPC call, span:{span}", span);
 
 				var grpcStatusCode = currentActivity?.Tags?.Where(n => n.Key == "grpc.status_code").FirstOrDefault().Value;
 				if (grpcStatusCode != null)
 					span.Outcome = GrpcHelper.GrpcReturnCodeToString(grpcStatusCode) == "OK" ? Outcome.Success : Outcome.Failure;
 
-				span.Context.Destination = UrlUtils.ExtractDestination(requestObject.RequestUri, _agent?.Logger);
+				span.Context.Destination = UrlUtils.ExtractDestination(requestObject.RequestUri, Logger);
 				span.Context.Destination.Service = UrlUtils.ExtractService(requestObject.RequestUri, span);
 
 				span.End();

--- a/src/Elastic.Apm.SqlClient/SqlClientDiagnosticListener.cs
+++ b/src/Elastic.Apm.SqlClient/SqlClientDiagnosticListener.cs
@@ -1,4 +1,5 @@
-// Licensed to Elasticsearch B.V under one or more agreements.
+// Licensed to Elasticsearch B.V under
+// one or more agreements.
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
 
@@ -7,36 +8,30 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Data;
 using Elastic.Apm.Api;
-using Elastic.Apm.DiagnosticSource;
+using Elastic.Apm.DiagnosticListeners;
 using Elastic.Apm.Helpers;
 using Elastic.Apm.Logging;
 using Elastic.Apm.Model;
 
 namespace Elastic.Apm.SqlClient
 {
-	internal class SqlClientDiagnosticListener : IDiagnosticListener
+	internal class SqlClientDiagnosticListener : DiagnosticListenerBase
 	{
-		private readonly ApmAgent _apmAgent;
-		private readonly IApmLogger _logger;
 		private readonly PropertyFetcherSet _microsoftPropertyFetcherSet = new PropertyFetcherSet();
 
 		private readonly ConcurrentDictionary<Guid, ISpan> _spans = new ConcurrentDictionary<Guid, ISpan>();
 
 		private readonly PropertyFetcherSet _systemPropertyFetcherSet = new PropertyFetcherSet();
 
-		public SqlClientDiagnosticListener(IApmAgent apmAgent)
-		{
-			_apmAgent = (ApmAgent)apmAgent;
-			_logger = _apmAgent.Logger.Scoped(nameof(SqlClientDiagnosticListener));
-		}
+		public SqlClientDiagnosticListener(IApmAgent apmAgent) : base(apmAgent) { }
 
-		public string Name => "SqlClientDiagnosticListener";
+		public override string Name => "SqlClientDiagnosticListener";
 
 		// prefix - Microsoft.Data.SqlClient. or System.Data.SqlClient.
-		public void OnNext(KeyValuePair<string, object> value)
+		protected override void HandleOnNext(KeyValuePair<string, object> value)
 		{
 			// check for competing instrumentation
-			if (_apmAgent.TracerInternal.CurrentSpan is Span span)
+			if (ApmAgent.Tracer.CurrentSpan is Span span)
 			{
 				if (span.InstrumentationFlag == InstrumentationFlag.EfCore || span.InstrumentationFlag == InstrumentationFlag.EfClassic)
 					return;
@@ -46,7 +41,7 @@ namespace Elastic.Apm.SqlClient
 
 			switch (value.Key)
 			{
-				case { } s when s.EndsWith("WriteCommandBefore") && _apmAgent.Tracer.CurrentTransaction != null:
+				case { } s when s.EndsWith("WriteCommandBefore") && ApmAgent.Tracer.CurrentTransaction != null:
 					HandleStartCommand(value.Value, value.Key.StartsWith("System") ? _systemPropertyFetcherSet : _microsoftPropertyFetcherSet);
 					break;
 				case { } s when s.EndsWith("WriteCommandAfter"):
@@ -65,7 +60,7 @@ namespace Elastic.Apm.SqlClient
 				if (propertyFetcherSet.StartCorrelationId.Fetch(payloadData) is Guid operationId
 					&& propertyFetcherSet.StartCommand.Fetch(payloadData) is IDbCommand dbCommand)
 				{
-					var span = _apmAgent.TracerInternal.DbSpanCommon.StartSpan(_apmAgent, dbCommand, InstrumentationFlag.SqlClient,
+					var span = (ApmAgent as ApmAgent)?.TracerInternal.DbSpanCommon.StartSpan(ApmAgent, dbCommand, InstrumentationFlag.SqlClient,
 						ApiConstants.SubtypeMssql);
 					_spans.TryAdd(operationId, span);
 				}
@@ -73,7 +68,7 @@ namespace Elastic.Apm.SqlClient
 			catch (Exception ex)
 			{
 				//ignore
-				_logger.Error()?.LogException(ex, "Exception was thrown while handling 'command started event'");
+				Logger.Error()?.LogException(ex, "Exception was thrown while handling 'command started event'");
 			}
 		}
 
@@ -92,13 +87,13 @@ namespace Elastic.Apm.SqlClient
 						statistics.ContainsKey("ExecutionTime") && statistics["ExecutionTime"] is long durationInMs && durationInMs > 0)
 						duration = TimeSpan.FromMilliseconds(durationInMs);
 
-					_apmAgent.TracerInternal.DbSpanCommon.EndSpan(span, dbCommand, Outcome.Success, duration);
+					(ApmAgent as ApmAgent)?.TracerInternal.DbSpanCommon.EndSpan(span, dbCommand, Outcome.Success, duration);
 				}
 			}
 			catch (Exception ex)
 			{
 				// ignore
-				_logger.Error()?.LogException(ex, "Exception was thrown while handling 'command succeeded event'");
+				Logger.Error()?.LogException(ex, "Exception was thrown while handling 'command succeeded event'");
 			}
 		}
 
@@ -113,10 +108,10 @@ namespace Elastic.Apm.SqlClient
 					if (propertyFetcherSet.Exception.Fetch(payloadData) is Exception exception) span.CaptureException(exception);
 
 					if (propertyFetcherSet.ErrorCommand.Fetch(payloadData) is IDbCommand dbCommand)
-						_apmAgent.TracerInternal.DbSpanCommon.EndSpan(span, dbCommand, Outcome.Failure);
+						(ApmAgent as ApmAgent)?.TracerInternal.DbSpanCommon.EndSpan(span, dbCommand, Outcome.Failure);
 					else
 					{
-						_logger.Warning()?.Log("Cannot extract database command from {PayloadData}", payloadData);
+						Logger.Warning()?.Log("Cannot extract database command from {PayloadData}", payloadData);
 						span.Outcome = Outcome.Failure;
 						span.End();
 					}
@@ -125,18 +120,8 @@ namespace Elastic.Apm.SqlClient
 			catch (Exception ex)
 			{
 				// ignore
-				_logger.Error()?.LogException(ex, "Exception was thrown while handling 'command failed event'");
+				Logger.Error()?.LogException(ex, "Exception was thrown while handling 'command failed event'");
 			}
-		}
-
-		public void OnError(Exception error)
-		{
-			// do nothing because it's not necessary to handle such event from provider
-		}
-
-		public void OnCompleted()
-		{
-			// do nothing because it's not necessary to handle such event from provider
 		}
 
 		private class PropertyFetcherSet

--- a/src/Elastic.Apm/Agent.cs
+++ b/src/Elastic.Apm/Agent.cs
@@ -252,7 +252,8 @@ namespace Elastic.Apm
 		public static void Setup(AgentComponents agentComponents)
 		{
 			if (LazyApmAgent.IsValueCreated)
-				agentComponents?.Logger?.Error()?.Log("The singleton APM agent has already been instantiated and can no longer be configured.");
+				agentComponents?.Logger?.Error()?.Log("The singleton APM agent has" +
+					" already been instantiated and can no longer be configured. Reusing existing instance");
 
 			Components = agentComponents;
 			_isConfigured = true;

--- a/src/Elastic.Apm/Agent.cs
+++ b/src/Elastic.Apm/Agent.cs
@@ -252,7 +252,7 @@ namespace Elastic.Apm
 		public static void Setup(AgentComponents agentComponents)
 		{
 			if (LazyApmAgent.IsValueCreated)
-				throw new InstanceAlreadyCreatedException("The singleton APM agent has already been instantiated and can no longer be configured.");
+				agentComponents?.Logger?.Error()?.Log("The singleton APM agent has already been instantiated and can no longer be configured.");
 
 			Components = agentComponents;
 			_isConfigured = true;
@@ -262,11 +262,6 @@ namespace Elastic.Apm
 		{
 			if (!LazyApmAgent.IsValueCreated)
 				Setup(apmAgent.Components);
-		}
-
-		internal class InstanceAlreadyCreatedException : Exception
-		{
-			internal InstanceAlreadyCreatedException(string message) : base(message) { }
 		}
 	}
 }

--- a/src/Elastic.Apm/DiagnosticListeners/DiagnosticListenerBase.cs
+++ b/src/Elastic.Apm/DiagnosticListeners/DiagnosticListenerBase.cs
@@ -1,0 +1,59 @@
+// Licensed to Elasticsearch B.V under
+// one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System;
+using System.Collections.Generic;
+using Elastic.Apm.DiagnosticSource;
+using Elastic.Apm.Logging;
+
+namespace Elastic.Apm.DiagnosticListeners
+{
+	/// <summary>
+	/// A base class for DiagnosticSource listeners which encapsulates common functionality - e.g. exception handling.
+	/// </summary>
+	public abstract class DiagnosticListenerBase : IDiagnosticListener
+	{
+		/// <summary>
+		/// A logger scoped to the child class.
+		/// </summary>
+		protected readonly IApmLogger Logger;
+
+		/// <summary>
+		/// Current Agent instance.
+		/// </summary>
+		protected readonly IApmAgent ApmAgent;
+
+		protected DiagnosticListenerBase(IApmAgent apmAgent)
+		{
+			ApmAgent = apmAgent;
+			Logger = apmAgent.Logger.Scoped(GetType().Name);
+		}
+
+		/// <summary>
+		/// Fires each time when <see cref="OnNext"/> is called.
+		/// Code within this method is guarded by a try-catch.
+		/// </summary>
+		/// <param name="kv"></param>
+		protected abstract void HandleOnNext(KeyValuePair<string, object> kv);
+
+		public abstract string Name { get; }
+
+		public void OnCompleted() { }
+
+		public virtual void OnError(Exception error) { }
+
+		public virtual void OnNext(KeyValuePair<string, object> kv)
+		{
+			try
+			{
+				HandleOnNext(kv);
+			}
+			catch (Exception e)
+			{
+				Logger.Error()?.LogException(e, "Failed capturing DiagnosticSource event");
+			}
+		}
+	}
+}

--- a/src/Elastic.Apm/DiagnosticListeners/DiagnosticListenerBase.cs
+++ b/src/Elastic.Apm/DiagnosticListeners/DiagnosticListenerBase.cs
@@ -18,12 +18,12 @@ namespace Elastic.Apm.DiagnosticListeners
 		/// <summary>
 		/// A logger scoped to the child class.
 		/// </summary>
-		protected readonly IApmLogger Logger;
+		protected IApmLogger Logger { get; }
 
 		/// <summary>
 		/// Current Agent instance.
 		/// </summary>
-		protected readonly IApmAgent ApmAgent;
+		protected IApmAgent ApmAgent { get; }
 
 		protected DiagnosticListenerBase(IApmAgent apmAgent)
 		{
@@ -40,7 +40,7 @@ namespace Elastic.Apm.DiagnosticListeners
 
 		public abstract string Name { get; }
 
-		public void OnCompleted() { }
+		public virtual void OnCompleted() { }
 
 		public virtual void OnError(Exception error) { }
 

--- a/src/Elastic.Apm/DiagnosticListeners/HttpDiagnosticListenerCoreImpl.cs
+++ b/src/Elastic.Apm/DiagnosticListeners/HttpDiagnosticListenerCoreImpl.cs
@@ -12,7 +12,7 @@ namespace Elastic.Apm.DiagnosticListeners
 		public HttpDiagnosticListenerCoreImpl(IApmAgent agent)
 			: base(agent) { }
 
-		internal override string ExceptionEventKey => "System.Net.Http.Exception";
+		protected override string ExceptionEventKey => "System.Net.Http.Exception";
 
 		public override string Name => "HttpHandlerDiagnosticListener";
 		internal override string StartEventKey => "System.Net.Http.HttpRequestOut.Start";

--- a/src/Elastic.Apm/DiagnosticListeners/HttpDiagnosticListenerFullFrameworkImpl.cs
+++ b/src/Elastic.Apm/DiagnosticListeners/HttpDiagnosticListenerFullFrameworkImpl.cs
@@ -14,7 +14,7 @@ namespace Elastic.Apm.DiagnosticListeners
 		public HttpDiagnosticListenerFullFrameworkImpl(IApmAgent agent)
 			: base(agent) { }
 
-		internal override string ExceptionEventKey => "System.Net.Http.Desktop.HttpRequestOut.Ex.Stop";
+		protected override string ExceptionEventKey => "System.Net.Http.Desktop.HttpRequestOut.Ex.Stop";
 
 		public override string Name => "System.Net.Http.Desktop";
 		internal override string StartEventKey => "System.Net.Http.Desktop.HttpRequestOut.Start";

--- a/src/Elastic.Apm/DiagnosticListeners/HttpDiagnosticListenerImplBase.cs
+++ b/src/Elastic.Apm/DiagnosticListeners/HttpDiagnosticListenerImplBase.cs
@@ -118,7 +118,7 @@ namespace Elastic.Apm.DiagnosticListeners
 		{
 			Logger.Trace()?.Log("Processing start event... Request URL: {RequestUrl}", Http.Sanitize(requestUrl));
 
-			var transaction = Agent.Tracer.CurrentTransaction;
+			var transaction = ApmAgent.Tracer.CurrentTransaction;
 			if (transaction == null)
 			{
 				Logger.Debug()?.Log("No current transaction, skip creating span for outgoing HTTP request");

--- a/src/Elastic.Apm/DiagnosticListeners/HttpDiagnosticListenerImplBase.cs
+++ b/src/Elastic.Apm/DiagnosticListeners/HttpDiagnosticListenerImplBase.cs
@@ -1,14 +1,13 @@
-// Licensed to Elasticsearch B.V under one or more agreements.
+// Licensed to Elasticsearch B.V under
+// one or more agreements.
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
 
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Linq;
 using System.Reflection;
 using Elastic.Apm.Api;
-using Elastic.Apm.DiagnosticSource;
 using Elastic.Apm.DistributedTracing;
 using Elastic.Apm.Logging;
 using Elastic.Apm.Model;
@@ -19,27 +18,20 @@ namespace Elastic.Apm.DiagnosticListeners
 	/// <summary>
 	/// Captures web requests initiated by <see cref="T:System.Net.Http.HttpClient" />
 	/// </summary>
-	internal abstract class HttpDiagnosticListenerImplBase<TRequest, TResponse> : IDiagnosticListener
+	internal abstract class HttpDiagnosticListenerImplBase<TRequest, TResponse> : DiagnosticListenerBase
 		where TRequest : class
 		where TResponse : class
 	{
 		private const string EventExceptionPropertyName = "Exception";
 		protected const string EventRequestPropertyName = "Request";
 		private const string EventResponsePropertyName = "Response";
-		protected readonly ScopedLogger Logger;
 
 		/// <summary>
 		/// Keeps track of ongoing requests
 		/// </summary>
 		internal readonly ConcurrentDictionary<TRequest, ISpan> ProcessingRequests = new ConcurrentDictionary<TRequest, ISpan>();
 
-		private readonly IApmAgent _agent;
-
-		protected HttpDiagnosticListenerImplBase(IApmAgent agent)
-		{
-			_agent = agent;
-			Logger = _agent.Logger?.Scoped("HttpDiagnosticListenerImplBase");
-		}
+		protected HttpDiagnosticListenerImplBase(IApmAgent agent) : base(agent) { }
 
 		protected abstract string RequestGetMethod(TRequest request);
 
@@ -51,85 +43,89 @@ namespace Elastic.Apm.DiagnosticListeners
 
 		protected abstract int ResponseGetStatusCode(TResponse response);
 
-		internal abstract string ExceptionEventKey { get; }
+		protected abstract string ExceptionEventKey { get; }
 
-		public abstract string Name { get; }
 		internal abstract string StartEventKey { get; }
 		internal abstract string StopEventKey { get; }
 
-		public void OnCompleted() { }
+		public override void OnError(Exception error) => Logger.Error()?.LogExceptionWithCaller(error, nameof(OnError));
 
-		public void OnError(Exception error) => Logger.Error()?.LogExceptionWithCaller(error, nameof(OnError));
-
-		public void OnNext(KeyValuePair<string, object> kv)
+		protected override void HandleOnNext(KeyValuePair<string, object> kv)
 		{
-			// We only print the key, we don't print the value, because it can contain a http request object, and its ToString prints
-			// the URL, which can contain username and password. See: https://github.com/elastic/apm-agent-dotnet/issues/515
-			Logger.Trace()?.Log("Called with key: `{DiagnosticEventKey}'", kv.Key);
-
-			if (string.IsNullOrEmpty(kv.Key))
+			try
 			{
-				Logger.Trace()?.Log($"Key is {(kv.Key == null ? "null" : "an empty string")} - exiting");
-				return;
-			}
+				// We only print the key, we don't print the value, because it can contain a http request object, and its ToString prints
+				// the URL, which can contain username and password. See: https://github.com/elastic/apm-agent-dotnet/issues/515
+				Logger.Trace()?.Log("Called with key: `{DiagnosticEventKey}'", kv.Key);
 
-			if (kv.Value == null)
+				if (string.IsNullOrEmpty(kv.Key))
+				{
+					Logger.Trace()?.Log($"Key is {(kv.Key == null ? "null" : "an empty string")} - exiting");
+					return;
+				}
+
+				if (kv.Value == null)
+				{
+					Logger.Trace()?.Log("Value is null - exiting");
+					return;
+				}
+
+				var requestObject = kv.Value.GetType().GetTypeInfo().GetDeclaredProperty(EventRequestPropertyName)?.GetValue(kv.Value);
+				if (requestObject == null)
+				{
+					Logger.Trace()?.Log("Event's {EventRequestPropertyName} property is null - exiting", EventRequestPropertyName);
+					return;
+				}
+
+				if (!(requestObject is TRequest request))
+				{
+					Logger.Trace()
+						?.Log("Actual type of object ({EventRequestPropertyActualType}) in event's {EventRequestPropertyName} property " +
+							"doesn't match the expected type ({EventRequestPropertyExpectedType}) - exiting",
+							requestObject.GetType().FullName, EventRequestPropertyName, typeof(TRequest).FullName);
+					return;
+				}
+
+				var requestUrl = RequestGetUri(request);
+				if (requestUrl == null)
+				{
+					Logger.Trace()?.Log("Request URL is null - exiting", EventRequestPropertyName);
+					return;
+				}
+
+				if (IsRequestFilteredOut(requestUrl))
+				{
+					Logger.Trace()?.Log("Request URL ({RequestUrl}) is filtered out - exiting", Http.Sanitize(requestUrl));
+					return;
+				}
+
+				if (kv.Key.Equals(StartEventKey))
+					ProcessStartEvent(request, requestUrl);
+				else if (kv.Key.Equals(StopEventKey))
+					ProcessStopEvent(kv.Value, request, requestUrl);
+				else if (kv.Key.Equals(ExceptionEventKey))
+					ProcessExceptionEvent(kv.Value, requestUrl);
+				else
+					Logger.Trace()?.Log("Unrecognized key `{DiagnosticEventKey}'", kv.Key);
+			}
+			catch (Exception e)
 			{
-				Logger.Trace()?.Log("Value is null - exiting");
-				return;
+				Logger.Error()?.LogException(e, "Exception during capturing outgoing HTTP request");
 			}
-
-			var requestObject = kv.Value.GetType().GetTypeInfo().GetDeclaredProperty(EventRequestPropertyName)?.GetValue(kv.Value);
-			if (requestObject == null)
-			{
-				Logger.Trace()?.Log("Event's {EventRequestPropertyName} property is null - exiting", EventRequestPropertyName);
-				return;
-			}
-
-			if (!(requestObject is TRequest request))
-			{
-				Logger.Trace()
-					?.Log("Actual type of object ({EventRequestPropertyActualType}) in event's {EventRequestPropertyName} property " +
-						"doesn't match the expected type ({EventRequestPropertyExpectedType}) - exiting",
-						requestObject.GetType().FullName, EventRequestPropertyName, typeof(TRequest).FullName);
-				return;
-			}
-
-			var requestUrl = RequestGetUri(request);
-			if (requestUrl == null)
-			{
-				Logger.Trace()?.Log("Request URL is null - exiting", EventRequestPropertyName);
-				return;
-			}
-
-			if (IsRequestFilteredOut(requestUrl))
-			{
-				Logger.Trace()?.Log("Request URL ({RequestUrl}) is filtered out - exiting", Http.Sanitize(requestUrl));
-				return;
-			}
-
-			if (kv.Key.Equals(StartEventKey))
-				ProcessStartEvent(request, requestUrl);
-			else if (kv.Key.Equals(StopEventKey))
-				ProcessStopEvent(kv.Value, request, requestUrl);
-			else if (kv.Key.Equals(ExceptionEventKey))
-				ProcessExceptionEvent(kv.Value, requestUrl);
-			else
-				Logger.Trace()?.Log("Unrecognized key `{DiagnosticEventKey}'", kv.Key);
 		}
 
 		private void ProcessStartEvent(TRequest request, Uri requestUrl)
 		{
 			Logger.Trace()?.Log("Processing start event... Request URL: {RequestUrl}", Http.Sanitize(requestUrl));
 
-			var transaction = _agent.Tracer.CurrentTransaction;
+			var transaction = Agent.Tracer.CurrentTransaction;
 			if (transaction == null)
 			{
 				Logger.Debug()?.Log("No current transaction, skip creating span for outgoing HTTP request");
 				return;
 			}
 
-			var span = ExecutionSegmentCommon.StartSpanOnCurrentExecutionSegment(_agent, $"{RequestGetMethod(request)} {requestUrl.Host}",
+			var span = ExecutionSegmentCommon.StartSpanOnCurrentExecutionSegment(ApmAgent, $"{RequestGetMethod(request)} {requestUrl.Host}",
 				ApiConstants.TypeExternal, ApiConstants.SubtypeHttp, InstrumentationFlag.HttpClient, true);
 
 			if (!ProcessingRequests.TryAdd(request, span))
@@ -157,13 +153,14 @@ namespace Elastic.Apm.DiagnosticListeners
 				}
 			}
 
-			if (!RequestHeadersContain(request, TraceContext.TraceStateHeaderName) && transaction.OutgoingDistributedTracingData != null && transaction.OutgoingDistributedTracingData.HasTraceState)
+			if (!RequestHeadersContain(request, TraceContext.TraceStateHeaderName) && transaction.OutgoingDistributedTracingData != null
+				&& transaction.OutgoingDistributedTracingData.HasTraceState)
 			{
 				RequestHeadersAdd(request, TraceContext.TraceStateHeaderName,
 					TraceContext.BuildTraceState(transaction.OutgoingDistributedTracingData));
 			}
 
-			if(span is Span spanInstance)
+			if (span is Span spanInstance)
 			{
 				if (!spanInstance.ShouldBeSentToApmServer)
 					return;
@@ -181,7 +178,7 @@ namespace Elastic.Apm.DiagnosticListeners
 			{
 				// if we don't find the request in the dictionary and current transaction is null, then this is not a big deal -
 				// it was probably not captured in Start either - so we skip with a debug log
-				if (_agent.Tracer.CurrentTransaction == null)
+				if (ApmAgent.Tracer.CurrentTransaction == null)
 				{
 					Logger.Debug()
 						?.Log("{eventName} called with no active current transaction, url: {url} - skipping event", nameof(ProcessStopEvent),
@@ -240,7 +237,7 @@ namespace Elastic.Apm.DiagnosticListeners
 				return;
 			}
 
-			var transaction = _agent.Tracer.CurrentTransaction;
+			var transaction = ApmAgent.Tracer.CurrentTransaction;
 
 			transaction?.CaptureException(exception, "Failed outgoing HTTP request");
 			//TODO: we don't know if exception is handled, currently reports handled = false
@@ -251,6 +248,6 @@ namespace Elastic.Apm.DiagnosticListeners
 		/// </summary>
 		/// <returns><c>true</c>, if request should not be captured, <c>false</c> otherwise.</returns>
 		/// <param name="requestUri">Request URI. It cannot be null</param>
-		private bool IsRequestFilteredOut(Uri requestUri) => _agent.ConfigurationReader.ServerUrl.IsBaseOf(requestUri);
+		private bool IsRequestFilteredOut(Uri requestUri) => ApmAgent.ConfigurationReader.ServerUrl.IsBaseOf(requestUri);
 	}
 }


### PR DESCRIPTION
Adapting code according to https://github.com/elastic/apm-agent-dotnet/pull/1162.


### Remove InstanceAlreadyCreatedException, instead we log now

In cases of multiple initializations, the agent previously fired an `InstanceAlreadyCreatedException`. This always happened when an already initialized agent was present and a 2. initialization was triggered. E.g. calling `Agent.Setup(AgentComponents)` twice, or enabling the agent with `UseAllElasticApm` and then calling `Agent.Setup()` manually, etc. With this PR, instead of throwing an exception and potentially crashing the app, we log an error and keep the original agent setup.


### Introduce DiagnosticListenerBase class which handles errors in OnNext

To make sure all DiagnosticSource listeners handle errors, this PR introduces `DiagnosticListenerBase` with a try-catch. With this, code in sub classes is automatically guarded.

_We almost already introduced such a base class in one of the PRs earlier... Now I think we have enough reason for it._