### PR TITLE
Log cloud metadata provider failures at trace level

### DIFF
--- a/src/Elastic.Apm/Cloud/AwsCloudMetadataProvider.cs
+++ b/src/Elastic.Apm/Cloud/AwsCloudMetadataProvider.cs
@@ -82,7 +82,9 @@ namespace Elastic.Apm.Cloud
 			}
 			catch (Exception e)
 			{
-				_logger.Info()?.LogException(e, "Unable to get {Provider} cloud metadata", Provider);
+				_logger.Trace()?.LogException(
+					e,
+					"Unable to get {Provider} cloud metadata. The application is likely not running in {Provider}", Provider);
 				return null;
 			}
 		}

--- a/src/Elastic.Apm/Cloud/AzureAppServiceMetadataProvider.cs
+++ b/src/Elastic.Apm/Cloud/AzureAppServiceMetadataProvider.cs
@@ -63,7 +63,7 @@ namespace Elastic.Apm.Cloud
 				if (!string.IsNullOrEmpty(value)) return false;
 
 				_logger.Trace()?.Log(
-					"Unable to get {Provider} cloud metadata as no {EnvironmentVariable} environment variable",
+					"Unable to get {Provider} cloud metadata as no {EnvironmentVariable} environment variable. The application is likely not running in {Provider}",
 					Provider,
 					key);
 

--- a/src/Elastic.Apm/Cloud/AzureCloudMetadataProvider.cs
+++ b/src/Elastic.Apm/Cloud/AzureCloudMetadataProvider.cs
@@ -73,7 +73,9 @@ namespace Elastic.Apm.Cloud
 			}
 			catch (Exception e)
 			{
-				_logger.Info()?.LogException(e, "Unable to get {Provider} cloud metadata", Provider);
+				_logger.Trace()?.LogException(
+					e,
+					"Unable to get {Provider} cloud metadata. The application is likely not running in {Provider}", Provider);
 				return null;
 			}
 		}

--- a/src/Elastic.Apm/Cloud/GcpCloudMetadataProvider.cs
+++ b/src/Elastic.Apm/Cloud/GcpCloudMetadataProvider.cs
@@ -93,7 +93,9 @@ namespace Elastic.Apm.Cloud
 			}
 			catch (Exception e)
 			{
-				_logger.Info()?.LogException(e, "Unable to get {Provider} cloud metadata", Provider);
+				_logger.Trace()?.LogException(
+					e,
+					"Unable to get {Provider} cloud metadata. The application is likely not running in {Provider}", Provider);
 				return null;
 			}
 		}


### PR DESCRIPTION
This commit logs the cloud metadata provider failures
at the trace level and adds more detail to the log message.

Closes #1283