### PR TITLE
Do not capture HTTP child spans for Elasticsearch

### DIFF
--- a/src/Elastic.Apm.Elasticsearch/ElasticsearchDiagnosticsListenerBase.cs
+++ b/src/Elastic.Apm.Elasticsearch/ElasticsearchDiagnosticsListenerBase.cs
@@ -47,7 +47,7 @@ namespace Elastic.Apm.Elasticsearch
 		{
 			span = null;
 			var transaction = ApmAgent.Tracer.CurrentTransaction;
-			if (transaction == null)
+			if (transaction is null)
 				return false;
 
 			span = (Span)ApmAgent.GetCurrentExecutionSegment()
@@ -56,6 +56,7 @@ namespace Elastic.Apm.Elasticsearch
 					ApiConstants.TypeDb,
 					ApiConstants.SubtypeElasticsearch);
 
+			span.InstrumentationFlag = InstrumentationFlag.Elasticsearch;
 			span.Action = name;
 			SetDbContext(span, instanceUri);
 			SetDestination(span, instanceUri);

--- a/src/Elastic.Apm/DiagnosticListeners/HttpDiagnosticListenerImplBase.cs
+++ b/src/Elastic.Apm/DiagnosticListeners/HttpDiagnosticListenerImplBase.cs
@@ -126,9 +126,8 @@ namespace Elastic.Apm.DiagnosticListeners
 		{
 			if (_realAgent?.TracerInternal.CurrentSpan is Span currentSpan)
 			{
-				// if there's a current span that has been instrumented for Azure, don't create a span for
-				// the current request
-				if (currentSpan.InstrumentationFlag == InstrumentationFlag.Azure)
+				// if the current span is an exit span, don't create a span for the current request
+				if (currentSpan.InstrumentationFlag == InstrumentationFlag.Azure || currentSpan.InstrumentationFlag == InstrumentationFlag.Elasticsearch)
 					return;
 			}
 

--- a/src/Elastic.Apm/Model/InstrumentationFlag.cs
+++ b/src/Elastic.Apm/Model/InstrumentationFlag.cs
@@ -23,6 +23,7 @@ namespace Elastic.Apm.Model
 		EfClassic = 1 << 3,
 		SqlClient = 1 << 4,
 		AspNetClassic = 1 << 5,
-		Azure = 1 << 6
+		Azure = 1 << 6,
+		Elasticsearch = 1 << 7,
 	}
 }

--- a/test/Elastic.Apm.Elasticsearch.Tests/Elastic.Apm.Elasticsearch.Tests.csproj
+++ b/test/Elastic.Apm.Elasticsearch.Tests/Elastic.Apm.Elasticsearch.Tests.csproj
@@ -17,7 +17,9 @@
     </PackageReference>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="2.1.0" />
     <PackageReference Include="Elasticsearch.Net.VirtualizedCluster" Version="7.6.1" />
-
+    <PackageReference Include="DotNet.Testcontainers" Version="1.0.0" />
+    <!-- Strong name any assemblies that aren't i.e. DotNet.Testcontainers -->
+    <PackageReference Include="StrongNamer" Version="0.2.5" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
   </ItemGroup>
   <ItemGroup>

--- a/test/Elastic.Apm.Elasticsearch.Tests/ElasticsearchFixture.cs
+++ b/test/Elastic.Apm.Elasticsearch.Tests/ElasticsearchFixture.cs
@@ -1,0 +1,41 @@
+// Licensed to Elasticsearch B.V under
+// one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System;
+using System.Threading.Tasks;
+using DotNet.Testcontainers.Containers.Builders;
+using Xunit;
+
+namespace Elastic.Apm.Elasticsearch.Tests
+{
+	public class ElasticsearchFixture : IDisposable, IAsyncLifetime
+	{
+		private readonly ElasticsearchTestContainer _container;
+
+		public ElasticsearchFixture()
+		{
+			var containerBuilder = new TestcontainersBuilder<ElasticsearchTestContainer>()
+				.WithElasticsearch(new ElasticsearchTestContainerConfiguration());
+
+			_container = containerBuilder.Build();
+		}
+
+		public string ConnectionString { get; private set; }
+
+		public async Task InitializeAsync()
+		{
+			await _container.StartAsync();
+			ConnectionString = _container.ConnectionString;
+		}
+
+		public async Task DisposeAsync()
+		{
+			await _container.StopAsync();
+			_container.Dispose();
+		}
+
+		public void Dispose() => _container?.Dispose();
+	}
+}

--- a/test/Elastic.Apm.Elasticsearch.Tests/ElasticsearchTestContainer.cs
+++ b/test/Elastic.Apm.Elasticsearch.Tests/ElasticsearchTestContainer.cs
@@ -1,0 +1,17 @@
+// Licensed to Elasticsearch B.V under
+// one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using DotNet.Testcontainers.Containers.Configurations;
+using DotNet.Testcontainers.Containers.Modules.Abstractions;
+
+namespace Elastic.Apm.Elasticsearch.Tests
+{
+	public class ElasticsearchTestContainer : HostedServiceContainer
+	{
+		internal ElasticsearchTestContainer(TestcontainersConfiguration configuration) : base(configuration) => Hostname = "localhost";
+
+		public override string ConnectionString => $"http://{Hostname}:{Port}";
+	}
+}

