### PR TITLE
Honor Transaction.Outcome set by public API in auto instrumentation

### DIFF
--- a/sample/SampleAspNetCoreApp/Controllers/HomeController.cs
+++ b/sample/SampleAspNetCoreApp/Controllers/HomeController.cs
@@ -264,6 +264,18 @@ namespace SampleAspNetCoreApp.Controllers
 		/// <returns>HTTP200 if the parameter is available in the method (aka not <code>null</code>), HTTP500 otherwise </returns>
 		[HttpPost("api/Home/Send")]
 		public IActionResult Send([FromBody] BaseReportFilter<SendMessageFilter> filter) => filter == null ? StatusCode(500) : Ok();
+
+		/// <summary>
+		/// A test case to make sure that setting <see cref="IExecutionSegment.Outcome"/> manually is not overwritten by auto instrumentation.
+		/// </summary>
+		/// <returns></returns>
+		[HttpGet]
+		public ActionResult SampleWithManuallySettingOutcome()
+		{
+			Agent.Tracer.CurrentTransaction.Outcome = Outcome.Failure;
+
+			return Ok();
+		}
 	}
 
 	public class BaseReportFilter<T>

--- a/src/Elastic.Apm.AspNetCore/WebRequestTransactionCreator.cs
+++ b/src/Elastic.Apm.AspNetCore/WebRequestTransactionCreator.cs
@@ -218,7 +218,7 @@ namespace Elastic.Apm.AspNetCore
 				{
 					transaction.Name = grpcCallInfo.methodname;
 					transaction.Result = GrpcHelper.GrpcReturnCodeToString(grpcCallInfo.result);
-					transaction.Outcome = GrpcHelper.GrpcServerReturnCodeToOutcome(transaction.Result);
+					transaction.SetOutcome(GrpcHelper.GrpcServerReturnCodeToOutcome(transaction.Result));
 				}
 
 				if (transaction.IsSampled)
@@ -239,10 +239,13 @@ namespace Elastic.Apm.AspNetCore
 
 		internal static void SetOutcomeForHttpResult(ITransaction transaction, int HttpReturnCode)
 		{
-			if (HttpReturnCode >= 500 || HttpReturnCode < 100)
-				transaction.Outcome = Outcome.Failure;
-			else
-				transaction.Outcome = Outcome.Success;
+			if (transaction is Transaction realTransaction)
+			{
+				if (HttpReturnCode >= 500 || HttpReturnCode < 100)
+					realTransaction.SetOutcome(Outcome.Failure);
+				else
+					realTransaction.SetOutcome(Outcome.Success);
+			}
 		}
 
 		/// <summary>

--- a/src/Elastic.Apm.AspNetFullFramework/ElasticApmModule.cs
+++ b/src/Elastic.Apm.AspNetFullFramework/ElasticApmModule.cs
@@ -362,9 +362,12 @@ namespace Elastic.Apm.AspNetFullFramework
 			}
 
 			transaction.Result = Transaction.StatusCodeToResult("HTTP", response.StatusCode);
-			transaction.Outcome = response.StatusCode >= 500
-				? Outcome.Failure
-				: Outcome.Success;
+			if (transaction is Transaction realTransaction)
+			{
+				realTransaction.SetOutcome(response.StatusCode >= 500
+					? Outcome.Failure
+					: Outcome.Success);
+			}
 
 			if (transaction.IsSampled)
 			{

--- a/src/Elastic.Apm/Model/ExecutionSegmentCommon.cs
+++ b/src/Elastic.Apm/Model/ExecutionSegmentCommon.cs
@@ -162,8 +162,13 @@ namespace Elastic.Apm.Model
 			Dictionary<string, Label> labels = null
 		)
 		{
-			if(executionSegment != null)
-				executionSegment.Outcome = Outcome.Failure;
+			if (executionSegment != null)
+			{
+				if (executionSegment is Transaction realTransaction)
+					realTransaction.SetOutcome(Outcome.Failure);
+				else
+					executionSegment.Outcome = Outcome.Failure;
+			}
 
 			var capturedCulprit = string.IsNullOrEmpty(culprit) ? GetCulprit(exception, configurationReader) : culprit;
 			var debugMessage = $"{nameof(ExecutionSegmentCommon)}.{nameof(CaptureException)}";
@@ -262,8 +267,13 @@ namespace Elastic.Apm.Model
 			Dictionary<string, Label> labels = null
 		)
 		{
-			if(executionSegment != null)
-				executionSegment.Outcome = Outcome.Failure;
+			if (executionSegment != null)
+			{
+				if (executionSegment is Transaction realTransaction)
+					realTransaction.SetOutcome(Outcome.Failure);
+				else
+					executionSegment.Outcome = Outcome.Failure;
+			}
 
 			var capturedCulprit = string.IsNullOrEmpty(culprit) ? "PublicAPI-CaptureException" : culprit;
 
@@ -322,8 +332,13 @@ namespace Elastic.Apm.Model
 			Dictionary<string, Label> labels = null
 		)
 		{
-			if(executionSegment != null)
-				executionSegment.Outcome = Outcome.Failure;
+			if (executionSegment != null)
+			{
+				if (executionSegment is Transaction realTransaction)
+					realTransaction.SetOutcome(Outcome.Failure);
+				else
+					executionSegment.Outcome = Outcome.Failure;
+			}
 
 			var error = new Error(errorLog, enclosingTransaction, parentId ?? executionSegment?.Id, logger, labels)
 			{

--- a/src/Elastic.Apm/Model/Transaction.cs
+++ b/src/Elastic.Apm/Model/Transaction.cs
@@ -301,6 +301,18 @@ namespace Elastic.Apm.Model
 		internal ChildDurationTimer ChildDurationTimer { get; } = new();
 
 		/// <summary>
+		/// Changes the <see cref="Outcome"/> by checking the <see cref="_outcomeChangedThroughApi"/> flag.
+		/// This method is intended for all auto instrumentation usages where the <see cref="Outcome"/> property needs to be set.
+		/// Setting outcome via the <see cref="Outcome"/> property is intended for users who use the public API.
+		/// </summary>
+		/// <param name="outcome">The outcome of the transaction will be set to this value if it wasn't change to the public API previously</param>
+		internal void SetOutcome(Outcome outcome)
+		{
+			if (!_outcomeChangedThroughApi)
+				_outcome = outcome;
+		}
+
+		/// <summary>
 		/// Holds configuration snapshot (which is immutable) that was current when this transaction started.
 		/// We would like transaction data to be consistent and not to be affected by possible changes in agent's configuration
 		/// between the start and the end of the transaction. That is why the way all the data is collected for the transaction


### PR DESCRIPTION
Solves https://github.com/elastic/apm-agent-dotnet/issues/1349 

When `Transaction.Outcome` is set within an incoming web request prior to this PR we ignored it and set it based on HTTP (or gRPC) return code. The intention was already in the original code that if the user set the outcome for a transaction (even if it's started by auto instrumentation) we honor that and don't change it.

This PR adapts this behaviour, specifically: when `Transaction.Outcome` is set manually through the public API, the agent will take that value and won't change it based on HTTP or gRPC status code. 