### PR TITLE
Sanitize HTTP headers when the agent reads them

### DIFF
--- a/src/Elastic.Apm.AspNetCore/WebRequestTransactionCreator.cs
+++ b/src/Elastic.Apm.AspNetCore/WebRequestTransactionCreator.cs
@@ -54,7 +54,8 @@ namespace Elastic.Apm.AspNetCore
 						logger.Debug()
 							?.Log(
 								"Incoming request with {TraceParentHeaderName} header. DistributedTracingData: {DistributedTracingData}. Continuing trace.",
-								containsPrefixedTraceParentHeader? TraceContext.TraceParentHeaderNamePrefixed : TraceContext.TraceParentHeaderName, tracingData);
+								containsPrefixedTraceParentHeader ? TraceContext.TraceParentHeaderNamePrefixed : TraceContext.TraceParentHeaderName,
+								tracingData);
 
 						transaction = tracer.StartTransaction(transactionName, ApiConstants.TypeRequest, tracingData);
 					}
@@ -63,7 +64,8 @@ namespace Elastic.Apm.AspNetCore
 						logger.Debug()
 							?.Log(
 								"Incoming request with invalid {TraceParentHeaderName} header (received value: {TraceParentHeaderValue}). Starting trace with new trace id.",
-								containsPrefixedTraceParentHeader? TraceContext.TraceParentHeaderNamePrefixed : TraceContext.TraceParentHeaderName, traceParentHeader);
+								containsPrefixedTraceParentHeader ? TraceContext.TraceParentHeaderNamePrefixed : TraceContext.TraceParentHeaderName,
+								traceParentHeader);
 
 						transaction = tracer.StartTransaction(transactionName, ApiConstants.TypeRequest);
 					}
@@ -124,7 +126,10 @@ namespace Elastic.Apm.AspNetCore
 
 		private static Dictionary<string, string> GetHeaders(IHeaderDictionary headers, IConfigSnapshot configSnapshot) =>
 			configSnapshot.CaptureHeaders && headers != null
-				? headers.ToDictionary(header => header.Key, header => header.Value.ToString())
+				? headers.ToDictionary(header => header.Key,
+					header => WildcardMatcher.IsAnyMatch(configSnapshot.SanitizeFieldNames, header.Key)
+						? Apm.Consts.Redacted
+						: header.Value.ToString())
 				: null;
 
 		private static string GetRawUrl(HttpRequest httpRequest, IApmLogger logger)

--- a/src/Elastic.Apm/Elastic.Apm.csproj
+++ b/src/Elastic.Apm/Elastic.Apm.csproj
@@ -68,7 +68,7 @@
     <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="2.0.2" />
     <PackageReference Include="System.Threading.Tasks.Dataflow" Version="4.9.0" />
     <!-- Used by Ben.Demystifier -->
-    <PackageReference Include="System.Reflection.Metadata" Version="5.0.0"/>
+    <PackageReference Include="System.Reflection.Metadata" Version="5.0.0" />
     <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
   </ItemGroup>
   

