### PR TITLE
Implement config to ignore the sampled flag in traceparent

### DIFF
--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -1045,6 +1045,31 @@ you must instead set the `LogLevel` for the internal APM logger under the `Loggi
 | `Error`                 | String
 |============
 
+[float]
+[[config-suppress-tracecontext-headers]]
+==== `SuppressTraceContextHeaders`
+
+By setting this to `true` the agent will ignore the W3C TraceContext headers.
+In practice this means that in case a caller service calls another service where this value is `true`, 
+the agent will ignore the known W3C headers, and it will start a new trace.
+
+This can be useful when a caller service always sets the sampled flag to false and the agent would have no chance to create any sampled transaction.
+
+NOTE: .NET 5 by default sets the W3C TraceContext headers, but without an active agent it sets the sampled flag to `false` leading to 0% sampling. If your service is called by an unmonitored .NET 5 application, setting this flag will instruct the agent to start a new trace and make a new sampling decision based on <<config-transaction-sample-rate>>.
+
+[options="header"]
+|============
+| Environment variable name | IConfiguration or Web.config key
+| `SUPPRESS_TRACECONTEXT_HEADERS`   | `ElasticApm:SuppressTraceContextHeader`
+|============
+
+[options="header"]
+|============
+| Default                 | Type
+| `false`                 | Boolean
+|============
+
+
 [[config-all-options-summary]]
 === All options summary
 
@@ -1080,6 +1105,7 @@ you must instead set the `LogLevel` for the internal APM logger under the `Loggi
 | <<config-service-version,`ServiceVersion`>> | No | Core
 | <<config-span-frames-min-duration,`SpanFramesMinDuration`>> | No | Stacktrace, Performance
 | <<config-stack-trace-limit,`StackTraceLimit`>> | No | Stacktrace, Performance
+| <<config-suppress-tracecontext-headers,`SuppressTraceContextHeaders`>> | No | Core
 | <<config-transaction-ignore-urls,`TransactionIgnoreUrls`>>  | Yes | HTTP, Performance
 | <<config-transaction-max-spans,`TransactionMaxSpans`>>  | Yes | Core, Performance
 | <<config-transaction-sample-rate,`TransactionSampleRate`>> | Yes | Core, Performance

--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -1046,21 +1046,22 @@ you must instead set the `LogLevel` for the internal APM logger under the `Loggi
 |============
 
 [float]
-[[config-suppress-tracecontext-headers]]
-==== `SuppressTraceContextHeaders`
+[[config-trace-context-ignore-sampled-false]]
+==== `TraceContextIgnoreSampledFalse`
 
-By setting this to `true` the agent will ignore the W3C TraceContext headers.
-In practice this means that in case a caller service calls another service where this value is `true`, 
-the agent will ignore the known W3C headers, and it will start a new trace.
+By setting this to `true` the agent will ignore the sampled part of the W3C TraceContext traceparent header when it's false and when the upstream transaction is not coming from a non-Elastic APM agent.
+In practice this means that in case a caller service calls another service where this value is `true`,
+the agent will ignore the sampling decision of the upstream service, and it will make a new sampling decision.
 
-This can be useful when a caller service always sets the sampled flag to false and the agent would have no chance to create any sampled transaction.
+This can be useful when a caller service always sets the sampled flag to false and the agent would have no chance to
+create any sampled transaction.
 
 NOTE: .NET 5 by default sets the W3C TraceContext headers, but without an active agent it sets the sampled flag to `false` leading to 0% sampling. If your service is called by an unmonitored .NET 5 application, setting this flag will instruct the agent to start a new trace and make a new sampling decision based on <<config-transaction-sample-rate>>.
 
 [options="header"]
 |============
-| Environment variable name | IConfiguration or Web.config key
-| `SUPPRESS_TRACECONTEXT_HEADERS`   | `ElasticApm:SuppressTraceContextHeader`
+| Environment variable name            | IConfiguration or Web.config key
+| `TRACE_CONTEXT_IGNORE_SAMPLED_FALSE` | `ElasticApm:TraceContextIgnoreSampledFalse`
 |============
 
 [options="header"]
@@ -1105,7 +1106,7 @@ NOTE: .NET 5 by default sets the W3C TraceContext headers, but without an active
 | <<config-service-version,`ServiceVersion`>> | No | Core
 | <<config-span-frames-min-duration,`SpanFramesMinDuration`>> | No | Stacktrace, Performance
 | <<config-stack-trace-limit,`StackTraceLimit`>> | No | Stacktrace, Performance
-| <<config-suppress-tracecontext-headers,`SuppressTraceContextHeaders`>> | No | Core
+| <<config-trace-context-ignore-sampled-false,`TraceContextIgnoreSampledFalse`>> | No | Core
 | <<config-transaction-ignore-urls,`TransactionIgnoreUrls`>>  | Yes | HTTP, Performance
 | <<config-transaction-max-spans,`TransactionMaxSpans`>>  | Yes | Core, Performance
 | <<config-transaction-sample-rate,`TransactionSampleRate`>> | Yes | Core, Performance

--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -1049,21 +1049,18 @@ you must instead set the `LogLevel` for the internal APM logger under the `Loggi
 [[config-trace-context-ignore-sampled-false]]
 ==== `TraceContextIgnoreSampledFalse`
 
+The agent uses the https://www.w3.org/TR/trace-context/[W3C Trace Context] specification and standards for distributed tracing. The traceparent header from the W3C Trace Context specification defines a https://www.w3.org/TR/trace-context/#sampled-flag[sampled flag] which is propagated from a caller service to a callee service, and determines whether a trace is sampled in the callee service. The default behavior of the agent honors the sampled flag value and behaves accordingly.
+
+There may be cases where you wish to change the default behavior of the agent with respect to the sampled flag. By setting the `TraceContextIgnoreSampled` configuration value to `true`, the agent ignores the sampled flag of the W3C Trace Context traceparent header when it has a value of `false` **and** and there is no agent specific tracestate header value present. In ignoring the sampled flag, the agent makes a sampling decision based on the <<config-transaction-sample-rate, sample rate>>. This can be useful when a caller service always sets a sampled flag value of `false`, that results in the agent never sampling any transactions.
+
 [IMPORTANT]
 --
-..NET 5 applications set the https://www.w3.org/TR/trace-context/[W3C Trace Context] headers for outgoing HTTP requests by default, but with the traceparent sampled flag set to `false`. If the application has an active agent, the agent will ensure that the sampled flag is propagated appropriately. If the application does not have an active agent however, and the application calls another application (the callee) that does have an active agent, the propagation of a sampled flag of `false` results in no sampled traces in the callee application.
+:dotnet5: .NET 5
 
