### PR TITLE
Skip packer cache on ARM

### DIFF
--- a/.ci/packer_cache.sh
+++ b/.ci/packer_cache.sh
@@ -2,4 +2,10 @@
 # shellcheck disable=SC1091
 source /usr/local/bin/bash_standard_lib.sh
 
-docker build --tag docker.elastic.co/observability-ci/apm-agent-dotnet-sdk-linux:latest .ci/docker/sdk-linux
+ARCH=$(uname -m| tr '[:upper:]' '[:lower:]')
+
+if [ "${ARCH}" == "x86_64" ] ; then
+    docker build --tag docker.elastic.co/observability-ci/apm-agent-dotnet-sdk-linux:latest .ci/docker/sdk-linux
+else
+    echo "The existing docker image on ARM is not supported yet."
+fi


### PR DESCRIPTION
Disable on ARM as long as the docker image uses amd64 arch:
- https://github.com/elastic/apm-agent-dotnet/blob/c6b7cb5f974f07301153ccf64389c30003511f00/.ci/docker/sdk-linux/Dockerfile#L20

