### PR TITLE
StartupHook: Introduce AssemblyLoadContext to load agent assemblies

### DIFF
--- a/src/Elastic.Apm.StartupHook.Loader/AgentLoadContext.cs
+++ b/src/Elastic.Apm.StartupHook.Loader/AgentLoadContext.cs
@@ -1,0 +1,57 @@
+﻿// Licensed to Elasticsearch B.V under
+// one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System;
+using System.IO;
+using System.Reflection;
+using System.Runtime.Loader;
+using ElasticApmStartupHook;
+using System.Linq;
+
+namespace Elastic.Apm.StartupHook.Loader
+{
+	/// <summary>
+	/// An <see cref="AssemblyLoadContext"/> implementation which loads agent dlls and dependencies of agent dlls.
+	/// </summary>
+	internal class AgentLoadContext : AssemblyLoadContext
+	{
+		public static string[] AgentDependencyLibsToLoad =
+		{
+			"System.Diagnostics.PerformanceCounter", "Microsoft.Diagnostics.Tracing.TraceEvent", "Newtonsoft.Json", "Elasticsearch.Net"
+		};
+
+		public static string[] AgentLibsToLoad =
+		{
+			"Elastic.Apm", "Elastic.Apm.Extensions.Hosting", "Elastic.Apm.AspNetCore", "Elastic.Apm.EntityFrameworkCore", "Elastic.Apm.SqlClient",
+			"Elastic.Apm.GrpcClient", "Elastic.Apm.Elasticsearch"
+		};
+
+		private readonly string _asssemblyDir;
+
+		private readonly StartupHookLogger _logger;
+
+		public AgentLoadContext(string assemblyDir, StartupHookLogger logger) => (_asssemblyDir, _logger) = (assemblyDir, logger);
+
+		protected override Assembly Load(AssemblyName assemblyName)
+		{
+			try
+			{
+				if (AgentLibsToLoad.Contains(assemblyName.Name) || AgentDependencyLibsToLoad.Contains(assemblyName.Name))
+				{
+					var path = Path.Combine(_asssemblyDir, assemblyName.Name + ".dll");
+					return LoadFromAssemblyPath(path);
+				}
+				// If it's not an agent assembly or an agent dependency, let's just reuse it from the default load context
+				return Default.LoadFromAssemblyName(assemblyName);
+			}
+			catch (Exception e)
+			{
+				_logger.WriteLine($"{nameof(AgentLoadContext)} Failed loading {assemblyName.Name}, exception: {e}");
+			}
+
+			return null;
+		}
+	}
+}

--- a/src/Elastic.Apm.StartupHook.Loader/AgentLoadContext.cs
+++ b/src/Elastic.Apm.StartupHook.Loader/AgentLoadContext.cs
@@ -19,7 +19,8 @@ namespace Elastic.Apm.StartupHook.Loader
 	{
 		public static HashSet<string> AgentDependencyLibsToLoad = new HashSet<string>
 		{
-			"System.Diagnostics.PerformanceCounter", "Microsoft.Diagnostics.Tracing.TraceEvent", "Newtonsoft.Json", "Elasticsearch.Net"
+			"System.Diagnostics.PerformanceCounter", "Microsoft.Diagnostics.Tracing.TraceEvent", "Newtonsoft.Json", "Elasticsearch.Net",
+			"Microsoft.AspNetCore.Http.Abstractions"
 		};
 
 		public static HashSet<string> AgentLibsToLoad = new HashSet<string>
@@ -41,6 +42,7 @@ namespace Elastic.Apm.StartupHook.Loader
 
 		protected override Assembly Load(AssemblyName assemblyName)
 		{
+			_logger.WriteLine($"AgentLoadContext tries loading: {assemblyName}");
 			try
 			{
 				if (AgentLibsToLoad.Contains(assemblyName.Name) || AgentDependencyLibsToLoad.Contains(assemblyName.Name))
@@ -49,7 +51,7 @@ namespace Elastic.Apm.StartupHook.Loader
 					return LoadFromAssemblyPath(path);
 				}
 				// If it's not an agent assembly or an agent dependency, let's just reuse it from the default load context
-				return Default.LoadFromAssemblyName(assemblyName);
+				//return Default.LoadFromAssemblyName(assemblyName);
 			}
 			catch (Exception e)
 			{

--- a/src/Elastic.Apm.StartupHook.Loader/AgentLoadContext.cs
+++ b/src/Elastic.Apm.StartupHook.Loader/AgentLoadContext.cs
@@ -51,6 +51,7 @@ namespace Elastic.Apm.StartupHook.Loader
 					return LoadFromAssemblyPath(path);
 				}
 				// If it's not an agent assembly or an agent dependency, let's just reuse it from the default load context
+				// Follow-up: maybe not a good idea... 
 				//return Default.LoadFromAssemblyName(assemblyName);
 			}
 			catch (Exception e)

