### PR TITLE
Create receive messaging span when inside transaction

### DIFF
--- a/src/Elastic.Apm.Azure.ServiceBus/AzureMessagingServiceBusDiagnosticListener.cs
+++ b/src/Elastic.Apm.Azure.ServiceBus/AzureMessagingServiceBusDiagnosticListener.cs
@@ -101,18 +101,29 @@ namespace Elastic.Apm.Azure.ServiceBus
 				? $"{ServiceBus.SegmentName} {action}"
 				: $"{ServiceBus.SegmentName} {action} from {queueName}";
 
-			var transaction = ApmAgent.Tracer.StartTransaction(transactionName, ApiConstants.TypeMessaging);
-			transaction.Context.Service = new Service(null, null) { Framework = _framework };
+			IExecutionSegment segment;
+			if (ApmAgent.Tracer.CurrentTransaction is null)
+			{
+				var transaction = ApmAgent.Tracer.StartTransaction(transactionName, ApiConstants.TypeMessaging);
+				transaction.Context.Service = new Service(null, null) { Framework = _framework };
+				segment = transaction;
+			}
+			else
+			{
+				var span = ApmAgent.GetCurrentExecutionSegment().StartSpan(transactionName, ApiConstants.TypeMessaging, ServiceBus.SubType, action);
+				segment = span;
+			}
 
 			// transaction creation will create an activity, so use this as the key.
 			var activityId = Activity.Current.Id;
 
-			if (!_processingSegments.TryAdd(activityId, transaction))
+			if (!_processingSegments.TryAdd(activityId, segment))
 			{
-				Logger.Error()?.Log(
-					"Could not add {Action} transaction {TransactionId} for activity {ActivityId} to tracked segments",
+				Logger.Trace()?.Log(
+					"Could not add {Action} {SegmentName} {TransactionId} for activity {ActivityId} to tracked segments",
 					action,
-					transaction.Id,
+					segment is ITransaction ? "transaction" : "span",
+					segment.Id,
 					activityId);
 			}
 		}


### PR DESCRIPTION
This commit updates the Azure Service Bus integrations to create messaging spans for receiving messages from
a queue or subscription when inside a traced transaction.