### PR TITLE
Sanitize Central config request URI and headers in logs

### DIFF
--- a/src/Elastic.Apm/Api/Request.cs
+++ b/src/Elastic.Apm/Api/Request.cs
@@ -77,7 +77,7 @@ namespace Elastic.Apm.Api
 		public string Full
 		{
 			get => _full;
-			set => _full = Http.Sanitize(value, out var newValue) ? newValue : value;
+			set => _full = Sanitization.TrySanitizeUrl(value, out var newValue, out _) ? newValue : value;
 		}
 
 		[MaxLength]
@@ -95,7 +95,7 @@ namespace Elastic.Apm.Api
 		public string Raw
 		{
 			get => _raw;
-			set => _raw = Http.Sanitize(value, out var newValue) ? newValue : value;
+			set => _raw = Sanitization.TrySanitizeUrl(value, out var newValue, out _) ? newValue : value;
 		}
 
 		/// <summary>

--- a/src/Elastic.Apm/BackendComm/BackendCommUtils.cs
+++ b/src/Elastic.Apm/BackendComm/BackendCommUtils.cs
@@ -46,19 +46,19 @@ namespace Elastic.Apm.BackendComm
 			/// service.name and service.environment are URL encoded in the returned URL.</param>
 			internal static Uri BuildGetConfigAbsoluteUrl(Uri baseUrl, Service service)
 			{
-				var strBuilder = new StringBuilder("config/v1/agents");
+				var builder = new StringBuilder("config/v1/agents");
 				var prefix = '?';
 
 				if (service.Name != null)
 				{
-					strBuilder.Append(prefix).Append($"service.name={UrlEncode(service.Name)}");
+					builder.Append(prefix).Append("service.name=").Append(UrlEncode(service.Name));
 					prefix = '&';
 				}
 
 				if (service.Environment != null)
-					strBuilder.Append(prefix).Append($"service.environment={UrlEncode(service.Environment)}");
+					builder.Append(prefix).Append("service.environment=").Append(UrlEncode(service.Environment));
 
-				return CombineAbsoluteAndRelativeUrls(baseUrl, /* relativeUri: */ strBuilder.ToString());
+				return CombineAbsoluteAndRelativeUrls(baseUrl, builder.ToString());
 			}
 
 			/// <summary>
