### PR TITLE
[Doc] Adding some notes about disabled agent

### DIFF
--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -191,6 +191,8 @@ mostly idle in this state, so the overhead should be negligible.
 
 You can use this setting to dynamically disable Elastic APM at runtime.
 
+NOTE: Setting `Recording` to `false` influences the behavior of the <<public-api>>. When the agent is not active it won't keep track of transactions, spans and any related properties on those.
+
 [options="header"]
 |============
 | Environment variable name       | IConfiguration or Web.config key
@@ -211,6 +213,8 @@ You can use this setting to dynamically disable Elastic APM at runtime.
 
 Setting to false will completely disable the agent, including instrumentation and remote config polling.
 If you want to dynamically change the status of the agent, use <<config-recording,`recording`>> instead.
+
+NOTE: Setting `Enabled` to `false` influences the behavior of the <<public-api>>. When the agent is not active it won't keep track of transactions, spans and any related properties on those.
 
 [options="header"]
 |============

--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -191,7 +191,7 @@ mostly idle in this state, so the overhead should be negligible.
 
 You can use this setting to dynamically disable Elastic APM at runtime.
 
-NOTE: Setting `Recording` to `false` influences the behavior of the <<public-api>>. When the agent is not active it won't keep track of transactions, spans and any related properties on those.
+WARNING: Setting `Recording` to `false` influences the behavior of the <<public-api>>. When the agent is not active it won't keep track of transactions, spans and any related properties on those.
 
 [options="header"]
 |============
@@ -214,7 +214,7 @@ NOTE: Setting `Recording` to `false` influences the behavior of the <<public-api
 Setting to false will completely disable the agent, including instrumentation and remote config polling.
 If you want to dynamically change the status of the agent, use <<config-recording,`recording`>> instead.
 
-NOTE: Setting `Enabled` to `false` influences the behavior of the <<public-api>>. When the agent is not active it won't keep track of transactions, spans and any related properties on those.
+WARNING: Setting `Enabled` to `false` influences the behavior of the <<public-api>>. When the agent is not active it won't keep track of transactions, spans and any related properties on those.
 
 [options="header"]
 |============

--- a/docs/public-api.asciidoc
+++ b/docs/public-api.asciidoc
@@ -211,6 +211,7 @@ var transaction2 = Agent.Tracer.StartTransaction("Transaction2", "TestTransactio
      DistributedTracingData.TryDeserializeFromString(serializedDistributedTracingData));
 ----
 
+NOTE: The `OutgoingDistributedTracingData` property can be `null`. One such scenario is when the agent is disabled.
 
 //----------------------------
 [float]


### PR DESCRIPTION
Inspired by https://github.com/elastic/apm-agent-dotnet/issues/1080. The goal here is to make clear that if you disable the agent, the Public API will behave differently.