### PR TITLE
Get transaction name from Web API controller route template

### DIFF
--- a/.ci/windows/msbuild-tools.ps1
+++ b/.ci/windows/msbuild-tools.ps1
@@ -3,12 +3,12 @@
 #
 
 # Install visualstudio2019buildtools
-choco install visualstudio2019buildtools -m -y --no-progress --force -r --version=16.8.5.0
+choco install visualstudio2019buildtools -m -y --no-progress --force -r --version=16.9.0.0
 if ($LASTEXITCODE -ne 0) {
   Write-Host "visualstudio2019buildtools installation failed."
   exit 1
 }
-choco install visualstudio2019professional -m -y --no-progress --force -r --version=16.8.5.0 --package-parameters "--includeRecommended --includeOptional"
+choco install visualstudio2019professional -m -y --no-progress --force -r --version=16.9.0.0 --package-parameters "--includeRecommended --includeOptional"
 if ($LASTEXITCODE -ne 0) {
   Write-Host "visualstudio2019professional installation failed."
   exit 1

--- a/sample/AspNetFullFrameworkSampleApp/AspNetFullFrameworkSampleApp.csproj
+++ b/sample/AspNetFullFrameworkSampleApp/AspNetFullFrameworkSampleApp.csproj
@@ -142,6 +142,7 @@
     <Compile Include="Mvc\JsonBadRequestResult.cs" />
     <Compile Include="Mvc\JsonNetValueProviderFactory.cs" />
     <Compile Include="Mvc\StreamResult.cs" />
+    <Compile Include="Controllers\AttributeRoutingWebApiController.cs" />
   </ItemGroup>
   <ItemGroup Condition="'$(OS)' == 'WINDOWS_NT'">
     <Content Include="Content\bootstrap-grid.css" />

--- a/sample/AspNetFullFrameworkSampleApp/Controllers/AttributeRoutingWebApiController.cs
+++ b/sample/AspNetFullFrameworkSampleApp/Controllers/AttributeRoutingWebApiController.cs
@@ -1,0 +1,21 @@
+// Licensed to Elasticsearch B.V under
+// one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System.Web.Http;
+
+namespace AspNetFullFrameworkSampleApp.Controllers
+{
+	[RoutePrefix(RoutePrefix)]
+	public class AttributeRoutingWebApiController : ApiController
+	{
+		public const string RoutePrefix = "api/AttributeRoutingWebApi";
+		public const string Route = "{id}";
+
+		[HttpGet]
+		[Route(Route)]
+		public IHttpActionResult Get(string id) =>
+			Ok($"attributed routed web api controller {id}");
+	}
+}

--- a/src/Elastic.Apm/Reflection/ExpressionBuilder.cs
+++ b/src/Elastic.Apm/Reflection/ExpressionBuilder.cs
@@ -1,0 +1,38 @@
+// Licensed to Elasticsearch B.V under
+// one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System;
+using System.Linq.Expressions;
+using System.Reflection;
+
+namespace Elastic.Apm.Reflection
+{
+	internal class ExpressionBuilder
+	{
+		/// <summary>
+		/// Builds a delegate to get a property of type <typeparamref name="TProperty"/> from an object
+		/// of type <typeparamref name="TObject"/>
+		/// </summary>
+		public static Func<TObject, TProperty> BuildPropertyGetter<TObject, TProperty>(string propertyName)
+		{
+			var parameterExpression = Expression.Parameter(typeof(TObject), "value");
+			var memberExpression = Expression.Property(parameterExpression, propertyName);
+			return Expression.Lambda<Func<TObject, TProperty>>(memberExpression, parameterExpression).Compile();
+		}
+
+		/// <summary>
+		/// Builds a delegate to get a property from an object. <paramref name="type"/> is cast to <see cref="Object"/>,
+		/// with the returned property cast to <see cref="Object"/>.
+		/// </summary>
+		public static Func<object, object> BuildPropertyGetter(Type type, PropertyInfo propertyInfo)
+		{
+			var parameterExpression = Expression.Parameter(typeof(object), "value");
+			var parameterCastExpression = Expression.Convert(parameterExpression, type);
+			var memberExpression = Expression.Property(parameterCastExpression, propertyInfo);
+			var returnCastExpression = Expression.Convert(memberExpression, typeof(object));
+			return Expression.Lambda<Func<object, object>>(returnCastExpression, parameterExpression).Compile();
+		}
+	}
+}

--- a/test/Elastic.Apm.AspNetFullFramework.Tests/TestsBase.cs
+++ b/test/Elastic.Apm.AspNetFullFramework.Tests/TestsBase.cs
@@ -187,6 +187,9 @@ namespace Elastic.Apm.AspNetFullFramework.Tests
 			internal static readonly SampleAppUrlPathData WebApiPage =
 				new SampleAppUrlPathData(WebApiController.Path, 200);
 
+			internal static SampleAppUrlPathData AttributeRoutingWebApiPage(string id) =>
+				new SampleAppUrlPathData(AttributeRoutingWebApiController.RoutePrefix + "/" + id, 200);
+
 			internal static readonly SampleAppUrlPathData WebformsPage =
 				new SampleAppUrlPathData(nameof(Webforms) + ".aspx", 200);
 

--- a/test/Elastic.Apm.AspNetFullFramework.Tests/TransactionNameTests.cs
+++ b/test/Elastic.Apm.AspNetFullFramework.Tests/TransactionNameTests.cs
@@ -8,6 +8,7 @@ using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Text;
 using System.Threading.Tasks;
+using AspNetFullFrameworkSampleApp.Controllers;
 using FluentAssertions;
 using Xunit;
 using Xunit.Abstractions;
@@ -115,6 +116,20 @@ namespace Elastic.Apm.AspNetFullFramework.Tests
 				receivedData.Transactions.Count.Should().Be(1);
 				var transaction = receivedData.Transactions.Single();
 				transaction.Name.Should().Be("GET WebApi");
+			});
+		}
+
+		[AspNetFullFrameworkFact]
+		public async Task Name_Should_Be_RouteTemplate_When_WebApi_Attribute_Routing()
+		{
+			var pathData = SampleAppUrlPaths.AttributeRoutingWebApiPage("foo");
+			await SendGetRequestToSampleAppAndVerifyResponse(pathData.Uri, pathData.StatusCode);
+
+			await WaitAndCustomVerifyReceivedData(receivedData =>
+			{
+				receivedData.Transactions.Count.Should().Be(1);
+				var transaction = receivedData.Transactions.Single();
+				transaction.Name.Should().Be($"GET {AttributeRoutingWebApiController.RoutePrefix}/{AttributeRoutingWebApiController.Route}");
 			});
 		}
 


### PR DESCRIPTION
This commit updates ElasticApmModule to get the transaction
name for a Web API controller routed with attribute routing
from the "MS_SubRoutes" route data value.

A delegate to get the template from IHttpRouteData when
System.Web.Http is referenced.

Closes #1176