@@ -190,7 +190,7 @@ namespace Elastic.Apm.BackendComm
 
 			logger.Debug()
 				?.Log("Building HTTP client with BaseAddress: {ApmServerUrl} for {dbgCallerDesc}..."
-					, serverUrlBase, dbgCallerDesc);
+					, serverUrlBase.Sanitize(), dbgCallerDesc);
 			var httpClient =
 				new HttpClient(httpMessageHandler ?? CreateHttpClientHandler(config, loggerArg)) { BaseAddress = serverUrlBase };
 			httpClient.DefaultRequestHeaders.UserAgent.Add(

--- a/src/Elastic.Apm/BackendComm/CentralConfig/CentralConfigFetcher.cs
+++ b/src/Elastic.Apm/BackendComm/CentralConfig/CentralConfigFetcher.cs
@@ -92,7 +92,6 @@ namespace Elastic.Apm.BackendComm.CentralConfig
 		protected override async Task WorkLoopIteration()
 		{
 			++_dbgIterationsCount;
-			var waitingLogSeverity = LogLevel.Trace;
 			WaitInfoS waitInfo;
 			HttpRequestMessage httpRequest = null;
 			HttpResponseMessage httpResponse = null;

--- a/src/Elastic.Apm/BackendComm/CentralConfig/CentralConfigFetcher.cs
+++ b/src/Elastic.Apm/BackendComm/CentralConfig/CentralConfigFetcher.cs
@@ -118,12 +118,20 @@ namespace Elastic.Apm.BackendComm.CentralConfig
 			}
 			catch (Exception ex)
 			{
-				waitInfo = ex is FailedToFetchConfigException fEx
-					? fEx.WaitInfo
-					: new WaitInfoS(WaitTimeIfAnyError, "Default wait time is used because exception was thrown"
-						+ " while fetching configuration from APM Server and parsing it.");
+				var level = LogLevel.Error;
 
-				_logger.Info()?.LogException(ex, "Exception was thrown while fetching configuration from APM Server and parsing it."
+				if (ex is FailedToFetchConfigException fetchConfigException)
+				{
+					waitInfo = fetchConfigException.WaitInfo;
+					level = fetchConfigException.Severity;
+				}
+				else
+				{
+					waitInfo = new WaitInfoS(WaitTimeIfAnyError, "Default wait time is used because exception was thrown"
+							+ " while fetching configuration from APM Server and parsing it.");
+				}
+
+				_logger.IfLevel(level)?.LogException(ex, "Exception was thrown while fetching configuration from APM Server and parsing it."
 						+ " ETag: `{ETag}'. URL: `{Url}'. Apm Server base URL: `{ApmServerUrl}'. WaitInterval: {WaitInterval}."
 						+ " dbgIterationsCount: {dbgIterationsCount}."
 						+ Environment.NewLine + "+-> Request:{HttpRequest}"

--- a/src/Elastic.Apm/BackendComm/CentralConfig/CentralConfigResponseParser.cs
+++ b/src/Elastic.Apm/BackendComm/CentralConfig/CentralConfigResponseParser.cs
@@ -86,12 +86,10 @@ namespace Elastic.Apm.BackendComm.CentralConfig
 		{
 			if (httpResponse.IsSuccessStatusCode) return true;
 
-			var statusCode = (int)httpResponse.StatusCode;
-			var severity = 400 <= statusCode && statusCode < 500 ? LogLevel.Debug : LogLevel.Error;
-
-			string message;
+			var severity = LogLevel.Error;
 			var statusAsString = $"HTTP status code is {httpResponse.ReasonPhrase} ({(int)httpResponse.StatusCode})";
-			var msgPrefix = $"{statusAsString} which most likely means that ";
+			string message;
+
 			// ReSharper disable once SwitchStatementMissingSomeCases
 			switch (httpResponse.StatusCode)
 			{
@@ -107,21 +105,24 @@ namespace Elastic.Apm.BackendComm.CentralConfig
 					return false;
 
 				case HttpStatusCode.BadRequest: // 400
-					severity = LogLevel.Error;
 					message = $"{statusAsString} which is unexpected";
 					break;
 
 				case HttpStatusCode.Forbidden: // 403
-					message = msgPrefix + "APM Server supports the central configuration endpoint but Kibana connection is not enabled";
+					severity = LogLevel.Debug;
+					message = $"{statusAsString} which most likely means that APM Server supports the central configuration "
+						+ "endpoint but Kibana connection is not enabled";
 					break;
 
 				case HttpStatusCode.NotFound: // 404
-					message = msgPrefix + "APM Server is an old (pre 7.3) version which doesn't support the central configuration endpoint";
+					severity = LogLevel.Debug;
+					message = $"{statusAsString} which most likely means that APM Server is an old (pre 7.3) version which "
+						+ "doesn't support the central configuration endpoint";
 					break;
 
 				case HttpStatusCode.ServiceUnavailable: // 503
-					message = msgPrefix + "APM Server supports the central configuration endpoint and Kibana connection is enabled"
-						+ ", but Kibana connection is unavailable";
+					message = $"{statusAsString} which most likely means that APM Server supports the central configuration "
+						+ "endpoint and Kibana connection is enabled, but Kibana connection is unavailable";
 					break;
 
 				default:

--- a/src/Elastic.Apm/Consts.cs
+++ b/src/Elastic.Apm/Consts.cs
@@ -8,8 +8,8 @@ namespace Elastic.Apm
 	{
 		internal const int PropertyMaxLength = 1024;
 
-		internal static string AgentName => "dotnet";
+		internal const string AgentName = "dotnet";
 
-		internal static string Redacted = "[REDACTED]";
+		internal const string Redacted = "[REDACTED]";
 	}
 }

--- a/src/Elastic.Apm/DiagnosticListeners/HttpDiagnosticListenerImplBase.cs
+++ b/src/Elastic.Apm/DiagnosticListeners/HttpDiagnosticListenerImplBase.cs
@@ -9,6 +9,7 @@ using System.Collections.Generic;
 using System.Reflection;
 using Elastic.Apm.Api;
 using Elastic.Apm.DistributedTracing;
+using Elastic.Apm.Helpers;
 using Elastic.Apm.Logging;
 using Elastic.Apm.Model;
 
@@ -103,7 +104,7 @@ namespace Elastic.Apm.DiagnosticListeners
 
 				if (IsRequestFilteredOut(requestUrl))
 				{
-					Logger.Trace()?.Log("Request URL ({RequestUrl}) is filtered out - exiting", Http.Sanitize(requestUrl));
+					Logger.Trace()?.Log("Request URL ({RequestUrl}) is filtered out - exiting", requestUrl.Sanitize());
 					return;
 				}
 
@@ -124,7 +125,7 @@ namespace Elastic.Apm.DiagnosticListeners
 
 		private void ProcessStartEvent(TRequest request, Uri requestUrl)
 		{
-			Logger.Trace()?.Log("Processing start event... Request URL: {RequestUrl}", Http.Sanitize(requestUrl));
+			Logger.Trace()?.Log("Processing start event... Request URL: {RequestUrl}", requestUrl.Sanitize());
 
 			var transaction = ApmAgent.Tracer.CurrentTransaction;
 			if (transaction is null)
@@ -174,13 +175,13 @@ namespace Elastic.Apm.DiagnosticListeners
 
 					if (span is null)
 					{
-						Logger.Trace()?.Log("Could not create span for outgoing HTTP request to {RequestUrl}", Http.Sanitize(requestUrl));
+						Logger.Trace()?.Log("Could not create span for outgoing HTTP request to {RequestUrl}", requestUrl.Sanitize());
 						return;
 					}
 				}
 				else
 				{
-					Logger.Trace()?.Log("Skip creating span for outgoing HTTP request to {RequestUrl} as not to known service", Http.Sanitize(requestUrl));
+					Logger.Trace()?.Log("Skip creating span for outgoing HTTP request to {RequestUrl} as not to known service", requestUrl.Sanitize());
 					return;
 				}
 			}
@@ -231,7 +232,7 @@ namespace Elastic.Apm.DiagnosticListeners
 
 		private void ProcessStopEvent(object eventValue, TRequest request, Uri requestUrl)
 		{
-			Logger.Trace()?.Log("Processing stop event... Request URL: {RequestUrl}", Http.Sanitize(requestUrl));
+			Logger.Trace()?.Log("Processing stop event... Request URL: {RequestUrl}", requestUrl.Sanitize().ToString());
 
 			if (!ProcessingRequests.TryRemove(request, out var span))
 			{
@@ -241,13 +242,13 @@ namespace Elastic.Apm.DiagnosticListeners
 				{
 					Logger.Debug()
 						?.Log("{eventName} called with no active current transaction, url: {url} - skipping event", nameof(ProcessStopEvent),
-							Http.Sanitize(requestUrl));
+							requestUrl.Sanitize().ToString());
 				}
 				else
 				{
 					Logger.Debug()
 						?.Log("Could not remove request from processing requests. This likely means it was not captured to begin with." +
-							"Request: method: {HttpMethod}, URL: {RequestUrl}", RequestGetMethod(request), Http.Sanitize(requestUrl));
+							"Request: method: {HttpMethod}, URL: {RequestUrl}", RequestGetMethod(request), requestUrl.Sanitize().ToString());
 				}
 
 				return;
@@ -285,7 +286,7 @@ namespace Elastic.Apm.DiagnosticListeners
 
 		protected virtual void ProcessExceptionEvent(object eventValue, Uri requestUrl)
 		{
-			Logger.Trace()?.Log("Processing exception event... Request URL: {RequestUrl}", Http.Sanitize(requestUrl));
+			Logger.Trace()?.Log("Processing exception event... Request URL: {RequestUrl}", requestUrl.Sanitize().ToString());
 
 			if (!(eventValue.GetType().GetTypeInfo().GetDeclaredProperty(EventExceptionPropertyName)?.GetValue(eventValue) is Exception exception))
 			{

--- a/src/Elastic.Apm/Helpers/Sanitization.cs
+++ b/src/Elastic.Apm/Helpers/Sanitization.cs
@@ -60,8 +60,9 @@ namespace Elastic.Apm.Helpers
 		{
 			try
 			{
-				result = uri.Sanitize().ToString();
-				return true;
+				var sanitized = uri.Sanitize();
+				result = sanitized.ToString();
+				return sanitized != uri;
 			}
 			catch
 			{

--- a/src/Elastic.Apm/Helpers/Sanitization.cs
+++ b/src/Elastic.Apm/Helpers/Sanitization.cs
@@ -1,0 +1,88 @@
+// Licensed to Elasticsearch B.V under
+// one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+
+namespace Elastic.Apm.Helpers
+{
+	internal static class Sanitization
+	{
+		/// <summary>
+		/// Sanitizes a <see cref="HttpRequestMessage"/>, redacting user info from the request URI and HTTP headers that
+		/// match any of the matchers.
+		/// </summary>
+		/// <remarks>
+		/// The <see cref="HttpRequestMessage"/> instance is mutated, so this method should not be used for logging
+		/// **before** using the instance in a request.
+		/// </remarks>
+		/// <param name="message">The message to sanitize</param>
+		/// <param name="matchers">The matchers used to redact HTTP headers</param>
+		/// <returns>A sanitized <see cref="HttpRequestMessage"/></returns>
+		internal static HttpRequestMessage Sanitize(this HttpRequestMessage message, IReadOnlyList<WildcardMatcher> matchers)
+		{
+			if (message is null)
+				return null;
+
+			message.RequestUri = message.RequestUri.Sanitize();
+
+			var headers = message.Headers.Select(h => h.Key).ToList();
+			foreach (var header in headers)
+			{
+				if (WildcardMatcher.IsAnyMatch(matchers, header) && message.Headers.Remove(header))
+					message.Headers.TryAddWithoutValidation(header, Consts.Redacted);
+			}
+
+			return message;
+		}
+
+		/// <summary>
+		/// Redacts username and password, if present
+		/// </summary>
+		internal static Uri Sanitize(this Uri uri)
+		{
+			if (string.IsNullOrEmpty(uri.UserInfo))
+				return uri;
+
+			var builder = new UriBuilder(uri)
+			{
+				UserName = Consts.Redacted,
+				Password = Consts.Redacted
+			};
+			return builder.Uri;
+		}
+
+		internal static bool Sanitize(Uri uri, out string result)
+		{
+			try
+			{
+				result = uri.Sanitize().ToString();
+				return true;
+			}
+			catch
+			{
+				result = null;
+				return false;
+			}
+		}
+
+		internal static bool TrySanitizeUrl(string uri, out string sanitizedUri, out Uri originalUri)
+		{
+			try
+			{
+				originalUri = new Uri(uri, UriKind.RelativeOrAbsolute);
+				return Sanitize(originalUri, out sanitizedUri);
+			}
+			catch
+			{
+				sanitizedUri = null;
+				originalUri = null;
+				return false;
+			}
+		}
+	}
+}

--- a/src/Elastic.Apm/Report/PayloadSenderV2.cs
+++ b/src/Elastic.Apm/Report/PayloadSenderV2.cs
@@ -104,7 +104,7 @@ namespace Elastic.Apm.Report
 					+ ", FlushInterval: {FlushInterval}"
 					+ ", MaxBatchEventCount: {MaxBatchEventCount}"
 					+ ", MaxQueueEventCount: {MaxQueueEventCount}"
-					, _intakeV2EventsAbsoluteUrl, _flushInterval.ToHms(), config.MaxBatchEventCount, _maxQueueEventCount);
+					, _intakeV2EventsAbsoluteUrl.Sanitize(), _flushInterval.ToHms(), config.MaxBatchEventCount, _maxQueueEventCount);
 
 			_eventQueue = new BatchBlock<object>(config.MaxBatchEventCount);
 
@@ -323,9 +323,7 @@ namespace Elastic.Apm.Report
 								+ " Events intake API absolute URL: {EventsIntakeAbsoluteUrl}."
 								+ " APM Server response: status code: {ApmServerResponseStatusCode}"
 								+ ", content: \n{ApmServerResponseContent}"
-								, Http.Sanitize(_intakeV2EventsAbsoluteUrl, out var sanitizedServerUrl)
-									? sanitizedServerUrl
-									: _intakeV2EventsAbsoluteUrl.ToString()
+								, _intakeV2EventsAbsoluteUrl.Sanitize()
 								, response?.StatusCode,
 								response is null ? null : await response.Content.ReadAsStringAsync().ConfigureAwait(false));
 					}
@@ -345,9 +343,7 @@ namespace Elastic.Apm.Report
 					?.Log(
 						"Cancellation requested. Following events were not transferred successfully to the server ({ApmServerUrl}):"
 							+ $"{Environment.NewLine}{TextUtils.Indentation}{{SerializedItems}}"
-						, Http.Sanitize(HttpClient.BaseAddress, out var sanitizedServerUrl)
-							? sanitizedServerUrl
-							: HttpClient.BaseAddress.ToString()
+						, HttpClient.BaseAddress.Sanitize()
 						, string.Join($",{Environment.NewLine}{TextUtils.Indentation}", queueItems));
 
 				// throw to allow Workloop to handle
@@ -360,9 +356,7 @@ namespace Elastic.Apm.Report
 						e,
 						"Failed sending events. Following events were not transferred successfully to the server ({ApmServerUrl}):"
 							+ $"{Environment.NewLine}{TextUtils.Indentation}{{SerializedItems}}"
-						, Http.Sanitize(HttpClient.BaseAddress, out var sanitizedServerUrl)
-							? sanitizedServerUrl
-							: HttpClient.BaseAddress.ToString()
+						, HttpClient.BaseAddress.Sanitize()
 						, string.Join($",{Environment.NewLine}{TextUtils.Indentation}", queueItems)
 					);
 			}

--- a/test/Elastic.Apm.AspNetCore.Tests/SanitizeFieldNamesTests.cs
+++ b/test/Elastic.Apm.AspNetCore.Tests/SanitizeFieldNamesTests.cs
@@ -190,7 +190,7 @@ namespace Elastic.Apm.AspNetCore.Tests
 			_capturedPayload.FirstTransaction.Context.Request.Headers.Should().NotBeNull();
 
 			foreach (var header in headerNames)
-				_capturedPayload.FirstTransaction.Context.Request.Headers[header].Should().Be("[REDACTED]");
+				_capturedPayload.FirstTransaction.Context.Request.Headers[header].Should().Be(Apm.Consts.Redacted);
 		}
 
 		/// <summary>
@@ -245,7 +245,7 @@ namespace Elastic.Apm.AspNetCore.Tests
 			_capturedPayload.FirstTransaction.Context.Request.Should().NotBeNull();
 			_capturedPayload.FirstTransaction.Context.Request.Headers.Should().NotBeNull();
 
-			_capturedPayload.FirstTransaction.Context.Request.Headers["foo"].Should().Be("[REDACTED]");
+			_capturedPayload.FirstTransaction.Context.Request.Headers["foo"].Should().Be(Apm.Consts.Redacted);
 		}
 
 		///// <summary>
