### PR TITLE
Add TargetFramework NET5.0 to Elastic.Apm.AspNetCore & co

### DIFF
--- a/sample/SampleAspNetCoreApp/SampleAspNetCoreApp.csproj
+++ b/sample/SampleAspNetCoreApp/SampleAspNetCoreApp.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.0;netcoreapp3.1;net5.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   
@@ -18,6 +18,11 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="3.1.0" />
     <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="3.1.0" />
     <PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="3.1.0" />
+  </ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net5.0' ">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="5.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="5.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="5.0.0" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Data\" />

--- a/sample/SampleAspNetCoreApp/Startup.cs
+++ b/sample/SampleAspNetCoreApp/Startup.cs
@@ -52,7 +52,7 @@ namespace SampleAspNetCoreApp
 		}
 
 		// This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
-#if NETCOREAPP3_0 || NETCOREAPP3_1
+#if NETCOREAPP3_0 || NETCOREAPP3_1 || NET5_0
 		public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
 #else
 		public void Configure(IApplicationBuilder app, IHostingEnvironment env)
@@ -75,7 +75,7 @@ namespace SampleAspNetCoreApp
 
 		public static void ConfigureRoutingAndMvc(IApplicationBuilder app)
 		{
-#if NETCOREAPP3_0 || NETCOREAPP3_1
+#if NETCOREAPP3_0 || NETCOREAPP3_1 || NET5_0
 			app.UseRouting();
 
 			app.UseAuthentication();

--- a/sample/WebApiSample/Startup.cs
+++ b/sample/WebApiSample/Startup.cs
@@ -23,7 +23,7 @@ namespace WebApiSample
 
 
 		// This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
-#if NETCOREAPP3_0 || NETCOREAPP3_1
+#if NETCOREAPP3_0 || NETCOREAPP3_1 || NET5_0
 		public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
 #else
 		public void Configure(IApplicationBuilder app, IHostingEnvironment env)
@@ -39,7 +39,7 @@ namespace WebApiSample
 
 			app.UseHttpsRedirection();
 
-#if NETCOREAPP3_0 || NETCOREAPP3_1
+#if NETCOREAPP3_0 || NETCOREAPP3_1 || NET5_0
 			app.UseRouting();
 
 			app.UseEndpoints(endpoints => { endpoints.MapControllers(); });

--- a/sample/WebApiSample/WebApiSample.csproj
+++ b/sample/WebApiSample/WebApiSample.csproj
@@ -1,11 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.0;netcoreapp3.1;net5.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' != 'netcoreapp3.0' AND '$(TargetFramework)' != 'netcoreapp3.1' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.1' ">
     <PackageReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
 

--- a/src/Elastic.Apm.AspNetCore/ApmMiddlewareExtension.cs
+++ b/src/Elastic.Apm.AspNetCore/ApmMiddlewareExtension.cs
@@ -88,7 +88,7 @@ namespace Elastic.Apm.AspNetCore
 		}
 
 		internal static string GetEnvironmentName(this IServiceProvider serviceProvider) =>
-#if NETCOREAPP3_0
+#if NETCOREAPP3_0 || NET5_0
 			(serviceProvider.GetService(typeof(IWebHostEnvironment)) as IWebHostEnvironment)?.EnvironmentName;
 #else
 			(serviceProvider.GetService(typeof(IHostingEnvironment)) as IHostingEnvironment)?.EnvironmentName;

--- a/src/Elastic.Apm.AspNetCore/Elastic.Apm.AspNetCore.csproj
+++ b/src/Elastic.Apm.AspNetCore/Elastic.Apm.AspNetCore.csproj
@@ -5,7 +5,7 @@
     <PackageId>Elastic.Apm.AspNetCore</PackageId>
     <Description>Elastic APM for ASP.NET Core. This package contains auto instrumentation for ASP.NET Core. See: https://github.com/elastic/apm-agent-dotnet/tree/master/docs</Description>
     <PackageTags>apm, monitoring, elastic, elasticapm, analytics, aspnetcore</PackageTags>
-    <TargetFrameworks>netstandard2.0;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netcoreapp3.0;net5.0</TargetFrameworks>
     <IsPackable>true</IsPackable>
   </PropertyGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
@@ -22,6 +22,12 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="3.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.0.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="3.0.0" />
+  </ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net5.0' ">
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="5.0.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Elastic.Apm.Extensions.Hosting\Elastic.Apm.Extensions.Hosting.csproj" />

