### PR TITLE
Update dynamic values from central configuration

### DIFF
--- a/src/Elastic.Apm/BackendComm/CentralConfig/CentralConfigReader.cs
+++ b/src/Elastic.Apm/BackendComm/CentralConfig/CentralConfigReader.cs
@@ -70,9 +70,9 @@ namespace Elastic.Apm.BackendComm.CentralConfig
 			StackTraceLimit = GetSimpleConfigurationValue(CentralConfigResponseParser.CentralConfigPayload.StackTraceLimitKey, ParseStackTraceLimit);
 			Recording = GetSimpleConfigurationValue(CentralConfigResponseParser.CentralConfigPayload.Recording, ParseRecording);
 			SanitizeFieldNames =
-				GetConfigurationValue(CentralConfigResponseParser.CentralConfigPayload.SanitizeFieldNames, ParseSanitizeFieldNames);
+				GetConfigurationValue(CentralConfigResponseParser.CentralConfigPayload.SanitizeFieldNames, ParseSanitizeFieldNamesImpl);
 			TransactionIgnoreUrls =
-				GetConfigurationValue(CentralConfigResponseParser.CentralConfigPayload.TransactionIgnoreUrls, ParseTransactionIgnoreUrls);
+				GetConfigurationValue(CentralConfigResponseParser.CentralConfigPayload.TransactionIgnoreUrls, ParseTransactionIgnoreUrlsImpl);
 			IgnoreMessageQueues =
 				GetConfigurationValue(CentralConfigResponseParser.CentralConfigPayload.IgnoreMessageQueues, ParseIgnoreMessageQueuesImpl);
 		}

--- a/src/Elastic.Apm/Config/AbstractConfigurationReader.cs
+++ b/src/Elastic.Apm/Config/AbstractConfigurationReader.cs
@@ -373,7 +373,7 @@ namespace Elastic.Apm.Config
 			_cachedWildcardMatchersTransactionIgnoreUrls.IfNotInited?.InitOrGet(() => ParseTransactionIgnoreUrlsImpl(kv))
 			?? _cachedWildcardMatchersTransactionIgnoreUrls.Value;
 
-		private IReadOnlyList<WildcardMatcher> ParseTransactionIgnoreUrlsImpl(ConfigurationKeyValue kv)
+		internal IReadOnlyList<WildcardMatcher> ParseTransactionIgnoreUrlsImpl(ConfigurationKeyValue kv)
 		{
 			if (kv?.Value == null) return DefaultValues.TransactionIgnoreUrls;
 


### PR DESCRIPTION
This commit fixes a bug to update the SanitizeFieldNames and TransactionIgnoreUrls configuration values, if values have been received from central configuration.

Before this fix, the parsing methods will return the cached values from initial configuration.