### PR TITLE
Get Command and Key for StackExchange.Redis spans

### DIFF
--- a/src/Elastic.Apm.StackExchange.Redis/ElasticApmProfiler.cs
+++ b/src/Elastic.Apm.StackExchange.Redis/ElasticApmProfiler.cs
@@ -45,8 +45,6 @@ namespace Elastic.Apm.StackExchange.Redis
 					CommandAndKeyFetcher = ExpressionBuilder.BuildPropertyGetter(messageType, commandAndKey);
 				}
 			}
-
-
 		}
 
 		public ElasticApmProfiler(Func<IApmAgent> agentGetter)

--- a/src/Elastic.Apm/Reflection/ExpressionBuilder.cs
+++ b/src/Elastic.Apm/Reflection/ExpressionBuilder.cs
@@ -39,6 +39,19 @@ namespace Elastic.Apm.Reflection
 		/// Builds a delegate to get a property from an object. <paramref name="type"/> is cast to <see cref="Object"/>,
 		/// with the returned property cast to <see cref="Object"/>.
 		/// </summary>
+		public static Func<object, object> BuildFieldGetter(Type type, FieldInfo fieldInfo)
+		{
+			var parameterExpression = Expression.Parameter(typeof(object), "value");
+			var parameterCastExpression = Expression.Convert(parameterExpression, type);
+			var memberExpression = Expression.Field(parameterCastExpression, fieldInfo);
+			var returnCastExpression = Expression.Convert(memberExpression, typeof(object));
+			return Expression.Lambda<Func<object, object>>(returnCastExpression, parameterExpression).Compile();
+		}
+
+		/// <summary>
+		/// Builds a delegate to get a property from an object. <paramref name="type"/> is cast to <see cref="Object"/>,
+		/// with the returned property cast to <see cref="Object"/>.
+		/// </summary>
 		public static Func<object, object> BuildPropertyGetter(Type type, string propertyName)
 		{
 			var parameterExpression = Expression.Parameter(typeof(object), "value");

--- a/test/Elastic.Apm.StackExchange.Redis.Tests/ProfilingSessionTests.cs
+++ b/test/Elastic.Apm.StackExchange.Redis.Tests/ProfilingSessionTests.cs
@@ -150,7 +150,12 @@ namespace Elastic.Apm.StackExchange.Redis.Tests
 				parentSpans.Should().HaveCount(topLevelSpans);
 
 				var parentSpanId = parentSpans.OrderByDescending(s => s.Timestamp).First().Id;
-				transactionSpans.Count(s => s.ParentId == parentSpanId).Should().Be(spansPerParentSpan);
+
+				var spansOfParentSpan = transactionSpans.Where(s => s.ParentId == parentSpanId).ToList();
+
+				spansOfParentSpan.Should().HaveCount(spansPerParentSpan);
+				foreach (var span in spansOfParentSpan)
+					span.Context?.Db?.Statement.Should().MatchRegex(@"[G|S]ET string\d");
 			}
 
 			await container.StopAsync();


### PR DESCRIPTION
This commit updates the StackExchange.Redis instrumentation to attempt to
get the redis message command and key for captured DB statements through
reflection, falling back to command in the event reflected properties are not
available.

Closes #1364