### PR TITLE
Update SystemInfoHelper.cs

### DIFF
--- a/src/Elastic.Apm/Helpers/SystemInfoHelper.cs
+++ b/src/Elastic.Apm/Helpers/SystemInfoHelper.cs
@@ -86,7 +86,7 @@ namespace Elastic.Apm.Helpers
 			if (!string.IsNullOrWhiteSpace(kubernetesPodUid) || _containerUidRegex.IsMatch(idPart) || _shortenedUuidRegex.IsMatch(idPart))
 				return new Container { Id = idPart };
 
-			_logger.Debug()?.Log("Could not parse container ID from '/proc/self/cgroup' line: {line}", line);
+			_logger.Info()?.Log("Could not parse container ID from '/proc/self/cgroup' line: {line}", line);
 			return null;
 		}
 

--- a/src/Elastic.Apm/Helpers/SystemInfoHelper.cs
+++ b/src/Elastic.Apm/Helpers/SystemInfoHelper.cs
@@ -147,7 +147,9 @@ namespace Elastic.Apm.Helpers
 				_logger.Error()?.LogException(e, "Exception while parsing container id");
 			}
 
-			_logger.Warning()?.Log("Failed parsing container id - the agent will not report container id");
+			_logger.Info()
+				?.Log(
+					"Failed parsing container id - the agent will not report container id. Likely the application is not running within a container");
 			return null;
 		}
 


### PR DESCRIPTION
We read container related infos from '/proc/self/cgroup'. This file exists on Linux, but if it's not a container then reading the container info won't return a result.

When this happens, currently we print a warning, but that is normal behaviour on Linux without containerization. We got reports that the warning log causes additional troubles in some environments.

This PR changes the log to info.