### PR TITLE
Update editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -29,15 +29,22 @@ indent_size = 2
 # ---
 
 # ---
-# langugage conventions https://docs.microsoft.com/en-us/visualstudio/ide/editorconfig-code-style-settings-reference#language-conventions
+# language conventions https://docs.microsoft.com/en-us/visualstudio/ide/editorconfig-code-style-settings-reference#language-conventions
 
 # Sort using and Import directives with System.* appearing first
 dotnet_sort_system_directives_first = true
 
-# Prefer this.X except for _fields
-# TODO can we force _ for private fields?
-# TODO elevate severity after code cleanup to warning minimum
-# TODO use language latest
+# https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/naming-rules?view=vs-2017
+dotnet_naming_rule.private_members_with_underscore.symbols  = private_fields
+dotnet_naming_rule.private_members_with_underscore.style    = prefix_underscore
+dotnet_naming_rule.private_members_with_underscore.severity = suggestion
+
+dotnet_naming_symbols.private_fields.applicable_kinds           = field
+dotnet_naming_symbols.private_fields.applicable_accessibilities = private
+
+dotnet_naming_style.prefix_underscore.capitalization = camel_case
+dotnet_naming_style.prefix_underscore.required_prefix = _
+
 dotnet_style_qualification_for_field = false:error
 dotnet_style_qualification_for_property = false:error
 dotnet_style_qualification_for_method = false:error
@@ -90,26 +97,26 @@ csharp_preferred_modifier_order = public,private,protected,internal,static,exter
 
 # Newline settings (Allman yo!)
 csharp_new_line_before_open_brace = all
-csharp_new_line_before_else = true:error
-csharp_new_line_before_catch = true:error
-csharp_new_line_before_finally = true:error
+csharp_new_line_before_else = true
+csharp_new_line_before_catch = true
+csharp_new_line_before_finally = true
 csharp_new_line_before_members_in_object_initializers = true
 # just a suggestion do to our JSON tests that use anonymous types to 
 # represent json quite a bit (makes copy paste easier).
-csharp_new_line_before_members_in_anonymous_types = true:suggestion
-csharp_new_line_between_query_expression_clauses = true:error
+csharp_new_line_before_members_in_anonymous_types = true
+csharp_new_line_between_query_expression_clauses = true
 
 # Indent
-csharp_indent_case_contents = true:error
-csharp_indent_switch_labels = true:error
-csharp_space_after_cast = false:error
-csharp_space_after_keywords_in_control_flow_statements = true:error
-csharp_space_between_method_declaration_parameter_list_parentheses = false:error
-csharp_space_between_method_call_parameter_list_parentheses = false:error
+csharp_indent_case_contents = true
+csharp_indent_switch_labels = true
+csharp_space_after_cast = false
+csharp_space_after_keywords_in_control_flow_statements = true
+csharp_space_between_method_declaration_parameter_list_parentheses = false
+csharp_space_between_method_call_parameter_list_parentheses = false
 
 #Wrap
-csharp_preserve_single_line_statements = false:error
-csharp_preserve_single_line_blocks = true:error
+csharp_preserve_single_line_statements = false
+csharp_preserve_single_line_blocks = true
 
 # Resharper
 resharper_csharp_braces_for_lock=required_for_multiline
@@ -122,6 +129,9 @@ resharper_csharp_braces_for_ifelse=required_for_multiline
 
 resharper_csharp_accessor_owner_body=expression_body
 
+resharper_redundant_case_label_highlighting=do_not_show
+resharper_redundant_argument_default_value_highlighting=do_not_show
+
 [Jenkinsfile]
 indent_style = space
 indent_size = 2
@@ -133,3 +143,6 @@ insert_final_newline = true
 [*.{sh,bat,ps1}]
 trim_trailing_whitespace=true
 insert_final_newline=true
+
+[*.sh]
+end_of_line = lf


### PR DESCRIPTION
This commit updates the rules in editorconfig; It removes warnings for syntax errors and includes configuration to underscore prefix
private fields.