--- a/src/Elastic.Apm.NetCoreAll/Elastic.Apm.NetCoreAll.csproj
+++ b/src/Elastic.Apm.NetCoreAll/Elastic.Apm.NetCoreAll.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netcoreapp3.0;net5.0</TargetFrameworks>
     <RootNamespace>Elastic.Apm.NetCoreAll</RootNamespace>
     <PackageId>Elastic.Apm.NetCoreAll</PackageId>
     <Description>Elastic APM .NET agent. This is a convenient package that automatically pulls in ASP.NET Core, and Entity Framework Core auto instrumentation with the Elastic APM .NET Agent. If your application uses the Microsoft.AspNetCore.All package the easiest way to reference the Elastic APM project is to use this package. If you only need specific functionalities (e.g. EF Core monitoring, or ASP.NET Core without EF Core monitoring, etc) you can reference specific Elastic.Apm packages. See: https://github.com/elastic/apm-agent-dotnet/tree/master/docs</Description>

--- a/test/Elastic.Apm.AspNetCore.Static.Tests/Elastic.Apm.AspNetCore.Static.Tests.csproj
+++ b/test/Elastic.Apm.AspNetCore.Static.Tests/Elastic.Apm.AspNetCore.Static.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
     <PropertyGroup>
-      <TargetFrameworks>netcoreapp2.1;netcoreapp3.0;netcoreapp3.1</TargetFrameworks>
+      <TargetFrameworks>netcoreapp2.1;netcoreapp3.0;netcoreapp3.1;net5.0</TargetFrameworks>
     </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="5.6.0" />
@@ -23,6 +23,9 @@
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1' ">
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="3.1.0" />
+  </ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net5.0' ">
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="5.0.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\Elastic.Apm.AspNetCore\Elastic.Apm.AspNetCore.csproj" />

--- a/test/Elastic.Apm.AspNetCore.Tests/AspNetCoreBasicTests.cs
+++ b/test/Elastic.Apm.AspNetCore.Tests/AspNetCoreBasicTests.cs
@@ -96,8 +96,11 @@ namespace Elastic.Apm.AspNetCore.Tests
 
 			var aspNetCoreVersion = Assembly.Load("Microsoft.AspNetCore").GetName().Version.ToString();
 			_agent.Service.Framework.Version.Should().Be(aspNetCoreVersion);
-
+#if NET5_0
+			_agent.Service.Runtime.Name.Should().Be(Runtime.DotNet5Name);
+#else
 			_agent.Service.Runtime.Name.Should().Be(Runtime.DotNetCoreName);
+#endif
 			_agent.Service.Runtime.Version.Should().Be(Directory.GetParent(typeof(object).Assembly.Location).Name);
 
 			var transaction = _capturedPayload.FirstTransaction;
@@ -122,7 +125,9 @@ namespace Elastic.Apm.AspNetCore.Tests
 			}
 
 			//test transaction.context.request
-#if NETCOREAPP3_0 || NETCOREAPP3_1
+#if NET5_0
+			transaction.Context.Request.HttpVersion.Should().Be("1.1");
+#elif NETCOREAPP3_0 || NETCOREAPP3_1
 			transaction.Context.Request.HttpVersion.Should().Be("2");
 #else
 			transaction.Context.Request.HttpVersion.Should().Be("2.0");
@@ -242,7 +247,12 @@ namespace Elastic.Apm.AspNetCore.Tests
 			var aspNetCoreVersion = Assembly.Load("Microsoft.AspNetCore").GetName().Version.ToString();
 			_agent.Service.Framework.Version.Should().Be(aspNetCoreVersion);
 
+#if NET5_0
+			_agent.Service.Runtime.Name.Should().Be(Runtime.DotNet5Name);
+#else
 			_agent.Service.Runtime.Name.Should().Be(Runtime.DotNetCoreName);
+#endif
+
 			_agent.Service.Runtime.Version.Should().Be(Directory.GetParent(typeof(object).Assembly.Location).Name);
 
 
@@ -271,7 +281,9 @@ namespace Elastic.Apm.AspNetCore.Tests
 			}
 
 			//test transaction.context.request
-#if NETCOREAPP3_0 || NETCOREAPP3_1
+#if NET5_0
+			transaction.Context.Request.HttpVersion.Should().Be("1.1");
+#elif NETCOREAPP3_0 || NETCOREAPP3_1 
 			transaction.Context.Request.HttpVersion.Should().Be("2");
 #else
 			transaction.Context.Request.HttpVersion.Should().Be("2.0");
@@ -310,7 +322,7 @@ namespace Elastic.Apm.AspNetCore.Tests
 
 			response.IsSuccessStatusCode.Should().BeTrue();
 
-			_capturedPayload.WaitForSpans(count:5);
+			_capturedPayload.WaitForSpans(count: 5);
 			_capturedPayload.WaitForTransactions();
 			_capturedPayload.SpansOnFirstTransaction.Should().NotBeEmpty().And.Contain(n => n.Context.Db != null);
 		}