@@ -273,7 +273,7 @@ namespace Elastic.Apm.AspNetCore.Tests
 			_capturedPayload.FirstTransaction.Context.Should().NotBeNull();
 			_capturedPayload.FirstTransaction.Context.Request.Should().NotBeNull();
 			_capturedPayload.FirstTransaction.Context.Request.Headers.Should().NotBeNull();
-			_capturedPayload.FirstTransaction.Context.Request.Headers[headerName].Should().Be(shouldBeSanitized ? "[REDACTED]" : headerValue);
+			_capturedPayload.FirstTransaction.Context.Request.Headers[headerName].Should().Be(shouldBeSanitized ? Apm.Consts.Redacted : headerValue);
 		}
 
 		///// <summary>
@@ -296,7 +296,7 @@ namespace Elastic.Apm.AspNetCore.Tests
 			_capturedPayload.FirstTransaction.Context.Should().NotBeNull();
 			_capturedPayload.FirstTransaction.Context.Request.Should().NotBeNull();
 			_capturedPayload.FirstTransaction.Context.Request.Headers.Should().NotBeNull();
-			_capturedPayload.FirstTransaction.Context.Request.Headers[headerName].Should().Be("[REDACTED]");
+			_capturedPayload.FirstTransaction.Context.Request.Headers[headerName].Should().Be(Apm.Consts.Redacted);
 		}
 
 		/// <summary>
