### PR TITLE
Move BreakdownMetricsProvider to PayloadSender

### DIFF
--- a/docs/metrics.asciidoc
+++ b/docs/metrics.asciidoc
@@ -175,3 +175,70 @@ Platform: all.
 
 The approximate accumulated collection elapsed time in milliseconds.
 --
+
+[float]
+[[metrics-application]]
+=== Built-in application metrics
+
+To power the {apm-app-ref}/transactions.html[Time spent by span type] graph,
+the agent collects summarized metrics about the timings of spans and transactions,
+broken down by span type.
+
+*`transaction.duration`*::
++
+--
+type: simple timer
+
+This timer tracks the duration of transactions and allows for the creation of graphs displaying a weighted average.
+
+Fields:
+
+* `sum.us`: The sum of all transaction durations in ms since the last report (the delta)
+* `count`: The count of all transactions since the last report (the delta)
+
+You can filter and group by these dimensions:
+
+* `transaction.name`: The name of the transaction
+* `transaction.type`: The type of the transaction, for example `request`
+
+--
+
+
+*`transaction.breakdown.count`*::
++
+--
+type: long
+
+format: count (delta)
+
+The number of transactions for which breakdown metrics (`span.self_time`) have been created.
+As the Java agent tracks the breakdown for both sampled and non-sampled transactions,
+this metric is equivalent to `transaction.duration.count`
+
+You can filter and group by these dimensions:
+
+* `transaction.name`: The name of the transaction
+* `transaction.type`: The type of the transaction, for example `request`
+
+--
+
+*`span.self_time`*::
++
+--
+type: simple timer
+
+This timer tracks the span self-times and is the basis of the transaction breakdown visualization.
+
+Fields:
+
+* `sum.us`: The sum of all span self-times in ms since the last report (the delta)
+* `count`: The count of all span self-times since the last report (the delta)
+
+You can filter and group by these dimensions:
+
+* `transaction.name`: The name of the transaction
+* `transaction.type`: The type of the transaction, for example `request`
+* `span.type`: The type of the span, for example `app`, `template` or `db`
+* `span.subtype`: The sub-type of the span, for example `mysql` (optional)
+
+--

--- a/docs/metrics.asciidoc
+++ b/docs/metrics.asciidoc
@@ -192,7 +192,7 @@ This timer tracks the duration of transactions and allows for the creation of gr
 
 Fields:
 
-* `sum.us`: The sum of all transaction durations in ms since the last report (the delta)
+* `sum.us`: The sum of all transaction durations in microseconds since the last report (the delta)
 * `count`: The count of all transactions since the last report (the delta)
 
 You can filter and group by these dimensions:
@@ -230,7 +230,7 @@ This timer tracks the span self-times and is the basis of the transaction breakd
 
 Fields:
 
-* `sum.us`: The sum of all span self-times in ms since the last report (the delta)
+* `sum.us`: The sum of all span self-times in microseconds since the last report (the delta)
 * `count`: The count of all span self-times since the last report (the delta)
 
 You can filter and group by these dimensions:

--- a/docs/metrics.asciidoc
+++ b/docs/metrics.asciidoc
@@ -174,7 +174,6 @@ format: ms
 Platform: all.
 
 The approximate accumulated collection elapsed time in milliseconds.
---
 
 [float]
 [[metrics-application]]

--- a/sample/SampleAspNetCoreApp/appsettings.json
+++ b/sample/SampleAspNetCoreApp/appsettings.json
@@ -2,7 +2,7 @@
   "Logging": {
     "LogLevel": {
       "Default": "Warning",
-      "Elastic.Apm": "Debug"
+      "Elastic.Apm": "Error"
     }
   },
   "AllowedHosts": "*",

--- a/sample/SampleAspNetCoreApp/appsettings.json
+++ b/sample/SampleAspNetCoreApp/appsettings.json
@@ -2,7 +2,7 @@
   "Logging": {
     "LogLevel": {
       "Default": "Warning",
-      "Elastic.Apm": "Error"
+      "Elastic.Apm": "Debug"
     }
   },
   "AllowedHosts": "*",

--- a/src/Elastic.Apm/AgentComponents.cs
+++ b/src/Elastic.Apm/AgentComponents.cs
@@ -49,25 +49,25 @@ namespace Elastic.Apm
 
 				ApmServerInfo = apmServerInfo ?? new ApmServerInfo();
 
+				breakdownMetricsProvider ??= new BreakdownMetricsProvider();
 				PayloadSender = payloadSender
 					?? new PayloadSenderV2(Logger, ConfigStore.CurrentSnapshot, Service, system, ApmServerInfo,
-						isEnabled: ConfigurationReader.Enabled);
+						isEnabled: ConfigurationReader.Enabled, breakdownMetricsProvider: breakdownMetricsProvider);
+
+				MetricsCollector = metricsCollector ?? new MetricsCollector(Logger, PayloadSender, ConfigStore, breakdownMetricsProvider);
 
 				HttpTraceConfiguration = new HttpTraceConfiguration();
 
 				if (ConfigurationReader.Enabled)
 				{
-					breakdownMetricsProvider ??= new BreakdownMetricsProvider();
-
 					CentralConfigFetcher = centralConfigFetcher ?? new CentralConfigFetcher(Logger, ConfigStore, Service);
-					MetricsCollector = metricsCollector ?? new MetricsCollector(Logger, PayloadSender, ConfigStore, breakdownMetricsProvider);
 					MetricsCollector.StartCollecting();
 				}
 				else
 					Logger.Info()?.Log("The Elastic APM .NET Agent is disabled - the agent won't capture traces and metrics.");
 
 				TracerInternal = new Tracer(Logger, Service, PayloadSender, ConfigStore,
-					currentExecutionSegmentsContainer ?? new CurrentExecutionSegmentsContainer(), ApmServerInfo, breakdownMetricsProvider);
+					currentExecutionSegmentsContainer ?? new CurrentExecutionSegmentsContainer(), ApmServerInfo);
 			}
 			catch (Exception e)
 			{

--- a/src/Elastic.Apm/AgentComponents.cs
+++ b/src/Elastic.Apm/AgentComponents.cs
@@ -57,16 +57,10 @@ namespace Elastic.Apm
 
 				if (ConfigurationReader.Enabled)
 				{
-					var isBreakdownEnabled =
-						!WildcardMatcher.IsAnyMatch(ConfigStore.CurrentSnapshot.DisableMetrics, BreakdownMetricsProvider.SpanSelfTime);
-
-					if (isBreakdownEnabled)
-						breakdownMetricsProvider ??= new BreakdownMetricsProvider();
+					breakdownMetricsProvider ??= new BreakdownMetricsProvider();
 
 					CentralConfigFetcher = centralConfigFetcher ?? new CentralConfigFetcher(Logger, ConfigStore, Service);
-					MetricsCollector = metricsCollector ?? (isBreakdownEnabled
-						? new MetricsCollector(Logger, PayloadSender, ConfigStore, breakdownMetricsProvider)
-						: new MetricsCollector(Logger, PayloadSender, ConfigStore));
+					MetricsCollector = metricsCollector ?? new MetricsCollector(Logger, PayloadSender, ConfigStore, breakdownMetricsProvider);
 					MetricsCollector.StartCollecting();
 				}
 				else

--- a/src/Elastic.Apm/AgentComponents.cs
+++ b/src/Elastic.Apm/AgentComponents.cs
@@ -31,7 +31,8 @@ namespace Elastic.Apm
 			IMetricsCollector metricsCollector,
 			ICurrentExecutionSegmentsContainer currentExecutionSegmentsContainer,
 			ICentralConfigFetcher centralConfigFetcher,
-			IApmServerInfo apmServerInfo
+			IApmServerInfo apmServerInfo,
+			BreakdownMetricsProvider breakdownMetricsProvider = null
 		)
 		{
 			try
@@ -54,11 +55,9 @@ namespace Elastic.Apm
 
 				HttpTraceConfiguration = new HttpTraceConfiguration();
 
-				BreakdownMetricsProvider breakdownMetricsProvider = null;
-
 				if (ConfigurationReader.Enabled)
 				{
-					breakdownMetricsProvider = new BreakdownMetricsProvider();
+					breakdownMetricsProvider ??= new BreakdownMetricsProvider();
 
 					CentralConfigFetcher = centralConfigFetcher ?? new CentralConfigFetcher(Logger, ConfigStore, Service);
 					MetricsCollector = metricsCollector ?? new MetricsCollector(Logger, PayloadSender, ConfigStore, breakdownMetricsProvider);

--- a/src/Elastic.Apm/AgentComponents.cs
+++ b/src/Elastic.Apm/AgentComponents.cs
@@ -57,10 +57,16 @@ namespace Elastic.Apm
 
 				if (ConfigurationReader.Enabled)
 				{
-					breakdownMetricsProvider ??= new BreakdownMetricsProvider();
+					var isBreakdownEnabled =
+						!WildcardMatcher.IsAnyMatch(ConfigStore.CurrentSnapshot.DisableMetrics, BreakdownMetricsProvider.SpanSelfTime);
+
+					if (isBreakdownEnabled)
+						breakdownMetricsProvider ??= new BreakdownMetricsProvider();
 
 					CentralConfigFetcher = centralConfigFetcher ?? new CentralConfigFetcher(Logger, ConfigStore, Service);
-					MetricsCollector = metricsCollector ?? new MetricsCollector(Logger, PayloadSender, ConfigStore, breakdownMetricsProvider);
+					MetricsCollector = metricsCollector ?? (isBreakdownEnabled
+						? new MetricsCollector(Logger, PayloadSender, ConfigStore, breakdownMetricsProvider)
+						: new MetricsCollector(Logger, PayloadSender, ConfigStore));
 					MetricsCollector.StartCollecting();
 				}
 				else

--- a/src/Elastic.Apm/Api/Tracer.cs
+++ b/src/Elastic.Apm/Api/Tracer.cs
@@ -90,7 +90,7 @@ namespace Elastic.Apm.Api
 			{
 				if (sender is Transaction t)
 				{
-					_breakdownMetricsProvider.CaptureTransaction(t);
+					_breakdownMetricsProvider?.CaptureTransaction(t);
 					t.Ended -= RetValOnEnded;
 				}
 			}

--- a/src/Elastic.Apm/Api/Tracer.cs
+++ b/src/Elastic.Apm/Api/Tracer.cs
@@ -11,6 +11,7 @@ using System.Threading.Tasks;
 using Elastic.Apm.Config;
 using Elastic.Apm.Helpers;
 using Elastic.Apm.Logging;
+using Elastic.Apm.Metrics.MetricsProvider;
 using Elastic.Apm.Model;
 using Elastic.Apm.Report;
 using Elastic.Apm.ServerInfo;
@@ -24,6 +25,7 @@ namespace Elastic.Apm.Api
 		private readonly ScopedLogger _logger;
 		private readonly IPayloadSender _sender;
 		private readonly Service _service;
+		private readonly BreakdownMetricsProvider _breakdownMetricsProvider;
 
 		public Tracer(
 			IApmLogger logger,
@@ -31,7 +33,8 @@ namespace Elastic.Apm.Api
 			IPayloadSender payloadSender,
 			IConfigSnapshotProvider configProvider,
 			ICurrentExecutionSegmentsContainer currentExecutionSegmentsContainer,
-			IApmServerInfo apmServerInfo
+			IApmServerInfo apmServerInfo,
+			BreakdownMetricsProvider breakdownMetricsProvider
 		)
 		{
 			_logger = logger?.Scoped(nameof(Tracer));
@@ -41,6 +44,7 @@ namespace Elastic.Apm.Api
 			CurrentExecutionSegmentsContainer = currentExecutionSegmentsContainer.ThrowIfArgumentNull(nameof(currentExecutionSegmentsContainer));
 			DbSpanCommon = new DbSpanCommon(logger);
 			_apmServerInfo = apmServerInfo;
+			_breakdownMetricsProvider = breakdownMetricsProvider;
 		}
 
 		internal ICurrentExecutionSegmentsContainer CurrentExecutionSegmentsContainer { get; }
@@ -67,7 +71,7 @@ namespace Elastic.Apm.Api
 		{
 			var currentConfig = _configProvider.CurrentSnapshot;
 			var retVal = new Transaction(_logger, name, type, new Sampler(currentConfig.TransactionSampleRate), distributedTracingData
-				, _sender, currentConfig, CurrentExecutionSegmentsContainer, _apmServerInfo, ignoreActivity) { Service = _service };
+				, _sender, currentConfig, CurrentExecutionSegmentsContainer, _apmServerInfo, _breakdownMetricsProvider, ignoreActivity) { Service = _service };
 
 			_logger.Debug()?.Log("Starting {TransactionValue}", retVal);
 			return retVal;

--- a/src/Elastic.Apm/Api/Tracer.cs
+++ b/src/Elastic.Apm/Api/Tracer.cs
@@ -65,13 +65,21 @@ namespace Elastic.Apm.Api
 			return new NoopTransaction(name, type, CurrentExecutionSegmentsContainer);
 		}
 
+		internal Transaction StartTransactionInternal(string name, string type,
+			long? timestamp = null
+		)
+			=> StartTransactionInternal(name, type, null, false, timestamp);
+
 		private Transaction StartTransactionInternal(string name, string type, DistributedTracingData distributedTracingData = null,
-			bool ignoreActivity = false
+			bool ignoreActivity = false, long? timestamp = null
 		)
 		{
 			var currentConfig = _configProvider.CurrentSnapshot;
 			var retVal = new Transaction(_logger, name, type, new Sampler(currentConfig.TransactionSampleRate), distributedTracingData
-				, _sender, currentConfig, CurrentExecutionSegmentsContainer, _apmServerInfo, _breakdownMetricsProvider, ignoreActivity) { Service = _service };
+				, _sender, currentConfig, CurrentExecutionSegmentsContainer, _apmServerInfo, _breakdownMetricsProvider, ignoreActivity, timestamp)
+			{
+				Service = _service
+			};
 
 			_logger.Debug()?.Log("Starting {TransactionValue}", retVal);
 			return retVal;

--- a/src/Elastic.Apm/Metrics/IMetricsProvider.cs
+++ b/src/Elastic.Apm/Metrics/IMetricsProvider.cs
@@ -1,9 +1,10 @@
-// Licensed to Elasticsearch B.V under one or more agreements.
+// Licensed to Elasticsearch B.V under
+// one or more agreements.
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
 
 using System.Collections.Generic;
-using Elastic.Apm.Api;
+using Elastic.Apm.Helpers;
 
 namespace Elastic.Apm.Metrics
 {
@@ -28,6 +29,17 @@ namespace Elastic.Apm.Metrics
 		string DbgName { get; }
 
 		/// <summary>
+		/// Indicates if metrics were already collected - or there was an attempt to collect them.
+		/// Until this property is false, metrics from the implementor won't be collected.
+		/// This property exists to cover cases when the metric collection happens in the background
+		/// (e.g. collecting GC metrics through EventListener) and values are not captured directly in
+		/// the <see cref="GetSamples" /> method.
+		/// If metrics are captured on the fly in <see cref="GetSamples" /> just set this to <code>true</code>
+		/// during initialization.
+		/// </summary>
+		bool IsMetricAlreadyCaptured { get; }
+
+		/// <summary>
 		/// The main part of the provider, the implementor should do the work to read the value(s) of the given metric(s) in this
 		/// method.
 		/// </summary>
@@ -35,14 +47,13 @@ namespace Elastic.Apm.Metrics
 		IEnumerable<MetricSet> GetSamples();
 
 		/// <summary>
-		/// Indicates if metrics were already collected - or there was an attempt to collect them.
-		/// Until this property is false, metrics from the implementor won't be collected.
-		/// This property exists to cover cases when the metric collection happens in the background
-		/// (e.g. collecting GC metrics through EventListener) and values are not captured directly in
-		/// the <see cref="GetSamples"/> method.
-		/// If metrics are captured on the fly in <see cref="GetSamples"/> just set this to <code>true</code>
-		/// during initialization.
+		/// Indicates whether this instance is enabled to collect metrics based on the DisableMetrics config.
+		/// The implementor must match the <paramref name="disabledMetrics"></paramref> against metrics which it collects.
+		/// If the implementor collects multiple metrics, this method returns <code>true</code> if any of the metrics it
+		/// collects is enabled, <code>false</code> otherwise.
 		/// </summary>
-		bool IsMetricAlreadyCaptured { get; }
+		/// <param name="disabledMetrics">The list of disabled metrics</param>
+		/// <returns><code>true</code> if any of the metrics collected is enabled, <code>false</code> otherwise.</returns>
+		bool IsEnabled(IReadOnlyList<WildcardMatcher> disabledMetrics);
 	}
 }

