### PR TITLE
Make sure the TraceEventSession is stopped in GcMetricsProvider

### DIFF
--- a/src/Elastic.Apm/Metrics/MetricsCollector.cs
+++ b/src/Elastic.Apm/Metrics/MetricsCollector.cs
@@ -97,8 +97,15 @@ namespace Elastic.Apm.Metrics
 				GcMetricsProvider.GcTimeName);
 			if (collectGcCount || collectGen0Size || collectGen1Size || collectGen2Size || collectGen3Size)
 			{
-				MetricsProviders.Add(new GcMetricsProvider(_logger, collectGcCount, collectGen0Size, collectGen1Size, collectGen2Size,
-					collectGen3Size, collectGcTime));
+				try
+				{
+					MetricsProviders.Add(new GcMetricsProvider(_logger, collectGcCount, collectGen0Size, collectGen1Size, collectGen2Size,
+						collectGen3Size, collectGcTime));
+				}
+				catch (Exception e)
+				{
+					_logger.Warning()?.LogException(e, "Failed loading {ProviderName}", nameof(GcMetricsProvider));
+				}
 			}
 
 			var collectCgroupMemLimitBytes = !WildcardMatcher.IsAnyMatch(currentConfigSnapshot.DisableMetrics,

--- a/src/Elastic.Apm/Metrics/MetricsProvider/GcMetricsProvider.cs
+++ b/src/Elastic.Apm/Metrics/MetricsProvider/GcMetricsProvider.cs
@@ -199,7 +199,7 @@ namespace Elastic.Apm.Metrics.MetricsProvider
 
 		private void RuntimeGCEnd(TraceProcess traceProcess, Microsoft.Diagnostics.Tracing.Analysis.GC.TraceGC gc)
 		{
-			if (traceProcess.ProcessID == Process.GetCurrentProcess().Id)
+			if (traceProcess.ProcessID == _currentProcessId)
 			{
 				if (!_isMetricAlreadyCaptured)
 				{

--- a/src/Elastic.Apm/Metrics/MetricsProvider/GcMetricsProvider.cs
+++ b/src/Elastic.Apm/Metrics/MetricsProvider/GcMetricsProvider.cs
@@ -164,6 +164,7 @@ namespace Elastic.Apm.Metrics.MetricsProvider
 				_traceEventSession.Source.Clr.GCStop -= ClrOnGCStop;
 				_traceEventSession.Source.Clr.GCHeapStats -= ClrOnGCHeapStats;
 				_traceEventSession.Source.Clr.GCStart -= ClrOnStart;
+				_traceEventSession.Stop(true);
 				_traceEventSession.Dispose();
 
 				if (_traceEventSessionTask.IsCompleted || _traceEventSessionTask.IsFaulted || _traceEventSessionTask.IsCanceled)

--- a/src/Elastic.Apm/Metrics/MetricsProvider/GcMetricsProvider.cs
+++ b/src/Elastic.Apm/Metrics/MetricsProvider/GcMetricsProvider.cs
@@ -176,7 +176,7 @@ namespace Elastic.Apm.Metrics.MetricsProvider
 				_traceEventSession.Source.Dispose();
 				_traceEventSession.Dispose();
 
-				if (_traceEventSessionTask.IsCompleted || _traceEventSessionTask.IsFaulted || _traceEventSessionTask.IsCanceled)
+				if (_traceEventSessionTask != null && (_traceEventSessionTask.IsCompleted || _traceEventSessionTask.IsFaulted || _traceEventSessionTask.IsCanceled))
 					_traceEventSessionTask.Dispose();
 			}
 		}

--- a/test/Elastic.Apm.Tests/MetricsTests.cs
+++ b/test/Elastic.Apm.Tests/MetricsTests.cs
@@ -298,7 +298,6 @@ namespace Elastic.Apm.Tests
 				var hasGenSize = false;
 				var hasGcTime = false;
 
-
 				for (var j = 0; j < 1000; j++)
 				{
 					for (var i = 0; i < 500; i++)

--- a/test/Elastic.Apm.Tests/MetricsTests.cs
+++ b/test/Elastic.Apm.Tests/MetricsTests.cs
@@ -298,7 +298,7 @@ namespace Elastic.Apm.Tests
 				var hasGenSize = false;
 				var hasGcTime = false;
 
-				for (var j = 0; j < 1000; j++)
+				for (var j = 0; j < 10; j++)
 				{
 					for (var i = 0; i < 500; i++)
 					{

--- a/test/Elastic.Apm.Tests/MetricsTests.cs
+++ b/test/Elastic.Apm.Tests/MetricsTests.cs
@@ -302,7 +302,9 @@ namespace Elastic.Apm.Tests
 				{
 					for (var i = 0; i < 500; i++)
 					{
-						var _ = new int[10000000];
+						var array = new int[10000000];
+						// In order to make sure the line above is not optimized away, let's use the array:
+						Console.WriteLine($"GC test, int[] allocated with length: {array.Length}");
 					}
 
 					GC.Collect(2, GCCollectionMode.Forced, true, true);
@@ -311,7 +313,9 @@ namespace Elastic.Apm.Tests
 
 					for (var i = 0; i < 500; i++)
 					{
-						var _ = new int[10000000];
+						var array = new int[10000000];
+						// In order to make sure the line above is not optimized away, let's use the array:
+						Console.WriteLine($"GC test, int[] allocated with length: {array.Length}");
 					}
 
 					GC.Collect(2, GCCollectionMode.Forced, true, true);

--- a/test/Elastic.Apm.Tests/MetricsTests.cs
+++ b/test/Elastic.Apm.Tests/MetricsTests.cs
@@ -101,7 +101,7 @@ namespace Elastic.Apm.Tests
 		{
 			var mockPayloadSender = new MockPayloadSender();
 			var testLogger = new TestLogger(LogLevel.Information);
-			using (var mc = new MetricsCollector(testLogger, mockPayloadSender, new ConfigStore(new MockConfigSnapshot(), testLogger)))
+			using (var mc = new MetricsCollector(testLogger, mockPayloadSender, new ConfigStore(new MockConfigSnapshot(disableMetrics: "*"), testLogger)))
 			{
 				mc.MetricsProviders.Clear();
 				var providerWithException = new MetricsProviderWithException();
@@ -301,19 +301,23 @@ namespace Elastic.Apm.Tests
 
 				for (var j = 0; j < 1000; j++)
 				{
-					for (var i = 0; i < 300_000; i++)
+					for (var i = 0; i < 500; i++)
 					{
-						var _ = new int[100];
+						var _ = new int[10000000];
 					}
 
-					GC.Collect();
+					GC.Collect(2, GCCollectionMode.Forced, true, true);
+					GC.WaitForFullGCComplete();
+					GC.Collect(2, GCCollectionMode.Forced, true, true);
 
-					for (var i = 0; i < 300_000; i++)
+					for (var i = 0; i < 500; i++)
 					{
-						var _ = new int[100];
+						var _ = new int[10000000];
 					}
 
-					GC.Collect();
+					GC.Collect(2, GCCollectionMode.Forced, true, true);
+					GC.WaitForFullGCComplete();
+					GC.Collect(2, GCCollectionMode.Forced, true, true);
 
 					var samples = gcMetricsProvider.GetSamples()?.ToArray();
 


### PR DESCRIPTION
Fixes https://github.com/elastic/apm-agent-dotnet/issues/1217 

- In the `CollectGcMetrics` do allocations on LOH and trigger LOH GC.
- Call `_traceEventSession.Source.Dispose();` in `GcMetricsProvider.Dispose()` - this was the key to fix the hang in CI (more details [here](https://github.com/elastic/apm-agent-dotnet/pull/1218#issuecomment-795948317)).
- On FullFramework use `TraceLoadedDotNetRuntime.GCEnd` to get GC duration instead of manually calculating it between the start and the stop event.