### PR TITLE
agent-zip: use assembly-rewriter during agent-zip creation to not depend on Newtonsoft.Json.dll

### DIFF
--- a/build/scripts/Build.fs
+++ b/build/scripts/Build.fs
@@ -202,9 +202,9 @@ module Build =
         let agentDir = Paths.BuildOutput name |> DirectoryInfo
 
         let internalizeJsonDotNet pathToDlls = 
-            let agentDllPath = pathToDlls + new string([|Path.DirectorySeparatorChar|]) + "Elastic.Apm.dll"
-            let newtonsoftJsonDllPath = pathToDlls + new string([|Path.DirectorySeparatorChar|]) + "Newtonsoft.Json.dll"
-            let newNewtonsoftJsonDllPath = pathToDlls + new string([|Path.DirectorySeparatorChar|]) + "ApmNewtonsoft.Json.dll"
+            let agentDllPath = sprintf "%s%c%s" pathToDlls Path.DirectorySeparatorChar "Elastic.Apm.dll" 
+            let newtonsoftJsonDllPath = sprintf "%s%c%s" pathToDlls Path.DirectorySeparatorChar "Newtonsoft.Json.dll"
+            let newNewtonsoftJsonDllPath = sprintf "%s%c%s" pathToDlls Path.DirectorySeparatorChar "ApmNewtonsoft.Json.dll"
             let args = ["-i"; agentDllPath; "-o "; agentDllPath; "-i "; newtonsoftJsonDllPath;  "-o"; newNewtonsoftJsonDllPath]
             Tooling.Rewriter args
 

--- a/build/scripts/Tooling.fs
+++ b/build/scripts/Tooling.fs
@@ -69,3 +69,10 @@ module Tooling =
         restoreDotnetTools.Force()    
         let args = args |> String.concat " "
         DotNet.Exec ["assembly-differ"; args]
+
+    let restoreOnce = lazy(DotNet.Exec ["tool"; "restore"])
+
+    let Rewriter args =
+        restoreDotnetTools.Force()
+        let args = args |> String.concat " "
+        DotNet.Exec ["assembly-rewriter"; args]

--- a/dotnet-tools.json
+++ b/dotnet-tools.json
@@ -7,6 +7,12 @@
       "commands": [
         "assembly-differ"
       ]
+    },
+    "assembly-rewriter": {
+      "version": "0.12.0",
+      "commands": [
+        "assembly-rewriter"
+      ]
     }
   }
 }

--- a/src/Elastic.Apm.StartupHook.Loader/Loader.cs
+++ b/src/Elastic.Apm.StartupHook.Loader/Loader.cs
@@ -42,7 +42,7 @@ namespace Elastic.Apm.StartupHook.Loader
 		public static void Initialize()
 		{
 			var agentLibsToLoad =  new[]{ "Elastic.Apm", "Elastic.Apm.Extensions.Hosting", "Elastic.Apm.AspNetCore", "Elastic.Apm.EntityFrameworkCore", "Elastic.Apm.SqlClient", "Elastic.Apm.GrpcClient", "Elastic.Apm.Elasticsearch" };
-			var agentDependencyLibsToLoad = new[] { "System.Diagnostics.PerformanceCounter", "Microsoft.Diagnostics.Tracing.TraceEvent", "Newtonsoft.Json", "Elasticsearch.Net" };
+			var agentDependencyLibsToLoad = new[] { "System.Diagnostics.PerformanceCounter", "Microsoft.Diagnostics.Tracing.TraceEvent", "ApmNewtonsoft.Json", "Elasticsearch.Net" };
 
 			foreach (var libToLoad in agentDependencyLibsToLoad)
 				AssemblyLoadContext.Default.LoadFromAssemblyPath(Path.Combine(AssemblyDirectory, libToLoad + ".dll"));


### PR DESCRIPTION
With this PR we get rid of the `Newtonsoft.Json.dll` dependency in the agent-zip for zero code attachment.

Some comments: I wanted to merge `Newtonsoft.Json.dll` instead of just renaming it, but I ran into this error:

```
[2021-03-17T18:53:36.74+01:00][Repack][Info   ]Adding assembly for merge: ...\build\output\ElasticApmAgent\5.0.0\Elastic.Apm.dll
[2021-03-17T18:53:36.88+01:00][Repack][Info   ]Adding assembly for merge:  ...\build\output\ElasticApmAgent\5.0.0\ApmNewtonsoft.Json.dll
[2021-03-17T18:53:36.92+01:00][Repack][Info   ]Processing references
Mono.Cecil.AssemblyResolutionException: Failed to resolve assembly: 'IKVM.Runtime, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null'
   at Mono.Cecil.BaseAssemblyResolver.Resolve(AssemblyNameReference name, ReaderParameters parameters)
   at Mono.Cecil.BaseAssemblyResolver.Resolve(String fullName, ReaderParameters parameters)
   at Mono.Cecil.BaseAssemblyResolver.Resolve(String fullName)
   at ILRepacking.IKVMLineIndexer.PostRepackReferences()
   at ILRepacking.Steps.ReferencesRepackStep.Perform()
   at ILRepacking.ILRepack.Repack()
   at AssemblyRewriter.Program.Run(Options options) in /home/runner/work/assembly-rewriter/assembly-rewriter/src/assembly-rewriter/Program.cs:line 69
:: agent-zip: Failed! Process exited with '2' "assembly-rewriter -i  ...\output\ElasticApmAgent\5.0.0\Elastic.Apm.dll -o  ...\build\output\ElasticApmAgent\5.0.0\Elastic.Apm.dll -i  ...\build\output\ElasticApmAgent\5.0.0\Newtonsoft.Json.dll -o  ...\build\output\ElasticApmAgent\5.0.0\ApmNewtonsoft.Json.dll -m" (24.75 s)
```

Both our F# scripts and just running something like this ends up with the same issue: `assembly-rewriter -i Elastic.Apm.dll -o NElastic.Apm.dll -i Newtonsoft.Json.dll -o NNewtonsoft.Json.dll -m`

Merging into a single assembly is not strictly needed, but if there are ideas on how to fix it I can follow up on this.