### PR TITLE
[Doc] Improve docs on stack trace capturing

### DIFF
--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -956,6 +956,8 @@ Setting it to 0 will disable stack trace collection. Any positive integer value 
 | `ELASTIC_APM_STACK_TRACE_LIMIT` | `ElasticApm:StackTraceLimit`
 |============
 
+NOTE: If you would like to disable stack trace capturing only for spans, but still capture stack traces for errors, set the <<SpanFramesMinDuration>> config to `0`.
+
 [float]
 [[config-span-frames-min-duration]]
 ==== `SpanFramesMinDuration` (performance)

--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -956,7 +956,7 @@ Setting it to 0 will disable stack trace collection. Any positive integer value 
 | `ELASTIC_APM_STACK_TRACE_LIMIT` | `ElasticApm:StackTraceLimit`
 |============
 
-NOTE: If you would like to disable stack trace capturing only for spans, but still capture stack traces for errors, set the <<SpanFramesMinDuration>> config to `0`.
+NOTE: If you would like to disable stack trace capturing only for spans, but still capture stack traces for errors, set the <<config-span-frames-min-duration>> config to `0`.
 
 [float]
 [[config-span-frames-min-duration]]

--- a/docs/troubleshooting.asciidoc
+++ b/docs/troubleshooting.asciidoc
@@ -134,12 +134,10 @@ writing to standard output.
 [[agent-overhead]]
 === The agent causes too much overhead
 
-A good place to start is our <<config-all-options-summary>>. There are multiple settings there with the `Performance` keyword which help you to tweak the agent for your needs.
+A good place to start is [config-all-options-summary]. There are multiple settings with the `Performance` keyword which can help you tweak the agent for your needs.
 
-The most expensive operation in the agent is typically stack trace capturing. The agent, by default only captures stack traces for spans with a duration of 5ms or more, and with a limit of 50 stack frames.
+The most expensive operation in the agent is typically stack trace capturing. The agent, by default, only captures stack traces for spans with a duration of 5ms or more, and with a limit of 50 stack frames.
+If this is too much in your environment, consider disabling stack trace capturing either partially or entirely:
 
-If this is too much in your environment, the <<config-span-frames-min-duration>> and the <<config-stack-trace-limit>> are two configuration worth looking at.
-
-By setting <<config-stack-trace-limit>> to `0` you can disable stack trace capturing completely which in most applications reduces the agent overhead dramatically.
-
-If you would like to capture stack traces for errors but skip stack trace capturing for spans, you can set the <<config-span-frames-min-duration>> to `0` and leave the <<config-stack-trace-limit>> on default.
+- To disable stack trace capturing for spans, but continue to capture stack traces for errors, set the [config-span-frames-min-duration] to `0` and leave the [config-stack-trace-limit] on its default.
+- To disable stack trace capturing entirely –which in most applications reduces the agent overhead dramatically– set [config-stack-trace-limit] to `0`.

--- a/docs/troubleshooting.asciidoc
+++ b/docs/troubleshooting.asciidoc
@@ -129,3 +129,17 @@ set ELASTIC_APM_STARTUP_HOOKS_LOGGING=1
 and then running the application in a context where the environment variable will be visible. In setting this value,
 an `ElasticApmAgentStartupHook.log` file is written to in the directory containing the startup hook assembly, in addition to
 writing to standard output.
+
+[float]
+[[agent-overhead]]
+=== The agent causes too much overhead
+
+A good place to start is our <<config-all-options-summary>>. There are multiple settings there with the `Performance` keyword which help you to tweak the agent for your needs.
+
+The most expensive operation in the agent is typically stack trace capturing. The agent, by default only captures stack traces for spans with a duration of 5ms or more, and with a limit of 50 stack frames.
+
+If this is too much in your environment, the <<config-span-frames-min-duration>> and the <<config-stack-trace-limit>> are two configuration worth looking at.
+
+By setting <<config-stack-trace-limit>> to `0` you can disable stack trace capturing completely which in most applications reduces the agent overhead dramatically.
+
+If you would like to capture stack traces for errors but skip stack trace capturing for spans, you can set the <<config-span-frames-min-duration>> to `0` and leave the <<config-stack-trace-limit>> on default.


### PR DESCRIPTION
Added a note on how to turn off stack trace capturing for spans, but keep it for errors. Also added a troubleshooting item which explains stack trace capturing overhead in a but more detail.

Inspired by https://github.com/elastic/apm-agent-dotnet/issues/1204 and https://github.com/elastic/apm-agent-dotnet/issues/1145.