### PR TITLE
Move error capturing to Error event handler

### DIFF
--- a/src/Elastic.Apm.AspNetFullFramework/ElasticApmModule.cs
+++ b/src/Elastic.Apm.AspNetFullFramework/ElasticApmModule.cs
@@ -270,8 +270,7 @@ namespace Elastic.Apm.AspNetFullFramework
 				if (exception is HttpUnhandledException unhandledException && unhandledException.InnerException != null)
 					exception = unhandledException.InnerException;
 
-				var segment = (IExecutionSegment)Agent.Instance.Tracer.CurrentSpan ?? transaction;
-				segment.CaptureException(exception);
+				transaction.CaptureException(exception);
 			}
 		}
 


### PR DESCRIPTION
This PR moves the capturing of exceptions to an Error event handler. This handler runs before an `Application_Error` event handler that may be defined on the `HttpApplication` derived type in Global.asax.cs, which may perform some action with errors that affects collecting them in the EndRequest handler e.g. calling `Server.ClearError()`;