### PR TITLE
Small improvements

### DIFF
--- a/src/Elastic.Apm/Metrics/MetricsProvider/BreakdownMetricsProvider.cs
+++ b/src/Elastic.Apm/Metrics/MetricsProvider/BreakdownMetricsProvider.cs
@@ -17,7 +17,7 @@ namespace Elastic.Apm.Metrics.MetricsProvider
 		internal const string SpanSelfTime = "span.self_time";
 		internal const int MetricLimit = 1000;
 
-		private List<MetricSet> _itemsToSend = new();
+		private readonly List<MetricSet> _itemsToSend = new();
 		private readonly IApmLogger _logger;
 
 		/// <summary>

--- a/src/Elastic.Apm/Metrics/MetricsProvider/BreakdownMetricsProvider.cs
+++ b/src/Elastic.Apm/Metrics/MetricsProvider/BreakdownMetricsProvider.cs
@@ -21,7 +21,7 @@ namespace Elastic.Apm.Metrics.MetricsProvider
 		private readonly IApmLogger _logger;
 
 		/// <summary>
-		/// Indicates if the 10K limit log was already printed.
+		/// Indicates if the metric limit log was already printed.
 		/// </summary>
 		private bool _loggedWarning;
 
@@ -72,7 +72,9 @@ namespace Elastic.Apm.Metrics.MetricsProvider
 
 						_logger.Warning()
 							?.Log(
-								$"The limit of {MetricLimit} metricsets has been reached, no new metricsets will be created until the current set is sent to APM Server.");
+								"The limit of {MetricLimit} metricsets has been reached, no new metricsets will be created until "
+								+ "the current set is sent to APM Server.",
+								MetricLimit);
 						_loggedWarning = true;
 					}
 				}
@@ -93,8 +95,9 @@ namespace Elastic.Apm.Metrics.MetricsProvider
 					if (!_loggedWarning)
 					{
 						_logger.Warning()
-							?.Log(
-								$"The limit of {MetricLimit} metricsets has been reached, no new metricsets will be created until the current set is sent to APM Server.");
+							?.Log("The limit of {MetricLimit} metricsets has been reached, no new metricsets will be created until "
+								+ "the current set is sent to APM Server.",
+								MetricLimit);
 						_loggedWarning = true;
 					}
 				}
@@ -107,8 +110,9 @@ namespace Elastic.Apm.Metrics.MetricsProvider
 
 			lock (_lock)
 			{
-				retVal = _itemsToSend;
-				_itemsToSend = new List<MetricSet>(MetricLimit);
+				retVal = new List<MetricSet>(_itemsToSend.Count);
+				retVal.AddRange(_itemsToSend);
+				_itemsToSend.Clear();
 				_transactionCount = 0;
 				_loggedWarning = false;
 			}

--- a/src/Elastic.Apm/Metrics/MetricsProvider/BreakdownMetricsProvider.cs
+++ b/src/Elastic.Apm/Metrics/MetricsProvider/BreakdownMetricsProvider.cs
@@ -4,6 +4,7 @@
 // See the LICENSE file in the project root for more information
 
 using System.Collections.Generic;
+using System.Linq;
 using Elastic.Apm.Api;
 using Elastic.Apm.Helpers;
 using Elastic.Apm.Logging;
@@ -14,14 +15,15 @@ namespace Elastic.Apm.Metrics.MetricsProvider
 	internal class BreakdownMetricsProvider : IMetricsProvider
 	{
 		internal const string SpanSelfTime = "span.self_time";
+		internal const int MetricLimit = 1000;
 
-		private readonly List<MetricSet> _itemsToSend = new();
+		private List<MetricSet> _itemsToSend = new();
 		private readonly IApmLogger _logger;
 
 		/// <summary>
 		/// Indicates if the 10K limit log was already printed.
 		/// </summary>
-		private bool loggedWarning = false;
+		private bool _loggedWarning;
 
 		private readonly object _lock = new();
 		private int _transactionCount;
@@ -62,16 +64,16 @@ namespace Elastic.Apm.Metrics.MetricsProvider
 							Transaction = new TransactionInfo { Name = transaction.Name, Type = transaction.Type }
 						};
 
-					if (_itemsToSend.Count < 1000)
+					if (_itemsToSend.Count < MetricLimit)
 						_itemsToSend.Add(metricSet);
 					else
 					{
-						if (loggedWarning) continue;
+						if (_loggedWarning) continue;
 
 						_logger.Warning()
 							?.Log(
-								"The limit of 1000 metricsets has been reached, no new metricsets will be created.");
-						loggedWarning = true;
+								$"The limit of {MetricLimit} metricsets has been reached, no new metricsets will be created until the current set is sent to APM Server.");
+						_loggedWarning = true;
 					}
 				}
 
@@ -84,15 +86,16 @@ namespace Elastic.Apm.Metrics.MetricsProvider
 							new("transaction.breakdown.count", _transactionCount),
 						}) { Transaction = new TransactionInfo { Name = transaction.Name, Type = transaction.Type } };
 
-				if (_itemsToSend.Count < 1000)
+				if (_itemsToSend.Count < MetricLimit)
 					_itemsToSend.Add(transactionMetric);
 				else
 				{
-					if (!loggedWarning)
+					if (!_loggedWarning)
 					{
 						_logger.Warning()
 							?.Log(
-								"The limit of 1000 metricsets has been reached, no new metricsets will be created until the current set is sent to APM Server.");
+								$"The limit of {MetricLimit} metricsets has been reached, no new metricsets will be created until the current set is sent to APM Server.");
+						_loggedWarning = true;
 					}
 				}
 			}
@@ -100,14 +103,14 @@ namespace Elastic.Apm.Metrics.MetricsProvider
 
 		public IEnumerable<MetricSet> GetSamples()
 		{
-			var retVal = new List<MetricSet>(_itemsToSend.Count < 1000 ? _itemsToSend.Count : 1000);
+			List<MetricSet> retVal;
 
 			lock (_lock)
 			{
-				retVal.AddRange(_itemsToSend);
-				_itemsToSend.Clear();
+				retVal = _itemsToSend;
+				_itemsToSend = new List<MetricSet>(MetricLimit);
 				_transactionCount = 0;
-				loggedWarning = false;
+				_loggedWarning = false;
 			}
 
 			return retVal;

--- a/src/Elastic.Apm/Model/DbSpanCommon.cs
+++ b/src/Elastic.Apm/Model/DbSpanCommon.cs
@@ -56,7 +56,6 @@ namespace Elastic.Apm.Model
 				}
 
 				capturedSpan.Outcome = outcome;
-				capturedSpan.End();
 			}
 
 			span.End();


### PR DESCRIPTION
- Avoid calling span.End() twice in DbSpanCommon
- Swap and assign new list for breakdown metrics