### PR TITLE
Allow access to MetricSet and improve memory allocation on MetricSample

### DIFF
--- a/src/Elastic.Apm/Api/MetricSample.cs
+++ b/src/Elastic.Apm/Api/MetricSample.cs
@@ -10,13 +10,17 @@ namespace Elastic.Apm.Api
 	/// <summary>
 	/// A single metric sample.
 	/// </summary>
-	public class MetricSample
+	public readonly struct MetricSample
 	{
 		public MetricSample(string key, double value)
-			=> KeyValue = new KeyValuePair<string, double>(key, value);
+		{
+			Key = key;
+			Value = value;
+		}
 
-		internal KeyValuePair<string, double> KeyValue { get; }
+		internal string Key { get; }
+		internal double Value { get; }
 
-		public override string ToString() => new ToStringBuilder(nameof(MetricSample)) { { KeyValue.Key, KeyValue.Value } }.ToString();
+		public override string ToString() => new ToStringBuilder(nameof(MetricSample)) { { Key, Value } }.ToString();
 	}
 }

--- a/src/Elastic.Apm/Helpers/TimeUtils.cs
+++ b/src/Elastic.Apm/Helpers/TimeUtils.cs
@@ -6,7 +6,7 @@ using System;
 
 namespace Elastic.Apm.Helpers
 {
-	public static class TimeUtils
+	internal static class TimeUtils
 	{
 		/// <summary>
 		/// DateTime.UnixEpoch Field does not exist in .NET Standard 2.0
@@ -14,7 +14,7 @@ namespace Elastic.Apm.Helpers
 		/// </summary>
 		internal static readonly DateTime UnixEpochDateTime = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
 
-		public static long TimestampNow() => ToTimestamp(DateTime.UtcNow);
+		internal static long TimestampNow() => ToTimestamp(DateTime.UtcNow);
 
 		/// <summary>
 		/// UTC based and formatted as microseconds since Unix epoch.

--- a/src/Elastic.Apm/Helpers/TimeUtils.cs
+++ b/src/Elastic.Apm/Helpers/TimeUtils.cs
@@ -6,7 +6,7 @@ using System;
 
 namespace Elastic.Apm.Helpers
 {
-	internal static class TimeUtils
+	public static class TimeUtils
 	{
 		/// <summary>
 		/// DateTime.UnixEpoch Field does not exist in .NET Standard 2.0
@@ -14,7 +14,7 @@ namespace Elastic.Apm.Helpers
 		/// </summary>
 		internal static readonly DateTime UnixEpochDateTime = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
 
-		internal static long TimestampNow() => ToTimestamp(DateTime.UtcNow);
+		public static long TimestampNow() => ToTimestamp(DateTime.UtcNow);
 
 		/// <summary>
 		/// UTC based and formatted as microseconds since Unix epoch.

--- a/src/Elastic.Apm/Metrics/MetricSet.cs
+++ b/src/Elastic.Apm/Metrics/MetricSet.cs
@@ -10,7 +10,7 @@ using Newtonsoft.Json;
 namespace Elastic.Apm.Metrics
 {
 	[JsonConverter(typeof(MetricSetConverter))]
-	internal class MetricSet : IMetricSet
+	public class MetricSet : IMetricSet
 	{
 		public MetricSet(long timestamp, IEnumerable<MetricSample> samples)
 			=> (Timestamp, Samples) = (timestamp, samples);

--- a/src/Elastic.Apm/Metrics/MetricSet.cs
+++ b/src/Elastic.Apm/Metrics/MetricSet.cs
@@ -4,6 +4,7 @@
 
 using System.Collections.Generic;
 using Elastic.Apm.Api;
+using Elastic.Apm.Helpers;
 using Elastic.Apm.Report.Serialization;
 using Newtonsoft.Json;
 
@@ -12,6 +13,9 @@ namespace Elastic.Apm.Metrics
 	[JsonConverter(typeof(MetricSetConverter))]
 	public class MetricSet : IMetricSet
 	{
+		public MetricSet(IEnumerable<MetricSample> samples)
+			: this(TimeUtils.TimestampNow(), samples)  { }
+
 		public MetricSet(long timestamp, IEnumerable<MetricSample> samples)
 			=> (Timestamp, Samples) = (timestamp, samples);
 

--- a/src/Elastic.Apm/Metrics/MetricsCollector.cs
+++ b/src/Elastic.Apm/Metrics/MetricsCollector.cs
@@ -210,7 +210,7 @@ namespace Elastic.Apm.Metrics
 					_logger.Trace()?.Log("Start collecting {MetricsProviderName}", metricsProvider.DbgName);
 
 					var samplesFromProvider = metricsProvider.GetSamples()
-						?.Where(x => !double.IsNaN(x.KeyValue.Value) && !double.IsInfinity(x.KeyValue.Value))
+						?.Where(x => !double.IsNaN(x.Value) && !double.IsInfinity(x.Value))
 						.ToArray();
 
 					if (samplesFromProvider != null && samplesFromProvider.Length > 0)

--- a/src/Elastic.Apm/Metrics/MetricsCollector.cs
+++ b/src/Elastic.Apm/Metrics/MetricsCollector.cs
@@ -168,7 +168,7 @@ namespace Elastic.Apm.Metrics
 				return;
 			}
 
-			var metricSet = new MetricSet(TimeUtils.TimestampNow(), samplesFromAllProviders);
+			var metricSet = new MetricSet(samplesFromAllProviders);
 
 			try
 			{

--- a/src/Elastic.Apm/Report/Serialization/MetricSetConverter.cs
+++ b/src/Elastic.Apm/Report/Serialization/MetricSetConverter.cs
@@ -23,14 +23,14 @@ namespace Elastic.Apm.Report.Serialization
 			var addedKeys = new HashSet<string>();
 			foreach (var item in value.Samples)
 			{
-				if (addedKeys.Add(item.KeyValue.Key))
+				if (addedKeys.Add(item.Key))
 				{
-					writer.WritePropertyName(item.KeyValue.Key
+					writer.WritePropertyName(item.Key
 						.Replace('*', '_')
 						.Replace('"', '_'));
 					writer.WriteStartObject();
 					writer.WritePropertyName("value");
-					writer.WriteValue(item.KeyValue.Value);
+					writer.WriteValue(item.Value);
 					writer.WriteEndObject();
 				}
 			}

--- a/test/Elastic.Apm.Tests/ConfigTests.cs
+++ b/test/Elastic.Apm.Tests/ConfigTests.cs
@@ -948,13 +948,13 @@ namespace Elastic.Apm.Tests
 			var firstMetrics = mockPayloadSender.Metrics.First();
 			firstMetrics.Should().NotBeNull();
 
-			firstMetrics.Samples.Should().NotContain(n => n.KeyValue.Key.Contains("cpu"));
+			firstMetrics.Samples.Should().NotContain(n => n.Key.Contains("cpu"));
 
 			//These are collected on all platforms, with the given config they always should be there
 			firstMetrics.Samples.Should()
-				.Contain(n => n.KeyValue.Key.Equals("system.process.memory.size", StringComparison.InvariantCultureIgnoreCase));
+				.Contain(n => n.Key.Equals("system.process.memory.size", StringComparison.InvariantCultureIgnoreCase));
 			firstMetrics.Samples.Should()
-				.Contain(n => n.KeyValue.Key.Equals("system.process.memory.rss.bytes", StringComparison.InvariantCultureIgnoreCase));
+				.Contain(n => n.Key.Equals("system.process.memory.rss.bytes", StringComparison.InvariantCultureIgnoreCase));
 		}
 
 		[Theory]

--- a/test/Elastic.Apm.Tests/Metrics/CgroupMetricsProviderTests.cs
+++ b/test/Elastic.Apm.Tests/Metrics/CgroupMetricsProviderTests.cs
@@ -49,18 +49,18 @@ namespace Elastic.Apm.Tests.Metrics
 
 				samples.Should().HaveCountGreaterOrEqualTo(2);
 
-				var inactiveFileBytesSample = samples.SingleOrDefault(s => s.KeyValue.Key == SystemProcessCgroupMemoryStatsInactiveFileBytes);
+				var inactiveFileBytesSample = samples.SingleOrDefault(s => s.Key == SystemProcessCgroupMemoryStatsInactiveFileBytes);
 				inactiveFileBytesSample.Should().NotBeNull();
 
-				var memUsageSample = samples.SingleOrDefault(s => s.KeyValue.Key == SystemProcessCgroupMemoryMemUsageBytes);
+				var memUsageSample = samples.SingleOrDefault(s => s.Key == SystemProcessCgroupMemoryMemUsageBytes);
 				memUsageSample.Should().NotBeNull();
-				memUsageSample?.KeyValue.Value.Should().Be(value);
+				memUsageSample.Value.Should().Be(value);
 
 				if (memLimit.HasValue)
 				{
-					var memLimitSample = samples.SingleOrDefault(s => s.KeyValue.Key == SystemProcessCgroupMemoryMemLimitBytes);
+					var memLimitSample = samples.SingleOrDefault(s => s.Key == SystemProcessCgroupMemoryMemLimitBytes);
 					memLimitSample.Should().NotBeNull();
-					memLimitSample?.KeyValue.Value.Should().Be(memLimit);
+					memLimitSample.Value.Should().Be(memLimit);
 				}
 			}
 		}
@@ -87,12 +87,12 @@ namespace Elastic.Apm.Tests.Metrics
 			var cgroupMetrics = CreateUnlimitedSystemCgroupMetricsProvider("/proc/cgroup","/proc/unlimited/memory", "cgroup cgroup");
 			var samples = cgroupMetrics.GetSamples().ToList();
 
-			var memLimitSample = samples.SingleOrDefault(s => s.KeyValue.Key == SystemProcessCgroupMemoryMemLimitBytes);
+			var memLimitSample = samples.SingleOrDefault(s => s.Key == SystemProcessCgroupMemoryMemLimitBytes);
 			memLimitSample.Should().BeNull();
 
-			var memUsageSample = samples.SingleOrDefault(s => s.KeyValue.Key == SystemProcessCgroupMemoryMemUsageBytes);
+			var memUsageSample = samples.SingleOrDefault(s => s.Key == SystemProcessCgroupMemoryMemUsageBytes);
 			memUsageSample.Should().NotBeNull();
-			memUsageSample?.KeyValue.Value.Should().Be(964778496);
+			memUsageSample.Value.Should().Be(964778496);
 		}
 
 		[Fact]
@@ -101,12 +101,12 @@ namespace Elastic.Apm.Tests.Metrics
 			var cgroupMetrics = CreateUnlimitedSystemCgroupMetricsProvider("/proc/cgroup2","/proc/sys_cgroup2_unlimited", "cgroup2 cgroup");
 			var samples = cgroupMetrics.GetSamples().ToList();
 
-			var memLimitSample = samples.SingleOrDefault(s => s.KeyValue.Key == SystemProcessCgroupMemoryMemLimitBytes);
+			var memLimitSample = samples.SingleOrDefault(s => s.Key == SystemProcessCgroupMemoryMemLimitBytes);
 			memLimitSample.Should().BeNull();
 
-			var memUsageSample = samples.SingleOrDefault(s => s.KeyValue.Key == SystemProcessCgroupMemoryMemUsageBytes);
+			var memUsageSample = samples.SingleOrDefault(s => s.Key == SystemProcessCgroupMemoryMemUsageBytes);
 			memUsageSample.Should().NotBeNull();
-			memUsageSample?.KeyValue.Value.Should().Be(964778496);
+			memUsageSample.Value.Should().Be(964778496);
 		}
 
 		/// <summary>

--- a/test/Elastic.Apm.Tests/MetricsTests.cs
+++ b/test/Elastic.Apm.Tests/MetricsTests.cs
@@ -72,8 +72,8 @@ namespace Elastic.Apm.Tests
 			var retVal = systemTotalCpuProvider.GetSamples();
 			var metricSamples = retVal as MetricSample[] ?? retVal.ToArray();
 
-			metricSamples.First().KeyValue.Value.Should().BeGreaterOrEqualTo(0);
-			metricSamples.First().KeyValue.Value.Should().BeLessOrEqualTo(1);
+			metricSamples.First().Value.Should().BeGreaterOrEqualTo(0);
+			metricSamples.First().Value.Should().BeLessOrEqualTo(1);
 		}
 
 		[Fact]
@@ -82,7 +82,7 @@ namespace Elastic.Apm.Tests
 			var processTotalCpuProvider = new ProcessTotalCpuTimeProvider(new NoopLogger());
 			Thread.Sleep(1000); //See https://github.com/elastic/apm-agent-dotnet/pull/264#issuecomment-499778288
 			var retVal = processTotalCpuProvider.GetSamples();
-			retVal.First().KeyValue.Value.Should().BeInRange(0, 1);
+			retVal.First().Value.Should().BeInRange(0, 1);
 		}
 
 		[Fact]
@@ -93,7 +93,7 @@ namespace Elastic.Apm.Tests
 
 			var enumerable = retVal as MetricSample[] ?? retVal.ToArray();
 			enumerable.Should().NotBeEmpty();
-			enumerable.First().KeyValue.Value.Should().BeGreaterThan(0);
+			enumerable.First().Value.Should().BeGreaterThan(0);
 		}
 
 		[Fact]
