### PR TITLE
Install VS 2019 netcore workload tools

### DIFF
--- a/.ci/windows/msbuild-tools.ps1
+++ b/.ci/windows/msbuild-tools.ps1
@@ -2,19 +2,15 @@
 # This script installs the required tools to be used during the msbuild
 #
 
-# Install visualstudio2019buildtools
-choco install visualstudio2019buildtools -m -y --no-progress --force -r --version=16.9.0.0
-if ($LASTEXITCODE -ne 0) {
-  Write-Host "visualstudio2019buildtools installation failed."
-  exit 1
-}
-choco install visualstudio2019professional -m -y --no-progress --force -r --version=16.9.0.0 --package-parameters "--includeRecommended --includeOptional"
-if ($LASTEXITCODE -ne 0) {
-  Write-Host "visualstudio2019professional installation failed."
-  exit 1
-}
-choco install visualstudio2019-workload-netweb -m -y --no-progress --force -r --version=1.0.0
-if ($LASTEXITCODE -ne 0) {
-  Write-Host "visualstudio2019-workload-netweb installation failed."
-  exit 1
-}
+$ErrorActionPreference = "Stop"
+
+# Install visualstudio2019 and workloads needed to build ASP.NET and .NET Core apps
+Invoke-WebRequest -UseBasicParsing `
+    -Uri "https://download.visualstudio.microsoft.com/download/pr/cb1d5164-e767-4886-8955-2df3a7c816a8/b9ff67da6d68d6a653a612fd401283cc213b4ec4bae349dd3d9199659a7d9354/vs_BuildTools.exe" `
+    -OutFile "C:\tools\vs_BuildTools.exe"
+
+Start-Process "C:\tools\vs_BuildTools.exe" -ArgumentList "--add", "Microsoft.VisualStudio.Component.NuGet", `
+    "--add", "Microsoft.VisualStudio.Workload.NetCoreBuildTools;includeRecommended;includeOptional", `
+    "--add", "Microsoft.VisualStudio.Workload.MSBuildTools", `
+    "--add", "Microsoft.VisualStudio.Workload.WebBuildTools;includeRecommended;includeOptional", `
+    "--quiet", "--norestart", "--nocache" -NoNewWindow -Wait

--- a/.ci/windows/msbuild.bat
+++ b/.ci/windows/msbuild.bat
@@ -2,7 +2,7 @@
 :: This script runs the msbuild
 ::
 echo "Prepare context for VsDevCmd.bat"
-call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Professional\Common7\Tools\VsDevCmd.bat"
+call "C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\Common7\Tools\VsDevCmd.bat"
 nuget restore -verbosity detailed -NonInteractive
 
 msbuild /p:Configuration=Release

--- a/.ci/windows/test-iis.bat
+++ b/.ci/windows/test-iis.bat
@@ -1,8 +1,13 @@
 set ELASTIC_APM_TESTS_FULL_FRAMEWORK_ENABLED=true
 set sample_app_log_dir=C:\Elastic_APM_TEMP
 if not exist "%sample_app_log_dir%" mkdir "%sample_app_log_dir%"
-icacls %sample_app_log_dir% /t /grant Everyone:F
+icacls %sample_app_log_dir% /t /q /grant Everyone:F
 set ELASTIC_APM_ASP_NET_FULL_FRAMEWORK_SAMPLE_APP_LOG_FILE=%sample_app_log_dir%\Elastic.Apm.AspNetFullFramework.Tests.SampleApp.log
+
+REM enable permissions for the Application Pool Identity group
+icacls %cd% /t /q /grant "IIS_IUSRS:(OI)(CI)(IO)(RX)"
+REM enable permissions for the anonymous access group
+icacls %cd% /t /q /grant "IUSR:(OI)(CI)(IO)(RX)"
 
 dotnet test -c Release test\Elastic.Apm.AspNetFullFramework.Tests --no-build ^
  --verbosity normal ^

--- a/.ci/windows/tools.ps1
+++ b/.ci/windows/tools.ps1
@@ -3,9 +3,9 @@
 #
 
 # Install IIS
