### PR TITLE
Send destination info for embedded databases

### DIFF
--- a/src/Elastic.Apm.SqlClient/SqlEventListener.cs
+++ b/src/Elastic.Apm.SqlClient/SqlEventListener.cs
@@ -109,7 +109,7 @@ namespace Elastic.Apm.SqlClient
 					Type = Database.TypeSql
 				};
 
-				span.Context.Destination = _apmAgent.TracerInternal.DbSpanCommon.GetDestination($"Data Source={dataSource}", false, null);
+				span.Context.Destination = _apmAgent.TracerInternal.DbSpanCommon.GetDestination($"Data Source={dataSource}", null);
 
 				// At the moment only System.Data.SqlClient and Microsoft.Data.SqlClient spread events via EventSource with Microsoft-AdoNet-SystemData name
 				span.Subtype = ApiConstants.SubtypeMssql;

--- a/src/Elastic.Apm/Model/DbSpanCommon.cs
+++ b/src/Elastic.Apm/Model/DbSpanCommon.cs
@@ -37,10 +37,9 @@ namespace Elastic.Apm.Model
 		{
 			if (span is Span capturedSpan)
 			{
-
 				if (duration.HasValue) capturedSpan.Duration = duration.Value.TotalMilliseconds;
 
-				GetDefaultProperties(dbCommand.Connection.GetType().FullName, out var spanSubtype, out var isEmbeddedDb, out var defaultPort);
+				GetDefaultProperties(dbCommand.Connection.GetType().FullName, out var spanSubtype, out var defaultPort);
 				capturedSpan.Subtype = spanSubtype;
 				capturedSpan.Action = GetSpanAction(dbCommand.CommandType);
 
@@ -53,7 +52,7 @@ namespace Elastic.Apm.Model
 						Type = Database.TypeSql
 					};
 
-					capturedSpan.Context.Destination = GetDestination(dbCommand.Connection?.ConnectionString, isEmbeddedDb, defaultPort);
+					capturedSpan.Context.Destination = GetDestination(dbCommand.Connection?.ConnectionString, defaultPort);
 				}
 
 				capturedSpan.Outcome = outcome;
@@ -63,14 +62,12 @@ namespace Elastic.Apm.Model
 			span.End();
 		}
 
-		private static void GetDefaultProperties(string dbConnectionClassName, out string spanSubtype, out bool isEmbeddedDb, out int? defaultPort)
+		private static void GetDefaultProperties(string dbConnectionClassName, out string spanSubtype, out int? defaultPort)
 		{
-			isEmbeddedDb = false;
 			switch (dbConnectionClassName)
 			{
 				case { } str when str.ContainsOrdinalIgnoreCase("SQLite"):
 					spanSubtype = ApiConstants.SubtypeSqLite;
-					isEmbeddedDb = true;
 					defaultPort = null;
 					break;
 				case { } str when str.ContainsOrdinalIgnoreCase("MySQL"):
@@ -113,9 +110,9 @@ namespace Elastic.Apm.Model
 				_ => dbCommandType.ToString()
 			};
 
-		internal Destination GetDestination(string dbConnectionString, bool isEmbeddedDb, int? defaultPort)
+		internal Destination GetDestination(string dbConnectionString, int? defaultPort)
 		{
-			if (isEmbeddedDb || dbConnectionString == null) return null;
+			if (dbConnectionString == null) return null;
 
 			var destination = _dbConnectionStringParser.ExtractDestination(dbConnectionString);
 			if (destination == null) return null;

--- a/test/Elastic.Apm.AspNetCore.Tests/AspNetCoreBasicTests.cs
+++ b/test/Elastic.Apm.AspNetCore.Tests/AspNetCoreBasicTests.cs
@@ -381,7 +381,7 @@ namespace Elastic.Apm.AspNetCore.Tests
 				dbSpan.Subtype.Should().Be(ApiConstants.SubtypeSqLite);
 				dbSpan.ParentId.Should().Be(controllerActionSpan.Id);
 				dbSpan.Context.Db.Type.Should().Be(Database.TypeSql);
-				dbSpan.Context.Destination.Should().BeNull("because SQLite is an embedded DB");
+				dbSpan.Context.Destination.Should().NotBeNull();
 			}
 			var httpSpans = spans.Where(span => span.Context.Http != null);
 			httpSpans.Should().NotBeEmpty();

--- a/test/Elastic.Apm.AspNetFullFramework.Tests/DbSpanTests.cs
+++ b/test/Elastic.Apm.AspNetFullFramework.Tests/DbSpanTests.cs
@@ -60,7 +60,7 @@ namespace Elastic.Apm.AspNetFullFramework.Tests
 
 					span.Context.Db.Statement.Should().StartWith(dbStatements[i]);
 
-					span.Context.Destination.Should().BeNull("because SQLite is an embedded DB");
+					span.Context.Destination.Should().NotBeNull();
 
 					span.TraceId.Should().Be(transaction.TraceId);
 					span.TransactionId.Should().Be(transaction.Id);
@@ -166,7 +166,7 @@ namespace Elastic.Apm.AspNetFullFramework.Tests
 
 						dbSpan.Context.Db.Statement.Should().StartWith(dbStatements[i]);
 
-						dbSpan.Context.Destination.Should().BeNull("because SQLite is an embedded DB");
+						dbSpan.Context.Destination.Should().NotBeNull();
 
 						dbSpan.TraceId.Should().Be(transaction.TraceId);
 						dbSpan.TransactionId.Should().Be(transaction.Id);


### PR DESCRIPTION
Prior to this PR we had a check to not send destination info for local databases. Reason for this was the part `When to set destination.service.* fields?` in the [APM issue](https://github.com/elastic/apm/issues/180) that introduced this feature.

This causes things like SQLite never show up on service map. It seems that no other agent had this check - at least I asked and I got no specific acknowledgements that other agents would do the same.

Therefore this PR removes this check.

With this, local databases (like SQLite) will also show up on the service map.

<img width="1461" alt="image" src="https://user-images.githubusercontent.com/1091853/106511072-07193600-64d0-11eb-81db-326465f09bb1.png">

@alex-fedotyev fyi.