@@ -326,11 +326,11 @@ namespace Elastic.Apm.Tests
 
 					containsValue = samples != null && samples.Any();
 					hasGenSize = samples != null && samples
-						.Any(n => (n.KeyValue.Key.Contains("gen0size") || n.KeyValue.Key.Contains("gen1size")
-						|| n.KeyValue.Key.Contains("gen2size") || n.KeyValue.Key.Contains("gen3size"))
-						&& n.KeyValue.Value > 0);
+						.Any(n => (n.Key.Contains("gen0size") || n.Key.Contains("gen1size")
+						|| n.Key.Contains("gen2size") || n.Key.Contains("gen3size"))
+						&& n.Value > 0);
 					hasGcTime = samples != null && samples
-						.Any(n => n.KeyValue.Key.Contains("clr.gc.time") && n.KeyValue.Value > 0);
+						.Any(n => n.Key.Contains("clr.gc.time") && n.Value > 0);
 
 					if (containsValue && hasGenSize && hasGcTime)
 						break;

--- a/test/Elastic.Apm.Tests/SerializationTests.cs
+++ b/test/Elastic.Apm.Tests/SerializationTests.cs
@@ -421,8 +421,8 @@ namespace Elastic.Apm.Tests
 			var count = 0;
 			foreach (var sample in deserialized.Samples)
 			{
-				sample.KeyValue.Key.Should().Be(samples[count].KeyValue.Key.Replace("*", "_").Replace("\"", "_"));
-				sample.KeyValue.Value.Should().Be(samples[count].KeyValue.Value);
+				sample.Key.Should().Be(samples[count].Key.Replace("*", "_").Replace("\"", "_"));
+				sample.Value.Should().Be(samples[count].Value);
 				++count;
 			}
 		}


### PR DESCRIPTION
For users to send custom metrics, must have access to `MetricSet` as in #322 mentioned.
In the same time I did an optimization on `MetricSample`.

I'm working o a prototype to integrate `IPayloadSender.QueueMetrics` with `Metrics.NET` library