--- a/src/Elastic.Apm/Metrics/IMetricsProvider.cs
+++ b/src/Elastic.Apm/Metrics/IMetricsProvider.cs
@@ -32,7 +32,7 @@ namespace Elastic.Apm.Metrics
 		/// method.
 		/// </summary>
 		/// <returns>The key and the value of the metric(s)</returns>
-		IEnumerable<MetricSample> GetSamples();
+		IEnumerable<MetricSet> GetSamples();
 
 		/// <summary>
 		/// Indicates if metrics were already collected - or there was an attempt to collect them.

--- a/src/Elastic.Apm/Metrics/MetricSet.cs
+++ b/src/Elastic.Apm/Metrics/MetricSet.cs
@@ -20,5 +20,21 @@ namespace Elastic.Apm.Metrics
 
 		/// <inheritdoc />
 		public long Timestamp { get; set; }
+
+		public TransactionInfo Transaction { get; set; }
+
+		public SpanInfo Span { get; set; }
+	}
+
+	public class TransactionInfo
+	{
+		public string Name { get; set; }
+		public string Type { get; set; }
+	}
+
+	public class SpanInfo
+	{
+		public string Type { get; set; }
+		public string SybType { get; set; }
 	}
 }

--- a/src/Elastic.Apm/Metrics/MetricSet.cs
+++ b/src/Elastic.Apm/Metrics/MetricSet.cs
@@ -26,15 +26,15 @@ namespace Elastic.Apm.Metrics
 		public SpanInfo Span { get; set; }
 	}
 
-	public class TransactionInfo
+	internal class TransactionInfo
 	{
 		public string Name { get; set; }
 		public string Type { get; set; }
 	}
 
-	public class SpanInfo
+	internal class SpanInfo
 	{
 		public string Type { get; set; }
-		public string SybType { get; set; }
+		public string SubType { get; set; }
 	}
 }

--- a/src/Elastic.Apm/Metrics/MetricsCollector.cs
+++ b/src/Elastic.Apm/Metrics/MetricsCollector.cs
@@ -66,13 +66,15 @@ namespace Elastic.Apm.Metrics
 
 			MetricsProviders = new List<IMetricsProvider>();
 
-			//TODO check if disabled
 			if (metricsProvider != null)
 			{
 				foreach (var item in metricsProvider)
 				{
 					if (item != null)
-						MetricsProviders.Add(item);
+					{
+						if (!WildcardMatcher.IsAnyMatch(currentConfigSnapshot.DisableMetrics, BreakdownMetricsProvider.SpanSelfTime))
+							MetricsProviders.Add(item);
+					}
 				}
 			}
 
@@ -181,11 +183,7 @@ namespace Elastic.Apm.Metrics
 
 			try
 			{
-				//TODO: it'd be nice to do this in 1 call
-				foreach (var item in samplesFromAllProviders)
-				{
-					_payloadSender.QueueMetrics(item);
-				}
+				foreach (var item in samplesFromAllProviders) _payloadSender.QueueMetrics(item);
 
 				_logger.Debug()
 					?.Log("Metrics collected: {data}",

--- a/src/Elastic.Apm/Metrics/MetricsCollector.cs
+++ b/src/Elastic.Apm/Metrics/MetricsCollector.cs
@@ -69,15 +69,8 @@ namespace Elastic.Apm.Metrics
 			if (metricsProvider != null)
 			{
 				foreach (var item in metricsProvider)
-				{
-					if (item != null)
-					{
-						if (!WildcardMatcher.IsAnyMatch(currentConfigSnapshot.DisableMetrics, BreakdownMetricsProvider.SpanSelfTime))
-							MetricsProviders.Add(item);
-					}
-				}
+					if (item != null) MetricsProviders.Add(item);
 			}
-
 
 			if (!WildcardMatcher.IsAnyMatch(currentConfigSnapshot.DisableMetrics, ProcessTotalCpuTimeProvider.ProcessCpuTotalPct))
 				MetricsProviders.Add(new ProcessTotalCpuTimeProvider(_logger));

--- a/src/Elastic.Apm/Metrics/MetricsProvider/BreakdownMetricsProvider.cs
+++ b/src/Elastic.Apm/Metrics/MetricsProvider/BreakdownMetricsProvider.cs
@@ -1,4 +1,5 @@
-﻿// Licensed to Elasticsearch B.V under one or more agreements.
+﻿// Licensed to Elasticsearch B.V under
+// one or more agreements.
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
 
@@ -13,10 +14,12 @@ namespace Elastic.Apm.Metrics.MetricsProvider
 	internal class BreakdownMetricsProvider : IMetricsProvider
 	{
 		internal const string SpanSelfTime = "span.self_time";
-		public int ConsecutiveNumberOfFailedReads { get; set; }
+
+		private readonly List<MetricSet> _itemsToSend = new();
 
 		private readonly object _lock = new();
 		private int _transactionCount;
+		public int ConsecutiveNumberOfFailedReads { get; set; }
 
 		public string DbgName => nameof(BreakdownMetricsProvider);
 
@@ -29,7 +32,7 @@ namespace Elastic.Apm.Metrics.MetricsProvider
 			}
 		}
 
-		private readonly List<MetricSet> _itemsToSend = new();
+		public bool IsEnabled(IReadOnlyList<WildcardMatcher> matchers) => !WildcardMatcher.IsAnyMatch(matchers, SpanSelfTime);
 
 		public void CaptureTransaction(Transaction transaction)
 		{

--- a/src/Elastic.Apm/Metrics/MetricsProvider/BreakdownMetricsProvider.cs
+++ b/src/Elastic.Apm/Metrics/MetricsProvider/BreakdownMetricsProvider.cs
@@ -47,7 +47,7 @@ namespace Elastic.Apm.Metrics.MetricsProvider
 								new($"{SpanSelfTime}.count", item.Value.Count), new($"{SpanSelfTime}.sum.us", item.Value.TotalDuration * 1000)
 							})
 						{
-							Span = new SpanInfo { Type = item.Key.Item1, SubType = item.Key.Item2 },
+							Span = new SpanInfo { Type = item.Key.Type, SubType = item.Key.SubType },
 							Transaction = new TransactionInfo { Name = transaction.Name, Type = transaction.Type }
 						};
 
@@ -61,8 +61,7 @@ namespace Elastic.Apm.Metrics.MetricsProvider
 							new("transaction.duration.count", _transactionCount),
 							new("transaction.duration.sum.us", transaction.Duration!.Value * 1000),
 							new("transaction.breakdown.count", _transactionCount),
-						})
-					{ Transaction = new TransactionInfo { Name = transaction.Name, Type = transaction.Type } };
+						}) { Transaction = new TransactionInfo { Name = transaction.Name, Type = transaction.Type } };
 
 				_itemsToSend.Add(transactionMetric);
 			}

--- a/src/Elastic.Apm/Metrics/MetricsProvider/BreakdownMetricsProvider.cs
+++ b/src/Elastic.Apm/Metrics/MetricsProvider/BreakdownMetricsProvider.cs
@@ -3,8 +3,12 @@
 // See the LICENSE file in the project root for more information
 
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Linq;
 using Elastic.Apm.Api;