-If your application is called by an unmonitored .NET 5 application, setting `TraceContextIgnoreSampledFalse` to `true` will instruct the agent to start a new trace and make a new sampling decision based on <<config-transaction-sample-rate>> when the traceparent sampled flag is `false` and there is no agent specific tracestate present.
+{dotnet5} applications set the W3C Trace Context for outgoing HTTP requests by default, but with the traceparent header sampled flag set to `false`. If a {dotnet5} application has an active agent, the agent ensures that the sampled flag is propagated with the agent's sampling decision. If a {dotnet5} application does not have an active agent however, and the application calls another service that does have an active agent, the propagation of a sampled flag value of `false` results in no sampled transactions in the callee service.
+
+If your application is called by an {dotnet5} application that does not have an active agent, setting the `TraceContextIgnoreSampledFalse` configuration value to `true` instructs the agent to start a new transaction and make a sampling decision based on the <<config-transaction-sample-rate, sample rate>>, when the traceparent header sampled flag has a value of `false` **and** there is no agent specific tracestate header value present.
 --
-
-The agent uses the W3C TraceContext standard for distributed tracing. The traceparent header from the W3C TraceContext standard defines a flag called `sampled`, which stored whether a trace is sampled or not and by default the agent accepts this flag and behaves accordingly.
-
-By setting this config to `true`, the agent will ignore the sampled part of the W3C TraceContext traceparent header when it's false and when the upstream transaction is not coming from a non-Elastic APM agent.
-In practice this means that in case a caller service calls another service where this value is `true`,
-the agent will ignore the sampling decision of the upstream service, and it will make a new sampling decision.
-
-This can be useful when a caller service always sets the sampled flag to false and the agent would have no chance to
-create any sampled transaction.
 
 [options="header"]
 |============

