### PR TITLE
Update Elasticsearch sample

### DIFF
--- a/docs/supported-technologies.asciidoc
+++ b/docs/supported-technologies.asciidoc
@@ -89,14 +89,14 @@ We support automatic instrumentation for the following data access technologies.
 
 | Elasticsearch (Elasticsearch.Net and NEST)
 | 7.6.0
-| 
+| __If you're using 7.10.1 or 7.11.0, upgrade to at least 7.11.1 which fixes a bug in capture__
 | 1.6.0
-|===
 
 | Redis (StackExchange.Redis)
 | 2.0.495
 | A DB span is automatically created for each profiled redis command peformed by StackExchange.Redis 
 | 1.8.0
+|===
 
 [float]
 [[supported-networking-client-side-technologies]]

--- a/sample/ElasticsearchSample/ElasticsearchSample.csproj
+++ b/sample/ElasticsearchSample/ElasticsearchSample.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="3.1.3" />
-    <PackageReference Include="NEST" Version="7.6.1" />
+    <PackageReference Include="NEST" Version="7.11.1" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\Elastic.Apm.Elasticsearch\Elastic.Apm.Elasticsearch.csproj" />

--- a/sample/ElasticsearchSample/Program.cs
+++ b/sample/ElasticsearchSample/Program.cs
@@ -17,6 +17,7 @@ namespace ElasticsearchSample
 		}
 
 		private static ConnectionSettings DefaultConnectionSettings(ConnectionSettings s) => s
+			.PingTimeout(TimeSpan.FromSeconds(5))
 			.DefaultIndex("index")
 			.DisableDirectStreaming();
 


### PR DESCRIPTION
Relates: #1094

This commit updates the Elasticsearch Sample to use NEST 7.11.1. Add note about upgrading from 7.10.1 and 7.11.0 to at least 7.11.1.