+using Elastic.Apm.Helpers;
+using Elastic.Apm.Model;
 
 namespace Elastic.Apm.Metrics.MetricsProvider
 {
@@ -12,18 +16,66 @@ namespace Elastic.Apm.Metrics.MetricsProvider
 	{
 		public int ConsecutiveNumberOfFailedReads { get; set; }
 
+		private readonly object _lock = new();
+
 		public string DbgName => nameof(BreakdownMetricsProvider);
 
-		public bool IsMetricAlreadyCaptured => ItemsToSend.Count > 0;
+		public bool IsMetricAlreadyCaptured
+		{
+			get
+			{
+				lock (_lock)
+					return _itemsToSend.Count > 0;
+			}
+		}
 
-		//TODO make it concurrent
-		public List<MetricSet> ItemsToSend { get; set; } = new List<MetricSet>();
+		private readonly List<MetricSet> _itemsToSend = new();
+
+		public void CaptureTransaction(Transaction transaction)
+		{
+			lock (_lock)
+			{
+				var timestampNow = TimeUtils.TimestampNow();
+
+				foreach (var item in transaction.SpanTimings)
+				{
+					var metricSet =
+						new MetricSet(timestampNow,
+							new List<MetricSample>
+							{
+								new("span.self_time.count", item.Value.Count), new("span.self_time.sum.us", item.Value.TotalDuration)
+							})
+						{
+							Span = new SpanInfo { Type = item.Key.Item1, SubType = item.Key.Item2 },
+							Transaction = new TransactionInfo { Name = transaction.Name, Type = transaction.Type }
+						};
+
+					_itemsToSend.Add(metricSet);
+				}
+
+				var transactionMetric =
+					new MetricSet(timestampNow,
+						new List<MetricSample>
+						{
+							new("transaction.duration.count", _itemsToSend.Count + 1),
+							new("transaction.duration.sum.us", transaction.Duration!.Value),
+							new("transaction.breakdown.count", _itemsToSend.Count + 1),
+						})
+					{ Transaction = new TransactionInfo { Name = transaction.Name, Type = transaction.Type } };
+
+				_itemsToSend.Add(transactionMetric);
+			}
+		}
 
 		public IEnumerable<MetricSet> GetSamples()
 		{
-			var retVal = new List<MetricSet>(ItemsToSend);
+			var retVal = new List<MetricSet>();
 
-			ItemsToSend.Clear();
+			lock (_lock)
+			{
+				retVal.AddRange(_itemsToSend.Take(1000));
+				_itemsToSend.Clear();
+			}
 
 			return retVal;
 		}

--- a/src/Elastic.Apm/Metrics/MetricsProvider/BreakdownMetricsProvider.cs
+++ b/src/Elastic.Apm/Metrics/MetricsProvider/BreakdownMetricsProvider.cs
@@ -12,6 +12,7 @@ namespace Elastic.Apm.Metrics.MetricsProvider
 {
 	internal class BreakdownMetricsProvider : IMetricsProvider
 	{
+		internal const string SpanSelfTime = "span.self_time";
 		public int ConsecutiveNumberOfFailedReads { get; set; }
 
 		private readonly object _lock = new();
@@ -43,7 +44,7 @@ namespace Elastic.Apm.Metrics.MetricsProvider
 						new MetricSet(timestampNow,
 							new List<MetricSample>
 							{
-								new("span.self_time.count", item.Value.Count), new("span.self_time.sum.us", item.Value.TotalDuration)
+								new($"{SpanSelfTime}.count", item.Value.Count), new($"{SpanSelfTime}.sum.us", item.Value.TotalDuration)
 							})
 						{
 							Span = new SpanInfo { Type = item.Key.Item1, SubType = item.Key.Item2 },

--- a/src/Elastic.Apm/Metrics/MetricsProvider/BreakdownMetricsProvider.cs
+++ b/src/Elastic.Apm/Metrics/MetricsProvider/BreakdownMetricsProvider.cs
@@ -1,0 +1,31 @@
+﻿// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System;
+using System.Collections.Generic;
+using Elastic.Apm.Api;
+
+namespace Elastic.Apm.Metrics.MetricsProvider
+{
+	internal class BreakdownMetricsProvider : IMetricsProvider
+	{
+		public int ConsecutiveNumberOfFailedReads { get; set; }
+
+		public string DbgName => nameof(BreakdownMetricsProvider);
+
+		public bool IsMetricAlreadyCaptured => ItemsToSend.Count > 0;
+
+		//TODO make it concurrent
+		public List<MetricSet> ItemsToSend { get; set; } = new List<MetricSet>();
+
+		public IEnumerable<MetricSet> GetSamples()
+		{
+			var retVal = new List<MetricSet>(ItemsToSend);
+
+			ItemsToSend.Clear();
+
+			return retVal;
+		}
+	}
+}

--- a/src/Elastic.Apm/Metrics/MetricsProvider/BreakdownMetricsProvider.cs
+++ b/src/Elastic.Apm/Metrics/MetricsProvider/BreakdownMetricsProvider.cs
@@ -44,7 +44,7 @@ namespace Elastic.Apm.Metrics.MetricsProvider
 						new MetricSet(timestampNow,
 							new List<MetricSample>
 							{
-								new($"{SpanSelfTime}.count", item.Value.Count), new($"{SpanSelfTime}.sum.us", item.Value.TotalDuration)
+								new($"{SpanSelfTime}.count", item.Value.Count), new($"{SpanSelfTime}.sum.us", item.Value.TotalDuration * 1000)
 							})
 						{
 							Span = new SpanInfo { Type = item.Key.Item1, SubType = item.Key.Item2 },
@@ -59,7 +59,7 @@ namespace Elastic.Apm.Metrics.MetricsProvider
 						new List<MetricSample>
 						{
 							new("transaction.duration.count", _transactionCount),
-							new("transaction.duration.sum.us", transaction.Duration!.Value),
+							new("transaction.duration.sum.us", transaction.Duration!.Value * 1000),
 							new("transaction.breakdown.count", _transactionCount),
 						})
 					{ Transaction = new TransactionInfo { Name = transaction.Name, Type = transaction.Type } };

--- a/src/Elastic.Apm/Metrics/MetricsProvider/CgroupMetricsProvider.cs
+++ b/src/Elastic.Apm/Metrics/MetricsProvider/CgroupMetricsProvider.cs
@@ -9,6 +9,7 @@ using System.Globalization;
 using System.IO;
 using System.Text.RegularExpressions;
 using Elastic.Apm.Api;
+using Elastic.Apm.Helpers;
 using Elastic.Apm.Logging;
 
 namespace Elastic.Apm.Metrics.MetricsProvider
@@ -212,7 +213,8 @@ namespace Elastic.Apm.Metrics.MetricsProvider
 				: null;
 		}
 
-		private string GetMaxMemoryFile(string maxMemoryFile, string cgroupUnlimitedConstant) {
+		private string GetMaxMemoryFile(string maxMemoryFile, string cgroupUnlimitedConstant)
+		{
 			try
 			{
 				using var reader = new StreamReader(maxMemoryFile);
@@ -235,7 +237,7 @@ namespace Elastic.Apm.Metrics.MetricsProvider
 		public int ConsecutiveNumberOfFailedReads { get; set; }
 		public string DbgName { get; } = nameof(CgroupMetricsProvider);
 
-		public IEnumerable<MetricSample> GetSamples()
+		public IEnumerable<MetricSet> GetSamples()
 		{
 			if (_cGroupFiles is null)
 				return null;
@@ -251,7 +253,7 @@ namespace Elastic.Apm.Metrics.MetricsProvider
 			if (_collectMemLimitBytes)
 				GetMemoryMemLimitBytes(samples);
 
-			return samples;
+			return new List<MetricSet> { new MetricSet(TimeUtils.TimestampNow(), samples) };
 		}
 
 		// ReSharper disable once SuggestBaseTypeForParameter

--- a/src/Elastic.Apm/Metrics/MetricsProvider/FreeAndTotalMemoryProvider.cs
+++ b/src/Elastic.Apm/Metrics/MetricsProvider/FreeAndTotalMemoryProvider.cs
@@ -1,4 +1,5 @@
-// Licensed to Elasticsearch B.V under one or more agreements.
+// Licensed to Elasticsearch B.V under
+// one or more agreements.
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
 
@@ -24,13 +25,24 @@ namespace Elastic.Apm.Metrics.MetricsProvider
 		private readonly bool _collectFreeMemory;
 		private readonly bool _collectTotalMemory;
 
-		public FreeAndTotalMemoryProvider(bool collectFreeMemory, bool collectTotalMemory) =>
-			(_collectFreeMemory, _collectTotalMemory, IsMetricAlreadyCaptured) = (collectFreeMemory, collectTotalMemory, true);
+		public FreeAndTotalMemoryProvider(IReadOnlyList<WildcardMatcher> disabledMetrics)
+		{
+			IsMetricAlreadyCaptured = true;
+			_collectFreeMemory = IsFreeMemoryEnabled(disabledMetrics);
+			_collectTotalMemory = IsTotalMemoryEnabled(disabledMetrics);
+		}
 
 		public int ConsecutiveNumberOfFailedReads { get; set; }
 		public string DbgName => "total and free memory";
 
 		public bool IsMetricAlreadyCaptured { get; }
+
+		public bool IsEnabled(IReadOnlyList<WildcardMatcher> disabledMetrics) =>
+			IsFreeMemoryEnabled(disabledMetrics) || IsTotalMemoryEnabled(disabledMetrics);
+
+		private bool IsFreeMemoryEnabled(IReadOnlyList<WildcardMatcher> disabledMetrics) => !WildcardMatcher.IsAnyMatch(disabledMetrics, FreeMemory);
+
+		private bool IsTotalMemoryEnabled(IReadOnlyList<WildcardMatcher> disabledMetrics) => !WildcardMatcher.IsAnyMatch(disabledMetrics, TotalMemory);
 
 		public IEnumerable<MetricSet> GetSamples()
 		{

--- a/src/Elastic.Apm/Metrics/MetricsProvider/GcMetricsProvider.cs
+++ b/src/Elastic.Apm/Metrics/MetricsProvider/GcMetricsProvider.cs
@@ -132,29 +132,29 @@ namespace Elastic.Apm.Metrics.MetricsProvider
 		/// </summary>
 		internal string TraceEventSessionName { get; }
 
-		public IEnumerable<MetricSample> GetSamples()
+		public IEnumerable<MetricSet> GetSamples()
 		{
 			var gcTimeInMs = Interlocked.Read(ref _gcTimeInTicks) / 10_000.0;
 			Interlocked.Exchange(ref _gcTimeInTicks, 0);
 
 			if (_gcCount != 0 || _gen0Size != 0 || _gen2Size != 0 || _gen3Size != 0 || gcTimeInMs > 0)
 			{
-				var retVal = new List<MetricSample>(5);
+				var samples = new List<MetricSample>(5);
 
 				if (_collectGcCount)
-					retVal.Add(new MetricSample(GcCountName, _gcCount));
+					samples.Add(new MetricSample(GcCountName, _gcCount));
 				if (_collectGcTime)
-					retVal.Add(new MetricSample(GcTimeName, Math.Round(gcTimeInMs, 6)));
+					samples.Add(new MetricSample(GcTimeName, Math.Round(gcTimeInMs, 6)));
 				if (_collectGcGen0Size)
-					retVal.Add(new MetricSample(GcGen0SizeName, _gen0Size));
+					samples.Add(new MetricSample(GcGen0SizeName, _gen0Size));
 				if (_collectGcGen1Size)
-					retVal.Add(new MetricSample(GcGen1SizeName, _gen1Size));
+					samples.Add(new MetricSample(GcGen1SizeName, _gen1Size));
 				if (_collectGcGen2Size)
-					retVal.Add(new MetricSample(GcGen2SizeName, _gen2Size));
+					samples.Add(new MetricSample(GcGen2SizeName, _gen2Size));
 				if (_collectGcGen3Size)
-					retVal.Add(new MetricSample(GcGen3SizeName, _gen3Size));
+					samples.Add(new MetricSample(GcGen3SizeName, _gen3Size));
 
-				return retVal;
+				return new List<MetricSet> { new MetricSet(TimeUtils.TimestampNow(), samples) };
 			}
 			_logger.Trace()
 				?.Log(

--- a/src/Elastic.Apm/Metrics/MetricsProvider/ProcessTotalCpuTimeProvider.cs
+++ b/src/Elastic.Apm/Metrics/MetricsProvider/ProcessTotalCpuTimeProvider.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Runtime.InteropServices;
 using Elastic.Apm.Api;
+using Elastic.Apm.Helpers;
 using Elastic.Apm.Logging;
 
 namespace Elastic.Apm.Metrics.MetricsProvider
@@ -39,7 +40,7 @@ namespace Elastic.Apm.Metrics.MetricsProvider
 		public int ConsecutiveNumberOfFailedReads { get; set; }
 		public string DbgName => "process total CPU time";
 
-		public IEnumerable<MetricSample> GetSamples()
+		public IEnumerable<MetricSet> GetSamples()
 		{
 			// We have to make sure that the timespan of the wall clock time is the same or longer than the potential max possible CPU time -
 			// we do this by the order in which we capture those.
@@ -83,7 +84,8 @@ namespace Elastic.Apm.Metrics.MetricsProvider
 
 			_lastTimeWindowStart = timeWindowStart;
 			_lastCurrentProcessCpuTime = cpuUsage;
-			return new List<MetricSample> { new MetricSample(ProcessCpuTotalPct, cpuUsageTotal) };
+
+			return new List<MetricSet> { new MetricSet(TimeUtils.TimestampNow(), new List<MetricSample> { new MetricSample(ProcessCpuTotalPct, cpuUsageTotal) })};
 		}
 
 		public bool IsMetricAlreadyCaptured { get; }

--- a/src/Elastic.Apm/Metrics/MetricsProvider/ProcessTotalCpuTimeProvider.cs
+++ b/src/Elastic.Apm/Metrics/MetricsProvider/ProcessTotalCpuTimeProvider.cs
@@ -1,4 +1,5 @@
-// Licensed to Elasticsearch B.V under one or more agreements.
+// Licensed to Elasticsearch B.V under
+// one or more agreements.
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
 
@@ -39,6 +40,8 @@ namespace Elastic.Apm.Metrics.MetricsProvider
 
 		public int ConsecutiveNumberOfFailedReads { get; set; }
 		public string DbgName => "process total CPU time";
+
+		public bool IsMetricAlreadyCaptured { get; }
 
 		public IEnumerable<MetricSet> GetSamples()
 		{
@@ -85,9 +88,12 @@ namespace Elastic.Apm.Metrics.MetricsProvider
 			_lastTimeWindowStart = timeWindowStart;
 			_lastCurrentProcessCpuTime = cpuUsage;
 
-			return new List<MetricSet> { new MetricSet(TimeUtils.TimestampNow(), new List<MetricSample> { new MetricSample(ProcessCpuTotalPct, cpuUsageTotal) })};
+			return new List<MetricSet>
+			{
+				new MetricSet(TimeUtils.TimestampNow(), new List<MetricSample> { new MetricSample(ProcessCpuTotalPct, cpuUsageTotal) })
+			};
 		}
 
-		public bool IsMetricAlreadyCaptured { get; }
+		public bool IsEnabled(IReadOnlyList<WildcardMatcher> disabledMetrics) => !WildcardMatcher.IsAnyMatch(disabledMetrics, ProcessCpuTotalPct);
 	}
 }

--- a/src/Elastic.Apm/Metrics/MetricsProvider/ProcessWorkingSetAndVirtualMemoryProvider.cs
+++ b/src/Elastic.Apm/Metrics/MetricsProvider/ProcessWorkingSetAndVirtualMemoryProvider.cs
@@ -1,4 +1,5 @@
-// Licensed to Elasticsearch B.V under one or more agreements.
+// Licensed to Elasticsearch B.V under
+// one or more agreements.
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
 
@@ -17,14 +18,26 @@ namespace Elastic.Apm.Metrics.MetricsProvider
 		private readonly bool _collectProcessVirtualMemory;
 		private readonly bool _collectProcessWorkingSetMemory;
 
-		public ProcessWorkingSetAndVirtualMemoryProvider(bool collectProcessVirtualMemory, bool collectProcessWorkingSetMemory) =>
-			(_collectProcessVirtualMemory, _collectProcessWorkingSetMemory, IsMetricAlreadyCaptured) =
-			(collectProcessVirtualMemory, collectProcessWorkingSetMemory, true);
+		public ProcessWorkingSetAndVirtualMemoryProvider(IReadOnlyList<WildcardMatcher> disabledMetrics)
+		{
+			IsMetricAlreadyCaptured = true;
+			_collectProcessVirtualMemory = IsProcessVirtualMemoryEnabled(disabledMetrics);
+			_collectProcessWorkingSetMemory = IsProcessWorkingSetMemoryEnabled(disabledMetrics);
+		}
 
 		public int ConsecutiveNumberOfFailedReads { get; set; }
 		public string DbgName => "process's working set and virtual memory size";
 
 		public bool IsMetricAlreadyCaptured { get; }
+
+		public bool IsEnabled(IReadOnlyList<WildcardMatcher> disabledMetrics) =>
+			IsProcessVirtualMemoryEnabled(disabledMetrics) || IsProcessWorkingSetMemoryEnabled(disabledMetrics);
+
+		private bool IsProcessVirtualMemoryEnabled(IReadOnlyList<WildcardMatcher> disabledMetrics) =>
+			!WildcardMatcher.IsAnyMatch(disabledMetrics, ProcessVirtualMemory);
+
+		private bool IsProcessWorkingSetMemoryEnabled(IReadOnlyList<WildcardMatcher> disabledMetrics) =>
+			!WildcardMatcher.IsAnyMatch(disabledMetrics, ProcessWorkingSetMemory);
 
 		public IEnumerable<MetricSet> GetSamples()
 		{

--- a/src/Elastic.Apm/Metrics/MetricsProvider/ProcessWorkingSetAndVirtualMemoryProvider.cs
+++ b/src/Elastic.Apm/Metrics/MetricsProvider/ProcessWorkingSetAndVirtualMemoryProvider.cs
@@ -5,6 +5,7 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using Elastic.Apm.Api;
+using Elastic.Apm.Helpers;
 
 namespace Elastic.Apm.Metrics.MetricsProvider
 {
@@ -25,27 +26,27 @@ namespace Elastic.Apm.Metrics.MetricsProvider
 
 		public bool IsMetricAlreadyCaptured { get; }
 
-		public IEnumerable<MetricSample> GetSamples()
+		public IEnumerable<MetricSet> GetSamples()
 		{
 			var process = Process.GetCurrentProcess();
 			var virtualMemory = process.VirtualMemorySize64;
 			var workingSet = process.WorkingSet64;
 
-			var retVal = new List<MetricSample>();
+			var samples = new List<MetricSample>();
 
 			if (_collectProcessVirtualMemory)
 			{
 				if (virtualMemory != 0)
-					retVal.Add(new MetricSample(ProcessVirtualMemory, virtualMemory));
+					samples.Add(new MetricSample(ProcessVirtualMemory, virtualMemory));
 			}
 
 			if (_collectProcessWorkingSetMemory)
 			{
 				if (workingSet != 0)
-					retVal.Add(new MetricSample(ProcessWorkingSetMemory, workingSet));
+					samples.Add(new MetricSample(ProcessWorkingSetMemory, workingSet));
 			}
 
-			return retVal;
+			return new List<MetricSet> { new MetricSet(TimeUtils.TimestampNow(), samples) };
 		}
 	}
 }

--- a/src/Elastic.Apm/Metrics/MetricsProvider/SystemTotalCpuProvider.cs
+++ b/src/Elastic.Apm/Metrics/MetricsProvider/SystemTotalCpuProvider.cs
@@ -1,4 +1,5 @@
-// Licensed to Elasticsearch B.V under one or more agreements.
+// Licensed to Elasticsearch B.V under
+// one or more agreements.
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
 
@@ -65,6 +66,8 @@ namespace Elastic.Apm.Metrics.MetricsProvider
 		public int ConsecutiveNumberOfFailedReads { get; set; }
 		public string DbgName => "total system CPU time";
 
+		public bool IsMetricAlreadyCaptured => true;
+
 		internal (bool success, long idle, long total) ReadProcStat()
 		{
 			using (var sr = GetProcStatAsStream())
@@ -109,7 +112,10 @@ namespace Elastic.Apm.Metrics.MetricsProvider
 
 				var val = _processorTimePerfCounter.NextValue();
 
-				return new List<MetricSet> { new MetricSet(TimeUtils.TimestampNow(), new List<MetricSample> { new MetricSample(SystemCpuTotalPct, (double)val / 100) })};
+				return new List<MetricSet>
+				{
+					new MetricSet(TimeUtils.TimestampNow(), new List<MetricSample> { new MetricSample(SystemCpuTotalPct, (double)val / 100) })
+				};
 			}
 
 			if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
@@ -124,13 +130,16 @@ namespace Elastic.Apm.Metrics.MetricsProvider
 				_prevIdleTime = idle;
 				_prevTotalTime = total;
 
-				return new List<MetricSet> { new MetricSet(TimeUtils.TimestampNow(), new List<MetricSample> { new MetricSample(SystemCpuTotalPct, notIdle) }) };
+				return new List<MetricSet>
+				{
+					new MetricSet(TimeUtils.TimestampNow(), new List<MetricSample> { new MetricSample(SystemCpuTotalPct, notIdle) })
+				};
 			}
 
 			return null;
 		}
 
-		public bool IsMetricAlreadyCaptured => true;
+		public bool IsEnabled(IReadOnlyList<WildcardMatcher> disabledMetrics) => !WildcardMatcher.IsAnyMatch(disabledMetrics, SystemCpuTotalPct);
 
 		public void Dispose()
 		{

--- a/src/Elastic.Apm/Model/Span.cs
+++ b/src/Elastic.Apm/Model/Span.cs
@@ -372,10 +372,10 @@ namespace Elastic.Apm.Model
 				_payloadSender.QueueSpan(this);
 			}
 
-			if (_enclosingTransaction.SpanTimings.ContainsKey((Type, Subtype)))
-				_enclosingTransaction.SpanTimings[(Type, Subtype)].IncrementTimer(SelfDuration);
+			if (_enclosingTransaction.SpanTimings.ContainsKey(new SpanTypeAndSubtype(Type, Subtype)))
+				_enclosingTransaction.SpanTimings[new SpanTypeAndSubtype(Type, Subtype)].IncrementTimer(SelfDuration);
 			else
-				_enclosingTransaction.SpanTimings.TryAdd((Type, Subtype), new SpanTimer(SelfDuration));
+				_enclosingTransaction.SpanTimings.TryAdd(new SpanTypeAndSubtype(Type, Subtype), new SpanTimer(SelfDuration));
 
 			if (isFirstEndCall)
 				_currentExecutionSegmentsContainer.CurrentSpan = _parentSpan;

--- a/src/Elastic.Apm/Model/Span.cs
+++ b/src/Elastic.Apm/Model/Span.cs
@@ -363,9 +363,8 @@ namespace Elastic.Apm.Model
 				_payloadSender.QueueSpan(this);
 			}
 
-			// TODO: this can be done shorter
 			if (_enclosingTransaction.SpanTimings.ContainsKey((Type, Subtype)))
-				_enclosingTransaction.SpanTimings[(Type, Subtype)].IncrementTimer(SelfDuration); //  = _enclosingTransaction.SpanTimings[(Type, Subtype)] + SelfDuration;
+				_enclosingTransaction.SpanTimings[(Type, Subtype)].IncrementTimer(SelfDuration);
 			else
 				_enclosingTransaction.SpanTimings.TryAdd((Type, Subtype), new SpanTimer(SelfDuration));
 

--- a/src/Elastic.Apm/Model/Span.cs
+++ b/src/Elastic.Apm/Model/Span.cs
@@ -33,8 +33,8 @@ namespace Elastic.Apm.Model
 		private readonly Span _parentSpan;
 		private readonly IPayloadSender _payloadSender;
 
-		// This constructor is meant for deserialization
 		[JsonConstructor]
+		// ReSharper disable once UnusedMember.Local - this is meant for deserialization
 		private Span(double duration, string id, string name, string parentId)
 		{
 			Duration = duration;

--- a/src/Elastic.Apm/Model/Span.cs
+++ b/src/Elastic.Apm/Model/Span.cs
@@ -12,11 +12,9 @@ using Elastic.Apm.Api.Constraints;
 using Elastic.Apm.Config;
 using Elastic.Apm.Helpers;
 using Elastic.Apm.Logging;
-using Elastic.Apm.Metrics.MetricsProvider;
 using Elastic.Apm.Report;
 using Elastic.Apm.ServerInfo;
 using Elastic.Apm.Libraries.Newtonsoft.Json;
-using Elastic.Apm.Libraries.Newtonsoft.Json.Converters;
 
 namespace Elastic.Apm.Model
 {
@@ -24,7 +22,6 @@ namespace Elastic.Apm.Model
 	internal class Span : ISpan
 	{
 		private readonly IApmServerInfo _apmServerInfo;
-		private readonly BreakdownMetricsProvider _breakdownMetricsProvider;
 
 		private readonly ChildDurationTimer _childDurationTimer = new ChildDurationTimer();
 		private readonly Lazy<SpanContext> _context = new Lazy<SpanContext>();
@@ -56,7 +53,6 @@ namespace Elastic.Apm.Model
 			IApmLogger logger,
 			ICurrentExecutionSegmentsContainer currentExecutionSegmentsContainer,
 			IApmServerInfo apmServerInfo,
-			BreakdownMetricsProvider breakdownMetricsProvider,
 			Span parentSpan = null,
 			InstrumentationFlag instrumentationFlag = InstrumentationFlag.None,
 			bool captureStackTraceOnStart = false,
@@ -73,7 +69,6 @@ namespace Elastic.Apm.Model
 			_parentSpan = parentSpan;
 			_enclosingTransaction = enclosingTransaction;
 			_apmServerInfo = apmServerInfo;
-			_breakdownMetricsProvider = breakdownMetricsProvider;
 			Name = name;
 			Type = type;
 
@@ -287,7 +282,7 @@ namespace Elastic.Apm.Model
 		)
 		{
 			var retVal = new Span(name, type, Id, TraceId, _enclosingTransaction, _payloadSender, _logger, _currentExecutionSegmentsContainer,
-				_apmServerInfo, _breakdownMetricsProvider, this, instrumentationFlag, captureStackTraceOnStart, timestamp);
+				_apmServerInfo, this, instrumentationFlag, captureStackTraceOnStart, timestamp);
 
 			if (!string.IsNullOrEmpty(subType))
 				retVal.Subtype = subType;

--- a/src/Elastic.Apm/Model/Span.cs
+++ b/src/Elastic.Apm/Model/Span.cs
@@ -318,7 +318,6 @@ namespace Elastic.Apm.Model
 						" Start time: {Time} (as timestamp: {Timestamp}), Duration: {Duration}ms",
 						this, TimeUtils.FormatTimestampForLog(Timestamp), Timestamp, Duration);
 
-				//_enclosingTransaction?.SpanTimings.
 				_parentSpan?._childDurationTimer.OnChildEnd((long)(Timestamp + Duration.Value * 1000));
 				_childDurationTimer.OnSpanEnd((long)(Timestamp + Duration.Value * 1000));
 				_enclosingTransaction.ChildDurationTimer.OnChildEnd((long)(Timestamp + Duration.Value * 1000));

--- a/src/Elastic.Apm/Model/Span.cs
+++ b/src/Elastic.Apm/Model/Span.cs
@@ -559,12 +559,9 @@ namespace Elastic.Apm.Model
 
 	internal class ChildDurationTimer
 	{
-
-
 		private int _activeChildren;
 		private long _start;
 		private double _duration;
-
 
 		/// <summary>
 		/// Starts the timer if it has not been started already.
@@ -607,20 +604,5 @@ namespace Elastic.Apm.Model
 
 		private void IncrementDuration(long epochMicros)
 		 => _duration = TimeUtils.DurationBetweenTimestamps(_start, epochMicros);
-		//duration.addAndGet(epochMicros - start.get());
-
-
-		//@Override
-		//public void resetState()
-		//{
-		//	activeChildren.set(0);
-		//	start.set(0);
-		//	duration.set(0);
-		//}
-
-		//public long getDuration()
-		//{
-		//	return duration.get();
-		//}
 	}
 }

--- a/src/Elastic.Apm/Model/SpanTypeAndSubtype.cs
+++ b/src/Elastic.Apm/Model/SpanTypeAndSubtype.cs
@@ -1,0 +1,19 @@
+// Licensed to Elasticsearch B.V under
+// one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+namespace Elastic.Apm.Model
+{
+	/// <summary>
+	/// Encapsulates type and subtype
+	/// </summary>
+	internal struct SpanTypeAndSubtype
+	{
+		public SpanTypeAndSubtype(string type, string subType) => (Type, SubType) = (type, subType);
+		public SpanTypeAndSubtype(string type) => (Type, SubType) = (type, null);
+		public string Type { get; }
+		public string SubType { get; set; }
+		public static SpanTypeAndSubtype AppSpanType => new SpanTypeAndSubtype("app");
+	}
+}

--- a/src/Elastic.Apm/Model/Transaction.cs
+++ b/src/Elastic.Apm/Model/Transaction.cs
@@ -43,9 +43,8 @@ namespace Elastic.Apm.Model
 		private readonly IApmLogger _logger;
 		private readonly IPayloadSender _sender;
 
-		// This constructor is meant for serialization
 		[JsonConstructor]
-		// ReSharper disable once UnusedMember.Local
+		// ReSharper disable once UnusedMember.Local - this constructor is meant for serialization
 		private Transaction(Context context, string name, string type, double duration, long timestamp, string id, string traceId, string parentId,
 			bool isSampled, string result, SpanCount spanCount
 		)
@@ -367,7 +366,7 @@ namespace Elastic.Apm.Model
 				_outcome = value;
 			}
 		}
-		
+
 		[JsonIgnore]
 		public DistributedTracingData OutgoingDistributedTracingData => new DistributedTracingData(TraceId, Id, IsSampled, _traceState);
 

--- a/src/Elastic.Apm/Model/Transaction.cs
+++ b/src/Elastic.Apm/Model/Transaction.cs
@@ -395,8 +395,7 @@ namespace Elastic.Apm.Model
 		[JsonProperty("sample_rate")]
 		internal double? SampleRate { get; }
 
-		[JsonIgnore]
-		public double SelfDuration => Duration.HasValue ? Duration.Value - ChildDurationTimer.Duration : 0;
+		internal double SelfDuration => Duration.HasValue ? Duration.Value - ChildDurationTimer.Duration : 0;
 
 		internal Service Service;
 
@@ -484,8 +483,7 @@ namespace Elastic.Apm.Model
 						" Start time: {Time} (as timestamp: {Timestamp}), Duration: {Duration}ms",
 						this, TimeUtils.FormatTimestampForLog(Timestamp), Timestamp, Duration);
 
-				//TODO: set _childDurationTimer
-				ChildDurationTimer.OnSpanEnd((long)(Timestamp + Duration.Value));
+				ChildDurationTimer.OnSpanEnd((long)(Timestamp + Duration.Value * 1000));
 			}
 			else
 			{

--- a/src/Elastic.Apm/Model/Transaction.cs
+++ b/src/Elastic.Apm/Model/Transaction.cs
@@ -516,7 +516,10 @@ namespace Elastic.Apm.Model
 			handler?.Invoke(this, EventArgs.Empty);
 			Ended = null;
 
-			SpanTimings.TryAdd(("app", null), new SpanTimer(SelfDuration));
+			if (SpanTimings.ContainsKey(("app", null)))
+				SpanTimings[("app", null)].IncrementTimer(SelfDuration);
+			else
+				SpanTimings.TryAdd(("app", null), new SpanTimer(SelfDuration));
 
 			_breakdownMetricsProvider?.CaptureTransaction(this);
 

--- a/src/Elastic.Apm/Model/Transaction.cs
+++ b/src/Elastic.Apm/Model/Transaction.cs
@@ -15,7 +15,6 @@ using Elastic.Apm.Config;
 using Elastic.Apm.DistributedTracing;
 using Elastic.Apm.Helpers;
 using Elastic.Apm.Logging;
-using Elastic.Apm.Metrics.MetricsProvider;
 using Elastic.Apm.Report;
 using Elastic.Apm.ServerInfo;
 using Elastic.Apm.Libraries.Newtonsoft.Json;
@@ -28,7 +27,7 @@ namespace Elastic.Apm.Model
 
 		internal readonly TraceState _traceState;
 
-		internal readonly ConcurrentDictionary<(string, string), SpanTimer> SpanTimings = new();
+		internal readonly ConcurrentDictionary<SpanTypeAndSubtype, SpanTimer> SpanTimings = new();
 
 		/// <summary>
 		/// The agent also starts an Activity when a transaction is started and stops it when the transaction ends.
@@ -506,10 +505,10 @@ namespace Elastic.Apm.Model
 			if (!isFirstEndCall)
 				return;
 
-			if (SpanTimings.ContainsKey(("app", null)))
-				SpanTimings[("app", null)].IncrementTimer(SelfDuration);
+			if (SpanTimings.ContainsKey(SpanTypeAndSubtype.AppSpanType))
+				SpanTimings[SpanTypeAndSubtype.AppSpanType].IncrementTimer(SelfDuration);
 			else
-				SpanTimings.TryAdd(("app", null), new SpanTimer(SelfDuration));
+				SpanTimings.TryAdd(SpanTypeAndSubtype.AppSpanType, new SpanTimer(SelfDuration));
 
 			var handler = Ended;
 			handler?.Invoke(this, EventArgs.Empty);

--- a/src/Elastic.Apm/Report/Serialization/MetricSetConverter.cs
+++ b/src/Elastic.Apm/Report/Serialization/MetricSetConverter.cs
@@ -17,6 +17,39 @@ namespace Elastic.Apm.Report.Serialization
 		public override void WriteJson(JsonWriter writer, MetricSet value, JsonSerializer serializer)
 		{
 			writer.WriteStartObject();
+			if (value.Transaction != null)
+			{
+				
+				writer.WritePropertyName("transaction");
+
+				writer.WriteStartObject();
+
+				writer.WritePropertyName("name");
+				writer.WriteValue(value.Transaction.Name);
+
+				writer.WritePropertyName("type");
+				writer.WriteValue(value.Transaction.Type);
+
+				writer.WriteEndObject();
+			}
+
+			if (value.Span != null)
+			{
+
+				writer.WritePropertyName("span");
+
+				writer.WriteStartObject();
+
+				writer.WritePropertyName("type");
+				writer.WriteValue(value.Span.Type);
+
+				writer.WritePropertyName("subtype");
+				writer.WriteValue(value.Span.SybType);
+
+				writer.WriteEndObject();
+			}
+
+
 			writer.WritePropertyName("samples");
 			writer.WriteStartObject();
 

--- a/src/Elastic.Apm/Report/Serialization/MetricSetConverter.cs
+++ b/src/Elastic.Apm/Report/Serialization/MetricSetConverter.cs
@@ -44,7 +44,7 @@ namespace Elastic.Apm.Report.Serialization
 				writer.WriteValue(value.Span.Type);
 
 				writer.WritePropertyName("subtype");
-				writer.WriteValue(value.Span.SybType);
+				writer.WriteValue(value.Span.SubType);
 
 				writer.WriteEndObject();
 			}

--- a/test/Elastic.Apm.Tests.Utilities/NoopPayloadSender.cs
+++ b/test/Elastic.Apm.Tests.Utilities/NoopPayloadSender.cs
@@ -3,15 +3,25 @@
 // See the LICENSE file in the project root for more information
 
 using Elastic.Apm.Api;
+using Elastic.Apm.Metrics.MetricsProvider;
+using Elastic.Apm.Model;
 using Elastic.Apm.Report;
 
 namespace Elastic.Apm.Tests.Utilities
 {
-	public class NoopPayloadSender : IPayloadSender
+	internal class NoopPayloadSender : IPayloadSender
 	{
+		private readonly BreakdownMetricsProvider _breakdownMetricsProvider;
+
+		public NoopPayloadSender(BreakdownMetricsProvider breakdownMetricsProvider = null) => _breakdownMetricsProvider = breakdownMetricsProvider;
+
 		public void QueueError(IError error) { }
 
-		public void QueueTransaction(ITransaction transaction) { }
+		public void QueueTransaction(ITransaction transaction)
+		{
+			if(transaction is Transaction realTransaction)
+				_breakdownMetricsProvider?.CaptureTransaction(realTransaction);
+		}
 
 		public void QueueSpan(ISpan span) { }
 

--- a/test/Elastic.Apm.Tests/BreakdownTests.cs
+++ b/test/Elastic.Apm.Tests/BreakdownTests.cs
@@ -92,9 +92,9 @@ namespace Elastic.Apm.Tests
 				);
 		}
 
-		// 								  total self type
+		//                                  total self type
 		// ██████████████████████████████    30   30 transaction
-		//			10        20        30
+		//          10        20        30
 		[Fact]
 		public void AcceptanceTest1()
 		{
@@ -129,10 +129,10 @@ namespace Elastic.Apm.Tests
 				);
 		}
 
-		//									 total self type
+		//                                  total self type
 		// ██████████░░░░░░░░░░██████████    30   20 transaction
 		// └─────────██████████              10   10 db.mysql
-		//			10        20        30
+		//          10        20        30
 		// {"metricset":{"timestamp":1556893458387000,"transaction":{"name":"test","type":"request"},"samples":{"transaction.duration.count":{"value":1},"transaction.duration.sum.us":{"value":30},"transaction.breakdown.count":{"value":1}}}}
 		// {"metricset":{"timestamp":1556893458387000,"transaction":{"name":"test","type":"request"},"span":{"type":"db","subtype":"mysql"},"samples":{"span.self_time.count":{"value":1},"span.self_time.sum.us":{"value":10}}}}
 		// {"metricset":{"timestamp":1556893458387000,"transaction":{"name":"test","type":"request"},"span":{"type":"app"},"samples":{"span.self_time.count":{"value":1},"span.self_time.sum.us":{"value":20}}}}
@@ -188,11 +188,11 @@ namespace Elastic.Apm.Tests
 				);
 		}
 