@@ -317,14 +317,14 @@ namespace Elastic.Apm.AspNetCore.Tests
 			_capturedPayload.FirstTransaction.Context.Should().NotBeNull();
 			_capturedPayload.FirstTransaction.Context.Request.Should().NotBeNull();
 			_capturedPayload.FirstTransaction.Context.Request.Headers.Should().NotBeNull();
-			_capturedPayload.FirstTransaction.Context.Request.Headers[headerName].Should().Be("[REDACTED]");
+			_capturedPayload.FirstTransaction.Context.Request.Headers[headerName].Should().Be(Apm.Consts.Redacted);
 
 			_capturedPayload.WaitForErrors();
 			_capturedPayload.Errors.Should().NotBeEmpty();
 			_capturedPayload.FirstError.Context.Should().NotBeNull();
 			_capturedPayload.FirstError.Context.Request.Should().NotBeNull();
 			_capturedPayload.FirstError.Context.Request.Headers.Should().NotBeNull();
-			_capturedPayload.FirstError.Context.Request.Headers[headerName].Should().Be("[REDACTED]");
+			_capturedPayload.FirstError.Context.Request.Headers[headerName].Should().Be(Apm.Consts.Redacted);
 		}
 
 		///// <summary>
@@ -351,7 +351,7 @@ namespace Elastic.Apm.AspNetCore.Tests
 			_capturedPayload.FirstTransaction.Context.Should().NotBeNull();
 			_capturedPayload.FirstTransaction.Context.Request.Should().NotBeNull();
 			_capturedPayload.FirstTransaction.Context.Request.Headers.Should().NotBeNull();