@@ -366,7 +378,7 @@ namespace Elastic.Apm.AspNetCore.Tests
 			response.IsSuccessStatusCode.Should().BeTrue();
 
 			_capturedPayload.WaitForTransactions();
-			_capturedPayload.WaitForSpans(count:6);
+			_capturedPayload.WaitForSpans(count: 6);
 			var spans = _capturedPayload.SpansOnFirstTransaction;
 			spans.Should().NotBeEmpty();
 			var controllerActionSpan = spans.Last();

--- a/test/Elastic.Apm.AspNetCore.Tests/DistributedTracingAspNetCoreTests.cs
+++ b/test/Elastic.Apm.AspNetCore.Tests/DistributedTracingAspNetCoreTests.cs
@@ -2,6 +2,7 @@
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
 
+using System.Diagnostics;
 using System.Linq;
 using System.Net.Http;
 using System.Reflection;
@@ -144,7 +145,7 @@ namespace Elastic.Apm.AspNetCore.Tests
 		{
 			_agent1.ConfigStore.CurrentSnapshot = new MockConfigSnapshot(transactionSampleRate: "0");
 
-			await ExecuteAndCheckDistributedCall();
+			await ExecuteAndCheckDistributedCall(true);
 
 			// Since the trace is non-sampled both transactions should me marked as not sampled
 			_payloadSender1.FirstTransaction.IsSampled.Should().BeFalse();
@@ -191,8 +192,25 @@ namespace Elastic.Apm.AspNetCore.Tests
 			_agent2?.Dispose();
 		}
 
-		private async Task ExecuteAndCheckDistributedCall()
+		/// <summary>
+		/// Executes the distributed tracing call between the 2 services.
+		/// </summary>
+		/// <param name="PreventStartingActivity">If true, we'll create an actvity on .NET 5</param>
+		/// <returns></returns>
+		private async Task ExecuteAndCheckDistributedCall(bool PreventStartingActivity = false)
 		{
+#if NET5_0
+			// .NET 5 has built-in W3C TraceContext support and Activity uses the W3C id format by default (pre .NET 5 it was opt-in)
+			// This means if there is no active activity, the outgoing HTTP request on HttpClient will add the traceparent header with
+			// a flag recorded=false. The agent would pick this up on the incoming call and start an unsampled transaction.
+			// To prevent this we start an activity and set the recorded flag to true.
+			Activity activity = null;
+			if (!PreventStartingActivity)
+			{
+				activity = new Activity("foo").Start();
+				activity.ActivityTraceFlags = ActivityTraceFlags.Recorded;
+			}
+#endif
 			var client = new HttpClient();
 			var res = await client.GetAsync("http://localhost:5901/Home/DistributedTracingMiniSample");
 			res.IsSuccessStatusCode.Should().BeTrue();
@@ -202,6 +220,10 @@ namespace Elastic.Apm.AspNetCore.Tests
 
 			//make sure the 2 transactions have the same traceid:
 			_payloadSender2.FirstTransaction.TraceId.Should().Be(_payloadSender1.FirstTransaction.TraceId);
+#if NET5_0
+			if (!PreventStartingActivity)
+				activity.Dispose();
+#endif
 		}
 	}
 }

--- a/test/Elastic.Apm.AspNetCore.Tests/DistributedTracingAspNetCoreTests.cs
+++ b/test/Elastic.Apm.AspNetCore.Tests/DistributedTracingAspNetCoreTests.cs
@@ -208,7 +208,7 @@ namespace Elastic.Apm.AspNetCore.Tests
 			if (!PreventStartingActivity)
 			{
 				activity = new Activity("foo").Start();
-				activity.ActivityTraceFlags = ActivityTraceFlags.Recorded;
+				activity.ActivityTraceFlags |= ActivityTraceFlags.Recorded;
 			}
 #endif
 			var client = new HttpClient();

--- a/test/Elastic.Apm.AspNetCore.Tests/Elastic.Apm.AspNetCore.Tests.csproj
+++ b/test/Elastic.Apm.AspNetCore.Tests/Elastic.Apm.AspNetCore.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.0;netcoreapp3.1;net5.0</TargetFrameworks>
     <AssemblyName>Elastic.Apm.AspNetCore.Tests</AssemblyName>
     <RootNamespace>Elastic.Apm.AspNetCore.Tests</RootNamespace>
   </PropertyGroup>
@@ -26,6 +26,9 @@
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1' ">
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="3.1.0" />
+  </ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net5.0' ">
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="5.0.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\Elastic.Apm.AspNetCore\Elastic.Apm.AspNetCore.csproj" />


### PR DESCRIPTION
Fixes https://github.com/elastic/apm-agent-dotnet/issues/1194. 

Also turning on all ASP.NET Core tests for .NET 5 as well.