### PR TITLE
Don't package Elastic.Apm.Specification

### DIFF
--- a/src/Elastic.Apm.Specification/Elastic.Apm.Specification.csproj
+++ b/src/Elastic.Apm.Specification/Elastic.Apm.Specification.csproj
@@ -1,7 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
+      <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
+      <IsPackable>false</IsPackable>
     </PropertyGroup>
 
     <ItemGroup>


### PR DESCRIPTION
This commit sets Elastic.Apm.Specification as
a `<IsPackable>false</IsPackable>` project so
that it is not packaged into a nuget package for
release.

Releasing from CI uses a constrained list
in .ci/linux/deploy.sh to determine what can
be released, but if there is a need to release from
local, this constraint will not be adhered to.