### PR TITLE
DotnetProject.cs  - handle path with space in it

### DIFF
--- a/test/Elastic.Apm.StartupHook.Tests/DotnetProject.cs
+++ b/test/Elastic.Apm.StartupHook.Tests/DotnetProject.cs
@@ -129,7 +129,7 @@ namespace Elastic.Apm.StartupHook.Tests
 			{
 				"new", template,
 				"--name", name,
-				"--output", directory,
+				"--output", $"\"{directory}\"",
 				"--framework", framework
 			}.Concat(arguments);
 


### PR DESCRIPTION
Ran into an issue on Windows where the path includes an empty space. Adding `"` to handle it.