-		// 									total self type
+		//                                   total self type
 		// ██████████░░░░░░░░░░██████████    30   20 transaction
 		// ├─────────██████████              10   10 db.mysql
 		// └─────────██████████              10   10 db.mysql
-		//			10        20        30
+		//          10        20        30
 		// {"metricset":{"timestamp":1556893458375000,"transaction":{"name":"test","type":"request"},"samples":{"transaction.duration.count":{"value":1},"transaction.duration.sum.us":{"value":30},"transaction.breakdown.count":{"value":1}}}}
 		// {"metricset":{"timestamp":1556893458375000,"transaction":{"name":"test","type":"request"},"span":{"type":"db","subtype":"mysql"},"samples":{"span.self_time.count":{"value":2},"span.self_time.sum.us":{"value":20}}}}
 		// {"metricset":{"timestamp":1556893458375000,"transaction":{"name":"test","type":"request"},"span":{"type":"app"},"samples":{" ":{"value":1},"span.self_time.sum.us":{"value":20}}}}
@@ -251,11 +251,11 @@ namespace Elastic.Apm.Tests
 				);
 		}
 
-		// 								  total self type
+		//                                   total self type
 		// ██████████░░░░░░░░░░░░░░░█████    30   15 transaction
 		// ├─────────██████████              10   10 db.mysql
 		// └──────────────██████████         10   10 db.mysql
-		//			10        20        30
+		//          10        20        30
 		// {"metricset":{"timestamp":1556893458417000,"transaction":{"name":"test","type":"request"},"samples":{"transaction.duration.count":{"value":1},"transaction.duration.sum.us":{"value":30},"transaction.breakdown.count":{"value":1}}}}
 		// {"metricset":{"timestamp":1556893458417000,"transaction":{"name":"test","type":"request"},"span":{"type":"db","subtype":"mysql"},"samples":{"span.self_time.count":{"value":2},"span.self_time.sum.us":{"value":20}}}}
 		// {"metricset":{"timestamp":1556893458417000,"transaction":{"name":"test","type":"request"},"span":{"type":"app"},"samples":{"span.self_time.count":{"value":1},"span.self_time.sum.us":{"value":15}}}}
@@ -313,11 +313,11 @@ namespace Elastic.Apm.Tests
 				);
 		}
 
-		//									total self type
+		//                                   total self type
 		// █████░░░░░░░░░░░░░░░░░░░░█████    30   10 transaction
 		// ├────██████████                   10   10 db.mysql
 		// └──────────────██████████         10   10 db.mysql
