### PR TITLE
Use 10K limit for CaptureBody similar to the Java agent

### DIFF
--- a/src/Elastic.Apm.AspNetCore/Consts.cs
+++ b/src/Elastic.Apm.AspNetCore/Consts.cs
@@ -8,7 +8,7 @@ namespace Elastic.Apm.AspNetCore
 {
 	internal static class Consts
 	{
-		public const int RequestBodyMaxLength = 2048;
+		public const int RequestBodyMaxLength = 10000;
 
 		internal static class OpenIdClaimTypes
 		{


### PR DESCRIPTION
From https://github.com/elastic/apm-agent-dotnet/issues/1359.

Change the request body limit to 10K - this is the limit that the Java agent [uses](https://www.elastic.co/guide/en/apm/agent/java/current/config-core.html#config-capture-body).