### PR TITLE
Better logging in PayloadSenderV2 on task cancellation

### DIFF
--- a/src/Elastic.Apm/BackendComm/BackendCommComponentBase.cs
+++ b/src/Elastic.Apm/BackendComm/BackendCommComponentBase.cs
@@ -90,7 +90,7 @@ namespace Elastic.Apm.BackendComm
 						await WorkLoopIteration().ConfigureAwait(false);
 					// ReSharper disable once FunctionNeverReturns
 				}
-				, dbgCallerMethodName: ThisClassName + "." + DbgUtils.CurrentMethodName()).ConfigureAwait(false);
+				, dbgCallerMethodName: _dbgName + "." + DbgUtils.CurrentMethodName()).ConfigureAwait(false);
 
 			_logger.Debug()?.Log("Signaling work loop completed event...");
 			_loopCompleted.Set();

--- a/src/Elastic.Apm/Helpers/ExceptionUtils.cs
+++ b/src/Elastic.Apm/Helpers/ExceptionUtils.cs
@@ -54,10 +54,10 @@ namespace Elastic.Apm.Helpers
 					?.Log(MethodExitingNormallyMsgFmt + ". Current thread: {ThreadDesc}", dbgCallerMethodName
 						, DbgUtils.CurrentThreadDesc);
 			}
-			catch (OperationCanceledException ex)
+			catch (OperationCanceledException)
 			{
 				logger.Debug()
-					?.LogException(ex, MethodExitingCancelledMsgFmt + ". Current thread: {ThreadDesc}", dbgCallerMethodName
+					?.Log(MethodExitingCancelledMsgFmt + ". Current thread: {ThreadDesc}", dbgCallerMethodName
 						, DbgUtils.CurrentThreadDesc);
 
 				if (!shouldSwallowCancellation) throw;

--- a/src/Elastic.Apm/Model/Metadata.cs
+++ b/src/Elastic.Apm/Model/Metadata.cs
@@ -1,0 +1,32 @@
+// Licensed to Elasticsearch B.V under
+// one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using Elastic.Apm.Api;
+using Elastic.Apm.Helpers;
+
+namespace Elastic.Apm.Model
+{
+	[Specification("docs/spec/v2/metadata.json")]
+	internal class Metadata
+	{
+		/// <inheritdoc cref="Api.Cloud"/>
+		public Api.Cloud Cloud { get; set; }
+
+		public LabelsDictionary Labels { get; set; } = new LabelsDictionary();
+
+		// ReSharper disable once UnusedAutoPropertyAccessor.Global - used by Json.Net
+		public Service Service { get; set; }
+
+		// ReSharper disable once UnusedAutoPropertyAccessor.Global
+		public Api.System System { get; set; }
+
+		/// <summary>
+		/// Method to conditionally serialize <see cref="Labels" /> - serialize only when there is at least one label.
+		/// See
+		/// <a href="https://www.newtonsoft.com/json/help/html/ConditionalProperties.htm">the relevant Json.NET Documentation</a>
+		/// </summary>
+		public bool ShouldSerializeLabels() => !Labels.IsEmpty();
+	}
+}

--- a/src/Elastic.Apm/Report/PayloadSenderV2.cs
+++ b/src/Elastic.Apm/Report/PayloadSenderV2.cs
@@ -316,7 +316,7 @@ namespace Elastic.Apm.Report
 					var response = await HttpClient.PostAsync(_intakeV2EventsAbsoluteUrl, content, CancellationTokenSource.Token)
 						.ConfigureAwait(false);
 
-					if (!response.IsSuccessStatusCode)
+					if (response is null || !response.IsSuccessStatusCode)
 					{
 						_logger?.Error()
 							?.Log("Failed sending event."
@@ -326,7 +326,8 @@ namespace Elastic.Apm.Report
 								, Http.Sanitize(_intakeV2EventsAbsoluteUrl, out var sanitizedServerUrl)
 									? sanitizedServerUrl
 									: _intakeV2EventsAbsoluteUrl.ToString()
-								, response.StatusCode, await response.Content.ReadAsStringAsync().ConfigureAwait(false));
+								, response?.StatusCode,
+								response is null ? null : await response.Content.ReadAsStringAsync().ConfigureAwait(false));
 					}
 					else
 					{


### PR DESCRIPTION
This commit updates PayloadSenderV2 to handle task cancellation
exceptions specifically, that may occur during the sending workloop
iteration.

The number of items that were not sent is logged, but the exception
no longer is, as it doesn't provide value. In addition, the exception
is rethrown to allow BackendCommComponentBase to log cancellation.

- Move Metadata to Model
- Remove use of Indent() extension method and replace with indentation
in the joining characters. Indent the first item.