-		//			10        20        30
+		//          10        20        30
 		// {"metricset":{"timestamp":1556893458462000,"transaction":{"name":"test","type":"request"},"samples":{"transaction.duration.count":{"value":1},"transaction.duration.sum.us":{"value":30},"transaction.breakdown.count":{"value":1}}}}
 		// {"metricset":{"timestamp":1556893458462000,"transaction":{"name":"test","type":"request"},"span":{"type":"db","subtype":"mysql"},"samples":{"span.self_time.count":{"value":2},"span.self_time.sum.us":{"value":20}}}}
 		// {"metricset":{"timestamp":1556893458462000,"transaction":{"name":"test","type":"request"},"span":{"type":"app"},"samples":{"span.self_time.count":{"value":1},"span.self_time.sum.us":{"value":10}}}}
@@ -379,7 +379,7 @@ namespace Elastic.Apm.Tests
 		// ██████████░░░░░█████░░░░░█████    30   20 transaction
 		// ├─────────█████                    5    5 db.mysql
 		// └───────────────────█████          5    5 db.mysql
-		//			10        20        30
+		//          10        20        30
 		// {"metricset":{"timestamp":1556893458453000,"transaction":{"name":"test","type":"request"},"samples":{"transaction.duration.count":{"value":1},"transaction.duration.sum.us":{"value":30},"transaction.breakdown.count":{"value":1}}}}
 		// {"metricset":{"timestamp":1556893458453000,"transaction":{"name":"test","type":"request"},"span":{"type":"db","subtype":"mysql"},"samples":{"span.self_time.count":{"value":2},"span.self_time.sum.us":{"value":10}}}}
 		// {"metricset":{"timestamp":1556893458453000,"transaction":{"name":"test","type":"request"},"span":{"type":"app"},"samples":{"span.self_time.count":{"value":1},"span.self_time.sum.us":{"value":20}}}}

--- a/test/Elastic.Apm.Tests/BreakdownTests.cs
+++ b/test/Elastic.Apm.Tests/BreakdownTests.cs
@@ -27,7 +27,8 @@ namespace Elastic.Apm.Tests
 		[Fact]
 		public void TransactionWithSpans()
 		{
-			var payloadSender = new MockPayloadSender();
+			var breakdownMetricsProvider = new BreakdownMetricsProvider();
+			var payloadSender = new MockPayloadSender(breakdownMetricsProvider: breakdownMetricsProvider);
 			using var agent = new ApmAgent(
 				new AgentComponents(
 					new NoopLogger(),
@@ -36,7 +37,8 @@ namespace Elastic.Apm.Tests
 					null, //metricsCollector will be set in AgentComponents.ctor
 					new CurrentExecutionSegmentsContainer(),
 					new NoopCentralConfigFetcher(),
-					new MockApmServerInfo(new ElasticVersion(7, 12, 0, string.Empty))));
+					new MockApmServerInfo(new ElasticVersion(7, 12, 0, string.Empty)),
+					breakdownMetricsProvider));
 
 			Transaction transaction = null;
 			Span span1 = null;