--- a/src/Elastic.Apm.StartupHook.Loader/AgentLoadContext.cs
+++ b/src/Elastic.Apm.StartupHook.Loader/AgentLoadContext.cs
@@ -4,35 +4,40 @@
 // See the LICENSE file in the project root for more information
 
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
 using System.Runtime.Loader;
 using ElasticApmStartupHook;
-using System.Linq;
 
 namespace Elastic.Apm.StartupHook.Loader
 {
 	/// <summary>
-	/// An <see cref="AssemblyLoadContext"/> implementation which loads agent dlls and dependencies of agent dlls.
+	/// An <see cref="AssemblyLoadContext" /> implementation which loads agent dlls and dependencies of agent dlls.
 	/// </summary>
 	internal class AgentLoadContext : AssemblyLoadContext
 	{
-		public static string[] AgentDependencyLibsToLoad =
+		public static HashSet<string> AgentDependencyLibsToLoad = new HashSet<string>
 		{
 			"System.Diagnostics.PerformanceCounter", "Microsoft.Diagnostics.Tracing.TraceEvent", "Newtonsoft.Json", "Elasticsearch.Net"
 		};
 
-		public static string[] AgentLibsToLoad =
+		public static HashSet<string> AgentLibsToLoad = new HashSet<string>
 		{
-			"Elastic.Apm", "Elastic.Apm.Extensions.Hosting", "Elastic.Apm.AspNetCore", "Elastic.Apm.EntityFrameworkCore", "Elastic.Apm.SqlClient",
-			"Elastic.Apm.GrpcClient", "Elastic.Apm.Elasticsearch"
+			"Elastic.Apm",
+			"Elastic.Apm.Extensions.Hosting",
+			"Elastic.Apm.AspNetCore",
+			"Elastic.Apm.EntityFrameworkCore",
+			"Elastic.Apm.SqlClient",
+			"Elastic.Apm.GrpcClient",
+			"Elastic.Apm.Elasticsearch"
 		};
 
-		private readonly string _asssemblyDir;
+		private readonly string _assemblyDir;
 
 		private readonly StartupHookLogger _logger;
 
-		public AgentLoadContext(string assemblyDir, StartupHookLogger logger) => (_asssemblyDir, _logger) = (assemblyDir, logger);
+		public AgentLoadContext(string assemblyDir, StartupHookLogger logger) => (_assemblyDir, _logger) = (assemblyDir, logger);
 
 		protected override Assembly Load(AssemblyName assemblyName)
 		{
@@ -40,7 +45,7 @@ namespace Elastic.Apm.StartupHook.Loader
 			{
 				if (AgentLibsToLoad.Contains(assemblyName.Name) || AgentDependencyLibsToLoad.Contains(assemblyName.Name))
 				{
-					var path = Path.Combine(_asssemblyDir, assemblyName.Name + ".dll");
+					var path = Path.Combine(_assemblyDir, assemblyName.Name + ".dll");
 					return LoadFromAssemblyPath(path);
 				}
 				// If it's not an agent assembly or an agent dependency, let's just reuse it from the default load context
@@ -48,7 +53,7 @@ namespace Elastic.Apm.StartupHook.Loader
 			}
 			catch (Exception e)
 			{
-				_logger.WriteLine($"{nameof(AgentLoadContext)} Failed loading {assemblyName.Name}, exception: {e}");
+				_logger.WriteLine($"{nameof(AgentLoadContext)} Failed loading {assemblyName}, exception: {e}");
 			}
 
 			return null;

--- a/src/Elastic.Apm.StartupHook.Loader/Elastic.Apm.StartupHook.Loader.csproj
+++ b/src/Elastic.Apm.StartupHook.Loader/Elastic.Apm.StartupHook.Loader.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netcoreapp2.1</TargetFramework>
+        <TargetFramework>netcoreapp2.2</TargetFramework>
         <IsPackable>false</IsPackable>
     </PropertyGroup>
 

--- a/src/Elastic.Apm.StartupHook.Loader/Elastic.Apm.StartupHook.Loader.csproj
+++ b/src/Elastic.Apm.StartupHook.Loader/Elastic.Apm.StartupHook.Loader.csproj
@@ -1,18 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>netcoreapp2.1</TargetFramework>
         <IsPackable>false</IsPackable>
     </PropertyGroup>
-
-    <ItemGroup>
-      <ProjectReference Include="..\Elastic.Apm.AspNetCore\Elastic.Apm.AspNetCore.csproj" />
-      <ProjectReference Include="..\Elastic.Apm.Elasticsearch\Elastic.Apm.Elasticsearch.csproj" />
-      <ProjectReference Include="..\Elastic.Apm.EntityFrameworkCore\Elastic.Apm.EntityFrameworkCore.csproj" />
-      <ProjectReference Include="..\Elastic.Apm.SqlClient\Elastic.Apm.SqlClient.csproj" />
-      <ProjectReference Include="..\Elastic.Apm.GrpcClient\Elastic.Apm.GrpcClient.csproj" />
-      <ProjectReference Include="..\Elastic.Apm\Elastic.Apm.csproj" />
-    </ItemGroup>
 
     <ItemGroup>
       <Compile Include="..\ElasticApmAgentStartupHook\StartupHookLogger.cs">

--- a/src/Elastic.Apm.StartupHook.Loader/Elastic.Apm.StartupHook.Loader.csproj
+++ b/src/Elastic.Apm.StartupHook.Loader/Elastic.Apm.StartupHook.Loader.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netcoreapp2.2</TargetFramework>
+        <TargetFramework>netcoreapp3.1</TargetFramework>
         <IsPackable>false</IsPackable>
     </PropertyGroup>
 

--- a/src/Elastic.Apm.StartupHook.Loader/Loader.cs
+++ b/src/Elastic.Apm.StartupHook.Loader/Loader.cs
@@ -69,7 +69,7 @@ namespace Elastic.Apm.StartupHook.Loader
 
 		public static void LoadAssembly(string assemblyName)
 		{
-			if (AppDomain.CurrentDomain.GetAssemblies().Any(n => n.FullName == assemblyName))
+			if (AppDomain.CurrentDomain.GetAssemblies().Any(n => n.FullName.Equals(assemblyName, StringComparison.Ordinal)))
 			{
 				Logger.WriteLine($"{assemblyName} is alrady loaded - we don't try to load it");
 				return;
@@ -80,7 +80,6 @@ namespace Elastic.Apm.StartupHook.Loader
 				var path = Path.Combine(AssemblyDirectory, assemblyName + ".dll");
 				Logger.WriteLine($"Try loading: {path}");
 				_agentLoadContext.LoadFromAssemblyName(new AssemblyName(assemblyName));
-
 				Logger.WriteLine($"Loaded {path}");
 			}
 			catch (Exception e)

--- a/src/Elastic.Apm.StartupHook.Loader/Loader.cs
+++ b/src/Elastic.Apm.StartupHook.Loader/Loader.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.IO;
+using System.Linq;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.Loader;
@@ -19,11 +20,51 @@ using ElasticApmStartupHook;
 
 namespace Elastic.Apm.StartupHook.Loader
 {
+
+	internal class AgentLoadContext : AssemblyLoadContext
+	{
+		public static string[] agentLibsToLoad = new[] { "Elastic.Apm", "Elastic.Apm.Extensions.Hosting", "Elastic.Apm.AspNetCore", "Elastic.Apm.EntityFrameworkCore", "Elastic.Apm.SqlClient", "Elastic.Apm.GrpcClient", "Elastic.Apm.Elasticsearch" };
+		public static string[] agentDependencyLibsToLoad = new[] { "System.Diagnostics.PerformanceCounter", "Microsoft.Diagnostics.Tracing.TraceEvent", "Newtonsoft.Json", "Elasticsearch.Net" };
+
+		private readonly StartupHookLogger _logger;
+		private readonly string _asssemblyDir;
+
+		public AgentLoadContext(string assemblyDir, StartupHookLogger logger) => (_asssemblyDir, _logger) = (assemblyDir, logger);
+
+		protected override Assembly Load(AssemblyName assemblyName)
+		{
+			try
+			{
+				if (agentLibsToLoad.Contains(assemblyName.Name) || agentDependencyLibsToLoad.Contains(assemblyName.Name))
+				{
+					var path = Path.Combine(_asssemblyDir, assemblyName.Name + ".dll");
+					return LoadFromAssemblyPath(path);
+				}
+				else
+				{
+					// If it's not an agent assembly or an agent dependency, let's just reuse it from the default load context
+					return Default.LoadFromAssemblyName(assemblyName);
+				}
+
+			}
+			catch (Exception e)
+			{
+				_logger.WriteLine($"{nameof(AgentLoadContext)} Failed loading {assemblyName.Name}, exception: {e}");
+			}
+
+			return null;
+		}
+	}
+
 	/// <summary>
 	/// Loads the agent assemblies, its dependent assemblies and starts it
 	/// </summary>
 	internal class Loader
 	{
+		private static readonly StartupHookLogger _logger = StartupHookLogger.Create();
+
+		private static AgentLoadContext _agentLoadContext;
+
 		/// <summary>
 		/// The directory in which the executing assembly is located
 		/// </summary>
@@ -41,15 +82,47 @@ namespace Elastic.Apm.StartupHook.Loader
 		/// </summary>
 		public static void Initialize()
 		{
-			var agentLibsToLoad =  new[]{ "Elastic.Apm", "Elastic.Apm.Extensions.Hosting", "Elastic.Apm.AspNetCore", "Elastic.Apm.EntityFrameworkCore", "Elastic.Apm.SqlClient", "Elastic.Apm.GrpcClient", "Elastic.Apm.Elasticsearch" };
-			var agentDependencyLibsToLoad = new[] { "System.Diagnostics.PerformanceCounter", "Microsoft.Diagnostics.Tracing.TraceEvent", "Newtonsoft.Json", "Elasticsearch.Net" };
+			_agentLoadContext = new AgentLoadContext(AssemblyDirectory, _logger);
 
-			foreach (var libToLoad in agentDependencyLibsToLoad)
-				AssemblyLoadContext.Default.LoadFromAssemblyPath(Path.Combine(AssemblyDirectory, libToLoad + ".dll"));
-			foreach (var libToLoad in agentLibsToLoad)
-				AssemblyLoadContext.Default.LoadFromAssemblyPath(Path.Combine(AssemblyDirectory, libToLoad + ".dll"));
+			foreach (var libToLoad in AgentLoadContext.agentDependencyLibsToLoad)
+				LoadAssembly(libToLoad);
+			foreach (var libToLoad in AgentLoadContext.agentLibsToLoad)
+				LoadAssembly(libToLoad);
+
+			AssemblyLoadContext.Default.Resolving += (context, assemblyName) =>
+			{
+				if (AgentLoadContext.agentDependencyLibsToLoad.Contains(assemblyName.Name) || AgentLoadContext.agentLibsToLoad.Contains(assemblyName.Name))
+				{
+					// If AssemblyLoadContext.Default tries to load an agent assembly or one of its dependencies, we return it from _agentLoadContext
+					return _agentLoadContext.LoadFromAssemblyName(new AssemblyName(assemblyName.Name));
+				}
+
+				return context.LoadFromAssemblyName(assemblyName);
+			};
 
 			StartAgent();
+		}
+
+		public static void LoadAssembly(string assemblyName)
+		{
+			if (AppDomain.CurrentDomain.GetAssemblies().Any(n => n.FullName == assemblyName))
+			{
+				_logger.WriteLine($"{assemblyName} is alrady loaded - we don't try to load it");
+				return;
+			}
+
+			try
+			{
+				var path = Path.Combine(AssemblyDirectory, assemblyName + ".dll");
+				_logger.WriteLine($"Try loading: {path}");
+				_agentLoadContext.LoadFromAssemblyName(new AssemblyName(assemblyName));
+
+				_logger.WriteLine($"Loaded {path}");
+			}
+			catch (Exception e)
+			{
+				_logger.WriteLine($"Failed loading {assemblyName} - Exception: {e.GetType()}, message: {e.Message}");
+			}
 		}
 
 		[MethodImpl(MethodImplOptions.NoInlining)]
@@ -57,26 +130,24 @@ namespace Elastic.Apm.StartupHook.Loader
 		{
 			Agent.Setup(new AgentComponents());
 
-			var logger = StartupHookLogger.Create();
-			LoadDiagnosticSubscriber(new HttpDiagnosticsSubscriber(), logger);
-			LoadDiagnosticSubscriber(new AspNetCoreDiagnosticSubscriber(), logger);
-			LoadDiagnosticSubscriber(new EfCoreDiagnosticsSubscriber(), logger);
-			LoadDiagnosticSubscriber(new SqlClientDiagnosticSubscriber(), logger);
-			LoadDiagnosticSubscriber(new ElasticsearchDiagnosticsSubscriber(), logger);
-			LoadDiagnosticSubscriber(new GrpcClientDiagnosticSubscriber(), logger);
+			LoadDiagnosticSubscriber(new HttpDiagnosticsSubscriber());
+			LoadDiagnosticSubscriber(new AspNetCoreDiagnosticSubscriber());
+			LoadDiagnosticSubscriber(new EfCoreDiagnosticsSubscriber());
+			LoadDiagnosticSubscriber(new SqlClientDiagnosticSubscriber());
+			LoadDiagnosticSubscriber(new ElasticsearchDiagnosticsSubscriber());
+			LoadDiagnosticSubscriber(new GrpcClientDiagnosticSubscriber());
 
-			HostBuilderExtensions.UpdateServiceInformation(Agent.Instance.Service);
-
-			static void LoadDiagnosticSubscriber(IDiagnosticsSubscriber diagnosticsSubscriber, StartupHookLogger logger)
+			static void LoadDiagnosticSubscriber(IDiagnosticsSubscriber diagnosticsSubscriber)
 			{
 				try
 				{
 					Agent.Subscribe(diagnosticsSubscriber);
+					_logger.WriteLine($"Successfully Subscribed to {diagnosticsSubscriber.GetType().Name}");
 				}
 				catch (Exception e)
 				{
-					logger.WriteLine($"Failed subscribing to {diagnosticsSubscriber.GetType().Name}, " +
-						$"Exception type: {e.GetType().Name}, message: {e.Message}");
+					_logger.WriteLine($"Failed subscribing to {diagnosticsSubscriber.GetType().Name}, " +
+						$"Exception {e}");
 				}
 			}
 		}

--- a/src/Elastic.Apm.StartupHook.Loader/Loader.cs
+++ b/src/Elastic.Apm.StartupHook.Loader/Loader.cs
@@ -45,7 +45,7 @@ namespace Elastic.Apm.StartupHook.Loader
 			foreach (var libToLoad in AgentLoadContext.AgentLibsToLoad)
 				LoadAssembly(libToLoad);
 
-
+			// Under testing - This seems to lead to stackoverflow when an assembly cannot be found.
 			//AssemblyLoadContext.Default.Resolving += (context, assemblyName) =>
 			//{
 			//	Logger.WriteLine($"Default load context resolver, resolving {assemblyName.Name} from AgentLoadContext");


### PR DESCRIPTION
Prior to this PR with the startuphook feature we loaded everything into `AssemblyLoadContext.Default`. This PR introduces a separate AssemblyLoadContext  to load agent assemblies and dependencies of agent assemblies.


Why we need this?
- The agent depends on `Newtonsoft.Json`  `Version="11.0.2"`
- If the application depends on a different version (which is not unlikely), we cause a conflict. What happens in those cases is that when we try to load `Newtonsoft.Json` with `AssemblyLoadContext.Default`, it throws an exception and the agent won't work.
- With an extra load context we can load the two versions at the same time, the app uses its own version and the agent also uses its own version, all good.


The problem this PR solves can be reproduced by creating an empty project, adding `<PackageReference Include="Newtonsoft.Json" Version="9.0.2" />` (or any version) to its `csproj` file and use the startuphook feature. Same happens when there is a dependency in the app which depends on `Newtonsoft.Json`.