### PR TITLE
Mark MicrosoftAzureBlobStorageTracer internal

### DIFF
--- a/src/Elastic.Apm.Azure.Storage/MicrosoftAzureBlobStorageTracer.cs
+++ b/src/Elastic.Apm.Azure.Storage/MicrosoftAzureBlobStorageTracer.cs
@@ -14,7 +14,7 @@ namespace Elastic.Apm.Azure.Storage
 	/// <summary>
 	/// Creates HTTP spans wth Azure Blob storage details from Microsoft.Azure.Storage.Blob
 	/// </summary>
-	public class MicrosoftAzureBlobStorageTracer : IHttpSpanTracer
+	internal class MicrosoftAzureBlobStorageTracer : IHttpSpanTracer
 	{
 		public bool IsMatch(string method, Uri requestUrl, Func<string, string> headerGetter) =>
 			requestUrl.Host.EndsWith(".blob.core.windows.net", StringComparison.Ordinal) ||


### PR DESCRIPTION
This commit marks MicrosoftAzureBlobStorageTracer as an internal
type; it should not be public.