### PR TITLE
Read recording key in AbstractConfigurationWithEnvFallbackReader

### DIFF
--- a/src/Elastic.Apm/Config/AbstractConfigurationWithEnvFallbackReader.cs
+++ b/src/Elastic.Apm/Config/AbstractConfigurationWithEnvFallbackReader.cs
@@ -84,7 +84,7 @@ namespace Elastic.Apm.Config
 			ParseMetricsInterval(Read(KeyNames.MetricsInterval, EnvVarNames.MetricsInterval));
 
 		public bool Recording =>
-			ParseEnabled(Read(KeyNames.Enabled, EnvVarNames.Enabled));
+			ParseEnabled(Read(KeyNames.Recording, EnvVarNames.Recording));
 
 		public IReadOnlyList<WildcardMatcher> SanitizeFieldNames =>
 			ParseSanitizeFieldNames(Read(KeyNames.SanitizeFieldNames, EnvVarNames.SanitizeFieldNames));

--- a/src/Elastic.Apm/Config/AbstractConfigurationWithEnvFallbackReader.cs
+++ b/src/Elastic.Apm/Config/AbstractConfigurationWithEnvFallbackReader.cs
@@ -84,7 +84,7 @@ namespace Elastic.Apm.Config
 			ParseMetricsInterval(Read(KeyNames.MetricsInterval, EnvVarNames.MetricsInterval));
 
 		public bool Recording =>
-			ParseEnabled(Read(KeyNames.Recording, EnvVarNames.Recording));
+			ParseRecording(Read(KeyNames.Recording, EnvVarNames.Recording));
 
 		public IReadOnlyList<WildcardMatcher> SanitizeFieldNames =>
 			ParseSanitizeFieldNames(Read(KeyNames.SanitizeFieldNames, EnvVarNames.SanitizeFieldNames));

--- a/test/Elastic.Apm.Tests/ConfigTests.cs
+++ b/test/Elastic.Apm.Tests/ConfigTests.cs
@@ -218,6 +218,19 @@ namespace Elastic.Apm.Tests
 			agent.ConfigurationReader.Recording.Should().BeTrue();
 		}
 
+		[Theory]
+		[InlineData("true", true)]
+		[InlineData("false", false)]
+		[InlineData("True", true)]
+		[InlineData("False", false)]
+		[InlineData("       True         ", true)]
+		[InlineData("       False        ", false)]
+		public void RecordingTestWithValidValue(string value, bool expected)
+		{
+			using var agent = new ApmAgent(new TestAgentComponents(config: new MockConfigSnapshot(recording: value)));
+			agent.ConfigurationReader.Recording.Should().Be(expected);
+		}
+
 		/// <summary>
 		/// Makes sure that in case Enabled is set to invalid value, the agent uses true as default value
 		/// </summary>


### PR DESCRIPTION
This commit fixes a bug whereby the Recording configuration value was reading
from the wrong configuration/environment key.

Fixes #1250