### PR TITLE
Unset parentId if TraceContextIgnoreSampledFalse is active

### DIFF
--- a/src/Elastic.Apm/Model/Transaction.cs
+++ b/src/Elastic.Apm/Model/Transaction.cs
@@ -238,6 +238,10 @@ namespace Elastic.Apm.Model
 				{
 					IsSampled = sampler.DecideIfToSample(idBytes);
 					_traceState?.SetSampleRate(sampler.Rate);
+
+					// In order to have a root transaction, we also unset the ParentId.
+					// This ensures there is a root transaction within elastic.
+					ParentId = null;
 				}
 				else
 					IsSampled = distributedTracingData.FlagRecorded;

--- a/test/Elastic.Apm.AspNetCore.Tests/DistributedTracingAspNetCoreTests.cs
+++ b/test/Elastic.Apm.AspNetCore.Tests/DistributedTracingAspNetCoreTests.cs
@@ -221,6 +221,9 @@ namespace Elastic.Apm.AspNetCore.Tests
 
 			// Assert that the transaction is sampled and the traceparent header was ignored
 			_payloadSender1.FirstTransaction.IsSampled.Should().BeTrue();
+
+			// Assert that the transaction is a root transaction
+			_payloadSender1.FirstTransaction.ParentId.Should().BeNullOrEmpty();
 		}
 
 		/// <summary>
@@ -245,6 +248,9 @@ namespace Elastic.Apm.AspNetCore.Tests
 
 			// Assert that the transaction is not sampled, so the traceparent header was not ignored
 			_payloadSender1.FirstTransaction.IsSampled.Should().BeFalse();
+
+			// Assert that the transaction is not a root transaction
+			_payloadSender1.FirstTransaction.ParentId.Should().NotBeNullOrEmpty();
 		}
 
 		/// <summary>
@@ -269,6 +275,9 @@ namespace Elastic.Apm.AspNetCore.Tests
 
 			// Assert that the transaction is sampled and the traceparent header was ignored
 			_payloadSender1.FirstTransaction.IsSampled.Should().BeTrue();
+
+			// Assert that the transaction is a root transaction
+			_payloadSender1.FirstTransaction.ParentId.Should().BeNullOrEmpty();
 		}
 
 		/// <summary>
@@ -293,6 +302,9 @@ namespace Elastic.Apm.AspNetCore.Tests
 
 			// Assert that the transaction is not sampled and the traceparent header was not ignored
 			_payloadSender1.FirstTransaction.IsSampled.Should().BeFalse();
+
+			// Assert that the transaction is not a root transaction
+			_payloadSender1.FirstTransaction.ParentId.Should().NotBeNullOrEmpty();
 		}
 
 		public async Task DisposeAsync()


### PR DESCRIPTION
Follow up from https://github.com/elastic/apm-agent-dotnet/pull/1310 


In https://github.com/elastic/apm-agent-dotnet/pull/1310  we introduced the `TraceContextIgnoreSampledFalse` config. By setting that to `true` the agent will make a new sampling decision when the upstream service calls with `traceparent: sampled:false` and it's not from our agent. 

One issue this setting addresses is the problem that for transactions where the caller sends `traceparent: sampled:false` in Kibana we showed this:

<img width="1496" alt="image" src="https://user-images.githubusercontent.com/1091853/127340300-5e542af2-963d-421f-8d28-c424e9e2febd.png">

Now, this problem was fixed in https://github.com/elastic/apm-agent-dotnet/pull/1310 - I doubled checked this. So even if there it's not a root transaction and the root is not in Elasticsearch, Kibana still properly fills that part.

On the other hand, such transaction will not show up under "traces" and it won't be part of any trace:
<img width="1488" alt="image" src="https://user-images.githubusercontent.com/1091853/127340608-db998871-4b64-41f6-b9e3-d2eb78b8dc61.png">


This PR makes sure that such transactions are root transactions by unsetting the parentid.