### PR TITLE
Skip running Elasticsearch docker test when docker not available

### DIFF
--- a/test/Elastic.Apm.AspNetFullFramework.Tests/TestsBase.cs
+++ b/test/Elastic.Apm.AspNetFullFramework.Tests/TestsBase.cs
@@ -601,7 +601,9 @@ namespace Elastic.Apm.AspNetFullFramework.Tests
 			system.Should().NotBeNull();
 
 			system.DetectedHostName.Should().Be(new SystemInfoHelper(LoggerBase).GetHostName());
+#pragma warning disable 618
 			system.HostName.Should().Be(AgentConfig.HostName ?? system.DetectedHostName);
+#pragma warning restore 618
 		}
 
 		private void FullFwAssertValid(ErrorDto error)

--- a/test/Elastic.Apm.Elasticsearch.Tests/ElasticsearchTests.cs
+++ b/test/Elastic.Apm.Elasticsearch.Tests/ElasticsearchTests.cs
@@ -8,6 +8,7 @@ using System.Threading.Tasks;
 using Elastic.Apm.Api;
 using Elastic.Apm.DiagnosticSource;
 using Elastic.Apm.Tests.Utilities;
+using Elastic.Apm.Tests.Utilities.Docker;
 using Elasticsearch.Net;
 using Elasticsearch.Net.VirtualizedCluster;
 using FluentAssertions;
@@ -25,7 +26,7 @@ namespace Elastic.Apm.Elasticsearch.Tests
 			_client = new ElasticLowLevelClient(settings);
 		}
 
-		[Fact]
+		[DockerFact]
 		public async Task Elasticsearch_Span_Does_Not_Have_Http_Child_Span()
 		{
 			var payloadSender = new MockPayloadSender();

--- a/test/Elastic.Apm.StackExchange.Redis.Tests/ProfilingSessionTests.cs
+++ b/test/Elastic.Apm.StackExchange.Redis.Tests/ProfilingSessionTests.cs
@@ -11,6 +11,7 @@ using DotNet.Testcontainers.Containers.Configurations.Databases;
 using DotNet.Testcontainers.Containers.Modules.Databases;
 using Elastic.Apm.Api;
 using Elastic.Apm.Tests.Utilities;
+using Elastic.Apm.Tests.Utilities.Docker;
 using StackExchange.Redis;
 using FluentAssertions;
 

--- a/test/Elastic.Apm.Tests.Utilities/Docker/DockerFactAttribute.cs
+++ b/test/Elastic.Apm.Tests.Utilities/Docker/DockerFactAttribute.cs
@@ -7,25 +7,29 @@ using System;
 using ProcNet;
 using Xunit;
 
-namespace Elastic.Apm.StackExchange.Redis.Tests
+namespace Elastic.Apm.Tests.Utilities.Docker
 {
 	/// <summary>
 	/// Test method that should be run only if docker exists on the host
 	/// </summary>
 	public class DockerFactAttribute : FactAttribute
 	{
-		public DockerFactAttribute()
+		private static readonly string _skip;
+
+		static DockerFactAttribute()
 		{
 			try
 			{
 				var result = Proc.Start(new StartArguments("docker", "--version"));
 				if (result.ExitCode != 0)
-					Skip = "docker not installed";
+					_skip = "docker not installed";
 			}
 			catch (Exception)
 			{
-				Skip = "could not get version of docker";
+				_skip = "could not get version of docker";
 			}
 		}
+
+		public DockerFactAttribute() => Skip = _skip;
 	}
 }


### PR DESCRIPTION
This commit updates the Elasticsearch integration test
that runs against a docker instance to be skipped
when docker is not on the machine e.g. Windows
.NET Core tests in CI