### PR TITLE
Create transactions for Azure Service Bus Processors

### DIFF
--- a/src/Elastic.Apm.Azure.ServiceBus/MicrosoftAzureServiceBusDiagnosticListener.cs
+++ b/src/Elastic.Apm.Azure.ServiceBus/MicrosoftAzureServiceBusDiagnosticListener.cs
@@ -27,6 +27,8 @@ namespace Elastic.Apm.Azure.ServiceBus
 		private readonly PropertyFetcherCollection _scheduleProperties = new PropertyFetcherCollection { "Entity", "Endpoint", "Status" };
 		private readonly PropertyFetcherCollection _receiveProperties = new PropertyFetcherCollection { "Entity", "Endpoint", "Status" };
 		private readonly PropertyFetcherCollection _receiveDeferredProperties = new PropertyFetcherCollection { "Entity", "Endpoint", "Status" };
+		private readonly PropertyFetcherCollection _processProperties = new PropertyFetcherCollection { "Entity", "Endpoint", "Status" };
+		private readonly PropertyFetcherCollection _processSessionProperties = new PropertyFetcherCollection { "Entity", "Endpoint", "Status" };
 		private readonly PropertyFetcher _exceptionProperty = new PropertyFetcher("Exception");
 		private readonly Framework _framework;
 
@@ -74,12 +76,56 @@ namespace Elastic.Apm.Azure.ServiceBus
 				case "Microsoft.Azure.ServiceBus.ReceiveDeferred.Stop":
 					OnStop(kv, _receiveDeferredProperties);
 					break;
+				case "Microsoft.Azure.ServiceBus.Process.Start":
+					OnProcessStart(kv, "PROCESS", _processProperties);
+					break;
+				case "Microsoft.Azure.ServiceBus.Process.Stop":
+					OnStop(kv, _processProperties);
+					break;
+				case "Microsoft.Azure.ServiceBus.ProcessSession.Start":
+					OnProcessStart(kv, "PROCESS", _processSessionProperties);
+					break;
+				case "Microsoft.Azure.ServiceBus.ProcessSession.Stop":
+					OnStop(kv, _processSessionProperties);
+					break;
 				case "Microsoft.Azure.ServiceBus.Exception":
 					OnException(kv);
 					break;
 				default:
 					Logger.Trace()?.Log("`{DiagnosticEventKey}' key is not a traced diagnostic event", kv.Key);
 					break;
+			}
+		}
+
+		private void OnProcessStart(KeyValuePair<string, object> kv, string action, PropertyFetcherCollection cachedProperties)
+		{
+			if (kv.Value is null)
+			{
+				Logger.Trace()?.Log("Value is null - exiting");
+				return;
+			}
+
+			var queueName = cachedProperties.Fetch(kv.Value,"Entity") as string;
+			if (MatchesIgnoreMessageQueues(queueName))
+				return;
+
+			var transactionName = queueName is null
+				? $"{ServiceBus.SegmentName} {action}"
+				: $"{ServiceBus.SegmentName} {action} from {queueName}";
+
+			var transaction = ApmAgent.Tracer.StartTransaction(transactionName, ApiConstants.TypeMessaging);
+			transaction.Context.Service = new Service(null, null) { Framework = _framework };
+
+			// transaction creation will create an activity, so use this as the key.
+			var activityId = Activity.Current.Id;
+
+			if (!_processingSegments.TryAdd(activityId, transaction))
+			{
+				Logger.Trace()?.Log(
+					"Could not add {Action} transaction {TransactionId} for activity {ActivityId} to tracked segments",
+					action,
+					transaction.Id,
+					activityId);
 			}
 		}
 

--- a/test/Elastic.Apm.Azure.ServiceBus.Tests/Azure/QueueScope.cs
+++ b/test/Elastic.Apm.Azure.ServiceBus.Tests/Azure/QueueScope.cs
@@ -29,7 +29,13 @@ namespace Elastic.Apm.Azure.ServiceBus.Tests.Azure
 			return new QueueScope(adminClient, queueName, response.Value);
 		}
 
-		public async ValueTask DisposeAsync() => 
+		public static async Task<QueueScope> CreateWithQueue(ServiceBusAdministrationClient adminClient, CreateQueueOptions options)
+		{
+			var response = await adminClient.CreateQueueAsync(options).ConfigureAwait(false);
+			return new QueueScope(adminClient, options.Name, response.Value);
+		}
+
+		public async ValueTask DisposeAsync() =>
 			await _adminClient.DeleteQueueAsync(QueueName).ConfigureAwait(false);
 	}
 }


### PR DESCRIPTION
This commit adds support for creating transactions for
ServiceBusProcessor and ServiceBusSessionProcessor
message processing, and the older Microsoft.Azure.ServiceBus
package equivalents.

Creating a transaction on process start allows a user
to capture spans during message processing.

Closes #1321