@@ -734,7 +736,7 @@ namespace Elastic.Apm.Tests
 			var agentComponents = new AgentComponents(
 				new NoopLogger(),
 				new MockConfigSnapshot(metricsInterval: "1s"),
-				new NoopPayloadSender(),
+				new NoopPayloadSender(breakdownMetricsProvider),
 				new FakeMetricsCollector(), //metricsCollector will be set in AgentComponents.ctor
 				new CurrentExecutionSegmentsContainer(),
 				new NoopCentralConfigFetcher(),

--- a/test/Elastic.Apm.Tests/BreakdownTests.cs
+++ b/test/Elastic.Apm.Tests/BreakdownTests.cs
@@ -96,7 +96,7 @@ namespace Elastic.Apm.Tests
 		// ██████████████████████████████    30   30 transaction
 		//          10        20        30
 		[Fact]
-		public void AcceptanceTest1()
+		public void AcceptanceTest01()
 		{
 			var (agent, breakdownMetricsProvider) = SetUpAgent();
 			using (agent)
@@ -138,7 +138,7 @@ namespace Elastic.Apm.Tests
 		// {"metricset":{"timestamp":1556893458387000,"transaction":{"name":"test","type":"request"},"span":{"type":"app"},"samples":{"span.self_time.count":{"value":1},"span.self_time.sum.us":{"value":20}}}}
 
 		[Fact]
-		public void AcceptanceTest2()
+		public void AcceptanceTest02()
 		{
 			var (agent, breakdownMetricsProvider) = SetUpAgent();
 			using (agent)
@@ -196,7 +196,7 @@ namespace Elastic.Apm.Tests
 		//{"metricset":{"timestamp":1556893458471000,"transaction":{"name":"test","type":"request"},"samples":{"transaction.duration.count":{"value":1},"transaction.duration.sum.us":{"value":30},"transaction.breakdown.count":{"value":1}}}}
 		//{"metricset":{"timestamp":1556893458471000,"transaction":{"name":"test","type":"request"},"span":{"type":"app"},"samples":{"span.self_time.count":{"value":2},"span.self_time.sum.us":{"value":30}}}}
 		[Fact]
-		public void AcceptanceTest3()
+		public void AcceptanceTest03()
 		{
 			var (agent, breakdownMetricsProvider) = SetUpAgent();
 			using (agent)
@@ -246,7 +246,7 @@ namespace Elastic.Apm.Tests
 		// {"metricset":{"timestamp":1556893458375000,"transaction":{"name":"test","type":"request"},"span":{"type":"app"},"samples":{" ":{"value":1},"span.self_time.sum.us":{"value":20}}}}
 
 		[Fact]
-		public void AcceptanceTest4()
+		public void AcceptanceTest04()
 		{
 			var (agent, breakdownMetricsProvider) = SetUpAgent();
 			using (agent)
@@ -308,7 +308,7 @@ namespace Elastic.Apm.Tests
 		// {"metricset":{"timestamp":1556893458417000,"transaction":{"name":"test","type":"request"},"span":{"type":"db","subtype":"mysql"},"samples":{"span.self_time.count":{"value":2},"span.self_time.sum.us":{"value":20}}}}
 		// {"metricset":{"timestamp":1556893458417000,"transaction":{"name":"test","type":"request"},"span":{"type":"app"},"samples":{"span.self_time.count":{"value":1},"span.self_time.sum.us":{"value":15}}}}
 		[Fact]
-		public void AcceptanceTest5()
+		public void AcceptanceTest05()
 		{
 			var (agent, breakdownMetricsProvider) = SetUpAgent();
 			using (agent)
@@ -370,7 +370,7 @@ namespace Elastic.Apm.Tests
 		// {"metricset":{"timestamp":1556893458462000,"transaction":{"name":"test","type":"request"},"span":{"type":"db","subtype":"mysql"},"samples":{"span.self_time.count":{"value":2},"span.self_time.sum.us":{"value":20}}}}
 		// {"metricset":{"timestamp":1556893458462000,"transaction":{"name":"test","type":"request"},"span":{"type":"app"},"samples":{"span.self_time.count":{"value":1},"span.self_time.sum.us":{"value":10}}}}
 		[Fact]
-		public void AcceptanceTest6()
+		public void AcceptanceTest06()
 		{
 			var (agent, breakdownMetricsProvider) = SetUpAgent();
 			using (agent)
@@ -423,7 +423,7 @@ namespace Elastic.Apm.Tests
 				);
 		}
 
-		//									total self type
+		//                                  total self type
 		// ██████████░░░░░█████░░░░░█████    30   20 transaction
 		// ├─────────█████                    5    5 db.mysql
 		// └───────────────────█████          5    5 db.mysql
@@ -432,7 +432,7 @@ namespace Elastic.Apm.Tests
 		// {"metricset":{"timestamp":1556893458453000,"transaction":{"name":"test","type":"request"},"span":{"type":"db","subtype":"mysql"},"samples":{"span.self_time.count":{"value":2},"span.self_time.sum.us":{"value":10}}}}
 		// {"metricset":{"timestamp":1556893458453000,"transaction":{"name":"test","type":"request"},"span":{"type":"app"},"samples":{"span.self_time.count":{"value":1},"span.self_time.sum.us":{"value":20}}}}
 		[Fact]
-		public void AcceptanceTest7()
+		public void AcceptanceTest07()
 		{
 			var (agent, breakdownMetricsProvider) = SetUpAgent();
 			using (agent)
@@ -481,6 +481,214 @@ namespace Elastic.Apm.Tests
 						&& n.Span.Type.Equals("db")
 						&& n.Span.SubType.Equals("mysql")
 						&& n.Samples.Any(s => s.KeyValue.Key.Equals("span.self_time.count") && s.KeyValue.Value == 2)
+						&& n.Samples.Any(s => s.KeyValue.Key.Equals("span.self_time.sum.us") && s.KeyValue.Value == 10)
+				);
+		}
+
+		//                                   total self type
+		// ██████████░░░░░░░░░░██████████    30   20 transaction
+		// └─────────█████░░░░░              10    5 app
+		//           └────██████████         10   10 db.mysql
+		//         10        20        30
+		//
+		// {"metricset":{"timestamp":1556893458398000,"transaction":{"name":"test","type":"request"},"samples":{"transaction.duration.count":{"value":1},"transaction.duration.sum.us":{"value":30},"transaction.breakdown.count":{"value":1}}}}
+		// {"metricset":{"timestamp":1556893458398000,"transaction":{"name":"test","type":"request"},"span":{"type":"db","subtype":"mysql"},"samples":{"span.self_time.count":{"value":1},"span.self_time.sum.us":{"value":10}}}}
+		// {"metricset":{"timestamp":1556893458398000,"transaction":{"name":"test","type":"request"},"span":{"type":"app"},"samples":{"span.self_time.count":{"value":2},"span.self_time.sum.us":{"value":25}}}}
+		[Fact]
+		public void AcceptanceTest08()
+		{
+			var (agent, breakdownMetricsProvider) = SetUpAgent();
+			using (agent)
+			{
+				var t = agent.TracerInternal.StartTransactionInternal("test", "request", 0);
+				t.Duration = 30;
+
+				var span = t.StartSpanInternal("foo", "app", timestamp: 10 * 1000);
+				span.Duration = 10;
+
+				var span2 = span.StartSpanInternal("db.mysql", "db", "mysql", timestamp: 15 * 1000);
+				span2.Duration = 10;
+
+				span.End();
+				span2.End();
+
+				t.End();
+			}
+
+			var metricSets = breakdownMetricsProvider.GetSamples();
+
+			var metrics = metricSets as MetricSet[] ?? metricSets.ToArray();
+			metrics.Should().NotBeNullOrEmpty();
+			metrics.Count().Should().Be(3);
+			metrics.Should()
+				.Contain(
+					n => n.Transaction.Name.Equals("test")
+						&& n.Transaction.Type.Equals("request")
+						&& n.Samples.Any(s => s.KeyValue.Key.Equals("transaction.duration.count") && s.KeyValue.Value == 1)
+						&& n.Samples.Any(s => s.KeyValue.Key.Equals("transaction.duration.sum.us") && s.KeyValue.Value == 30)
+						&& n.Samples.Any(s => s.KeyValue.Key.Equals("transaction.breakdown.count") && s.KeyValue.Value == 1)
+				);
+
+			metrics.Should()
+				.Contain(
+					n => n.Transaction.Name.Equals("test")
+						&& n.Transaction.Type.Equals("request")
+						&& n.Span.Type.Equals("app")
+						&& n.Samples.Any(s => s.KeyValue.Key.Equals("span.self_time.count") && s.KeyValue.Value == 2)
+						&& n.Samples.Any(s => s.KeyValue.Key.Equals("span.self_time.sum.us") && s.KeyValue.Value == 25)
+				);
+
+			metrics.Should()
+				.Contain(
+					n => n.Transaction.Name.Equals("test")
+						&& n.Transaction.Type.Equals("request")
+						&& n.Span.Type.Equals("db")
+						&& n.Span.SubType.Equals("mysql")
+						&& n.Samples.Any(s => s.KeyValue.Key.Equals("span.self_time.count") && s.KeyValue.Value == 1)
+						&& n.Samples.Any(s => s.KeyValue.Key.Equals("span.self_time.sum.us") && s.KeyValue.Value == 10)
+				);
+		}
+
+		//                                  total self type
+		// ██████████░░░░░░░░░░              20   10 transaction
+		// └─────────██████████░░░░░░░░░░    20   10 app
+		//           └─────────██████████    10   10 db.mysql
+		//          10        20        30
+		//
+		// {"metricset":{"timestamp":1556893458444000,"transaction":{"name":"test","type":"request"},"samples":{"transaction.duration.count":{"value":1},"transaction.duration.sum.us":{"value":20},"transaction.breakdown.count":{"value":1}}}}
+		// {"metricset":{"timestamp":1556893458444000,"transaction":{"name":"test","type":"request"},"span":{"type":"app"},"samples":{"span.self_time.count":{"value":1},"span.self_time.sum.us":{"value":10}}}}
+		[Fact]
+		public void AcceptanceTest09()
+		{
+			var (agent, breakdownMetricsProvider) = SetUpAgent();
+			using (agent)
+			{
+				var t = agent.TracerInternal.StartTransactionInternal("test", "request", 0);
+				t.Duration = 20;
+
+				var span = t.StartSpanInternal("foo", "app", timestamp: 10 * 1000);
+				span.Duration = 20;
+
+				t.End();
+				var span2 = span.StartSpanInternal("db.mysql", "db", "mysql", timestamp: 20 * 1000);
+				span2.Duration = 10;
+
+				span.End();
+				span2.End();
+			}
+
+			var metricSets = breakdownMetricsProvider.GetSamples();
+
+			var metrics = metricSets as MetricSet[] ?? metricSets.ToArray();
+			metrics.Should().NotBeNullOrEmpty();
+			metrics.Count().Should().Be(2);
+			metrics.Should()
+				.Contain(
+					n => n.Transaction.Name.Equals("test")
+						&& n.Transaction.Type.Equals("request")
+						&& n.Samples.Any(s => s.KeyValue.Key.Equals("transaction.duration.count") && s.KeyValue.Value == 1)
+						&& n.Samples.Any(s => s.KeyValue.Key.Equals("transaction.duration.sum.us") && s.KeyValue.Value == 20)
+						&& n.Samples.Any(s => s.KeyValue.Key.Equals("transaction.breakdown.count") && s.KeyValue.Value == 1)
+				);
+
+			metrics.Should()
+				.Contain(
+					n => n.Transaction.Name.Equals("test")
+						&& n.Transaction.Type.Equals("request")
+						&& n.Span.Type.Equals("app")
+						&& n.Samples.Any(s => s.KeyValue.Key.Equals("span.self_time.count") && s.KeyValue.Value == 1)
+						&& n.Samples.Any(s => s.KeyValue.Key.Equals("span.self_time.sum.us") && s.KeyValue.Value == 10)
+				);
+		}
+
+		//                                 total self type
+		// ██████████░░░░░░░░░░              20   10 transaction
+		// └─────────████████████████████    20   20 db.mysql
+		//          10        20        30
+		// {"metricset":{"timestamp":1556893458409000,"transaction":{"name":"test","type":"request"},"samples":{"transaction.duration.count":{"value":1},"transaction.duration.sum.us":{"value":20},"transaction.breakdown.count":{"value":1}}}}
+		// {"metricset":{"timestamp":1556893458409000,"transaction":{"name":"test","type":"request"},"span":{"type":"app"},"samples":{"span.self_time.count":{"value":1},"span.self_time.sum.us":{"value":10}}}}
+		[Fact]
+		public void AcceptanceTest10()
+		{
+			var (agent, breakdownMetricsProvider) = SetUpAgent();
+			using (agent)
+			{
+				var t = agent.TracerInternal.StartTransactionInternal("test", "request", 0);
+				t.Duration = 20;
+
+				var span = t.StartSpanInternal("db.mysql", "db", "mysql", timestamp: 10 * 1000);
+				span.Duration = 30;
+				t.End();
+				span.End();
+			}
+
+			var metricSets = breakdownMetricsProvider.GetSamples();
+
+			var metrics = metricSets as MetricSet[] ?? metricSets.ToArray();
+			metrics.Should().NotBeNullOrEmpty();
+			metrics.Count().Should().Be(2);
+			metrics.Should()
+				.Contain(
+					n => n.Transaction.Name.Equals("test")
+						&& n.Transaction.Type.Equals("request")
+						&& n.Samples.Any(s => s.KeyValue.Key.Equals("transaction.duration.count") && s.KeyValue.Value == 1)
+						&& n.Samples.Any(s => s.KeyValue.Key.Equals("transaction.duration.sum.us") && s.KeyValue.Value == 20)
+						&& n.Samples.Any(s => s.KeyValue.Key.Equals("transaction.breakdown.count") && s.KeyValue.Value == 1)
+				);
+
+			metrics.Should()
+				.Contain(
+					n => n.Transaction.Name.Equals("test")
+						&& n.Transaction.Type.Equals("request")
+						&& n.Span.Type.Equals("app")
+						&& n.Samples.Any(s => s.KeyValue.Key.Equals("span.self_time.count") && s.KeyValue.Value == 1)
+						&& n.Samples.Any(s => s.KeyValue.Key.Equals("span.self_time.sum.us") && s.KeyValue.Value == 10)
+				);
+		}
+
+		//                                 total self type
+		// ██████████                        10   10 transaction
+		// └───────────────────██████████    10   10 db.mysql
+		//         10        20        30
+		//
+		// {"metricset":{"timestamp":1556893458434000,"transaction":{"name":"test","type":"request"},"samples":{"transaction.duration.count":{"value":1},"transaction.duration.sum.us":{"value":10},"transaction.breakdown.count":{"value":1}}}}
+		// {"metricset":{"timestamp":1556893458434000,"transaction":{"name":"test","type":"request"},"span":{"type":"app"},"samples":{"span.self_time.count":{"value":1},"span.self_time.sum.us":{"value":10}}}}
+		[Fact]
+		public void AcceptanceTest11()
+		{
+			var (agent, breakdownMetricsProvider) = SetUpAgent();
+			using (agent)
+			{
+				var t = agent.TracerInternal.StartTransactionInternal("test", "request", 0);
+				t.Duration = 10;
+				t.End();
+
+				var span = t.StartSpanInternal("db.mysql", "db", "mysql", timestamp: 20 * 1000);
+				span.Duration = 10;
+
+				span.End();
+			}
+
+			var metricSets = breakdownMetricsProvider.GetSamples();
+
+			var metrics = metricSets as MetricSet[] ?? metricSets.ToArray();
+			metrics.Should().NotBeNullOrEmpty();
+			metrics.Count().Should().Be(2);
+			metrics.Should()
+				.Contain(
+					n => n.Transaction.Name.Equals("test")
+						&& n.Transaction.Type.Equals("request")
+						&& n.Samples.Any(s => s.KeyValue.Key.Equals("transaction.duration.count") && s.KeyValue.Value == 1)
+						&& n.Samples.Any(s => s.KeyValue.Key.Equals("transaction.duration.sum.us") && s.KeyValue.Value == 10)
+						&& n.Samples.Any(s => s.KeyValue.Key.Equals("transaction.breakdown.count") && s.KeyValue.Value == 1)
+				);
+
+			metrics.Should()
+				.Contain(
+					n => n.Transaction.Name.Equals("test")
+						&& n.Transaction.Type.Equals("request")
+						&& n.Span.Type.Equals("app")
+						&& n.Samples.Any(s => s.KeyValue.Key.Equals("span.self_time.count") && s.KeyValue.Value == 1)
 						&& n.Samples.Any(s => s.KeyValue.Key.Equals("span.self_time.sum.us") && s.KeyValue.Value == 10)
 				);
 		}

--- a/test/Elastic.Apm.Tests/BreakdownTests.cs
+++ b/test/Elastic.Apm.Tests/BreakdownTests.cs
@@ -1,0 +1,45 @@
+﻿// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System.Threading;
+using Elastic.Apm.Model;
+using Elastic.Apm.Tests.Utilities;
+using Xunit;
+
+namespace Elastic.Apm.Tests
+{
+	public class BreakdownTests
+	{
+		[Fact]
+		public void V()
+		{
+			var payloadSender = new MockPayloadSender();
+			using (var agent = new ApmAgent(new TestAgentComponents(payloadSender: payloadSender)))
+			{
+				Transaction transaction;
+				Span span1;
+				Span span2;
+				agent.Tracer.CaptureTransaction("Foo", "Bar", t =>
+				{
+					transaction = t as Transaction;
+					Thread.Sleep(100);
+					t.CaptureSpan("Foo", "Bar", s1 =>
+					{
+						span1 = s1 as Span;
+						Thread.Sleep(100);
+						s1.CaptureSpan("Foo", "Bar", s2 =>
+						{
+							span2 = s2 as Span;
+							Thread.Sleep(100);
+						});
+					});
+					Thread.Sleep(100);
+				});
+
+				// TODO add asserts
+
+			}
+		}
+	}
+}

--- a/test/Elastic.Apm.Tests/BreakdownTests.cs
+++ b/test/Elastic.Apm.Tests/BreakdownTests.cs
@@ -6,6 +6,7 @@ using System;
 using System.Linq;
 using System.Threading;
 using Elastic.Apm.Metrics;
+using Elastic.Apm.Metrics.MetricsProvider;
 using Elastic.Apm.Model;
 using Elastic.Apm.ServerInfo;
 using Elastic.Apm.Tests.Utilities;
@@ -88,6 +89,370 @@ namespace Elastic.Apm.Tests
 						sample.KeyValue.Value == transaction.SelfDuration) &&
 					((MetricSet)n)!.Samples.Any(sample => sample.KeyValue.Key.Equals("span.self_time.count") && sample.KeyValue.Value == 1)
 				);
+		}
+
+		// 								  total self type
+		// ██████████████████████████████    30   30 transaction
+		//			10        20        30
+		[Fact]
+		public void AcceptanceTest1()
+		{
+			var (agent, breakdownMetricsProvider) = SetUpAgent();
+			using (agent)
+			{
+				var t = agent.Tracer.StartTransaction("test", "request");
+				t.Duration = 30;
+				t.End();
+			}
+			var metricSets = breakdownMetricsProvider.GetSamples();
+
+			var metrics = metricSets as MetricSet[] ?? metricSets.ToArray();
+			metrics.Should().NotBeNullOrEmpty();
+			metrics.Count().Should().Be(2);
+			metrics.Should()
+				.Contain(
+					n => n.Transaction.Name.Equals("test")
+						&& n.Transaction.Type.Equals("request")
+						&& n.Samples.Any(s => s.KeyValue.Key.Equals("transaction.duration.count") && s.KeyValue.Value == 1)
+						&& n.Samples.Any(s => s.KeyValue.Key.Equals("transaction.duration.sum.us") && s.KeyValue.Value == 30)
+						&& n.Samples.Any(s => s.KeyValue.Key.Equals("transaction.breakdown.count") && s.KeyValue.Value == 1)
+				);
+
+			metrics.Should()
+				.Contain(
+					n => n.Transaction.Name.Equals("test")
+						&& n.Transaction.Type.Equals("request")
+						&& n.Span.Type.Equals("app")
+						&& n.Samples.Any(s => s.KeyValue.Key.Equals("span.self_time.count") && s.KeyValue.Value == 1)
+						&& n.Samples.Any(s => s.KeyValue.Key.Equals("span.self_time.sum.us") && s.KeyValue.Value == 30)
+				);
+		}
+
+		//									 total self type
+		// ██████████░░░░░░░░░░██████████    30   20 transaction
+		// └─────────██████████              10   10 db.mysql
+		//			10        20        30
+		// {"metricset":{"timestamp":1556893458387000,"transaction":{"name":"test","type":"request"},"samples":{"transaction.duration.count":{"value":1},"transaction.duration.sum.us":{"value":30},"transaction.breakdown.count":{"value":1}}}}
+		// {"metricset":{"timestamp":1556893458387000,"transaction":{"name":"test","type":"request"},"span":{"type":"db","subtype":"mysql"},"samples":{"span.self_time.count":{"value":1},"span.self_time.sum.us":{"value":10}}}}
+		// {"metricset":{"timestamp":1556893458387000,"transaction":{"name":"test","type":"request"},"span":{"type":"app"},"samples":{"span.self_time.count":{"value":1},"span.self_time.sum.us":{"value":20}}}}
+
+		[Fact]
+		public void AcceptanceTest2()
+		{
+			var (agent, breakdownMetricsProvider) = SetUpAgent();
+			using (agent)
+			{
+				var t = agent.TracerInternal.StartTransactionInternal("test", "request", 0);
+				t.Duration = 30;
+
+				var span = t.StartSpanInternal("db.mysql", "db", "mysql", timestamp: 10 * 1000);
+				span.Duration = 10;
+
+				span.End();
+
+				t.End();
+			}
+
+			var metricSets = breakdownMetricsProvider.GetSamples();
+
+			var metrics = metricSets as MetricSet[] ?? metricSets.ToArray();
+			metrics.Should().NotBeNullOrEmpty();
+			metrics.Count().Should().Be(3);
+			metrics.Should()
+				.Contain(
+					n => n.Transaction.Name.Equals("test")
+						&& n.Transaction.Type.Equals("request")
+						&& n.Samples.Any(s => s.KeyValue.Key.Equals("transaction.duration.count") && s.KeyValue.Value == 1)
+						&& n.Samples.Any(s => s.KeyValue.Key.Equals("transaction.duration.sum.us") && s.KeyValue.Value == 30)
+						&& n.Samples.Any(s => s.KeyValue.Key.Equals("transaction.breakdown.count") && s.KeyValue.Value == 1)
+				);
+
+			metrics.Should()
+				.Contain(
+					n => n.Transaction.Name.Equals("test")
+						&& n.Transaction.Type.Equals("request")
+						&& n.Span.Type.Equals("app")
+						&& n.Samples.Any(s => s.KeyValue.Key.Equals("span.self_time.count") && s.KeyValue.Value == 1)
+						&& n.Samples.Any(s => s.KeyValue.Key.Equals("span.self_time.sum.us") && s.KeyValue.Value == 20)
+				);
+
+			metrics.Should()
+				.Contain(
+					n => n.Transaction.Name.Equals("test")
+						&& n.Transaction.Type.Equals("request")
+						&& n.Span.Type.Equals("db")
+						&& n.Span.SubType.Equals("mysql")
+						&& n.Samples.Any(s => s.KeyValue.Key.Equals("span.self_time.count") && s.KeyValue.Value == 1)
+						&& n.Samples.Any(s => s.KeyValue.Key.Equals("span.self_time.sum.us") && s.KeyValue.Value == 10)
+				);
+		}
+
+		// 									total self type
+		// ██████████░░░░░░░░░░██████████    30   20 transaction
+		// ├─────────██████████              10   10 db.mysql
+		// └─────────██████████              10   10 db.mysql
+		//			10        20        30
+		// {"metricset":{"timestamp":1556893458375000,"transaction":{"name":"test","type":"request"},"samples":{"transaction.duration.count":{"value":1},"transaction.duration.sum.us":{"value":30},"transaction.breakdown.count":{"value":1}}}}
+		// {"metricset":{"timestamp":1556893458375000,"transaction":{"name":"test","type":"request"},"span":{"type":"db","subtype":"mysql"},"samples":{"span.self_time.count":{"value":2},"span.self_time.sum.us":{"value":20}}}}
+		// {"metricset":{"timestamp":1556893458375000,"transaction":{"name":"test","type":"request"},"span":{"type":"app"},"samples":{" ":{"value":1},"span.self_time.sum.us":{"value":20}}}}
+
+		[Fact]
+		public void AcceptanceTest3()
+		{
+			var (agent, breakdownMetricsProvider) = SetUpAgent();
+			using (agent)
+			{
+				var t = agent.TracerInternal.StartTransactionInternal("test", "request", 0);
+				t.Duration = 30;
+
+				var span = t.StartSpanInternal("db.mysql", "db", "mysql", timestamp: 10 * 1000);
+				var span2 = t.StartSpanInternal("db.mysql", "db", "mysql", timestamp: 10 * 1000);
+				span.Duration = 10;
+				span2.Duration = 10;
+
+				span.End();
+				span2.End();
+
+				t.End();
+			}
+
+			var metricSets = breakdownMetricsProvider.GetSamples();
+
+			var metrics = metricSets as MetricSet[] ?? metricSets.ToArray();
+			metrics.Should().NotBeNullOrEmpty();
+			metrics.Count().Should().Be(3);
+			metrics.Should()
+				.Contain(
+					n => n.Transaction.Name.Equals("test")
+						&& n.Transaction.Type.Equals("request")
+						&& n.Samples.Any(s => s.KeyValue.Key.Equals("transaction.duration.count") && s.KeyValue.Value == 1)
+						&& n.Samples.Any(s => s.KeyValue.Key.Equals("transaction.duration.sum.us") && s.KeyValue.Value == 30)
+						&& n.Samples.Any(s => s.KeyValue.Key.Equals("transaction.breakdown.count") && s.KeyValue.Value == 1)
+				);
+
+			metrics.Should()
+				.Contain(
+					n => n.Transaction.Name.Equals("test")
+						&& n.Transaction.Type.Equals("request")
+						&& n.Span.Type.Equals("app")
+						&& n.Samples.Any(s => s.KeyValue.Key.Equals("span.self_time.count") && s.KeyValue.Value == 1)
+						&& n.Samples.Any(s => s.KeyValue.Key.Equals("span.self_time.sum.us") && s.KeyValue.Value == 20)
+				);
+
+			metrics.Should()
+				.Contain(
+					n => n.Transaction.Name.Equals("test")
+						&& n.Transaction.Type.Equals("request")
+						&& n.Span.Type.Equals("db")
+						&& n.Span.SubType.Equals("mysql")
+						&& n.Samples.Any(s => s.KeyValue.Key.Equals("span.self_time.count") && s.KeyValue.Value == 2)
+						&& n.Samples.Any(s => s.KeyValue.Key.Equals("span.self_time.sum.us") && s.KeyValue.Value == 20)
+				);
+		}
+
+		// 								  total self type
+		// ██████████░░░░░░░░░░░░░░░█████    30   15 transaction
+		// ├─────────██████████              10   10 db.mysql
+		// └──────────────██████████         10   10 db.mysql
+		//			10        20        30
+		// {"metricset":{"timestamp":1556893458417000,"transaction":{"name":"test","type":"request"},"samples":{"transaction.duration.count":{"value":1},"transaction.duration.sum.us":{"value":30},"transaction.breakdown.count":{"value":1}}}}
+		// {"metricset":{"timestamp":1556893458417000,"transaction":{"name":"test","type":"request"},"span":{"type":"db","subtype":"mysql"},"samples":{"span.self_time.count":{"value":2},"span.self_time.sum.us":{"value":20}}}}
+		// {"metricset":{"timestamp":1556893458417000,"transaction":{"name":"test","type":"request"},"span":{"type":"app"},"samples":{"span.self_time.count":{"value":1},"span.self_time.sum.us":{"value":15}}}}
+		[Fact]
+		public void AcceptanceTest4()
+		{
+			var (agent, breakdownMetricsProvider) = SetUpAgent();
+			using (agent)
+			{
+				var t = agent.TracerInternal.StartTransactionInternal("test", "request", 0);
+				t.Duration = 30;
+
+				var span = t.StartSpanInternal("db.mysql", "db", "mysql", timestamp: 10 * 1000);
+				var span2 = t.StartSpanInternal("db.mysql", "db", "mysql", timestamp: 15 * 1000);
+				span.Duration = 10;
+				span2.Duration = 10;
+
+				span.End();
+				span2.End();
+
+				t.End();
+			}
+
+			var metricSets = breakdownMetricsProvider.GetSamples();
+
+			var metrics = metricSets as MetricSet[] ?? metricSets.ToArray();
+			metrics.Should().NotBeNullOrEmpty();
+			metrics.Count().Should().Be(3);
+			metrics.Should()
+				.Contain(
+					n => n.Transaction.Name.Equals("test")
+						&& n.Transaction.Type.Equals("request")
+						&& n.Samples.Any(s => s.KeyValue.Key.Equals("transaction.duration.count") && s.KeyValue.Value == 1)
+						&& n.Samples.Any(s => s.KeyValue.Key.Equals("transaction.duration.sum.us") && s.KeyValue.Value == 30)
+						&& n.Samples.Any(s => s.KeyValue.Key.Equals("transaction.breakdown.count") && s.KeyValue.Value == 1)
+				);
+
+			metrics.Should()
+				.Contain(
+					n => n.Transaction.Name.Equals("test")
+						&& n.Transaction.Type.Equals("request")
+						&& n.Span.Type.Equals("app")
+						&& n.Samples.Any(s => s.KeyValue.Key.Equals("span.self_time.count") && s.KeyValue.Value == 1)
+						&& n.Samples.Any(s => s.KeyValue.Key.Equals("span.self_time.sum.us") && s.KeyValue.Value == 15)
+				);
+
+			metrics.Should()
+				.Contain(
+					n => n.Transaction.Name.Equals("test")
+						&& n.Transaction.Type.Equals("request")
+						&& n.Span.Type.Equals("db")
+						&& n.Span.SubType.Equals("mysql")
+						&& n.Samples.Any(s => s.KeyValue.Key.Equals("span.self_time.count") && s.KeyValue.Value == 2)
+						&& n.Samples.Any(s => s.KeyValue.Key.Equals("span.self_time.sum.us") && s.KeyValue.Value == 20)
+				);
+		}
+
+		//									total self type
+		// █████░░░░░░░░░░░░░░░░░░░░█████    30   10 transaction
+		// ├────██████████                   10   10 db.mysql
+		// └──────────────██████████         10   10 db.mysql
+		//			10        20        30
+		// {"metricset":{"timestamp":1556893458462000,"transaction":{"name":"test","type":"request"},"samples":{"transaction.duration.count":{"value":1},"transaction.duration.sum.us":{"value":30},"transaction.breakdown.count":{"value":1}}}}
+		// {"metricset":{"timestamp":1556893458462000,"transaction":{"name":"test","type":"request"},"span":{"type":"db","subtype":"mysql"},"samples":{"span.self_time.count":{"value":2},"span.self_time.sum.us":{"value":20}}}}
+		// {"metricset":{"timestamp":1556893458462000,"transaction":{"name":"test","type":"request"},"span":{"type":"app"},"samples":{"span.self_time.count":{"value":1},"span.self_time.sum.us":{"value":10}}}}
+		[Fact]
+		public void AcceptanceTest5()
+		{
+			var (agent, breakdownMetricsProvider) = SetUpAgent();
+			using (agent)
+			{
+				var t = agent.TracerInternal.StartTransactionInternal("test", "request", 0);
+				t.Duration = 30;
+
+				var span = t.StartSpanInternal("db.mysql", "db", "mysql", timestamp: 5 * 1000);
+				var span2 = t.StartSpanInternal("db.mysql", "db", "mysql", timestamp: 15 * 1000);
+				span.Duration = 10;
+				span2.Duration = 10;
+
+				span.End();
+				span2.End();
+
+				t.End();
+			}
+
+			var metricSets = breakdownMetricsProvider.GetSamples();
+
+			var metrics = metricSets as MetricSet[] ?? metricSets.ToArray();
+			metrics.Should().NotBeNullOrEmpty();
+			metrics.Count().Should().Be(3);
+			metrics.Should()
+				.Contain(
+					n => n.Transaction.Name.Equals("test")
+						&& n.Transaction.Type.Equals("request")
+						&& n.Samples.Any(s => s.KeyValue.Key.Equals("transaction.duration.count") && s.KeyValue.Value == 1)
+						&& n.Samples.Any(s => s.KeyValue.Key.Equals("transaction.duration.sum.us") && s.KeyValue.Value == 30)
+						&& n.Samples.Any(s => s.KeyValue.Key.Equals("transaction.breakdown.count") && s.KeyValue.Value == 1)
+				);
+
+			metrics.Should()
+				.Contain(
+					n => n.Transaction.Name.Equals("test")
+						&& n.Transaction.Type.Equals("request")
+						&& n.Span.Type.Equals("app")
+						&& n.Samples.Any(s => s.KeyValue.Key.Equals("span.self_time.count") && s.KeyValue.Value == 1)
+						&& n.Samples.Any(s => s.KeyValue.Key.Equals("span.self_time.sum.us") && s.KeyValue.Value == 10)
+				);
+
+			metrics.Should()
+				.Contain(
+					n => n.Transaction.Name.Equals("test")
+						&& n.Transaction.Type.Equals("request")
+						&& n.Span.Type.Equals("db")
+						&& n.Span.SubType.Equals("mysql")
+						&& n.Samples.Any(s => s.KeyValue.Key.Equals("span.self_time.count") && s.KeyValue.Value == 2)
+						&& n.Samples.Any(s => s.KeyValue.Key.Equals("span.self_time.sum.us") && s.KeyValue.Value == 20)
+				);
+		}
+
+		//									total self type
+		// ██████████░░░░░█████░░░░░█████    30   20 transaction
+		// ├─────────█████                    5    5 db.mysql
+		// └───────────────────█████          5    5 db.mysql
+		//			10        20        30
+		// {"metricset":{"timestamp":1556893458453000,"transaction":{"name":"test","type":"request"},"samples":{"transaction.duration.count":{"value":1},"transaction.duration.sum.us":{"value":30},"transaction.breakdown.count":{"value":1}}}}
+		// {"metricset":{"timestamp":1556893458453000,"transaction":{"name":"test","type":"request"},"span":{"type":"db","subtype":"mysql"},"samples":{"span.self_time.count":{"value":2},"span.self_time.sum.us":{"value":10}}}}
+		// {"metricset":{"timestamp":1556893458453000,"transaction":{"name":"test","type":"request"},"span":{"type":"app"},"samples":{"span.self_time.count":{"value":1},"span.self_time.sum.us":{"value":20}}}}
+		[Fact]
+		public void AcceptanceTest6()
+		{
+			var (agent, breakdownMetricsProvider) = SetUpAgent();
+			using (agent)
+			{
+				var t = agent.TracerInternal.StartTransactionInternal("test", "request", 0);
+				t.Duration = 30;
+
+				var span = t.StartSpanInternal("db.mysql", "db", "mysql", timestamp: 10 * 1000);
+				span.Duration = 5;
+				span.End();
+
+				var span2 = t.StartSpanInternal("db.mysql", "db", "mysql", timestamp: 20 * 1000);
+				span2.Duration = 5;
+				span2.End();
+
+				t.End();
+			}
+
+			var metricSets = breakdownMetricsProvider.GetSamples();
+
+			var metrics = metricSets as MetricSet[] ?? metricSets.ToArray();
+			metrics.Should().NotBeNullOrEmpty();
+			metrics.Count().Should().Be(3);
+			metrics.Should()
+				.Contain(
+					n => n.Transaction.Name.Equals("test")
+						&& n.Transaction.Type.Equals("request")
+						&& n.Samples.Any(s => s.KeyValue.Key.Equals("transaction.duration.count") && s.KeyValue.Value == 1)
+						&& n.Samples.Any(s => s.KeyValue.Key.Equals("transaction.duration.sum.us") && s.KeyValue.Value == 30)
+						&& n.Samples.Any(s => s.KeyValue.Key.Equals("transaction.breakdown.count") && s.KeyValue.Value == 1)
+				);
+
+			metrics.Should()
+				.Contain(
+					n => n.Transaction.Name.Equals("test")
+						&& n.Transaction.Type.Equals("request")
+						&& n.Span.Type.Equals("app")
+						&& n.Samples.Any(s => s.KeyValue.Key.Equals("span.self_time.count") && s.KeyValue.Value == 1)
+						&& n.Samples.Any(s => s.KeyValue.Key.Equals("span.self_time.sum.us") && s.KeyValue.Value == 20)
+				);
+
+			metrics.Should()
+				.Contain(
+					n => n.Transaction.Name.Equals("test")
+						&& n.Transaction.Type.Equals("request")
+						&& n.Span.Type.Equals("db")
+						&& n.Span.SubType.Equals("mysql")
+						&& n.Samples.Any(s => s.KeyValue.Key.Equals("span.self_time.count") && s.KeyValue.Value == 2)
+						&& n.Samples.Any(s => s.KeyValue.Key.Equals("span.self_time.sum.us") && s.KeyValue.Value == 10)
+				);
+		}
+
+		private (ApmAgent, BreakdownMetricsProvider) SetUpAgent()
+		{
+			var breakdownMetricsProvider = new BreakdownMetricsProvider();
+
+			var agentComponents = new AgentComponents(
+				new NoopLogger(),
+				new MockConfigSnapshot(metricsInterval: "1s"),
+				new NoopPayloadSender(),
+				new FakeMetricsCollector(), //metricsCollector will be set in AgentComponents.ctor
+				new CurrentExecutionSegmentsContainer(),
+				new NoopCentralConfigFetcher(),
+				new MockApmServerInfo(new ElasticVersion(7, 12, 0, string.Empty)),
+				breakdownMetricsProvider);
+
+			var agent = new ApmAgent(agentComponents);
+
+			return (agent, breakdownMetricsProvider);
 		}
 	}
 }