--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -1049,14 +1049,21 @@ you must instead set the `LogLevel` for the internal APM logger under the `Loggi
 [[config-trace-context-ignore-sampled-false]]
 ==== `TraceContextIgnoreSampledFalse`
 
-By setting this to `true` the agent will ignore the sampled part of the W3C TraceContext traceparent header when it's false and when the upstream transaction is not coming from a non-Elastic APM agent.
+[IMPORTANT]
+--
+..NET 5 applications set the https://www.w3.org/TR/trace-context/[W3C Trace Context] headers for outgoing HTTP requests by default, but with the traceparent sampled flag set to `false`. If the application has an active agent, the agent will ensure that the sampled flag is propagated appropriately. If the application does not have an active agent however, and the application calls another application (the callee) that does have an active agent, the propagation of a sampled flag of `false` results in no sampled traces in the callee application.
+
+If your application is called by an unmonitored .NET 5 application, setting `TraceContextIgnoreSampledFalse` to `true` will instruct the agent to start a new trace and make a new sampling decision based on <<config-transaction-sample-rate>> when the traceparent sampled flag is `false` and there is no agent specific tracestate present.
+--
+
+The agent uses the W3C TraceContext standard for distributed tracing. The traceparent header from the W3C TraceContext standard defines a flag called `sampled`, which stored whether a trace is sampled or not and by default the agent accepts this flag and behaves accordingly.
+
+By setting this config to `true`, the agent will ignore the sampled part of the W3C TraceContext traceparent header when it's false and when the upstream transaction is not coming from a non-Elastic APM agent.
 In practice this means that in case a caller service calls another service where this value is `true`,
 the agent will ignore the sampling decision of the upstream service, and it will make a new sampling decision.
 
 This can be useful when a caller service always sets the sampled flag to false and the agent would have no chance to
 create any sampled transaction.
-
-NOTE: .NET 5 by default sets the W3C TraceContext headers, but without an active agent it sets the sampled flag to `false` leading to 0% sampling. If your service is called by an unmonitored .NET 5 application, setting this flag will instruct the agent to start a new trace and make a new sampling decision based on <<config-transaction-sample-rate>>.
 
 [options="header"]
 |============

--- a/src/Elastic.Apm/BackendComm/CentralConfig/CentralConfigFetcher.cs
+++ b/src/Elastic.Apm/BackendComm/CentralConfig/CentralConfigFetcher.cs
@@ -306,7 +306,7 @@ namespace Elastic.Apm.BackendComm.CentralConfig
 			public bool UseElasticTraceparentHeader => _wrapped.UseElasticTraceparentHeader;
 
 			public bool VerifyServerCert => _wrapped.VerifyServerCert;
-			public bool SuppressTraceContextHeaders => _wrapped.SuppressTraceContextHeaders;
+			public bool TraceContextIgnoreSampledFalse => _wrapped.TraceContextIgnoreSampledFalse;
 		}
 	}
 }

--- a/src/Elastic.Apm/BackendComm/CentralConfig/CentralConfigFetcher.cs
+++ b/src/Elastic.Apm/BackendComm/CentralConfig/CentralConfigFetcher.cs
@@ -306,6 +306,7 @@ namespace Elastic.Apm.BackendComm.CentralConfig
 			public bool UseElasticTraceparentHeader => _wrapped.UseElasticTraceparentHeader;
 
 			public bool VerifyServerCert => _wrapped.VerifyServerCert;
+			public bool SuppressTraceContextHeaders => _wrapped.SuppressTraceContextHeaders;
 		}
 	}
 }

--- a/src/Elastic.Apm/Config/AbstractConfigurationReader.cs
+++ b/src/Elastic.Apm/Config/AbstractConfigurationReader.cs
@@ -199,6 +199,13 @@ namespace Elastic.Apm.Config
 			return true;
 		}
 
+		protected bool ParseSuppressTraceContextHeaders(ConfigurationKeyValue kv)
+		{
+			if (kv == null || string.IsNullOrEmpty(kv.Value)) return DefaultValues.SuppressTraceContextHeaders;
+			// ReSharper disable once SimplifyConditionalTernaryExpression
+			return bool.TryParse(kv.Value, out var value) ? value : DefaultValues.SuppressTraceContextHeaders;
+		}
+
 		protected bool ParseVerifyServerCert(ConfigurationKeyValue kv)
 		{
 			if (kv == null || string.IsNullOrEmpty(kv.Value)) return DefaultValues.VerifyServerCert;

--- a/src/Elastic.Apm/Config/AbstractConfigurationReader.cs
+++ b/src/Elastic.Apm/Config/AbstractConfigurationReader.cs
@@ -201,9 +201,9 @@ namespace Elastic.Apm.Config
 
 		protected bool ParseTraceContextIgnoreSampledFalse(ConfigurationKeyValue kv)
 		{
-			if (kv == null || string.IsNullOrEmpty(kv.Value)) return DefaultValues.SuppressTraceContextHeaders;
+			if (kv == null || string.IsNullOrEmpty(kv.Value)) return DefaultValues.TraceContextIgnoreSampledFalse;
 			// ReSharper disable once SimplifyConditionalTernaryExpression
-			return bool.TryParse(kv.Value, out var value) ? value : DefaultValues.SuppressTraceContextHeaders;
+			return bool.TryParse(kv.Value, out var value) ? value : DefaultValues.TraceContextIgnoreSampledFalse;
 		}
 
 		protected bool ParseVerifyServerCert(ConfigurationKeyValue kv)

--- a/src/Elastic.Apm/Config/AbstractConfigurationReader.cs
+++ b/src/Elastic.Apm/Config/AbstractConfigurationReader.cs
@@ -199,7 +199,7 @@ namespace Elastic.Apm.Config
 			return true;
 		}
 
-		protected bool ParseSuppressTraceContextHeaders(ConfigurationKeyValue kv)
+		protected bool ParseTraceContextIgnoreSampledFalse(ConfigurationKeyValue kv)
 		{
 			if (kv == null || string.IsNullOrEmpty(kv.Value)) return DefaultValues.SuppressTraceContextHeaders;
 			// ReSharper disable once SimplifyConditionalTernaryExpression

--- a/src/Elastic.Apm/Config/AbstractConfigurationWithEnvFallbackReader.cs
+++ b/src/Elastic.Apm/Config/AbstractConfigurationWithEnvFallbackReader.cs
@@ -135,8 +135,8 @@ namespace Elastic.Apm.Config
 
 		public virtual int StackTraceLimit => _stackTraceLimit.Value;
 
-		public bool SuppressTraceContextHeaders =>
-			ParseSuppressTraceContextHeaders(Read(KeyNames.SuppressTraceContextHeader, EnvVarNames.SuppressTraceContextHeader));
+		public bool TraceContextIgnoreSampledFalse =>
+			ParseTraceContextIgnoreSampledFalse(Read(KeyNames.TraceContextIgnoreSampledFalse, EnvVarNames.TraceContextIgnoreSampledFalse));
 
 		public IReadOnlyList<WildcardMatcher> TransactionIgnoreUrls =>
 			ParseTransactionIgnoreUrls(Read(KeyNames.TransactionIgnoreUrls, EnvVarNames.TransactionIgnoreUrls));

--- a/src/Elastic.Apm/Config/AbstractConfigurationWithEnvFallbackReader.cs
+++ b/src/Elastic.Apm/Config/AbstractConfigurationWithEnvFallbackReader.cs
@@ -1,4 +1,5 @@
-﻿// Licensed to Elasticsearch B.V under one or more agreements.
+﻿// Licensed to Elasticsearch B.V under
+// one or more agreements.
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
 
@@ -94,21 +95,6 @@ namespace Elastic.Apm.Config
 		public virtual string ServerCert => ParseServerCert(Read(KeyNames.ServerCert, EnvVarNames.ServerCert));
 
 		/// <inheritdoc />
-		[Obsolete("Use ServerUrl")]
-		public virtual IReadOnlyList<Uri> ServerUrls
-		{
-			get
-			{
-				// Use ServerUrl if there's no value for ServerUrls so that usage of ServerUrls
-				// outside of the agent will work with ServerUrl
-				var configurationKeyValue = Read(KeyNames.ServerUrls, EnvVarNames.ServerUrls);
-				return ParseServerUrls(!string.IsNullOrEmpty(configurationKeyValue.Value)
-					? configurationKeyValue
-					: Read(KeyNames.ServerUrl, EnvVarNames.ServerUrl));
-			}
-		}
-
-		/// <inheritdoc />
 		public virtual Uri ServerUrl
 		{
 			get
@@ -123,6 +109,21 @@ namespace Elastic.Apm.Config
 			}
 		}
 
+		/// <inheritdoc />
+		[Obsolete("Use ServerUrl")]
+		public virtual IReadOnlyList<Uri> ServerUrls
+		{
+			get
+			{
+				// Use ServerUrl if there's no value for ServerUrls so that usage of ServerUrls
+				// outside of the agent will work with ServerUrl
+				var configurationKeyValue = Read(KeyNames.ServerUrls, EnvVarNames.ServerUrls);
+				return ParseServerUrls(!string.IsNullOrEmpty(configurationKeyValue.Value)
+					? configurationKeyValue
+					: Read(KeyNames.ServerUrl, EnvVarNames.ServerUrl));
+			}
+		}
+
 		public virtual string ServiceName => ParseServiceName(Read(KeyNames.ServiceName, EnvVarNames.ServiceName));
 
 		public string ServiceNodeName => ParseServiceNodeName(Read(KeyNames.ServiceNodeName, EnvVarNames.ServiceNodeName));
@@ -133,6 +134,9 @@ namespace Elastic.Apm.Config
 		public virtual double SpanFramesMinDurationInMilliseconds => _spanFramesMinDurationInMilliseconds.Value;
 
 		public virtual int StackTraceLimit => _stackTraceLimit.Value;
+
+		public bool SuppressTraceContextHeaders =>
+			ParseSuppressTraceContextHeaders(Read(KeyNames.SuppressTraceContextHeader, EnvVarNames.SuppressTraceContextHeader));
 
 		public IReadOnlyList<WildcardMatcher> TransactionIgnoreUrls =>
 			ParseTransactionIgnoreUrls(Read(KeyNames.TransactionIgnoreUrls, EnvVarNames.TransactionIgnoreUrls));

--- a/src/Elastic.Apm/Config/ConfigConsts.cs
+++ b/src/Elastic.Apm/Config/ConfigConsts.cs
@@ -143,7 +143,7 @@ namespace Elastic.Apm.Config
 			public const string ServiceVersion = Prefix + "SERVICE_VERSION";
 			public const string SpanFramesMinDuration = Prefix + "SPAN_FRAMES_MIN_DURATION";
 			public const string StackTraceLimit = Prefix + "STACK_TRACE_LIMIT";
-			public const string SuppressTraceContextHeader = Prefix + "SUPPRESS_TRACECONTEXT_HEADERS";
+			public const string TraceContextIgnoreSampledFalse = Prefix + "TRACE_CONTEXT_IGNORE_SAMPLED_FALSE";
 			public const string TransactionIgnoreUrls = Prefix + "TRANSACTION_IGNORE_URLS";
 			public const string TransactionMaxSpans = Prefix + "TRANSACTION_MAX_SPANS";
 			public const string TransactionSampleRate = Prefix + "TRANSACTION_SAMPLE_RATE";
@@ -185,7 +185,7 @@ namespace Elastic.Apm.Config
 			public const string ServiceNodeName = Prefix + nameof(ServiceNodeName);
 			public const string ServiceVersion = Prefix + nameof(ServiceVersion);
 			public const string SpanFramesMinDuration = Prefix + nameof(SpanFramesMinDuration);
-			public const string SuppressTraceContextHeader = Prefix + nameof(SuppressTraceContextHeader);
+			public const string TraceContextIgnoreSampledFalse = Prefix + nameof(TraceContextIgnoreSampledFalse);
 			public const string StackTraceLimit = Prefix + nameof(StackTraceLimit);
 			public const string TransactionIgnoreUrls = Prefix + nameof(TransactionIgnoreUrls);
 			public const string TransactionMaxSpans = Prefix + nameof(TransactionMaxSpans);

--- a/src/Elastic.Apm/Config/ConfigConsts.cs
+++ b/src/Elastic.Apm/Config/ConfigConsts.cs
@@ -34,7 +34,7 @@ namespace Elastic.Apm.Config
 			public const string SpanFramesMinDuration = "5ms";
 			public const double SpanFramesMinDurationInMilliseconds = 5;
 			public const int StackTraceLimit = 50;
-			public const bool SuppressTraceContextHeaders = false;
+			public const bool TraceContextIgnoreSampledFalse = false;
 			public const int TransactionMaxSpans = 500;
 			public const double TransactionSampleRate = 1.0;
 			public const string UnknownServiceName = "unknown";

--- a/src/Elastic.Apm/Config/ConfigConsts.cs
+++ b/src/Elastic.Apm/Config/ConfigConsts.cs
@@ -34,6 +34,7 @@ namespace Elastic.Apm.Config
 			public const string SpanFramesMinDuration = "5ms";
 			public const double SpanFramesMinDurationInMilliseconds = 5;
 			public const int StackTraceLimit = 50;
+			public const bool SuppressTraceContextHeaders = false;
 			public const int TransactionMaxSpans = 500;
 			public const double TransactionSampleRate = 1.0;
 			public const string UnknownServiceName = "unknown";
@@ -142,6 +143,7 @@ namespace Elastic.Apm.Config
 			public const string ServiceVersion = Prefix + "SERVICE_VERSION";
 			public const string SpanFramesMinDuration = Prefix + "SPAN_FRAMES_MIN_DURATION";
 			public const string StackTraceLimit = Prefix + "STACK_TRACE_LIMIT";
+			public const string SuppressTraceContextHeader = Prefix + "SUPPRESS_TRACECONTEXT_HEADERS";
 			public const string TransactionIgnoreUrls = Prefix + "TRANSACTION_IGNORE_URLS";
 			public const string TransactionMaxSpans = Prefix + "TRANSACTION_MAX_SPANS";
 			public const string TransactionSampleRate = Prefix + "TRANSACTION_SAMPLE_RATE";
@@ -183,6 +185,7 @@ namespace Elastic.Apm.Config
 			public const string ServiceNodeName = Prefix + nameof(ServiceNodeName);
 			public const string ServiceVersion = Prefix + nameof(ServiceVersion);
 			public const string SpanFramesMinDuration = Prefix + nameof(SpanFramesMinDuration);
+			public const string SuppressTraceContextHeader = Prefix + nameof(SuppressTraceContextHeader);
 			public const string StackTraceLimit = Prefix + nameof(StackTraceLimit);
 			public const string TransactionIgnoreUrls = Prefix + nameof(TransactionIgnoreUrls);
 			public const string TransactionMaxSpans = Prefix + nameof(TransactionMaxSpans);

--- a/src/Elastic.Apm/Config/ConfigSnapshotFromReader.cs
+++ b/src/Elastic.Apm/Config/ConfigSnapshotFromReader.cs
@@ -1,4 +1,5 @@
-// Licensed to Elasticsearch B.V under one or more agreements.
+// Licensed to Elasticsearch B.V under
+// one or more agreements.
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
 
@@ -43,15 +44,19 @@ namespace Elastic.Apm.Config
 		public bool Recording => _content.Recording;
 		public IReadOnlyList<WildcardMatcher> SanitizeFieldNames => _content.SanitizeFieldNames;
 		public string SecretToken => _content.SecretToken;
-		[Obsolete("Use ServerUrl")]
-		public IReadOnlyList<Uri> ServerUrls => _content.ServerUrls;
 		public string ServerCert => _content.ServerCert;
 		public Uri ServerUrl => _content.ServerUrl;
+
+		[Obsolete("Use ServerUrl")]
+		public IReadOnlyList<Uri> ServerUrls => _content.ServerUrls;
+
 		public string ServiceName => _content.ServiceName;
 		public string ServiceNodeName => _content.ServiceNodeName;
 		public string ServiceVersion => _content.ServiceVersion;
 		public double SpanFramesMinDurationInMilliseconds => _content.SpanFramesMinDurationInMilliseconds;
 		public int StackTraceLimit => _content.StackTraceLimit;
+
+		public bool SuppressTraceContextHeaders => _content.SuppressTraceContextHeaders;
 		public IReadOnlyList<WildcardMatcher> TransactionIgnoreUrls => _content.TransactionIgnoreUrls;
 		public int TransactionMaxSpans => _content.TransactionMaxSpans;
 		public double TransactionSampleRate => _content.TransactionSampleRate;

--- a/src/Elastic.Apm/Config/ConfigSnapshotFromReader.cs
+++ b/src/Elastic.Apm/Config/ConfigSnapshotFromReader.cs
@@ -56,7 +56,7 @@ namespace Elastic.Apm.Config
 		public double SpanFramesMinDurationInMilliseconds => _content.SpanFramesMinDurationInMilliseconds;
 		public int StackTraceLimit => _content.StackTraceLimit;
 
-		public bool SuppressTraceContextHeaders => _content.SuppressTraceContextHeaders;
+		public bool TraceContextIgnoreSampledFalse => _content.TraceContextIgnoreSampledFalse;
 		public IReadOnlyList<WildcardMatcher> TransactionIgnoreUrls => _content.TransactionIgnoreUrls;
 		public int TransactionMaxSpans => _content.TransactionMaxSpans;
 		public double TransactionSampleRate => _content.TransactionSampleRate;

--- a/src/Elastic.Apm/Config/EnvironmentConfigurationReader.cs
+++ b/src/Elastic.Apm/Config/EnvironmentConfigurationReader.cs
@@ -123,6 +123,7 @@ namespace Elastic.Apm.Config
 
 		public bool VerifyServerCert => ParseVerifyServerCert(Read(ConfigConsts.EnvVarNames.VerifyServerCert));
 
+		public bool SuppressTraceContextHeaders => ParseSuppressTraceContextHeaders(Read(ConfigConsts.EnvVarNames.SuppressTraceContextHeader));
 		private ConfigurationKeyValue Read(string key) =>
 			new ConfigurationKeyValue(key, ReadEnvVarValue(key), Origin);
 	}

--- a/src/Elastic.Apm/Config/EnvironmentConfigurationReader.cs
+++ b/src/Elastic.Apm/Config/EnvironmentConfigurationReader.cs
@@ -123,7 +123,7 @@ namespace Elastic.Apm.Config
 
 		public bool VerifyServerCert => ParseVerifyServerCert(Read(ConfigConsts.EnvVarNames.VerifyServerCert));
 
-		public bool SuppressTraceContextHeaders => ParseSuppressTraceContextHeaders(Read(ConfigConsts.EnvVarNames.SuppressTraceContextHeader));
+		public bool TraceContextIgnoreSampledFalse => ParseTraceContextIgnoreSampledFalse(Read(ConfigConsts.EnvVarNames.TraceContextIgnoreSampledFalse));
 		private ConfigurationKeyValue Read(string key) =>
 			new ConfigurationKeyValue(key, ReadEnvVarValue(key), Origin);
 	}

--- a/src/Elastic.Apm/Config/IConfigurationReader.cs
+++ b/src/Elastic.Apm/Config/IConfigurationReader.cs
@@ -1,4 +1,5 @@
-// Licensed to Elasticsearch B.V under one or more agreements.
+// Licensed to Elasticsearch B.V under
+// one or more agreements.
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
 
@@ -51,8 +52,10 @@ namespace Elastic.Apm.Config
 		bool CentralConfig { get; }
 
 		/// <summary>
-		/// Specify which cloud provider should be assumed for metadata collection. By default, the agent will attempt to detect the cloud
-		/// provider or, if that fails, will use trial and error to collect the metadata. Valid options are "aws", "gcp", and "azure".
+		/// Specify which cloud provider should be assumed for metadata collection. By default, the agent will attempt to detect
+		/// the cloud
+		/// provider or, if that fails, will use trial and error to collect the metadata. Valid options are "aws", "gcp", and
+		/// "azure".
 		/// If this config value is set to "False", no cloud metadata will be collected.
 		/// </summary>
 		string CloudProvider { get; }
@@ -212,15 +215,15 @@ namespace Elastic.Apm.Config
 		string ServerCert { get; }
 
 		/// <summary>
+		/// The URL for APM server.
+		/// </summary>
+		Uri ServerUrl { get; }
+
+		/// <summary>
 		/// The URLs for APM server.
 		/// </summary>
 		[Obsolete("Use ServerUrl")]
 		IReadOnlyList<Uri> ServerUrls { get; }
-
-		/// <summary>
-		/// The URL for APM server.
-		/// </summary>
-		Uri ServerUrl { get; }
 
 		/// <summary>
 		/// The name of service instrumented by the APM agent. This is used to group all the errors and transactions
@@ -259,6 +262,16 @@ namespace Elastic.Apm.Config
 		int StackTraceLimit { get; }
 
 		/// <summary>
+		/// By setting this to <code>true</code> the agent will ignore the W3C TraceContext headers.
+		/// In practice this means that in case a caller service calls another service where this value is <code>true</code>,
+		/// the agent will ignore the known W3C headers, and it will start a new trace.
+		///
+		/// This can be useful when a caller service always sets the sampled flag to false and the agent would have no chance to
+		/// create any sampled transaction.
+		/// </summary>
+		bool SuppressTraceContextHeaders { get; }
+
+		/// <summary>
 		/// A list of patterns to match HTTP requests to ignore. An incoming HTTP request whose request line matches any of the
 		/// patterns will not be reported as a transaction.
 		/// </summary>
@@ -283,14 +296,17 @@ namespace Elastic.Apm.Config
 
 		/// <summary>
 		/// The sample rate for transactions.
-		/// By default, the agent will sample every transaction (e.g. a request to your service). To reduce overhead and storage requirements,
-		/// the sample rate can be set to a value between 0.0 and 1.0. The agent still records the overall time and result for unsampled
+		/// By default, the agent will sample every transaction (e.g. a request to your service). To reduce overhead and storage
+		/// requirements,
+		/// the sample rate can be set to a value between 0.0 and 1.0. The agent still records the overall time and result for
+		/// unsampled
 		/// transactions, but no context information, labels, or spans are recorded.
 		/// </summary>
 		double TransactionSampleRate { get; }
 
 		/// <summary>
-		/// If <c>true</c>, for all outgoing HTTP requests the agent stores the traceparent in a "elastic-apm-traceparent" header name.
+		/// If <c>true</c>, for all outgoing HTTP requests the agent stores the traceparent in a "elastic-apm-traceparent" header
+		/// name.
 		/// Otherwise, it'll use the official w3c "traceparent" header name.
 		/// </summary>
 		bool UseElasticTraceparentHeader { get; }

--- a/src/Elastic.Apm/Config/IConfigurationReader.cs
+++ b/src/Elastic.Apm/Config/IConfigurationReader.cs
@@ -262,14 +262,15 @@ namespace Elastic.Apm.Config
 		int StackTraceLimit { get; }
 
 		/// <summary>
-		/// By setting this to <code>true</code> the agent will ignore the W3C TraceContext headers.
+		/// By setting this to <code>true</code> the agent will ignore the sampled part of the W3C TraceContext traceparent header
+		/// when it's false and when the upstream transaction is not coming from an Elastic APM agent.
 		/// In practice this means that in case a caller service calls another service where this value is <code>true</code>,
-		/// the agent will ignore the known W3C headers, and it will start a new trace.
+		/// the agent will ignore the sampling decision of the upstream service, and it will make a new sampling decision.
 		///
 		/// This can be useful when a caller service always sets the sampled flag to false and the agent would have no chance to
 		/// create any sampled transaction.
 		/// </summary>
-		bool SuppressTraceContextHeaders { get; }
+		bool TraceContextIgnoreSampledFalse { get; }
 
 		/// <summary>
 		/// A list of patterns to match HTTP requests to ignore. An incoming HTTP request whose request line matches any of the

--- a/src/Elastic.Apm/Model/Transaction.cs
+++ b/src/Elastic.Apm/Model/Transaction.cs
@@ -106,7 +106,7 @@ namespace Elastic.Apm.Model
 				_activity = StartActivity();
 
 			var isSamplingFromDistributedTracingData = false;
-			if (distributedTracingData == null)
+			if (distributedTracingData == null || configSnapshot.SuppressTraceContextHeaders)
 			{
 				// We consider a newly created transaction **without** explicitly passed distributed tracing data
 				// to be a root transaction.

--- a/src/Elastic.Apm/Model/Transaction.cs
+++ b/src/Elastic.Apm/Model/Transaction.cs
@@ -208,7 +208,7 @@ namespace Elastic.Apm.Model
 				isSamplingFromDistributedTracingData = true;
 				_traceState = distributedTracingData.TraceState;
 
-				// If SuppressTraceContextHeaders is set and the upstream service is not from our agent (aka no sample rate set)
+				// If TraceContextIgnoreSampledFalse is set and the upstream service is not from our agent (aka no sample rate set)
 				// ignore the sampled flag and make a new sampling decision.
 				if (configSnapshot.TraceContextIgnoreSampledFalse && (distributedTracingData.TraceState == null
 					|| !distributedTracingData.TraceState.SampleRate.HasValue && !distributedTracingData.FlagRecorded))

--- a/test/Elastic.Apm.AspNetCore.Tests/DistributedTracingAspNetCoreTests.cs
+++ b/test/Elastic.Apm.AspNetCore.Tests/DistributedTracingAspNetCoreTests.cs
@@ -202,7 +202,7 @@ namespace Elastic.Apm.AspNetCore.Tests
 		}
 
 		/// <summary>
-		/// Sets the SuppressTraceContextHeaders config and makes sure that the traceparent header is ignored
+		/// Sets the TraceContextIgnoreSampledFalse config and makes sure that the traceparent header is ignored
 		/// </summary>
 		[Fact]
 		public async Task TraceContextIgnoreSampledFalse_WithNoTraceState()
@@ -224,7 +224,7 @@ namespace Elastic.Apm.AspNetCore.Tests
 		}
 
 		/// <summary>
-		/// Sets the TraceContextIgnoreSampledFalse config and makes sends a traceparent with es vendor part.
+		/// Sets the TraceContextIgnoreSampledFalse config and sends a traceparent with es vendor part.
 		/// Makes sure in that case the sampled flag from traceparent is honored.
 		/// </summary>
 		[Fact]
@@ -248,7 +248,7 @@ namespace Elastic.Apm.AspNetCore.Tests
 		}
 
 		/// <summary>
-		/// Sets the TraceContextIgnoreSampledFalse config and makes sends a traceparent without es vendor part.
+		/// Sets the TraceContextIgnoreSampledFalse config and sends a traceparent without es vendor part.
 		/// Makes sure in that case the sampled flag from traceparent is ignored.
 		/// </summary>
 		[Fact]
@@ -273,7 +273,7 @@ namespace Elastic.Apm.AspNetCore.Tests
 
 		/// <summary>
 		/// Does not set the TraceContextIgnoreSampledFalse config and makes sure that the traceparent header is not ignored.
-		/// This tests the default case when the config is not set, so the agent just follows W3C and takes the sampled flag as it is
+		/// This tests the default case when the config is not set, so the agent just follows W3C and takes the sampled flag as it is.
 		/// </summary>
 		[Fact]
 		public async Task TraceContextIgnoreSampledFalse_NotSet_WithNonEsTraceState_NotSampled()

--- a/test/Elastic.Apm.AspNetCore.Tests/DistributedTracingAspNetCoreTests.cs
+++ b/test/Elastic.Apm.AspNetCore.Tests/DistributedTracingAspNetCoreTests.cs
@@ -201,18 +201,19 @@ namespace Elastic.Apm.AspNetCore.Tests
 			_payloadSender1.FirstTransaction.ParentId.Should().Be(expectedParentId);
 		}
 
+		/// <summary>
 		/// Sets the SuppressTraceContextHeaders config and makes sure that the traceparent header is ignored
 		/// </summary>
 		[Fact]
-		public async Task SuppressTraceContextHeaders()
+		public async Task TraceContextIgnoreSampledFalse_WithNoTraceState()
 		{
-			// Set suppressTraceContextHeaders (and 100% sample rate)
+			// Set TraceContextIgnoreSampledFalse (and 100% sample rate)
 			_agent1.ConfigStore.CurrentSnapshot =
-				new MockConfigSnapshot(new NoopLogger(), suppressTraceContextHeaders: "true", transactionSampleRate: "1");
+				new MockConfigSnapshot(new NoopLogger(), traceContextIgnoreSampledFalse: "true", transactionSampleRate: "1");
 
 			var client = new HttpClient();
 
-			// Send traceparent wiht sampled=false
+			// Send traceparent with sampled=false
 			client.DefaultRequestHeaders.Add("traceparent", $"00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-00");
 
 			var res = await client.GetAsync("http://localhost:5901/Home/Index");
@@ -220,6 +221,78 @@ namespace Elastic.Apm.AspNetCore.Tests
 
 			// Assert that the transaction is sampled and the traceparent header was ignored
 			_payloadSender1.FirstTransaction.IsSampled.Should().BeTrue();
+		}
+
+		/// <summary>
+		/// Sets the TraceContextIgnoreSampledFalse config and makes sends a traceparent with es vendor part.
+		/// Makes sure in that case the sampled flag from traceparent is honored.
+		/// </summary>
+		[Fact]
+		public async Task TraceContextIgnoreSampledFalse_WithEsTraceState_NotSampled()
+		{
+			// Set TraceContextIgnoreSampledFalse (and 100% sample rate)
+			_agent1.ConfigStore.CurrentSnapshot =
+				new MockConfigSnapshot(new NoopLogger(), traceContextIgnoreSampledFalse: "true", transactionSampleRate: "1");
+
+			var client = new HttpClient();
+
+			// Send traceparent with sampled=false and tracestate with a valid es flag
+			client.DefaultRequestHeaders.Add("traceparent", $"00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-00");
+			client.DefaultRequestHeaders.Add("tracestate", $"es=s:0.5");
+
+			var res = await client.GetAsync("http://localhost:5901/Home/Index");
+			res.IsSuccessStatusCode.Should().BeTrue();
+
+			// Assert that the transaction is not sampled, so the traceparent header was not ignored
+			_payloadSender1.FirstTransaction.IsSampled.Should().BeFalse();
+		}
+
+		/// <summary>
+		/// Sets the TraceContextIgnoreSampledFalse config and makes sends a traceparent without es vendor part.
+		/// Makes sure in that case the sampled flag from traceparent is ignored.
+		/// </summary>
+		[Fact]
+		public async Task TraceContextIgnoreSampledFalse_WithNonEsTraceState_NotSampled()
+		{
+			// Set TraceContextIgnoreSampledFalse (and 100% sample rate)
+			_agent1.ConfigStore.CurrentSnapshot =
+				new MockConfigSnapshot(new NoopLogger(), traceContextIgnoreSampledFalse: "true", transactionSampleRate: "1");
+
+			var client = new HttpClient();
+
+			// Send traceparent with sampled=false and a tracestate with no es vendor flag
+			client.DefaultRequestHeaders.Add("traceparent", $"00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-00");
+			client.DefaultRequestHeaders.Add("tracestate", $"foo=bar:0.5");
+
+			var res = await client.GetAsync("http://localhost:5901/Home/Index");
+			res.IsSuccessStatusCode.Should().BeTrue();
+
+			// Assert that the transaction is sampled and the traceparent header was ignored
+			_payloadSender1.FirstTransaction.IsSampled.Should().BeTrue();
+		}
+
+		/// <summary>
+		/// Does not set the TraceContextIgnoreSampledFalse config and makes sure that the traceparent header is not ignored.
+		/// This tests the default case when the config is not set, so the agent just follows W3C and takes the sampled flag as it is
+		/// </summary>
+		[Fact]
+		public async Task TraceContextIgnoreSampledFalse_NotSet_WithNonEsTraceState_NotSampled()
+		{
+			// Set TraceContextIgnoreSampledFalse to default (and 100% sample rate)
+			_agent1.ConfigStore.CurrentSnapshot =
+				new MockConfigSnapshot(new NoopLogger(), traceContextIgnoreSampledFalse: "false", transactionSampleRate: "1");
+
+			var client = new HttpClient();
+
+			// Send traceparent with sampled=false
+			client.DefaultRequestHeaders.Add("traceparent", $"00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-00");
+			client.DefaultRequestHeaders.Add("tracestate", $"foo=bar:0.5");
+
+			var res = await client.GetAsync("http://localhost:5901/Home/Index");
+			res.IsSuccessStatusCode.Should().BeTrue();
+
+			// Assert that the transaction is not sampled and the traceparent header was not ignored
+			_payloadSender1.FirstTransaction.IsSampled.Should().BeFalse();
 		}
 
 		public async Task DisposeAsync()

--- a/test/Elastic.Apm.Tests.Utilities/MockConfigSnapshot.cs
+++ b/test/Elastic.Apm.Tests.Utilities/MockConfigSnapshot.cs
@@ -1,4 +1,5 @@
-// Licensed to Elasticsearch B.V under one or more agreements.
+// Licensed to Elasticsearch B.V under
+// one or more agreements.
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
 
@@ -46,6 +47,7 @@ namespace Elastic.Apm.Tests.Utilities
 		private readonly string _serviceVersion;
 		private readonly string _spanFramesMinDurationInMilliseconds;
 		private readonly string _stackTraceLimit;
+		private readonly string _suppressTraceContextHeaders;
 		private readonly string _transactionIgnoreUrls;
 		private readonly string _transactionMaxSpans;
 		private readonly string _transactionSampleRate;
@@ -89,7 +91,8 @@ namespace Elastic.Apm.Tests.Utilities
 			string recording = null,
 			string serverUrl = null,
 			string serverCert = null,
-			string ignoreMessageQueues = null
+			string ignoreMessageQueues = null,
+			string suppressTraceContextHeaders = null
 		) : base(logger, ThisClassName)
 		{
 			_serverUrls = serverUrls;
@@ -128,6 +131,7 @@ namespace Elastic.Apm.Tests.Utilities
 			_serverUrl = serverUrl;
 			_serverCert = serverCert;
 			_ignoreMessageQueues = ignoreMessageQueues;
+			_suppressTraceContextHeaders = suppressTraceContextHeaders;
 		}
 
 		public string ApiKey => ParseApiKey(Kv(EnvVarNames.ApiKey, _apiKey, Origin));
@@ -179,11 +183,6 @@ namespace Elastic.Apm.Tests.Utilities
 
 		public string ServerCert => ParseServerCert(Kv(EnvVarNames.ServerCert, _serverCert, Origin));
 
-		[Obsolete("Use ServerUrl")]
-		public IReadOnlyList<Uri> ServerUrls => ParseServerUrls(_serverUrls != null
-			? Kv(EnvVarNames.ServerUrls, _serverUrls, Origin)
-			: Kv(EnvVarNames.ServerUrl, _serverUrl, Origin));
-
 		public Uri ServerUrl
 		{
 			get
@@ -196,6 +195,11 @@ namespace Elastic.Apm.Tests.Utilities
 			}
 		}
 
+		[Obsolete("Use ServerUrl")]
+		public IReadOnlyList<Uri> ServerUrls => ParseServerUrls(_serverUrls != null
+			? Kv(EnvVarNames.ServerUrls, _serverUrls, Origin)
+			: Kv(EnvVarNames.ServerUrl, _serverUrl, Origin));
+
 		public string ServiceName => ParseServiceName(Kv(EnvVarNames.ServiceName, _serviceName, Origin));
 		public string ServiceNodeName => ParseServiceNodeName(Kv(EnvVarNames.ServiceNodeName, _serviceNodeName, Origin));
 		public string ServiceVersion => ParseServiceVersion(Kv(EnvVarNames.ServiceVersion, _serviceVersion, Origin));
@@ -205,6 +209,9 @@ namespace Elastic.Apm.Tests.Utilities
 			_spanFramesMinDurationInMilliseconds, Origin));
 
 		public int StackTraceLimit => ParseStackTraceLimit(Kv(EnvVarNames.StackTraceLimit, _stackTraceLimit, Origin));
+
+		public bool SuppressTraceContextHeaders =>
+			ParseSuppressTraceContextHeaders(Kv(EnvVarNames.SuppressTraceContextHeader, _suppressTraceContextHeaders, Origin));
 
 		public IReadOnlyList<WildcardMatcher> TransactionIgnoreUrls =>
 			ParseTransactionIgnoreUrls(Kv(EnvVarNames.TransactionIgnoreUrls, _transactionIgnoreUrls, Origin));

--- a/test/Elastic.Apm.Tests.Utilities/MockConfigSnapshot.cs
+++ b/test/Elastic.Apm.Tests.Utilities/MockConfigSnapshot.cs
@@ -47,7 +47,7 @@ namespace Elastic.Apm.Tests.Utilities
 		private readonly string _serviceVersion;
 		private readonly string _spanFramesMinDurationInMilliseconds;
 		private readonly string _stackTraceLimit;
-		private readonly string _suppressTraceContextHeaders;
+		private readonly string _traceContextIgnoreSampledFalse;
 		private readonly string _transactionIgnoreUrls;
 		private readonly string _transactionMaxSpans;
 		private readonly string _transactionSampleRate;
@@ -92,7 +92,7 @@ namespace Elastic.Apm.Tests.Utilities
 			string serverUrl = null,
 			string serverCert = null,
 			string ignoreMessageQueues = null,
-			string suppressTraceContextHeaders = null
+			string traceContextIgnoreSampledFalse = null
 		) : base(logger, ThisClassName)
 		{
 			_serverUrls = serverUrls;
@@ -131,7 +131,7 @@ namespace Elastic.Apm.Tests.Utilities
 			_serverUrl = serverUrl;
 			_serverCert = serverCert;
 			_ignoreMessageQueues = ignoreMessageQueues;
-			_suppressTraceContextHeaders = suppressTraceContextHeaders;
+			_traceContextIgnoreSampledFalse = traceContextIgnoreSampledFalse;
 		}
 
 		public string ApiKey => ParseApiKey(Kv(EnvVarNames.ApiKey, _apiKey, Origin));
@@ -210,8 +210,8 @@ namespace Elastic.Apm.Tests.Utilities
 
 		public int StackTraceLimit => ParseStackTraceLimit(Kv(EnvVarNames.StackTraceLimit, _stackTraceLimit, Origin));
 
-		public bool SuppressTraceContextHeaders =>
-			ParseSuppressTraceContextHeaders(Kv(EnvVarNames.SuppressTraceContextHeader, _suppressTraceContextHeaders, Origin));
+		public bool TraceContextIgnoreSampledFalse =>
+			ParseTraceContextIgnoreSampledFalse(Kv(EnvVarNames.TraceContextIgnoreSampledFalse, _traceContextIgnoreSampledFalse, Origin));
 
 		public IReadOnlyList<WildcardMatcher> TransactionIgnoreUrls =>
 			ParseTransactionIgnoreUrls(Kv(EnvVarNames.TransactionIgnoreUrls, _transactionIgnoreUrls, Origin));

--- a/test/Elastic.Apm.Tests/ConstructorTests.cs
+++ b/test/Elastic.Apm.Tests/ConstructorTests.cs
@@ -1,4 +1,5 @@
-// Licensed to Elasticsearch B.V under one or more agreements.
+// Licensed to Elasticsearch B.V under
+// one or more agreements.
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
 
@@ -70,6 +71,9 @@ namespace Elastic.Apm.Tests
 			public double TransactionSampleRate => ConfigConsts.DefaultValues.TransactionSampleRate;
 
 			public bool VerifyServerCert => ConfigConsts.DefaultValues.VerifyServerCert;
+
+			public bool SuppressTraceContextHeaders => ConfigConsts.DefaultValues.SuppressTraceContextHeaders;
+
 			public IReadOnlyCollection<string> ExcludedNamespaces => ConfigConsts.DefaultValues.DefaultExcludedNamespaces;
 			public IReadOnlyCollection<string> ApplicationNamespaces => ConfigConsts.DefaultValues.DefaultApplicationNamespaces;
 

--- a/test/Elastic.Apm.Tests/ConstructorTests.cs
+++ b/test/Elastic.Apm.Tests/ConstructorTests.cs
@@ -72,7 +72,7 @@ namespace Elastic.Apm.Tests
 
 			public bool VerifyServerCert => ConfigConsts.DefaultValues.VerifyServerCert;
 
-			public bool SuppressTraceContextHeaders => ConfigConsts.DefaultValues.SuppressTraceContextHeaders;
+			public bool TraceContextIgnoreSampledFalse => ConfigConsts.DefaultValues.SuppressTraceContextHeaders;
 
 			public IReadOnlyCollection<string> ExcludedNamespaces => ConfigConsts.DefaultValues.DefaultExcludedNamespaces;
 			public IReadOnlyCollection<string> ApplicationNamespaces => ConfigConsts.DefaultValues.DefaultApplicationNamespaces;

--- a/test/Elastic.Apm.Tests/ConstructorTests.cs
+++ b/test/Elastic.Apm.Tests/ConstructorTests.cs
@@ -72,7 +72,7 @@ namespace Elastic.Apm.Tests
 
 			public bool VerifyServerCert => ConfigConsts.DefaultValues.VerifyServerCert;
 
-			public bool TraceContextIgnoreSampledFalse => ConfigConsts.DefaultValues.SuppressTraceContextHeaders;
+			public bool TraceContextIgnoreSampledFalse => ConfigConsts.DefaultValues.TraceContextIgnoreSampledFalse;
 
 			public IReadOnlyCollection<string> ExcludedNamespaces => ConfigConsts.DefaultValues.DefaultExcludedNamespaces;
 			public IReadOnlyCollection<string> ApplicationNamespaces => ConfigConsts.DefaultValues.DefaultApplicationNamespaces;


### PR DESCRIPTION
### The problem 

We started seeing environments where the full trace is not within elastic and the sample rate is effectively 0% regardless of the `TransactionSampleRate` setting. Very likely this is because unmonitored .NET5+ services send a `traceparent` header with a sampled flag set to `0` ([doc on the change from Microsoft](https://docs.microsoft.com/en-us/dotnet/core/compatibility/core-libraries/5.0/default-activityidformat-changed#change-description))

### Proposed solution in this PR

We add a new setting called `SuppressTraceContextHeaders`. If this is `true` we ignore any distributed tracing data during transaction start and we make a new sampling decision regardless of the `traceparent` value.