--- a/src/Elastic.Apm/Filters/ErrorContextSanitizerFilter.cs
+++ b/src/Elastic.Apm/Filters/ErrorContextSanitizerFilter.cs
@@ -22,10 +22,9 @@ namespace Elastic.Apm.Filters
 			{
 				if (realError.Context.Request?.Headers != null && realError.ConfigSnapshot != null)
 				{
-					foreach (var key in realError.Context?.Request?.Headers?.Keys.ToList())
+					foreach (var key in realError.Context?.Request?.Headers?.Keys)
 					{
-						if (WildcardMatcher.IsAnyMatch(realError.ConfigSnapshot.SanitizeFieldNames, key)
-							&& realError.Context.Request.Headers[key] != Consts.Redacted)
+						if (WildcardMatcher.IsAnyMatch(realError.ConfigSnapshot.SanitizeFieldNames, key))
 							realError.Context.Request.Headers[key] = Consts.Redacted;
 					}
 				}

--- a/src/Elastic.Apm/Filters/ErrorContextSanitizerFilter.cs
+++ b/src/Elastic.Apm/Filters/ErrorContextSanitizerFilter.cs
@@ -1,0 +1,37 @@
+// Licensed to Elasticsearch B.V under
+// one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System.Linq;
+using Elastic.Apm.Api;
+using Elastic.Apm.Config;
+using Elastic.Apm.Helpers;
+using Elastic.Apm.Model;
+
+namespace Elastic.Apm.Filters
+{
+	/// <summary>
+	/// A filter that sanitizes fields on error based on the <see cref="IConfigurationReader.SanitizeFieldNames"/> setting
+	/// </summary>
+	internal class ErrorContextSanitizerFilter
+	{
+		public IError Filter(IError error)
+		{
+			if (error is Error realError)
+			{
+				if (realError.Context.Request?.Headers != null && realError.ConfigSnapshot != null)
+				{
+					foreach (var key in realError.Context?.Request?.Headers?.Keys.ToList())
+					{
+						if (WildcardMatcher.IsAnyMatch(realError.ConfigSnapshot.SanitizeFieldNames, key)
+							&& realError.Context.Request.Headers[key] != Consts.Redacted)
+							realError.Context.Request.Headers[key] = Consts.Redacted;
+					}
+				}
+			}
+
+			return error;
+		}
+	}
+}

--- a/src/Elastic.Apm/Filters/HeaderDictionarySanitizerFilter.cs
+++ b/src/Elastic.Apm/Filters/HeaderDictionarySanitizerFilter.cs
@@ -24,7 +24,8 @@ namespace Elastic.Apm.Filters
 				{
 					foreach (var key in realTransaction.Context?.Request?.Headers?.Keys.ToList())
 					{
-						if (WildcardMatcher.IsAnyMatch(realTransaction.ConfigSnapshot.SanitizeFieldNames, key))
+						if (WildcardMatcher.IsAnyMatch(realTransaction.ConfigSnapshot.SanitizeFieldNames, key)
+							&& realTransaction.Context.Request.Headers[key] != Consts.Redacted)
 							realTransaction.Context.Request.Headers[key] = Consts.Redacted;
 					}
 				}

--- a/src/Elastic.Apm/Filters/HeaderDictionarySanitizerFilter.cs
+++ b/src/Elastic.Apm/Filters/HeaderDictionarySanitizerFilter.cs
@@ -22,10 +22,9 @@ namespace Elastic.Apm.Filters
 			{
 				if (realTransaction.IsContextCreated && realTransaction.Context.Request?.Headers != null)
 				{
-					foreach (var key in realTransaction.Context?.Request?.Headers?.Keys.ToList())
+					foreach (var key in realTransaction.Context?.Request?.Headers?.Keys)
 					{
-						if (WildcardMatcher.IsAnyMatch(realTransaction.ConfigSnapshot.SanitizeFieldNames, key)
-							&& realTransaction.Context.Request.Headers[key] != Consts.Redacted)
+						if (WildcardMatcher.IsAnyMatch(realTransaction.ConfigSnapshot.SanitizeFieldNames, key))
 							realTransaction.Context.Request.Headers[key] = Consts.Redacted;
 					}
 				}

--- a/src/Elastic.Apm/Model/Error.cs
+++ b/src/Elastic.Apm/Model/Error.cs
@@ -5,6 +5,7 @@
 using System.Collections.Generic;
 using Elastic.Apm.Api;
 using Elastic.Apm.Api.Constraints;
+using Elastic.Apm.Config;
 using Elastic.Apm.Helpers;
 using Elastic.Apm.Logging;
 using Elastic.Apm.Libraries.Newtonsoft.Json;
@@ -13,8 +14,10 @@ namespace Elastic.Apm.Model
 {
 	internal class Error : IError
 	{
-		public Error(CapturedException capturedException, Transaction transaction, string parentId, IApmLogger loggerArg,
-			Dictionary<string, Label> labels = null
+		[JsonIgnore]
+		internal IConfigSnapshot ConfigSnapshot { get; }
+
+		public Error(CapturedException capturedException, Transaction transaction, string parentId, IApmLogger loggerArg, Dictionary<string, Label> labels = null
 		)
 			: this(transaction, parentId, loggerArg, labels) => Exception = capturedException;
 
@@ -33,6 +36,7 @@ namespace Elastic.Apm.Model
 				TraceId = transaction.TraceId;
 				TransactionId = transaction.Id;
 				Transaction = new TransactionData(transaction.IsSampled, transaction.Type);
+				ConfigSnapshot = transaction.ConfigSnapshot;
 			}
 
 			ParentId = parentId;

--- a/src/Elastic.Apm/Report/PayloadSenderV2.cs
+++ b/src/Elastic.Apm/Report/PayloadSenderV2.cs
@@ -109,13 +109,14 @@ namespace Elastic.Apm.Report
 
 			_eventQueue = new BatchBlock<object>(config.MaxBatchEventCount);
 
-			SetUpFilters(TransactionFilters, SpanFilters, apmServerInfo, logger);
+			SetUpFilters(TransactionFilters, SpanFilters, ErrorFilters, apmServerInfo, logger);
 			StartWorkLoop();
 		}
 
 		internal static void SetUpFilters(
 			List<Func<ITransaction, ITransaction>> transactionFilters,
 			List<Func<ISpan, ISpan>> spanFilters,
+			List<Func<IError, IError>> errorFilters,
 			IApmServerInfo apmServerInfo,
 			IApmLogger logger)
 		{
@@ -123,6 +124,7 @@ namespace Elastic.Apm.Report
 			transactionFilters.Add(new HeaderDictionarySanitizerFilter().Filter);
 			// with this, stack trace demystification and conversion to the intake API model happens on a non-application thread:
 			spanFilters.Add(new SpanStackTraceCapturingFilter(logger, apmServerInfo).Filter);
+			errorFilters.Add(new ErrorContextSanitizerFilter().Filter);
 		}
 
 		private bool _getApmServerVersion;

--- a/test/Elastic.Apm.Tests.Utilities/MockPayloadSender.cs
+++ b/test/Elastic.Apm.Tests.Utilities/MockPayloadSender.cs
@@ -19,6 +19,7 @@ namespace Elastic.Apm.Tests.Utilities
 	internal class MockPayloadSender : IPayloadSender
 	{
 		private readonly List<IError> _errors = new List<IError>();
+		private readonly List<Func<IError, IError>> _errorFilters = new List<Func<IError, IError>>();
 		private readonly object _lock = new object();
 		private readonly List<IMetricSet> _metrics = new List<IMetricSet>();
 		private readonly List<Func<ISpan, ISpan>> _spanFilters = new List<Func<ISpan, ISpan>>();
@@ -41,7 +42,7 @@ namespace Elastic.Apm.Tests.Utilities
 			_errorWaitHandle = _waitHandles[2];
 			_metricSetWaitHandle = _waitHandles[3];
 
-			PayloadSenderV2.SetUpFilters(_transactionFilters, _spanFilters, MockApmServerInfo.Version710, logger ?? new NoopLogger());
+			PayloadSenderV2.SetUpFilters(_transactionFilters, _spanFilters, _errorFilters, MockApmServerInfo.Version710, logger ?? new NoopLogger());
 		}
 
 		private readonly AutoResetEvent _transactionWaitHandle;


### PR DESCRIPTION
This PR changes a few things around HTTP header sanitization

- In case of HTTP calls, when the agent reads the headers, we already apply sanitization (prior to this, this only happened right before serialization).
- Also added a filter to sanitize HTTP headers on the captured errors.