### PR TITLE
Filter Jenkins branches

### DIFF
--- a/.ci/jobs/defaults.yml
+++ b/.ci/jobs/defaults.yml
@@ -29,6 +29,7 @@
         repo: apm-agent-dotnet
         repo-owner: elastic
         credentials-id: 2a9602aa-ab9f-4e52-baf3-b71ca88469c7-UserAndToken
+        head-filter-regex: '^(master|PR-.*|[1-9]\.[1-9]{1,3})$'
         ssh-checkout:
           credentials: f6c7695a-671e-4f4f-a331-acdce44ff9ba
         build-strategies:


### PR DESCRIPTION
This PR reflects a conversation in Slack which I will link back from to this issue.

This PR limits the branches being tested in Jenkins to a regex as follows: `^(master|PR-.*|[1-9]\.[1-9]{1,3})$`. This has the effect of removing the 1.x branch from the set of branches which are being tested by Jenkins, as discussed in Slack. It also removes a number of other branches from testing which are not in use.

The set of branches currently being tested looks as follows:

<img width="540" alt="Screen Shot 2021-08-02 at 10 20 59 AM" src="https://user-images.githubusercontent.com/111616/127828329-ff8af41a-1aaa-4fa6-b49e-0bbda9dc4595.png">

After merging this PR and re-scanning the repo, the list would appear as:
<img width="405" alt="Screen Shot 2021-08-02 at 10 10 19 AM" src="https://user-images.githubusercontent.com/111616/127828396-50344cd1-e498-4866-abf6-b108f12d1d1f.png">


