### PR TITLE
Support GraphQL Activity

### DIFF
--- a/src/Elastic.Apm.AspNetCore/WebRequestTransactionCreator.cs
+++ b/src/Elastic.Apm.AspNetCore/WebRequestTransactionCreator.cs
@@ -238,15 +238,13 @@ namespace Elastic.Apm.AspNetCore
 
 		private static RequestInfo? CollectRequestInfo(Transaction transaction)
 		{
-			switch (Activity.Current?.Parent?.OperationName)
-			{
-				case "Grpc.Net.Client.GrpcOut":
-					return CollectGrpcInfo(Activity.Current, transaction);
-				case "GraphQL":
-					return CollectGraphQlInfo(Activity.Current);
-				default:
-					return default;
-			}
+			if (Activity.Current?.Parent?.OperationName == "Grpc.Net.Client.GrpcOut")
+				return CollectGrpcInfo(Activity.Current?.Parent, transaction);
+
+			if (Activity.Current?.OperationName == "GraphQL")
+				return CollectGraphQlInfo(Activity.Current);
+
+			return default;
 		}
 
 		/// <summary>

--- a/src/Elastic.Apm.AspNetCore/WebRequestTransactionCreator.cs
+++ b/src/Elastic.Apm.AspNetCore/WebRequestTransactionCreator.cs
@@ -255,16 +255,16 @@ namespace Elastic.Apm.AspNetCore
 		private static RequestInfo? CollectGraphQlInfo(Activity activity)
 		{
 			RequestInfo? requestInfo = default;
-			var operationName = activity.Tags.FirstOrDefault(n => n.Key == "graphql.operation").Value;
-			var operationResult = activity.Tags.FirstOrDefault(n => n.Key == "graphql.result").Value;
-			var operationOutcome = activity.Tags.FirstOrDefault(n => n.Key == "graphql.outcome").Value;
+			var name = activity.Tags.FirstOrDefault(n => n.Key == "graphql.operation").Value;
+			var result = activity.Tags.FirstOrDefault(n => n.Key == "graphql.result").Value;
+			var rawOutcome = activity.Tags.FirstOrDefault(n => n.Key == "graphql.outcome").Value;
 
-			if (!string.IsNullOrEmpty(operationName) && !string.IsNullOrEmpty(operationResult))
+			if (!string.IsNullOrEmpty(name) && !string.IsNullOrEmpty(result) && !string.IsNullOrEmpty(rawOutcome))
 			{
-				if (!Enum.TryParse(operationOutcome, true, out Outcome outcome))
+				if (!Enum.TryParse(rawOutcome, true, out Outcome outcome))
 					outcome = Outcome.Unknown;
 
-				requestInfo = new RequestInfo(operationName, operationResult, outcome);
+				requestInfo = new RequestInfo(name, result, outcome);
 			}
 
 			return requestInfo;


### PR DESCRIPTION
As we discussed [here](https://github.com/elastic/apm-agent-dotnet/issues/1184) I added a posibility for any GraphQL library to can overwrite the `Name`, `Result` and `Outcome` of the `AspNetCore` `Transaction` in the same way as `Grpc` is implemented.

Because there is no common way of doing it, I've defined that:
- `Activity.OperationName` should be `GraphQL`
- `Activity.Tag` `graphql.operation` would be `Transaction.Name`
- `Activity.Tag` `graphql.result` would be `Transaction.Result`
- `Activity.Tag` `graphql.outcome` would be `Transaction.Outcome`

This will resolve #1184