--- a/test/Elastic.Apm.Tests/BreakdownTests.cs
+++ b/test/Elastic.Apm.Tests/BreakdownTests.cs
@@ -2,44 +2,92 @@
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
 
+using System;
+using System.Linq;
 using System.Threading;
+using Elastic.Apm.Metrics;
 using Elastic.Apm.Model;
+using Elastic.Apm.ServerInfo;
 using Elastic.Apm.Tests.Utilities;
+using FluentAssertions;
 using Xunit;
+
+// ReSharper disable CompareOfFloatsByEqualityOperator
 
 namespace Elastic.Apm.Tests
 {
 	public class BreakdownTests
 	{
+		/// <summary>
+		/// Captures transaction ---> span ---> span
+		/// Makes sure that all metrics related to breakdown are captured
+		/// </summary>
 		[Fact]
-		public void V()
+		public void TransactionWithSpans()
 		{
 			var payloadSender = new MockPayloadSender();
-			using (var agent = new ApmAgent(new TestAgentComponents(payloadSender: payloadSender)))
+			using var agent = new ApmAgent(
+				new AgentComponents(
+					new NoopLogger(),
+					new MockConfigSnapshot(metricsInterval: "1s"),
+					payloadSender,
+					null, //metricsCollector will be set in AgentComponents.ctor
+					new CurrentExecutionSegmentsContainer(),
+					new NoopCentralConfigFetcher(),
+					new MockApmServerInfo(new ElasticVersion(7, 12, 0, string.Empty))));
+
+			Transaction transaction = null;
+			Span span1 = null;
+			Span span2 = null;
+			agent.Tracer.CaptureTransaction("Foo", "Bar", t =>
 			{
-				Transaction transaction;
-				Span span1;
-				Span span2;
-				agent.Tracer.CaptureTransaction("Foo", "Bar", t =>
+				transaction = t as Transaction;
+				Thread.Sleep(100);
+				t.CaptureSpan("Foo1", "Bar", s1 =>
 				{
-					transaction = t as Transaction;
+					span1 = s1 as Span;
 					Thread.Sleep(100);
-					t.CaptureSpan("Foo", "Bar", s1 =>
+					s1.CaptureSpan("Foo2", "Bar2", s2 =>
 					{
-						span1 = s1 as Span;
+						span2 = s2 as Span;
 						Thread.Sleep(100);
-						s1.CaptureSpan("Foo", "Bar", s2 =>
-						{
-							span2 = s2 as Span;
-							Thread.Sleep(100);
-						});
 					});
-					Thread.Sleep(100);
 				});
+				Thread.Sleep(100);
+			});
 
-				// TODO add asserts
+			payloadSender.WaitForMetrics(TimeSpan.FromSeconds(5));
+			payloadSender.Metrics.Should().NotBeEmpty();
 
-			}
+			// Assert that span2 is captured and the span.self_time.sum.us == span2.Duration
+			payloadSender.Metrics.Should()
+				.Contain(n =>
+					n is MetricSet && ((MetricSet)n)!.Span.Type.Equals("Bar2") &&
+					string.IsNullOrEmpty(((MetricSet)n)!.Span.SubType) &&
+					((MetricSet)n)!.Samples.Any(sample =>
+						sample.KeyValue.Key.Equals("span.self_time.sum.us") && sample.KeyValue.Value == span2.Duration!.Value) &&
+					((MetricSet)n)!.Samples.Any(sample => sample.KeyValue.Key.Equals("span.self_time.count") && sample.KeyValue.Value == 1)
+				);
+
+			// Assert that span2 is captured and the span.self_time.sum.us == span1.Duration - span2.Duration
+			payloadSender.Metrics.Should()
+				.Contain(n =>
+					n is MetricSet && ((MetricSet)n)!.Span.Type.Equals("Bar") &&
+					string.IsNullOrEmpty(((MetricSet)n)!.Span.SubType) &&
+					((MetricSet)n)!.Samples.Any(sample => sample.KeyValue.Key.Equals("span.self_time.sum.us") &&
+						sample.KeyValue.Value == span1.Duration!.Value - span2.Duration!.Value) &&
+					((MetricSet)n)!.Samples.Any(sample => sample.KeyValue.Key.Equals("span.self_time.count") && sample.KeyValue.Value == 1)
+				);
+
+			// Assert that app (the transaction) is captured and the span.self_time.sum.us == transaction.SelfDuration
+			payloadSender.Metrics.Should()
+				.Contain(n =>
+					n is MetricSet && ((MetricSet)n)!.Span.Type.Equals("app") &&
+					string.IsNullOrEmpty(((MetricSet)n)!.Span.SubType) &&
+					((MetricSet)n)!.Samples.Any(sample => sample.KeyValue.Key.Equals("span.self_time.sum.us") &&
+						sample.KeyValue.Value == transaction.SelfDuration) &&
+					((MetricSet)n)!.Samples.Any(sample => sample.KeyValue.Key.Equals("span.self_time.count") && sample.KeyValue.Value == 1)
+				);
 		}
 	}
 }

--- a/test/Elastic.Apm.Tests/Metrics/CgroupMetricsProviderTests.cs
+++ b/test/Elastic.Apm.Tests/Metrics/CgroupMetricsProviderTests.cs
@@ -3,15 +3,15 @@
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
 
-using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using Elastic.Apm.Helpers;
 using Elastic.Apm.Metrics.MetricsProvider;
 using Elastic.Apm.Tests.Utilities;
 using FluentAssertions;
 using Xunit;
-using Xunit.Abstractions;
 using static Elastic.Apm.Metrics.MetricsProvider.CgroupMetricsProvider;
 
 namespace Elastic.Apm.Tests.Metrics
@@ -43,7 +43,7 @@ namespace Elastic.Apm.Tests.Metrics
 
 			using (tempFile)
 			{
-				var provider = new CgroupMetricsProvider(GetTestFilePath(selfCGroup), tempFile.Path, new NoopLogger());
+				var provider = new CgroupMetricsProvider(GetTestFilePath(selfCGroup), tempFile.Path, new NoopLogger(), new List<WildcardMatcher>());
 
 				var samples = provider.GetSamples().ToList();
 
@@ -120,7 +120,7 @@ namespace Elastic.Apm.Tests.Metrics
 			var tempFile = TempFile.CreateWithContents(
 				$"39 30 0:35 / {mountInfo} rw,nosuid,nodev,noexec,relatime shared:10 - {cgroup} rw,seclabel,memory\n");
 
-			return new CgroupMetricsProvider(GetTestFilePath(cGroupPath), tempFile.Path, new NoopLogger());
+			return new CgroupMetricsProvider(GetTestFilePath(cGroupPath), tempFile.Path, new NoopLogger(), new List<WildcardMatcher>());
 		}
 	}
 }

--- a/test/Elastic.Apm.Tests/Metrics/CgroupMetricsProviderTests.cs
+++ b/test/Elastic.Apm.Tests/Metrics/CgroupMetricsProviderTests.cs
@@ -49,18 +49,18 @@ namespace Elastic.Apm.Tests.Metrics
 
 				samples.Should().HaveCountGreaterOrEqualTo(2);
 
-				var inactiveFileBytesSample = samples.SingleOrDefault(s => s.KeyValue.Key == SystemProcessCgroupMemoryStatsInactiveFileBytes);
+				var inactiveFileBytesSample = samples.SingleOrDefault(s => s.Samples.First().KeyValue.Key == SystemProcessCgroupMemoryStatsInactiveFileBytes);
 				inactiveFileBytesSample.Should().NotBeNull();
 
-				var memUsageSample = samples.SingleOrDefault(s => s.KeyValue.Key == SystemProcessCgroupMemoryMemUsageBytes);
+				var memUsageSample = samples.SingleOrDefault(s => s.Samples.First().KeyValue.Key == SystemProcessCgroupMemoryMemUsageBytes);
 				memUsageSample.Should().NotBeNull();