-			_capturedPayload.FirstTransaction.Context.Request.Headers[returnedHeaderName].Should().Be("[REDACTED]");
+			_capturedPayload.FirstTransaction.Context.Request.Headers[returnedHeaderName].Should().Be(Apm.Consts.Redacted);
 		}
 
 

--- a/test/Elastic.Apm.Tests.Utilities/TestLogger.cs
+++ b/test/Elastic.Apm.Tests.Utilities/TestLogger.cs
@@ -21,6 +21,9 @@ namespace Elastic.Apm.Tests.Utilities
 
 		private TestLogger(LogLevel level, SynchronizedStringWriter writer) : base(level, writer, writer) => _writer = writer;
 
+		/// <summary>
+		/// Gets the log lines
+		/// </summary>
 		public IReadOnlyList<string> Lines
 		{
 			get
@@ -32,6 +35,18 @@ namespace Elastic.Apm.Tests.Utilities
 						.Split(Environment.NewLine.ToCharArray(), StringSplitOptions.RemoveEmptyEntries)
 						.ToList();
 				}
+			}
+		}
+
+		/// <summary>
+		/// Gets the log
+		/// </summary>
+		public string Log
+		{
+			get
+			{
+				lock (_writer.Lock)
+					return _writer.GetStringBuilder().ToString();
 			}
 		}
 	}

