### PR TITLE
Add test to assert that types under Elastic.Apm.Libraries.* are non-public

### DIFF
--- a/test/Elastic.Apm.Tests/LibrariesTests.cs
+++ b/test/Elastic.Apm.Tests/LibrariesTests.cs
@@ -1,0 +1,34 @@
+// Licensed to Elasticsearch B.V under
+// one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System;
+using System.Linq;
+using FluentAssertions;
+using Xunit;
+
+namespace Elastic.Apm.Tests
+{
+	public class LibrariesTests
+	{
+		/// <summary>
+		/// Asserts that all types under the Elastic.Apm.Libraries.* namespace are non-public types.
+		/// </summary>
+		[Fact]
+		public void AllTypesAreNonPublic()
+		{
+			var types = typeof(ApmAgent).Assembly.GetTypes()
+				.Where(t => t.Namespace != null && t.Namespace.StartsWith("Elastic.Apm.Libraries", StringComparison.Ordinal))
+				.ToArray();
+
+			types.Should().NotBeNullOrEmpty();
+
+			foreach (var type in types)
+			{
+				if (!type.IsNested)
+					type.IsNotPublic.Should().BeTrue($"{type.FullName} is expected to be a non-public type");
+			}
+		}
+	}
+}


### PR DESCRIPTION
Tests that our included 3rd party libs are all non-public.

Idea from https://github.com/elastic/apm-agent-dotnet/pull/1275#pullrequestreview-648794299 