### PR TITLE
fix: force to pass the BUILD_ID

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -523,7 +523,7 @@ def dotnet(Closure body){
   def dockerTagName = 'docker.elastic.co/observability-ci/apm-agent-dotnet-sdk-linux:latest'
   sh label: 'Docker build', script: "docker build --tag ${dockerTagName} .ci/docker/sdk-linux"
   def homePath = "${env.WORKSPACE}/${env.BASE_DIR}"
-  docker.image("${dockerTagName}").inside("-e HOME='${homePath}' -v /var/run/docker.sock:/var/run/docker.sock"){
+  docker.image("${dockerTagName}").inside("-e BUILD_ID=${BUILD_ID} -e HOME='${homePath}' -v /var/run/docker.sock:/var/run/docker.sock"){
     withAzureCredentials(path: "${homePath}", credentialsFile: '.credentials.json') {
       body()
     }


### PR DESCRIPTION
The BUILD_ID environment variable is not populated in the don't Docker container making the IP to connect wrong.