### PR TITLE
[Doc] Fix GC time doc

### DIFF
--- a/docs/metrics.asciidoc
+++ b/docs/metrics.asciidoc
@@ -169,9 +169,9 @@ The size of the generation 3 heap - also known as Large Object Heap (LOH).
 --
 type: long
 
-format: ticks
+format: ms
 
 Platform: all.
 
-The approximate accumulated collection elapsed time in https://docs.microsoft.com/en-us/dotnet/api/system.datetime.ticks[ticks].
+The approximate accumulated collection elapsed time in milliseconds.
 --


### PR DESCRIPTION
In https://github.com/elastic/apm-agent-dotnet/pull/1216 yesterday I made a mistake - by looking at the code I realize we send gc times in ms and not in ticks.