### PR TITLE
Prefer W3C traceparent over elastic-apm-traceparent

### DIFF
--- a/src/Elastic.Apm.AspNetCore/WebRequestTransactionCreator.cs
+++ b/src/Elastic.Apm.AspNetCore/WebRequestTransactionCreator.cs
@@ -36,12 +36,12 @@ namespace Elastic.Apm.AspNetCore
 				ITransaction transaction;
 				var transactionName = $"{context.Request.Method} {context.Request.Path}";
 
-				var containsPrefixedTraceParentHeader =
-					context.Request.Headers.TryGetValue(TraceContext.TraceParentHeaderNamePrefixed, out var traceParentHeader);
+				var containsTraceParentHeader =
+					context.Request.Headers.TryGetValue(TraceContext.TraceParentHeaderName, out var traceParentHeader);
 
-				var containsTraceParentHeader = false;
-				if (!containsPrefixedTraceParentHeader)
-					containsTraceParentHeader = context.Request.Headers.TryGetValue(TraceContext.TraceParentHeaderName, out traceParentHeader);
+				var containsPrefixedTraceParentHeader = false;
+				if (!containsTraceParentHeader)
+					containsPrefixedTraceParentHeader = context.Request.Headers.TryGetValue(TraceContext.TraceParentHeaderNamePrefixed, out traceParentHeader);
 
 				if (containsPrefixedTraceParentHeader || containsTraceParentHeader)
 				{


### PR DESCRIPTION
Prefer `traceparent` if present over `elastic-apm-traceparent`.

This PR does it for ASP.NET Core, fun fact: in the IIS Module for ASP.NET Classic we already have this precedence.