### PR TITLE
Avoid array allocation in DiagnosticInitializer

### DIFF
--- a/src/Elastic.Apm.AspNetCore/DiagnosticListener/AspNetCoreDiagnosticSubscriber.cs
+++ b/src/Elastic.Apm.AspNetCore/DiagnosticListener/AspNetCoreDiagnosticSubscriber.cs
@@ -15,7 +15,7 @@ namespace Elastic.Apm.AspNetCore.DiagnosticListener
 			if (!agent.ConfigurationReader.Enabled)
 				return retVal;
 
-			var subscriber = new DiagnosticInitializer(agent.Logger, new[] { new AspNetCoreDiagnosticListener(agent as ApmAgent), });
+			var subscriber = new DiagnosticInitializer(agent.Logger, new AspNetCoreDiagnosticListener(agent as ApmAgent));
 			retVal.Add(subscriber);
 
 			retVal.Add(System.Diagnostics.DiagnosticListener

--- a/src/Elastic.Apm.AspNetCore/DiagnosticListener/AspNetCoreErrorDiagnosticsSubscriber.cs
+++ b/src/Elastic.Apm.AspNetCore/DiagnosticListener/AspNetCoreErrorDiagnosticsSubscriber.cs
@@ -23,7 +23,7 @@ namespace Elastic.Apm.AspNetCore.DiagnosticListener
 			if (!agent.ConfigurationReader.Enabled)
 				return retVal;
 
-			var subscriber = new DiagnosticInitializer(agent.Logger, new[] { new AspNetCoreErrorDiagnosticListener(agent) });
+			var subscriber = new DiagnosticInitializer(agent.Logger, new AspNetCoreErrorDiagnosticListener(agent));
 			retVal.Add(subscriber);
 
 			retVal.Add(System.Diagnostics.DiagnosticListener

--- a/src/Elastic.Apm.Azure.ServiceBus/AzureMessagingServiceBusDiagnosticsSubscriber.cs
+++ b/src/Elastic.Apm.Azure.ServiceBus/AzureMessagingServiceBusDiagnosticsSubscriber.cs
@@ -21,7 +21,7 @@ namespace Elastic.Apm.Azure.ServiceBus
 		{
 			var retVal = new CompositeDisposable();
 
-			var initializer = new DiagnosticInitializer(agent.Logger, new[] { new AzureMessagingServiceBusDiagnosticListener(agent) });
+			var initializer = new DiagnosticInitializer(agent.Logger, new AzureMessagingServiceBusDiagnosticListener(agent));
 			retVal.Add(initializer);
 
 			retVal.Add(DiagnosticListener

--- a/src/Elastic.Apm.Azure.ServiceBus/MicrosoftAzureServiceBusDiagnosticsSubscriber.cs
+++ b/src/Elastic.Apm.Azure.ServiceBus/MicrosoftAzureServiceBusDiagnosticsSubscriber.cs
@@ -21,7 +21,7 @@ namespace Elastic.Apm.Azure.ServiceBus
 		{
 			var retVal = new CompositeDisposable();
 
-			var initializer = new DiagnosticInitializer(agent.Logger, new[] { new MicrosoftAzureServiceBusDiagnosticListener(agent) });
+			var initializer = new DiagnosticInitializer(agent.Logger, new MicrosoftAzureServiceBusDiagnosticListener(agent));
 			retVal.Add(initializer);
 
 			retVal.Add(DiagnosticListener

--- a/src/Elastic.Apm.Azure.Storage/AzureBlobStorageDiagnosticsSubscriber.cs
+++ b/src/Elastic.Apm.Azure.Storage/AzureBlobStorageDiagnosticsSubscriber.cs
@@ -21,7 +21,7 @@ namespace Elastic.Apm.Azure.Storage
 		{
 			var retVal = new CompositeDisposable();
 
-			var initializer = new DiagnosticInitializer(agent.Logger, new[] { new AzureBlobStorageDiagnosticListener(agent) });
+			var initializer = new DiagnosticInitializer(agent.Logger, new AzureBlobStorageDiagnosticListener(agent));
 			retVal.Add(initializer);
 
 			retVal.Add(DiagnosticListener

--- a/src/Elastic.Apm.Azure.Storage/AzureFileShareStorageDiagnosticsSubscriber.cs
+++ b/src/Elastic.Apm.Azure.Storage/AzureFileShareStorageDiagnosticsSubscriber.cs
@@ -21,7 +21,7 @@ namespace Elastic.Apm.Azure.Storage
 		{
 			var retVal = new CompositeDisposable();
 
-			var initializer = new DiagnosticInitializer(agent.Logger, new[] { new AzureFileShareStorageDiagnosticListener(agent) });
+			var initializer = new DiagnosticInitializer(agent.Logger, new AzureFileShareStorageDiagnosticListener(agent));
 			retVal.Add(initializer);
 
 			retVal.Add(DiagnosticListener

--- a/src/Elastic.Apm.Azure.Storage/AzureQueueStorageDiagnosticsSubscriber.cs
+++ b/src/Elastic.Apm.Azure.Storage/AzureQueueStorageDiagnosticsSubscriber.cs
@@ -21,7 +21,7 @@ namespace Elastic.Apm.Azure.Storage
 		{
 			var retVal = new CompositeDisposable();
 
-			var initializer = new DiagnosticInitializer(agent.Logger, new[] { new AzureQueueStorageDiagnosticListener(agent) });
+			var initializer = new DiagnosticInitializer(agent.Logger, new AzureQueueStorageDiagnosticListener(agent));
 			retVal.Add(initializer);
 
 			retVal.Add(DiagnosticListener

--- a/src/Elastic.Apm.EntityFrameworkCore/EfCoreDiagnosticsSubscriber.cs
+++ b/src/Elastic.Apm.EntityFrameworkCore/EfCoreDiagnosticsSubscriber.cs
@@ -22,7 +22,7 @@ namespace Elastic.Apm.EntityFrameworkCore
 			if (!agentComponents.ConfigurationReader.Enabled)
 				return retVal;
 
-			var subscriber = new DiagnosticInitializer(agentComponents.Logger, new[] { new EfCoreDiagnosticListener(agentComponents) });
+			var subscriber = new DiagnosticInitializer(agentComponents.Logger, new EfCoreDiagnosticListener(agentComponents));
 			retVal.Add(subscriber);
 
 			retVal.Add(DiagnosticListener

--- a/src/Elastic.Apm.GrpcClient/GrpcClientDiagnosticSubscriber.cs
+++ b/src/Elastic.Apm.GrpcClient/GrpcClientDiagnosticSubscriber.cs
@@ -21,7 +21,7 @@ namespace Elastic.Apm.GrpcClient
 				return retVal;
 
 			Listener = new GrpcClientDiagnosticListener(agent as ApmAgent);
-			var subscriber = new DiagnosticInitializer(agent.Logger, new[] { Listener });
+			var subscriber = new DiagnosticInitializer(agent.Logger, Listener);
 			retVal.Add(subscriber);
 
 			retVal.Add(DiagnosticListener

--- a/src/Elastic.Apm.SqlClient/SqlClientDiagnosticSubscriber.cs
+++ b/src/Elastic.Apm.SqlClient/SqlClientDiagnosticSubscriber.cs
@@ -24,7 +24,7 @@ namespace Elastic.Apm.SqlClient
 
 			if (PlatformDetection.IsDotNetCore || PlatformDetection.IsDotNet5)
 			{
-				var initializer = new DiagnosticInitializer(agentComponents.Logger, new[] { new SqlClientDiagnosticListener(agentComponents) });
+				var initializer = new DiagnosticInitializer(agentComponents.Logger, new SqlClientDiagnosticListener(agentComponents));
 
 				retVal.Add(initializer);
 

--- a/src/Elastic.Apm/DiagnosticSource/DiagnosticInitializer.cs
+++ b/src/Elastic.Apm/DiagnosticSource/DiagnosticInitializer.cs
@@ -65,14 +65,14 @@ namespace Elastic.Apm.DiagnosticSource
 
 			if (!subscribedAny)
 			{
-				var listeners = _listener != null
+				var listenerTypes = _listener != null
 					? _listener.GetType().FullName
 					: string.Join(", ", _listeners.Select(listener => listener.GetType().FullName));
 
 				_logger.Trace()
 					?.Log(
 						"There are no listeners in the current batch ({DiagnosticListeners}) that would like to subscribe to `{DiagnosticListenerName}' events source",
-						listeners,
+						listenerTypes,
 						value.Name);
 			}
 		}

--- a/src/Elastic.Apm/DiagnosticSource/DiagnosticInitializer.cs
+++ b/src/Elastic.Apm/DiagnosticSource/DiagnosticInitializer.cs
@@ -13,7 +13,9 @@ namespace Elastic.Apm.DiagnosticSource
 	internal class DiagnosticInitializer : IObserver<DiagnosticListener>, IDisposable
 	{
 		private readonly IEnumerable<IDiagnosticListener> _listeners;
+		private readonly IDiagnosticListener _listener;
 		private readonly ScopedLogger _logger;
+		private IDisposable _sourceSubscription;
 
 		internal DiagnosticInitializer(IApmLogger baseLogger, IEnumerable<IDiagnosticListener> listeners)
 		{
@@ -21,7 +23,11 @@ namespace Elastic.Apm.DiagnosticSource
 			_listeners = listeners;
 		}
 
-		private IDisposable _sourceSubscription;
+		internal DiagnosticInitializer(IApmLogger baseLogger, IDiagnosticListener listener)
+		{
+			_logger = baseLogger.Scoped(nameof(DiagnosticInitializer));
+			_listener = listener;
+		}
 
 		public void OnCompleted() { }
 
@@ -30,24 +36,43 @@ namespace Elastic.Apm.DiagnosticSource
 		public void OnNext(DiagnosticListener value)
 		{
 			var subscribedAny = false;
-			foreach (var listener in _listeners)
+
+			if (_listener != null)
 			{
-				if (value.Name == listener.Name)
+				if (value.Name == _listener.Name)
 				{
-					_sourceSubscription = value.Subscribe(listener);
+					_sourceSubscription = value.Subscribe(_listener);
 					_logger.Debug()
 						?.Log("Subscribed {DiagnosticListenerType} to `{DiagnosticListenerName}' events source",
-							listener.GetType().FullName, value.Name);
+							_listener.GetType().FullName, value.Name);
 					subscribedAny = true;
+				}
+			}
+			else
+			{
+				foreach (var listener in _listeners)
+				{
+					if (value.Name == listener.Name)
+					{
+						_sourceSubscription = value.Subscribe(listener);
+						_logger.Debug()
+							?.Log("Subscribed {DiagnosticListenerType} to `{DiagnosticListenerName}' events source",
+								listener.GetType().FullName, value.Name);
+						subscribedAny = true;
+					}
 				}
 			}
 
 			if (!subscribedAny)
 			{
+				var listeners = _listener != null
+					? _listener.GetType().FullName
+					: string.Join(", ", _listeners.Select(listener => listener.GetType().FullName));
+
 				_logger.Trace()
 					?.Log(
 						"There are no listeners in the current batch ({DiagnosticListeners}) that would like to subscribe to `{DiagnosticListenerName}' events source",
-						string.Join(", ", _listeners.Select(listener => listener.GetType().FullName)),
+						listeners,
 						value.Name);
 			}
 		}

--- a/src/Elastic.Apm/DiagnosticSource/HttpDiagnosticsSubscriber.cs
+++ b/src/Elastic.Apm/DiagnosticSource/HttpDiagnosticsSubscriber.cs
@@ -22,7 +22,7 @@ namespace Elastic.Apm.DiagnosticSource
 		{
 			var retVal = new CompositeDisposable();
 
-			var initializer = new DiagnosticInitializer(agent.Logger, new[] { HttpDiagnosticListener.New(agent) });
+			var initializer = new DiagnosticInitializer(agent.Logger, HttpDiagnosticListener.New(agent));
 			retVal.Add(initializer);
 
 			retVal.Add(DiagnosticListener


### PR DESCRIPTION
This commit avoids the array allocations when creating an instance of `DiagnosticInitializer`. All but one instantiation pass a single diagnostic listener.