### PR TITLE
Capture errors with startup hook auto instrumentation

### DIFF
--- a/docs/setup.asciidoc
+++ b/docs/setup.asciidoc
@@ -168,7 +168,7 @@ The following example only turns on outgoing HTTP monitoring (so, for instance, 
 [[zero-code-change-setup]]
 ==== Zero code change setup on .NET Core (added[1.7])
 
-If you can't or don't want to reference NuGet packages in your application, you can use the startup hook feature to inject the agent during startup, if your application runs on .NET Core. This feature is supported on .NET Core 2.2 and newer versions.
+If you can't or don't want to reference NuGet packages in your application, you can use the startup hook feature to inject the agent during startup, if your application runs on .NET Core. This feature is supported on .NET Core 3.0 and newer versions.
 
 Steps:
 

--- a/sample/Elastic.Apm.StartupHook.Sample/Controllers/HomeController.cs
+++ b/sample/Elastic.Apm.StartupHook.Sample/Controllers/HomeController.cs
@@ -21,5 +21,7 @@ namespace Elastic.Apm.StartupHook.Sample.Controllers
 
 		[ResponseCache(Duration = 0, Location = ResponseCacheLocation.None, NoStore = true)]
 		public IActionResult Error() => View(new ErrorViewModel { RequestId = Activity.Current?.Id ?? HttpContext.TraceIdentifier });
+
+		public IActionResult Exception() => throw new Exception("Exception thrown from controller action");
 	}
 }

--- a/src/Elastic.Apm.AspNetCore/DiagnosticListener/AspNetCoreDiagnosticListener.cs
+++ b/src/Elastic.Apm.AspNetCore/DiagnosticListener/AspNetCoreDiagnosticListener.cs
@@ -66,7 +66,7 @@ namespace Elastic.Apm.AspNetCore.DiagnosticListener
 						}
 					}
 					break;
-				case "Microsoft.AspNetCore.Diagnostics.UnhandledException": //Called when exception handler is registrered
+				case "Microsoft.AspNetCore.Diagnostics.UnhandledException": //Called when exception handler is registered
 				case "Microsoft.AspNetCore.Diagnostics.HandledException":
 					if (!(_defaultHttpContextFetcher.Fetch(kv.Value) is DefaultHttpContext httpContextDiagnosticsUnhandledException)) return;
 					if (!(_exceptionContextPropertyFetcher.Fetch(kv.Value) is Exception diagnosticsException)) return;

