### PR TITLE
Use current activity if there is one

### DIFF
--- a/src/Elastic.Apm/Model/Transaction.cs
+++ b/src/Elastic.Apm/Model/Transaction.cs
@@ -29,6 +29,8 @@ namespace Elastic.Apm.Model
 		private readonly IPayloadSender _sender;
 		private readonly string _traceState;
 
+		// Flags whether the agent created a new Activity for this transaction.
+		// If there is an existing Activity using W3C format, no Activity will be created and this remains false.
 		private bool _createdActivity;
 
 		// This constructor is meant for serialization
@@ -171,7 +173,7 @@ namespace Elastic.Apm.Model
 			}
 
 			// Also mark the sampling decision on the Activity
-			if (IsSampled && _activity != null && !ignoreActivity && _createdActivity)
+			if (IsSampled && _activity != null && !ignoreActivity)
 				_activity.ActivityTraceFlags |= ActivityTraceFlags.Recorded;
 
 			SampleRate = IsSampled ? sampler.Rate : 0;


### PR DESCRIPTION
This commit fixes a bug whereby `Activity.Current` should be used
to set the TraceId if

1. it's not null
2. it's using W3C Id format
3. activity are not being ignored