### PR TITLE
Cleanup Azure resource groups

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -564,9 +564,9 @@ def withAzureAuth(Closure body){
     def props = getVaultSecret(secret: 'secret/apm-team/ci/apm-agent-dotnet-azure')
     def authObj = props?.data
     withEnvMask(vars: [
-        [var: 'AZ_CLIENT_ID', password: "${authObj.client_id}"]
-        [var: 'AZ_CLIENT_SECRET', password: "${authObj.client_secret}"]
-        [var: 'AZ_SUBSCRIPTION_ID', password: "${authObj.subscription_id}"]
+        [var: 'AZ_CLIENT_ID', password: "${authObj.client_id}"],
+        [var: 'AZ_CLIENT_SECRET', password: "${authObj.client_secret}"],
+        [var: 'AZ_SUBSCRIPTION_ID', password: "${authObj.subscription_id}"],
         [var: 'AZ_TENANT_ID', password: "${authObj.tenant_id}"]
     ]) {
         cmd label: "Logging into Azure", script: "az login --service-principal --username ${AZ_CLIENT_ID} --password ${AZ_CLIENT_SECRET} --tenant ${AZ_TENANT_ID}"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -564,7 +564,7 @@ def withAzureAuth(Closure body){
         [var: 'AZ_TENANT_ID', password: "${authObj.tenant_id}"]
     ]) {
         cmd label: "Setup Azure CLI Repo Signing Key", script: "curl -sL https://packages.microsoft.com/keys/microsoft.asc |gpg --dearmor |sudo tee /etc/apt/trusted.gpg.d/microsoft.gpg > /dev/null"
-        cmd label: "Setup Azure CLI Repo", script: "echo \"deb [arch=amd64] https://packages.microsoft.com/repos/azure-cli/ $(lsb_release -cs) main\" |sudo tee /etc/apt/sources.list.d/azure-cli.list"
+        cmd label: "Setup Azure CLI Repo", script: "echo \"deb [arch=amd64] https://packages.microsoft.com/repos/azure-cli/\$(lsb_release -cs) main\" |sudo tee /etc/apt/sources.list.d/azure-cli.list"
         cmd label: "Install Azure CLI", script: "sudo apt-get update && sudo apt-get install azure-cli -y"
         cmd label: "Logging into Azure", script: "az login --service-principal --username ${AZ_CLIENT_ID} --password ${AZ_CLIENT_SECRET} --tenant ${AZ_TENANT_ID}"
         cmd label: "Setting Azure subscription", script: "az account set --subscription ${AZ_SUBSCRIPTION_ID}"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -561,13 +561,14 @@ def dotnet(Closure body){
 }
 
 def withAzureAuth(Closure body){
-    def authObj = getVaultSecret(secret: 'secret/apm-team/ci/apm-agent-dotnet-azure')
-    withEnvMask(vars:[
-        [var: 'AZ_CLIENT_ID', password: authObj.data.client_id]
-        [var: 'AZ_CLIENT_SECRET', password: authObj.data.client_secret]
-        [var: 'AZ_SUBSCRIPTION_ID', password: authObj.data.subscription_id]
-        [var: 'AZ_TENANT_ID', password: authObj.data.tenant_id]
-    ]){
+    def props = getVaultSecret(secret: 'secret/apm-team/ci/apm-agent-dotnet-azure')
+    def authObj = props?.data
+    withEnvMask(vars: [
+        [var: 'AZ_CLIENT_ID', password: "${authObj.client_id}"]
+        [var: 'AZ_CLIENT_SECRET', password: "${authObj.client_secret}"]
+        [var: 'AZ_SUBSCRIPTION_ID', password: "${authObj.subscription_id}"]
+        [var: 'AZ_TENANT_ID', password: "${authObj.tenant_id}"]
+    ]) {
         cmd label: "Logging into Azure", script: "az login --service-principal --username ${AZ_CLIENT_ID} --password ${AZ_CLIENT_SECRET} --tenant ${AZ_TENANT_ID}"
         cmd label: "Setting Azure subscription", script: "az account set --subscription ${AZ_SUBSCRIPTION_ID}"
         body()

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -514,10 +514,11 @@ pipeline {
   post {
         cleanup {
             withAzureAuth(){
-                if (isUnix()) {
+                whenTrue(isUnix()) {
                     sh label: "Checking and removing any Azure related resource groups",
                         script: "for group in `az group list --query \"[?name | starts_with(@,'${AZURE_RESOURCE_GROUP_PREFIX})']\" --out json|jq .[].name`;do az group delete --name $group --no-wait --yes;done"
-                } else {
+                }
+                whenFalse(isUnix()) {
                     powershell label: "Checking and removing any Azure related resource groups",
                         script: "az group list --query \"[?name | starts_with(@,'${AZURE_RESOURCE_GROUP_PREFIX})']\" --out json| ConvertFrom-Json | ForEach {az group delete --name $_.name --no-wait --yes}"
                 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -554,7 +554,7 @@ def dotnet(Closure body){
 def cleanupAzureResources(){
     def props = getVaultSecret(secret: 'secret/apm-team/ci/apm-agent-dotnet-azure')
     def authObj = props?.data
-    def dockerCmd = "docker run --rm -i -v ${BASE_DIR}/.azure:/root/.azure -v \$(pwd):/root mcr.microsoft.com/azure-cli:latest"
+    def dockerCmd = "docker run --rm -i -v .azure:/root/.azure mcr.microsoft.com/azure-cli:latest"
     withEnvMask(vars: [
         [var: 'AZ_CLIENT_ID', password: "${authObj.client_id}"],
         [var: 'AZ_CLIENT_SECRET', password: "${authObj.client_secret}"],

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -569,7 +569,7 @@ def cleanupAzureResources(){
             cmd label: "Setting Azure subscription",
                 script: "${dockerCmd} az account set --subscription ${AZ_SUBSCRIPTION_ID}"
             cmd label: "Checking and removing any Azure related resource groups",
-                script: "for group in `${dockerCmd} az group list --query \"[?name | starts_with(@,'${AZURE_RESOURCE_GROUP_PREFIX}')]\" --out json|jq .[].name`;do ${dockerCmd} az group delete --name \$group --no-wait --yes;done"
+                script: "for group in `${dockerCmd} az group list --query \"[?name | starts_with(@,'${AZURE_RESOURCE_GROUP_PREFIX}')]\" --out json|jq .[].name --raw-output`;do ${dockerCmd} az group delete --name \$group --no-wait --yes;done"
         }
     }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -554,7 +554,7 @@ def dotnet(Closure body){
 def cleanupAzureResources(){
     def props = getVaultSecret(secret: 'secret/apm-team/ci/apm-agent-dotnet-azure')
     def authObj = props?.data
-    def dockerCmd = "docker run --rm -i -v .azure:/root/.azure mcr.microsoft.com/azure-cli:latest"
+    def dockerCmd = "docker run --rm -i -v \$(pwd)/.azure:/root/.azure mcr.microsoft.com/azure-cli:latest"
     withEnvMask(vars: [
         [var: 'AZ_CLIENT_ID', password: "${authObj.client_id}"],
         [var: 'AZ_CLIENT_SECRET', password: "${authObj.client_secret}"],

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -569,7 +569,7 @@ def cleanupAzureResources(){
             cmd label: "Setting Azure subscription",
                 script: "${dockerCmd} az account set --subscription ${AZ_SUBSCRIPTION_ID}"
             cmd label: "Checking and removing any Azure related resource groups",
-                script: "for group in `${dockerCmd} az group list --query \"[?name | starts_with(@,'${AZURE_RESOURCE_GROUP_PREFIX}')]\" --out json|jq .[].name`;do az group delete --name \$group --no-wait --yes;done"
+                script: "for group in `${dockerCmd} az group list --query \"[?name | starts_with(@,'${AZURE_RESOURCE_GROUP_PREFIX}')]\" --out json|jq .[].name`;do ${dockerCmd} az group delete --name \$group --no-wait --yes;done"
         }
     }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,6 +16,7 @@ pipeline {
     OPBEANS_REPO = 'opbeans-dotnet'
     BENCHMARK_SECRET  = 'secret/apm-team/ci/benchmark-cloud'
     SLACK_CHANNEL = '#apm-agent-dotnet'
+    AZURE_RESOURCE_GROUP_PREFIX = "ci-dotnet"
   }
   options {
     timeout(time: 4, unit: 'HOURS')
@@ -512,6 +513,10 @@ pipeline {
   }
   post {
     cleanup {
+            withAzureCredentials(path: "${homePath}", credentialsFile: '.credentials.json') {
+                powershell label: "Checking and removing any Azure related resource groups",
+                    script: "az group list --query \"[?name | starts_with(@,'${AZURE_RESOURCE_GROUP_PREFIX})']\" --out json|jq .[].name | ForEach {az group delete --name $_}"
+            }
       notifyBuildResult()
     }
   }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -571,7 +571,7 @@ def withAzureAuth(Closure body){
     ]) {
         // This PATH should be fine as the cleanup runs on Ubuntu
         withEnv(["PATH=${env.PATH}:${env.HOME}/.local/bin"]) {
-            cmd label: "Install Azure CLI", script: "pip install --user azure-cli"
+            cmd label: "Install Azure CLI", script: "pip3 install --user azure-cli"
             cmd label: "Logging into Azure", script: "az login --service-principal --username ${AZ_CLIENT_ID} --password ${AZ_CLIENT_SECRET} --tenant ${AZ_TENANT_ID}"
             cmd label: "Setting Azure subscription", script: "az account set --subscription ${AZ_SUBSCRIPTION_ID}"
             body()

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -569,7 +569,7 @@ def cleanupAzureResources(){
             cmd label: "Setting Azure subscription",
                 script: "${dockerCmd} az account set --subscription ${AZ_SUBSCRIPTION_ID}"
             cmd label: "Checking and removing any Azure related resource groups",
-                script: "for group in `${dockerCmd} az group list --query \"[?name | starts_with(@,'${AZURE_RESOURCE_GROUP_PREFIX})']\" --out json|jq .[].name`;do az group delete --name $group --no-wait --yes;done"
+                script: "for group in `${dockerCmd} az group list --query \"[?name | starts_with(@,'${AZURE_RESOURCE_GROUP_PREFIX})']\" --out json|jq .[].name`;do az group delete --name \$group --no-wait --yes;done"
         }
     }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -569,9 +569,13 @@ def withAzureAuth(Closure body){
         [var: 'AZ_SUBSCRIPTION_ID', password: "${authObj.subscription_id}"],
         [var: 'AZ_TENANT_ID', password: "${authObj.tenant_id}"]
     ]) {
-        cmd label: "Logging into Azure", script: "az login --service-principal --username ${AZ_CLIENT_ID} --password ${AZ_CLIENT_SECRET} --tenant ${AZ_TENANT_ID}"
-        cmd label: "Setting Azure subscription", script: "az account set --subscription ${AZ_SUBSCRIPTION_ID}"
-        body()
+        // This PATH should be fine as the cleanup runs on Ubuntu
+        withEnv(["PATH=${env.PATH}:${env.HOME}/.local/bin"]) {
+            cmd label: "Install Azure CLI", script: "pip install --user azure-cli"
+            cmd label: "Logging into Azure", script: "az login --service-principal --username ${AZ_CLIENT_ID} --password ${AZ_CLIENT_SECRET} --tenant ${AZ_TENANT_ID}"
+            cmd label: "Setting Azure subscription", script: "az account set --subscription ${AZ_SUBSCRIPTION_ID}"
+            body()
+        }
     }
 }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -554,7 +554,7 @@ def dotnet(Closure body){
 def cleanupAzureResources(){
     def props = getVaultSecret(secret: 'secret/apm-team/ci/apm-agent-dotnet-azure')
     def authObj = props?.data
-    def dockerCmd = "docker run --rm -it -v ${BASE_DIR}/.azure:/root/.azure -v \$(pwd):/root mcr.microsoft.com/azure-cli:latest"
+    def dockerCmd = "docker run --rm -i -v ${BASE_DIR}/.azure:/root/.azure -v \$(pwd):/root mcr.microsoft.com/azure-cli:latest"
     withEnvMask(vars: [
         [var: 'AZ_CLIENT_ID', password: "${authObj.client_id}"],
         [var: 'AZ_CLIENT_SECRET', password: "${authObj.client_secret}"],

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -569,7 +569,7 @@ def cleanupAzureResources(){
             cmd label: "Setting Azure subscription",
                 script: "${dockerCmd} az account set --subscription ${AZ_SUBSCRIPTION_ID}"
             cmd label: "Checking and removing any Azure related resource groups",
-                script: "for group in `${dockerCmd} az group list --query \"[?name | starts_with(@,'${AZURE_RESOURCE_GROUP_PREFIX})']\" --out json|jq .[].name`;do az group delete --name \$group --no-wait --yes;done"
+                script: "for group in `${dockerCmd} az group list --query \"[?name | starts_with(@,'${AZURE_RESOURCE_GROUP_PREFIX}')]\" --out json|jq .[].name`;do az group delete --name \$group --no-wait --yes;done"
         }
     }
 }

--- a/test/Elastic.Apm.Azure.CosmosDb.Tests/AzureCosmosDbTestEnvironment.cs
+++ b/test/Elastic.Apm.Azure.CosmosDb.Tests/AzureCosmosDbTestEnvironment.cs
@@ -45,13 +45,10 @@ namespace Elastic.Apm.Azure.CosmosDb.Tests
 
 			_terraform = new TerraformResources(terraformResourceDirectory, credentials, messageSink);
 
-			var machineName = Environment.MachineName.ToLowerInvariant();
-			if (machineName.Length > 65)
-				machineName = machineName.Substring(0, 65);
-
+			var resourceGroupName = AzureResources.CreateResourceGroupName("cosmosdb-test");
 			_variables = new Dictionary<string, string>
 			{
-				["resource_group"] = $"dotnet-{machineName}-cosmosdb-test",
+				["resource_group"] = resourceGroupName,
 				["cosmos_db_account_name"] = "dotnet" + Guid.NewGuid().ToString("N").Substring(0, 18),
 			};
 

--- a/test/Elastic.Apm.Azure.ServiceBus.Tests/Azure/AzureServiceBusTestEnvironment.cs
+++ b/test/Elastic.Apm.Azure.ServiceBus.Tests/Azure/AzureServiceBusTestEnvironment.cs
@@ -45,13 +45,10 @@ namespace Elastic.Apm.Azure.ServiceBus.Tests.Azure
 
 			_terraform = new TerraformResources(terraformResourceDirectory, credentials, messageSink);
 
-			var machineName = Environment.MachineName.ToLowerInvariant();
-			if (machineName.Length > 66)
-				machineName = machineName.Substring(0, 66);
-
+			var resourceGroupName = AzureResources.CreateResourceGroupName("service-bus-test");
 			_variables = new Dictionary<string, string>
 			{
-				["resource_group"] = $"dotnet-{machineName}-service-bus-test",
+				["resource_group"] = resourceGroupName,
 				["servicebus_namespace"] = "dotnet-" + Guid.NewGuid()
 			};
 

--- a/test/Elastic.Apm.Azure.Storage.Tests/AzureStorageTestEnvironment.cs
+++ b/test/Elastic.Apm.Azure.Storage.Tests/AzureStorageTestEnvironment.cs
@@ -45,13 +45,10 @@ namespace Elastic.Apm.Azure.Storage.Tests
 
 			_terraform = new TerraformResources(terraformResourceDirectory, credentials, messageSink);
 
-			var machineName = Environment.MachineName.ToLowerInvariant();
-			if (machineName.Length > 66)
-				machineName = machineName.Substring(0, 66);
-
+			var resourceGroupName = AzureResources.CreateResourceGroupName("storage-test");
 			_variables = new Dictionary<string, string>
 			{
-				["resource_group"] = $"dotnet-{machineName}-storage-test",
+				["resource_group"] = resourceGroupName,
 				["storage_account_name"] = "dotnet" + Guid.NewGuid().ToString("N").Substring(0, 18),
 			};
 

--- a/test/Elastic.Apm.Tests.Utilities/Azure/AzureResourceException.cs
+++ b/test/Elastic.Apm.Tests.Utilities/Azure/AzureResourceException.cs
@@ -1,0 +1,16 @@
+// Licensed to Elasticsearch B.V under
+// one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System;
+
+namespace Elastic.Apm.Tests.Utilities.Azure
+{
+	public class AzureResourceException : Exception
+	{
+		public AzureResourceException(string message) : base(message)
+		{
+		}
+	}
+}

--- a/test/Elastic.Apm.Tests.Utilities/Azure/AzureResources.cs
+++ b/test/Elastic.Apm.Tests.Utilities/Azure/AzureResources.cs
@@ -1,0 +1,35 @@
+// Licensed to Elasticsearch B.V under
+// one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System;
+
+namespace Elastic.Apm.Tests.Utilities.Azure
+{
+	public static class AzureResources
+	{
+		public const int ResourceGroupMaxLength = 90;
+
+		public static string CreateResourceGroupName(string suffix)
+		{
+			var prefix = Environment.GetEnvironmentVariable("AZURE_RESOURCE_GROUP_PREFIX");
+			if (string.IsNullOrEmpty(prefix))
+				prefix = "dotnet";
+
+			// check that we'll be under the max length before calculating machine name truncation
+			var maxMachineNameLength = ResourceGroupMaxLength - (prefix + "--" + suffix).Length;
+			if (maxMachineNameLength < 0)
+			{
+				throw new AzureResourceException(
+					$"resource group name {prefix}-${{machine-name}}-{suffix} is longer than the maximum resource group name length of {ResourceGroupMaxLength}");
+			}
+
+			var machineName = Environment.MachineName.ToLowerInvariant();
+			if (machineName.Length > maxMachineNameLength)
+				machineName = machineName.Substring(0, maxMachineNameLength);
+
+			return $"{prefix}-{machineName}-{suffix}";
+		}
+	}
+}


### PR DESCRIPTION
Utilize a predefined AZ resource group prefix, we query the available resource
groups utilizing JMESPATH pulling out the group names. Finally passing that
through powershell's ForEach block to remove those remaining groups.

Related https://github.com/elastic/observability-robots/issues/497

Signed-off-by: Adam Stokes <51892+adam-stokes@users.noreply.github.com>