--- a/test/Elastic.Apm.Elasticsearch.Tests/ElasticsearchTestContainerConfiguration.cs
+++ b/test/Elastic.Apm.Elasticsearch.Tests/ElasticsearchTestContainerConfiguration.cs
@@ -1,0 +1,53 @@
+// Licensed to Elasticsearch B.V under
+// one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System.Linq;
+using System.Threading.Tasks;
+using DotNet.Testcontainers.Client;
+using DotNet.Testcontainers.Containers.Builders;
+using DotNet.Testcontainers.Containers.Configurations.Abstractions;
+using DotNet.Testcontainers.Containers.OutputConsumers;
+using DotNet.Testcontainers.Containers.WaitStrategies;
+
+namespace Elastic.Apm.Elasticsearch.Tests
+{
+	public static class TestcontainersBuilderExtensions
+	{
+		public static ITestcontainersBuilder<ElasticsearchTestContainer> WithElasticsearch(
+			this ITestcontainersBuilder<ElasticsearchTestContainer> builder,
+			ElasticsearchTestContainerConfiguration configuration
+		)
+		{
+			builder = configuration.Environments.Aggregate(builder, (current, environment) =>
+				current.WithEnvironment(environment.Key, environment.Value));
+
+			return builder
+				.WithImage(configuration.Image)
+				.WithPortBinding(configuration.Port, configuration.DefaultPort)
+				.WithWaitStrategy(configuration.WaitStrategy)
+				.ConfigureContainer(container =>
+				{
+					container.Port = configuration.DefaultPort;
+				});
+		}
+	}
+
+	public class ElasticsearchTestContainerConfiguration : HostedServiceConfiguration
+	{
+		private const int ElasticsearchDefaultPort = 9200;
+		private const string ElasticsearchImageVersion = "7.12.1";
+
+		public ElasticsearchTestContainerConfiguration()
+			: this($"docker.elastic.co/elasticsearch/elasticsearch:{ElasticsearchImageVersion}") { }
+
+		public ElasticsearchTestContainerConfiguration(string image) : base(image, ElasticsearchDefaultPort)
+		{
+			Environments["discovery.type"] = "single-node";
+			WaitStrategy = Wait.UntilBashCommandsAreCompleted("curl -s -k http://localhost:9200/_cluster/health | grep -vq '\"status\":\"\\(^red\\)\"'");
+		}
+
+		public override IWaitUntil WaitStrategy { get; }
+	}
+}

--- a/test/Elastic.Apm.Elasticsearch.Tests/ElasticsearchTests.cs
+++ b/test/Elastic.Apm.Elasticsearch.Tests/ElasticsearchTests.cs
@@ -1,0 +1,47 @@
+// Licensed to Elasticsearch B.V under
+// one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System;
+using System.Threading.Tasks;
+using Elastic.Apm.Api;
+using Elastic.Apm.DiagnosticSource;
+using Elastic.Apm.Tests.Utilities;
+using Elasticsearch.Net;
+using Elasticsearch.Net.VirtualizedCluster;
+using FluentAssertions;
+using Xunit;
+
+namespace Elastic.Apm.Elasticsearch.Tests
+{
+	public class ElasticsearchTests : IClassFixture<ElasticsearchFixture>
+	{
+		private readonly ElasticLowLevelClient _client;
+
+		public ElasticsearchTests(ElasticsearchFixture fixture)
+		{
+			var settings = new ConnectionConfiguration(new Uri(fixture.ConnectionString));
+			_client = new ElasticLowLevelClient(settings);
+		}
+
+		[Fact]
+		public async Task Elasticsearch_Span_Does_Not_Have_Http_Child_Span()
+		{
+			var payloadSender = new MockPayloadSender();
+			using (var agent = new ApmAgent(new TestAgentComponents(payloadSender: payloadSender)))
+			using (agent.Subscribe(new ElasticsearchDiagnosticsSubscriber(), new HttpDiagnosticsSubscriber()))
+			{
+				var searchResponse = await agent.Tracer.CaptureTransaction("Call Client", ApiConstants.ActionExec,
+					async () => await _client.SearchAsync<StringResponse>(PostData.Empty)
+				);
+				searchResponse.Should().NotBeNull();
+				searchResponse.Success.Should().BeTrue();
+				searchResponse.AuditTrail.Should().NotBeEmpty();
+
+				var spans = payloadSender.SpansOnFirstTransaction;
+				spans.Should().NotBeEmpty().And.NotContain(s => s.Subtype == ApiConstants.SubtypeHttp);
+			}
+		}
+	}
+}


### PR DESCRIPTION
This commit updates the Elasticsearch integration to
not capture HTTP child spans for calls to Elasticsearch.

An instrumentation flag is set by spans started by the
Elasticsearch integration diagnostic listeners that is
checked in the HttpDiagnosticListener.

We might consider refactoring to include an
Exit property on span in the future, that can be checked.

Closes #1276