-				memUsageSample?.KeyValue.Value.Should().Be(value);
+				memUsageSample?.Samples.First().KeyValue.Value.Should().Be(value);
 
 				if (memLimit.HasValue)
 				{
-					var memLimitSample = samples.SingleOrDefault(s => s.KeyValue.Key == SystemProcessCgroupMemoryMemLimitBytes);
+					var memLimitSample = samples.SingleOrDefault(s => s.Samples.First().KeyValue.Key == SystemProcessCgroupMemoryMemLimitBytes);
 					memLimitSample.Should().NotBeNull();
-					memLimitSample?.KeyValue.Value.Should().Be(memLimit);
+					memLimitSample?.Samples.First().KeyValue.Value.Should().Be(memLimit);
 				}
 			}
 		}
@@ -87,12 +87,12 @@ namespace Elastic.Apm.Tests.Metrics
 			var cgroupMetrics = CreateUnlimitedSystemCgroupMetricsProvider("/proc/cgroup","/proc/unlimited/memory", "cgroup cgroup");
 			var samples = cgroupMetrics.GetSamples().ToList();
 
-			var memLimitSample = samples.SingleOrDefault(s => s.KeyValue.Key == SystemProcessCgroupMemoryMemLimitBytes);
+			var memLimitSample = samples.SingleOrDefault(s => s.Samples.First().KeyValue.Key == SystemProcessCgroupMemoryMemLimitBytes);
 			memLimitSample.Should().BeNull();
 
-			var memUsageSample = samples.SingleOrDefault(s => s.KeyValue.Key == SystemProcessCgroupMemoryMemUsageBytes);
+			var memUsageSample = samples.SingleOrDefault(s => s.Samples.First().KeyValue.Key == SystemProcessCgroupMemoryMemUsageBytes);
 			memUsageSample.Should().NotBeNull();
-			memUsageSample?.KeyValue.Value.Should().Be(964778496);
+			memUsageSample?.Samples.First().KeyValue.Value.Should().Be(964778496);
 		}
 
 		[Fact]
@@ -101,12 +101,12 @@ namespace Elastic.Apm.Tests.Metrics
 			var cgroupMetrics = CreateUnlimitedSystemCgroupMetricsProvider("/proc/cgroup2","/proc/sys_cgroup2_unlimited", "cgroup2 cgroup");
 			var samples = cgroupMetrics.GetSamples().ToList();
 
-			var memLimitSample = samples.SingleOrDefault(s => s.KeyValue.Key == SystemProcessCgroupMemoryMemLimitBytes);
+			var memLimitSample = samples.SingleOrDefault(s => s.Samples.First().KeyValue.Key == SystemProcessCgroupMemoryMemLimitBytes);
 			memLimitSample.Should().BeNull();
 
-			var memUsageSample = samples.SingleOrDefault(s => s.KeyValue.Key == SystemProcessCgroupMemoryMemUsageBytes);
+			var memUsageSample = samples.SingleOrDefault(s => s.Samples.First().KeyValue.Key == SystemProcessCgroupMemoryMemUsageBytes);
 			memUsageSample.Should().NotBeNull();
-			memUsageSample?.KeyValue.Value.Should().Be(964778496);
+			memUsageSample?.Samples.First().KeyValue.Value.Should().Be(964778496);
 		}
 
 		/// <summary>

--- a/test/Elastic.Apm.Tests/MetricsTests.cs
+++ b/test/Elastic.Apm.Tests/MetricsTests.cs
@@ -44,10 +44,16 @@ namespace Elastic.Apm.Tests
 			get
 			{
 				yield return new object[] { null };
-				yield return new object[] { new List<MetricSample>() };
-				yield return new object[] { new List<MetricSample> { new MetricSample("key", double.NaN) } };
-				yield return new object[] { new List<MetricSample> { new MetricSample("key", double.NegativeInfinity) } };
-				yield return new object[] { new List<MetricSample> { new MetricSample("key", double.PositiveInfinity) } };
+				yield return new object[] { new List<MetricSet> { new(DateTime.UtcNow.Ticks, new List<MetricSample>()) } };
+				yield return new object[] { new List<MetricSet> { new(DateTime.UtcNow.Ticks, new List<MetricSample> { new("key", double.NaN) }) } };
+				yield return new object[]
+				{
+					new List<MetricSet> { new(DateTime.UtcNow.Ticks, new List<MetricSample> { new("key", double.NegativeInfinity) }) }
+				};
+				yield return new object[]
+				{
+					new List<MetricSet> { new(DateTime.UtcNow.Ticks, new List<MetricSample> { new("key", double.PositiveInfinity) }) }
+				};
 			}
 		}
 
@@ -70,10 +76,10 @@ namespace Elastic.Apm.Tests
 			using var systemTotalCpuProvider = new SystemTotalCpuProvider(new NoopLogger());
 			Thread.Sleep(1000); //See https://github.com/elastic/apm-agent-dotnet/pull/264#issuecomment-499778288
 			var retVal = systemTotalCpuProvider.GetSamples();
-			var metricSamples = retVal as MetricSample[] ?? retVal.ToArray();
+			var metricSamples = retVal as MetricSet[] ?? retVal.ToArray();
 
-			metricSamples.First().KeyValue.Value.Should().BeGreaterOrEqualTo(0);
-			metricSamples.First().KeyValue.Value.Should().BeLessOrEqualTo(1);
+			metricSamples.First().Samples.First().KeyValue.Value.Should().BeGreaterOrEqualTo(0);
+			metricSamples.First().Samples.First().KeyValue.Value.Should().BeLessOrEqualTo(1);
 		}
 
 		[Fact]
@@ -82,7 +88,7 @@ namespace Elastic.Apm.Tests
 			var processTotalCpuProvider = new ProcessTotalCpuTimeProvider(new NoopLogger());
 			Thread.Sleep(1000); //See https://github.com/elastic/apm-agent-dotnet/pull/264#issuecomment-499778288
 			var retVal = processTotalCpuProvider.GetSamples();
-			retVal.First().KeyValue.Value.Should().BeInRange(0, 1);
+			retVal.First().Samples.First().KeyValue.Value.Should().BeInRange(0, 1);
 		}
 
 		[Fact]
@@ -91,9 +97,9 @@ namespace Elastic.Apm.Tests
 			var processWorkingSetAndVirtualMemoryProvider = new ProcessWorkingSetAndVirtualMemoryProvider(true, true);
 			var retVal = processWorkingSetAndVirtualMemoryProvider.GetSamples();
 
-			var enumerable = retVal as MetricSample[] ?? retVal.ToArray();
+			var enumerable = retVal as MetricSet[] ?? retVal.ToArray();
 			enumerable.Should().NotBeEmpty();
-			enumerable.First().KeyValue.Value.Should().BeGreaterThan(0);
+			enumerable.First().Samples.First().KeyValue.Value.Should().BeGreaterThan(0);
 		}
 
 		[Fact]
@@ -101,7 +107,8 @@ namespace Elastic.Apm.Tests
 		{
 			var mockPayloadSender = new MockPayloadSender();
 			var testLogger = new TestLogger(LogLevel.Information);
-			using (var mc = new MetricsCollector(testLogger, mockPayloadSender, new ConfigStore(new MockConfigSnapshot(disableMetrics: "*"), testLogger)))
+			using (var mc = new MetricsCollector(testLogger, mockPayloadSender,
+				new ConfigStore(new MockConfigSnapshot(disableMetrics: "*"), testLogger)))
 			{
 				mc.MetricsProviders.Clear();
 				var providerWithException = new MetricsProviderWithException();
@@ -214,7 +221,7 @@ namespace Elastic.Apm.Tests
 
 		[Theory]
 		[MemberData(nameof(DisableProviderTestData))]
-		public void CollectAllMetrics_ShouldDisableProvider_WhenSamplesAreInvalid(List<MetricSample> samples)
+		internal void CollectAllMetrics_ShouldDisableProvider_WhenSamplesAreInvalid(List<MetricSet> samples)
 		{
 			const int iterations = MetricsCollector.MaxTryWithoutSuccess * 2;
 
@@ -262,7 +269,11 @@ namespace Elastic.Apm.Tests
 			metricsProviderMock.Setup(x => x.IsMetricAlreadyCaptured).Returns(true);
 
 			metricsProviderMock.Setup(x => x.GetSamples())
-				.Returns(() => new List<MetricSample> { new MetricSample("key1", double.NaN), new MetricSample("key2", 0.95) });
+				.Returns(() => new List<MetricSet>
+				{
+					new(DateTime.UtcNow.Ticks,
+						new List<MetricSample> { new MetricSample("key1", double.NaN), new MetricSample("key2", 0.95) })
+				});
 			metricsProviderMock.SetupProperty(x => x.ConsecutiveNumberOfFailedReads);
 
 			metricsCollector.MetricsProviders.Clear();
@@ -304,7 +315,7 @@ namespace Elastic.Apm.Tests
 					{
 						var array = new int[10000000];
 						// In order to make sure the line above is not optimized away, let's use the array:
-						Console.WriteLine($"GC test, int[] allocated with length: {array.Length}");
+						_output.WriteLine($"GC test, int[] allocated with length: {array.Length}");
 					}
 
 					GC.Collect(2, GCCollectionMode.Forced, true, true);
@@ -315,7 +326,7 @@ namespace Elastic.Apm.Tests
 					{
 						var array = new int[10000000];
 						// In order to make sure the line above is not optimized away, let's use the array:
-						Console.WriteLine($"GC test, int[] allocated with length: {array.Length}");
+						_output.WriteLine($"GC test, int[] allocated with length: {array.Length}");
 					}
 
 					GC.Collect(2, GCCollectionMode.Forced, true, true);
@@ -326,11 +337,11 @@ namespace Elastic.Apm.Tests
 
 					containsValue = samples != null && samples.Any();
 					hasGenSize = samples != null && samples
-						.Any(n => (n.KeyValue.Key.Contains("gen0size") || n.KeyValue.Key.Contains("gen1size")
-						|| n.KeyValue.Key.Contains("gen2size") || n.KeyValue.Key.Contains("gen3size"))
-						&& n.KeyValue.Value > 0);
+						.Any(n => (n.Samples.First().KeyValue.Key.Contains("gen0size") || n.Samples.First().KeyValue.Key.Contains("gen1size")
+								|| n.Samples.First().KeyValue.Key.Contains("gen2size") || n.Samples.First().KeyValue.Key.Contains("gen3size"))
+							&& n.Samples.First().KeyValue.Value > 0);
 					hasGcTime = samples != null && samples
-						.Any(n => n.KeyValue.Key.Contains("clr.gc.time") && n.KeyValue.Value > 0);
+						.Any(n => n.Samples.First().KeyValue.Key.Contains("clr.gc.time") && n.Samples.First().KeyValue.Value > 0);
 
 					if (containsValue && hasGenSize && hasGcTime)
 						break;
@@ -396,7 +407,7 @@ namespace Elastic.Apm.Tests
 
 			public int NumberOfGetValueCalls { get; private set; }
 
-			public IEnumerable<MetricSample> GetSamples()
+			IEnumerable<MetricSet> IMetricsProvider.GetSamples()
 			{
 				NumberOfGetValueCalls++;
 				throw new Exception(ExceptionMessage);
@@ -406,8 +417,7 @@ namespace Elastic.Apm.Tests
 		internal class TestSystemTotalCpuProvider : SystemTotalCpuProvider
 		{
 			public TestSystemTotalCpuProvider(string procStatContent) : base(new NoopLogger(),
-				new StreamReader(new MemoryStream(Encoding.UTF8.GetBytes(procStatContent))))
-			{ }
+				new StreamReader(new MemoryStream(Encoding.UTF8.GetBytes(procStatContent)))) { }
 		}
 	}
 }

--- a/test/Elastic.Apm.Tests/MetricsTests.cs
+++ b/test/Elastic.Apm.Tests/MetricsTests.cs
@@ -94,7 +94,7 @@ namespace Elastic.Apm.Tests
 		[Fact]
 		public void GetWorkingSetAndVirtualMemory()
 		{
-			var processWorkingSetAndVirtualMemoryProvider = new ProcessWorkingSetAndVirtualMemoryProvider(true, true);
+			var processWorkingSetAndVirtualMemoryProvider = new ProcessWorkingSetAndVirtualMemoryProvider(new List<WildcardMatcher>());
 			var retVal = processWorkingSetAndVirtualMemoryProvider.GetSamples();
 
 			var enumerable = retVal as MetricSet[] ?? retVal.ToArray();
@@ -294,7 +294,7 @@ namespace Elastic.Apm.Tests
 		{
 			var logger = new TestLogger(LogLevel.Trace);
 			string traceEventSessionName;
-			using (var gcMetricsProvider = new GcMetricsProvider(logger))
+			using (var gcMetricsProvider = new GcMetricsProvider(logger, new List<WildcardMatcher>()))
 			{
 				traceEventSessionName = gcMetricsProvider.TraceEventSessionName;
 				gcMetricsProvider.IsMetricAlreadyCaptured.Should().BeFalse();
@@ -412,6 +412,8 @@ namespace Elastic.Apm.Tests
 				NumberOfGetValueCalls++;
 				throw new Exception(ExceptionMessage);
 			}
+
+			public bool IsEnabled(IReadOnlyList<WildcardMatcher> disabledMetrics) => WildcardMatcher.IsAnyMatch(disabledMetrics, BreakdownMetricsProvider.SpanSelfTime);
 		}
 
 		internal class TestSystemTotalCpuProvider : SystemTotalCpuProvider

--- a/test/Elastic.Apm.Tests/SamplerTests.cs
+++ b/test/Elastic.Apm.Tests/SamplerTests.cs
@@ -6,6 +6,7 @@ using System;
 using System.Diagnostics;
 using System.Globalization;
 using Elastic.Apm.Helpers;
+using Elastic.Apm.Metrics.MetricsProvider;
 using Elastic.Apm.Model;
 using Elastic.Apm.Tests.Utilities;
 using FluentAssertions;
@@ -115,7 +116,8 @@ namespace Elastic.Apm.Tests
 				Activity.Current = null;
 
 				var transaction = new Transaction(noopLogger, "test transaction name", "test transaction type", sampler,
-					/* distributedTracingData: */ null, noopPayloadSender, configurationReader, currentExecutionSegmentsContainer, MockApmServerInfo.Version710);
+					/* distributedTracingData: */ null, noopPayloadSender, configurationReader, currentExecutionSegmentsContainer,
+					MockApmServerInfo.Version710, new BreakdownMetricsProvider());
 				if (transaction.IsSampled) ++sampledCount;
 
 				// ReSharper disable once InvertIf

--- a/test/Elastic.Apm.Tests/SamplerTests.cs
+++ b/test/Elastic.Apm.Tests/SamplerTests.cs
@@ -6,7 +6,6 @@ using System;
 using System.Diagnostics;
 using System.Globalization;
 using Elastic.Apm.Helpers;
-using Elastic.Apm.Metrics.MetricsProvider;
 using Elastic.Apm.Model;
 using Elastic.Apm.Tests.Utilities;
 using FluentAssertions;
@@ -117,7 +116,7 @@ namespace Elastic.Apm.Tests
 
 				var transaction = new Transaction(noopLogger, "test transaction name", "test transaction type", sampler,
 					/* distributedTracingData: */ null, noopPayloadSender, configurationReader, currentExecutionSegmentsContainer,
-					MockApmServerInfo.Version710, new BreakdownMetricsProvider());
+					MockApmServerInfo.Version710);
 				if (transaction.IsSampled) ++sampledCount;
 
 				// ReSharper disable once InvertIf


### PR DESCRIPTION
This is to address the comment from [here](https://github.com/elastic/apm-agent-dotnet/pull/1271#pullrequestreview-683490412).

I personally don't think this is a good idea - let's discuss in the [original PR](https://github.com/elastic/apm-agent-dotnet/pull/1271) and if we really need it, I'll cherry pick [the commit which moves the BreakdownMetricsProvider to `PayloadSenderV2`](https://github.com/elastic/apm-agent-dotnet/pull/1341/commits/2929cb5b08a893c10b6b757f00f6b8b58ae490a5) to the original PR.