-Install-WindowsFeature -Name Web-Server, Web-Mgmt-Tools ;
-Add-WindowsFeature NET-Framework-45-ASPNET ;
-Add-WindowsFeature Web-Asp-Net45 ;
+Install-WindowsFeature -Name Web-Server, Web-Mgmt-Tools
+Add-WindowsFeature NET-Framework-45-ASPNET
+Add-WindowsFeature Web-Asp-Net45
 
 # Install .Net SDKs
 choco install dotnetcore-sdk -m -y --no-progress -r --version 2.1.505

--- a/src/Elastic.Apm/Api/System.cs
+++ b/src/Elastic.Apm/Api/System.cs
@@ -50,7 +50,9 @@ namespace Elastic.Apm.Api
 				{ nameof(Container), Container },
 				{ nameof(ConfiguredHostName), ConfiguredHostName },
 				{ nameof(DetectedHostName), DetectedHostName },
+#pragma warning disable 618
 				{ nameof(HostName), HostName }
+#pragma warning restore 618
 			}.ToString();
 	}
 }

--- a/test/Elastic.Apm.Docker.Tests/BasicDockerTests.cs
+++ b/test/Elastic.Apm.Docker.Tests/BasicDockerTests.cs
@@ -4,6 +4,7 @@
 
 using System.IO;
 using Elastic.Apm.Report;
+using Elastic.Apm.Tests.Utilities.Docker;
 using FluentAssertions;
 using Xunit;
 
@@ -11,19 +12,15 @@ namespace Elastic.Apm.Docker.Tests
 {
 	public class BasicDockerTests
 	{
-		[Fact]
+		[RunningInDockerFact]
 		public void ContainerIdExistsTest()
 		{
-			if (!File.Exists("/proc/self/cgroup")) return; //only run in Docker
-
-			using (var agent = new ApmAgent(new AgentComponents()))
-			{
-				var payloadSender = agent.PayloadSender as PayloadSenderV2;
-				payloadSender.Should().NotBeNull();
-				payloadSender?.System.Should().NotBeNull();
-				payloadSender?.System.Container.Should().NotBeNull();
-				payloadSender?.System.Container.Id.Should().NotBeNullOrWhiteSpace();
-			}
+			using var agent = new ApmAgent(new AgentComponents());
+			var payloadSender = agent.PayloadSender as PayloadSenderV2;
+			payloadSender.Should().NotBeNull();
+			payloadSender?.System.Should().NotBeNull();
+			payloadSender?.System.Container.Should().NotBeNull();
+			payloadSender?.System.Container.Id.Should().NotBeNullOrWhiteSpace();
 		}
 	}
 }

--- a/test/Elastic.Apm.Tests.Utilities/Docker/DockerUtils.cs
+++ b/test/Elastic.Apm.Tests.Utilities/Docker/DockerUtils.cs
@@ -1,0 +1,25 @@
+// Licensed to Elasticsearch B.V under
+// one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System.IO;
+using Xunit;
+
+namespace Elastic.Apm.Tests.Utilities.Docker
+{
+	public class DockerUtils
+	{
+		public static bool IsRunningInDocker() =>
+			File.Exists("/proc/1/cgroup") && File.ReadAllText("/proc/1/cgroup").Contains("docker");
+	}
+
+	public class RunningInDockerFactAttribute : FactAttribute
+	{
+		public RunningInDockerFactAttribute()
+		{
+			if (!DockerUtils.IsRunningInDocker())
+				Skip = "Not running in a docker container";
+		}
+	}
+}

--- a/test/Elastic.Apm.Tests/HttpDiagnosticListenerTests.cs
+++ b/test/Elastic.Apm.Tests/HttpDiagnosticListenerTests.cs
@@ -778,7 +778,7 @@ namespace Elastic.Apm.Tests
 				/*ignore - result of the request does not matter */
 			}
 
-			logger.Lines.Should().NotContain(line => line.ToLower().Contains("warn"));
+			logger.Lines.Should().NotContain(line => line.ToLower().Contains("warn:"));
 		}
 
 		/// <summary>


### PR DESCRIPTION
This commit installs the Visual Studio 2019 .NET Core build tools
in order to support .NET Core projects whilst building and running
tests for ASP.NET Full Framework. The Visual Studio 2019
Professional choco package is not required.

Invoke the VS 2019 Build tools Developer prompt.