--- a/test/Elastic.Apm.Tests/BackendCommTests/PayloadSenderTests.cs
+++ b/test/Elastic.Apm.Tests/BackendCommTests/PayloadSenderTests.cs
@@ -11,6 +11,7 @@ using System.Net.Http.Headers;
 using System.Threading;
 using System.Threading.Tasks;
 using Elastic.Apm.Api;
+using Elastic.Apm.BackendComm;
 using Elastic.Apm.Config;
 using Elastic.Apm.Helpers;
 using Elastic.Apm.Logging;
@@ -22,6 +23,9 @@ using FluentAssertions.Extensions;
 using Xunit;
 using Xunit.Abstractions;
 using static Elastic.Apm.Tests.Utilities.FluentAssertionsUtils;
+using MockHttpMessageHandler = Elastic.Apm.Tests.Utilities.MockHttpMessageHandler;
+using RichardSzalay.MockHttp;
+using System = Elastic.Apm.Api.System;
 
 namespace Elastic.Apm.Tests.BackendCommTests
 {
@@ -45,6 +49,45 @@ namespace Elastic.Apm.Tests.BackendCommTests
 		public static IEnumerable<object[]> TestArgsVariantsWithVeryLongFlushInterval =>
 			TestArgsVariants(args => args.FlushInterval.HasValue && args.FlushInterval >= VeryLongFlushInterval).Select(t => new object[] { t });
 
+
+		[Fact]
+		public void Should_Sanitize_HttpRequestMessage_In_Log()
+		{
+			var testLogger = new TestLogger(LogLevel.Trace);
+			var secretToken = "secretToken";
+			var serverUrl = "http://username:password@localhost:8200";
+
+			var config = new MockConfigSnapshot(testLogger, logLevel: "Trace", serverUrl: serverUrl, secretToken: secretToken, flushInterval: "0");
+			var service = Service.GetDefaultService(config, testLogger);
+			var waitHandle = new ManualResetEvent(false);
+			var handler = new RichardSzalay.MockHttp.MockHttpMessageHandler();
+			var configUrl = BackendCommUtils.ApmServerEndpoints
+				.BuildIntakeV2EventsAbsoluteUrl(config.ServerUrl);
+
+			handler.When(configUrl.AbsoluteUri)
+				.Respond(_ =>
+				{
+					waitHandle.Set();
+					return new HttpResponseMessage(HttpStatusCode.ServiceUnavailable);
+				});
+
+			var payloadSender = new PayloadSenderV2(testLogger, config, service, new Api.System(), MockApmServerInfo.Version710, handler);
+			using var agent = new ApmAgent(new TestAgentComponents(LoggerBase, config, payloadSender));
+			agent.PayloadSender.QueueTransaction(new Transaction(agent, "TestName", "TestType"));
+
+			waitHandle.WaitOne();
+
+			var count = 0;
+			while (!testLogger.Log.Contains("Failed sending event.")
+				&& count < 10)
+			{
+				Thread.Sleep(500);
+				count++;
+			}
+
+			testLogger.Log.Should().NotContain(secretToken)
+				.And.Contain("http://[REDACTED]:[REDACTED]@localhost:8200").And.NotContain(serverUrl);
+		}
 		[Fact]
 		public async Task SecretToken_ShouldBeSent_WhenApiKeyIsNotSpecified()
 		{
@@ -138,19 +181,21 @@ namespace Elastic.Apm.Tests.BackendCommTests
 				await isRequestFinished.Task;
 			}
 
-			userAgentHeader
+			var headerValues = userAgentHeader.ToList();
+
+			headerValues
 				.Should()
 				.NotBeEmpty()
 				.And.HaveCount(3);
 
-			userAgentHeader.First().Product.Name.Should().Be($"elasticapm-{Consts.AgentName}");
-			userAgentHeader.First().Product.Version.Should().NotBeEmpty();
+			headerValues[0].Product.Name.Should().Be($"elasticapm-{Consts.AgentName}");
+			headerValues[0].Product.Version.Should().NotBeEmpty();
 
-			userAgentHeader.Skip(1).First().Product.Name.Should().Be("System.Net.Http");
-			userAgentHeader.Skip(1).First().Product.Version.Should().NotBeEmpty();
+			headerValues[1].Product.Name.Should().Be("System.Net.Http");
+			headerValues[1].Product.Version.Should().NotBeEmpty();
 
-			userAgentHeader.Skip(2).First().Product.Name.Should().NotBeEmpty();
-			userAgentHeader.Skip(2).First().Product.Version.Should().NotBeEmpty();
+			headerValues[2].Product.Name.Should().NotBeEmpty();
+			headerValues[2].Product.Version.Should().NotBeEmpty();
 		}
 
 		private static IEnumerable<TestArgs> TestArgsVariantsWithoutIndex()

