### PR TITLE
Allow custom registration of Redis ElasticApmProfiler

### DIFF
--- a/src/Elastic.Apm.StackExchange.Redis/ElasticApmProfiler.cs
+++ b/src/Elastic.Apm.StackExchange.Redis/ElasticApmProfiler.cs
@@ -18,7 +18,7 @@ namespace Elastic.Apm.StackExchange.Redis
 	/// <summary>
 	/// Captures redis commands sent with StackExchange.Redis client
 	/// </summary>
-	internal class ElasticApmProfiler
+	public class ElasticApmProfiler
 	{
 		private readonly ConcurrentDictionary<string, ProfilingSession> _executionSegmentSessions =
 			new ConcurrentDictionary<string, ProfilingSession>();


### PR DESCRIPTION
In order to register the profiler for `Microsoft.Extensions.Caching.StackExchangeRedis` we need public access to `ElasticApmProfiler` because the `IConnectionMultiplexer` is encapsulated in the `RedisCache` implementation.

Bellow is an example for which I have also opened a PR in https://github.com/dotnet/aspnetcore/pull/31018 to allow hooking up the `ProfilerSession`

```csharp
public static class ServiceCollectionExtensions
{
    public static void RegisterElasticApmRedis(this IServiceCollection services)
    {
        services
            .AddSingleton<IDistributedCache>(sp =>
            {
                var profiler = new ElasticApmProfiler(sp.GetService<IApmAgent>);
                var options = new RedisCacheOptions()
                {
                    Configuration = "localhost",
                    ProfilingSession = profiler.GetProfilingSession
                };

                return new RedisCache(options);
            });
    }
}
```