### PR TITLE
Revert "Update dotnet sdk 5.0 docker image"

### DIFF
--- a/.ci/docker/sdk-linux/Dockerfile
+++ b/.ci/docker/sdk-linux/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:5.0.102-ca-patch-buster-slim
+FROM mcr.microsoft.com/dotnet/sdk:5.0
 
 ENV DOTNET_ROOT=/usr/share/dotnet
 ENV PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:${DOTNET_ROOT}/tools:${DOTNET_ROOT}


### PR DESCRIPTION
Reverts elastic/apm-agent-dotnet#1149

This `5.0.102-ca-patch-buster-slim` tag is no longer needed and is no longer serviced.

Context: https://github.com/dotnet/dotnet-docker/issues/2742

As an aside, do you have any feedback on how .NET container images can be improved? Do they meet your expectations?