### PR TITLE
Update CloudProviderSteps.cs

### DIFF
--- a/test/Elastic.Apm.Feature.Tests/CloudProviderSteps.cs
+++ b/test/Elastic.Apm.Feature.Tests/CloudProviderSteps.cs
@@ -38,7 +38,7 @@ namespace Elastic.Apm.Feature.Tests
 		{
 			var output = _scenarioContext.ScenarioContainer.Resolve<ITestOutputHelper>();
 			var logger = new XUnitLogger(LogLevel.Trace, output);
-			var config = new MockConfigSnapshot(logger, cloudProvider: cloudProvider);
+			var config = new MockConfigSnapshot(logger, cloudProvider: cloudProvider, flushInterval: "0");
 
 			var payloadCollector = new PayloadCollector();
 			_scenarioContext.Set(payloadCollector);


### PR DESCRIPTION
Noticed that these tests run very long. This is from here: https://github.com/elastic/apm-agent-dotnet/pull/1221#discussion_r603417227

Test run prior to this: (1,2min)

![image](https://user-images.githubusercontent.com/1091853/115604186-5f96ed00-a2e1-11eb-9130-74ff881e2208.png)

With the PR: (324ms)
![image](https://user-images.githubusercontent.com/1091853/115604246-70dff980-a2e1-11eb-8081-45d95616c77b.png)