--- a/test/Elastic.Apm.Tests/HttpDiagnosticListenerTests.cs
+++ b/test/Elastic.Apm.Tests/HttpDiagnosticListenerTests.cs
@@ -302,8 +302,8 @@ namespace Elastic.Apm.Tests
 				firstSpan.Should().NotBeNull();
 				firstSpan.Context.Http.Url.Should()
 					.Be(uriBuilder.Uri.ToString()
-						.Replace("TestUser", "[REDACTED]")
-						.Replace("TestPassword", "[REDACTED]"));
+						.Replace("TestUser", Consts.Redacted)
+						.Replace("TestPassword", Consts.Redacted));
 				firstSpan.Context.Http.StatusCode.Should().Be(200);
 				firstSpan.Context.Http.Method.Should().Be(HttpMethod.Get.Method);
 				firstSpan.Context.Destination.Address.Should().Be(new Uri(localServer.Uri).Host);
@@ -615,7 +615,7 @@ namespace Elastic.Apm.Tests
 
 				// looking for lines with "localhost:8082" and asserting that those contain [REDACTED].
 				foreach (var lineWithHttpLog in logger.Lines.Where(n => n.Contains($"{uriBuilder.Host}:{uriBuilder.Port}")))
-					lineWithHttpLog.Should().Contain("[REDACTED]");
+					lineWithHttpLog.Should().Contain(Consts.Redacted);
 			}
 		}
 


### PR DESCRIPTION
This commit sanitizes the request URI and headers of
request to fetch central configuration, to redact username/password info
and sensitive headers.

- Move sanitization methods to separate Santization helper class.
- Add test to assert central config sensitive request details are redacted.
- Use Consts.Redacted wherever "[REDACTED]" is needed.

Fixes #1376