--- a/src/Elastic.Apm.AspNetCore/DiagnosticListener/AspNetCoreDiagnosticSubscriber.cs
+++ b/src/Elastic.Apm.AspNetCore/DiagnosticListener/AspNetCoreDiagnosticSubscriber.cs
@@ -4,7 +4,7 @@ using Elastic.Apm.DiagnosticSource;
 namespace Elastic.Apm.AspNetCore.DiagnosticListener
 {
 	/// <summary>
-	/// A Diagnostic listner to create transactions based on diagnostic source events for ASP.NET Core.
+	/// A Diagnostic listener to create transactions based on diagnostic source events for ASP.NET Core.
 	/// This itself manages all transaction and error capturing without the need for a middleware.
 	/// </summary>
 	public class AspNetCoreDiagnosticSubscriber : IDiagnosticsSubscriber

--- a/src/Elastic.Apm.StartupHook.Loader/Loader.cs
+++ b/src/Elastic.Apm.StartupHook.Loader/Loader.cs
@@ -20,7 +20,7 @@ using ElasticApmStartupHook;
 namespace Elastic.Apm.StartupHook.Loader
 {
 	/// <summary>
-	/// Loads the agent assemblies, its dependent assemblies and starts it
+	/// Starts the agent
 	/// </summary>
 	internal class Loader
 	{
@@ -37,23 +37,9 @@ namespace Elastic.Apm.StartupHook.Loader
 		}
 
 		/// <summary>
-		/// Initializes assemblies and starts the agent
+		/// Initializes and starts the agent
 		/// </summary>
 		public static void Initialize()
-		{
-			var agentLibsToLoad =  new[]{ "Elastic.Apm", "Elastic.Apm.Extensions.Hosting", "Elastic.Apm.AspNetCore", "Elastic.Apm.EntityFrameworkCore", "Elastic.Apm.SqlClient", "Elastic.Apm.GrpcClient", "Elastic.Apm.Elasticsearch" };
-			var agentDependencyLibsToLoad = new[] { "System.Diagnostics.PerformanceCounter", "Microsoft.Diagnostics.Tracing.TraceEvent", "Elasticsearch.Net" };
-
-			foreach (var libToLoad in agentDependencyLibsToLoad)
-				AssemblyLoadContext.Default.LoadFromAssemblyPath(Path.Combine(AssemblyDirectory, libToLoad + ".dll"));
-			foreach (var libToLoad in agentLibsToLoad)
-				AssemblyLoadContext.Default.LoadFromAssemblyPath(Path.Combine(AssemblyDirectory, libToLoad + ".dll"));
-
-			StartAgent();
-		}
-
-		[MethodImpl(MethodImplOptions.NoInlining)]
-		private static void StartAgent()
 		{
 			Agent.Setup(new AgentComponents());
 

--- a/src/ElasticApmAgentStartupHook/StartupHookLogger.cs
+++ b/src/ElasticApmAgentStartupHook/StartupHookLogger.cs
@@ -5,13 +5,20 @@
 
 using System;
 using System.IO;
+using System.Reflection;
+using System.Runtime.Loader;
 
 namespace ElasticApmStartupHook
 {
+	internal class ElasticApmAssemblyLoadContext : AssemblyLoadContext
+	{
+		protected override Assembly Load(AssemblyName assemblyName) => null;
+	}
+
 	/// <summary>
 	/// Logs startup hook process, useful for debugging purposes.
 	/// </summary>
-	public class StartupHookLogger
+	internal class StartupHookLogger
 	{
 		private readonly bool _enabled;
 		private readonly string _logPath;


### PR DESCRIPTION
This commit updates the startup hook auto instrumentation feature to capture thrown exceptions through the subscribed
`AspNetCoreDiagnosticListener`.

When an unhandled exception is thrown, ASP.NET Core's `DeveloperExceptionPageMiddleware` will raise a diagnostic
event with key "Microsoft.AspNetCore.Diagnostics.UnhandledException" if there is a listener listening to the event. If no listener is subscribed, the event is not captured.

Update how assemblies are loaded in the startup hook auto instrumentation. Register an event handler to the `AssemblyLoadContext.Default.Resolving` event to load assemblies that exist in the loader directory with matching version and public key. For assemblies starting with Elastic.Apm, that may contain DiagnosticListeners, load into `AssemblyLoadContext.Default` to allow listeners to register via `DiagnosticListener.AllListeners.Subscribe()`. For any other assemblies, load them into a separate AssemblyLoadContext to avoid version conflicts with assemblies that the application may reference. An example of the problem this avoids is System.Reflection.Metadata; The APM agent's source included version of Ben.Demystifier depends on System.Reflection.Metadata 5.0.0, but an application may reference a different version, such as ASP.NET Core 3.0, which references System.Reflection.Metadata 1.4.4.0 by default.

Add integration tests for capturing errors from startup hooks for netcoreapp3.0, netcoreapp3.1 and net5.0.

Update documentation for startup hooks to indicate that this feature is supported in .NET Core 3.0 and newer. .NET Core 2.2 is End of Life (EOL) and no longer supported by Microsoft. In testing startup hooks with .NET Core 2.2, Diagnostic Listeners do not subscribe to ASP.NET Core diagnostic events. On initial investigation, the System.Diagnostics.DiagnosticSource assembly loaded in the startup hooks is version 4.0.3.1. When listeners come to subscribe, System.Diagnostics.DiagnosticSource 4.0.4.0 that listeners are compiled against is loaded into the separate AssemblyLoadContext, which might be why listeners do not end up subscribing. Considering .NET Core 2.2 is EOL however, no further effort has been put into making this work.

Fixes #1233