### PR TITLE
Use Kubernetes pod id determined from cgroup file

### DIFF
--- a/src/Elastic.Apm/AgentComponents.cs
+++ b/src/Elastic.Apm/AgentComponents.cs
@@ -43,7 +43,7 @@ namespace Elastic.Apm
 				Service = Service.GetDefaultService(ConfigurationReader, Logger);
 
 				var systemInfoHelper = new SystemInfoHelper(Logger);
-				var system = systemInfoHelper.ParseSystemInfo(ConfigurationReader.HostName);
+				var system = systemInfoHelper.GetSystemInfo(ConfigurationReader.HostName);
 
 				ConfigStore = new ConfigStore(new ConfigSnapshotFromReader(ConfigurationReader, "local"), Logger);
 

--- a/src/Elastic.Apm/Helpers/SystemInfoHelper.cs
+++ b/src/Elastic.Apm/Helpers/SystemInfoHelper.cs
@@ -14,35 +14,30 @@ namespace Elastic.Apm.Helpers
 {
 	internal class SystemInfoHelper
 	{
-		private const string ContainerUidRegexString = "^[0-9a-fA-F]{64}$";
-
-		private const string ShortenedUuidPattern = "^[0-9a-fA-F]{8}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{4,}";
-
-		private const string PodRegexString = @"(?:^/kubepods[\S]*/pod([^/]+)$)|"
-			+ @"(?:^/kubepods\.slice/(kubepods-[^/]+\.slice/)?kubepods[^/]*-pod([^/]+)\.slice$)";
-
-		private readonly Regex _containerUidRegex = new Regex(ContainerUidRegexString);
-		private readonly Regex _shortenedUuidRegex = new Regex(ShortenedUuidPattern);
-		private readonly Regex _podRegex = new Regex(PodRegexString);
+		private readonly Regex _containerUidRegex = new Regex("^[0-9a-fA-F]{64}$");
+		private readonly Regex _shortenedUuidRegex = new Regex("^[0-9a-fA-F]{8}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{4,}");
+		private readonly Regex _podRegex = new Regex(
+			@"(?:^/kubepods[\S]*/pod([^/]+)$)|(?:^/kubepods\.slice/(kubepods-[^/]+\.slice/)?kubepods[^/]*-pod([^/]+)\.slice$)");
 
 		private readonly IApmLogger _logger;
 
 		public SystemInfoHelper(IApmLogger logger)
 			=> _logger = logger.Scoped(nameof(SystemInfoHelper));
 
-		private Container ParseContainerId(string line)
+		internal void ParseContainerId(Api.System system, string reportedHostName, string line)
 		{
-			//Copied from the Java agent, and C#-ified
-
-			string kubernetesPodUid = null;
-
 			var fields = line.Split(':');
-			if (fields.Length != 3) return null;
+			if (fields.Length != 3)
+				return;
 
 			var cGroupPath = fields[2];
-			var idPart = Path.GetFileName(cGroupPath);
+			var lastIndexSlash = cGroupPath.LastIndexOf('/');
+			if (lastIndexSlash == -1)
+				return;
 
-			if (string.IsNullOrWhiteSpace(idPart)) return null;
+			var idPart = cGroupPath.Substring(lastIndexSlash + 1);
+			if (string.IsNullOrWhiteSpace(idPart))
+				return;
 
 			// Legacy, e.g.: /system.slice/docker-<CID>.scope
 			if (idPart.EndsWith(".scope"))
@@ -52,29 +47,25 @@ namespace Elastic.Apm.Helpers
 			}
 
 			// Looking for kubernetes info
-			var dirPathPart = Path.GetDirectoryName(cGroupPath);
-			if (dirPathPart != null)
+			var dir = cGroupPath.Substring(0, lastIndexSlash);
+			if (dir.Length > 0)
 			{
-				var dir = dirPathPart;
-
-				var matcher = _podRegex.Match(dir);
-
-				if (matcher.Success)
+				var match = _podRegex.Match(dir);
+				if (match.Success)
 				{
-					for (var i = 1; i <= matcher.Groups.Count; i++)
+					for (var i = 1; i <= match.Groups.Count; i++)
 					{
-						var podUid = matcher.Groups[i].Value;
+						var podUid = match.Groups[i].Value;
 						if (!string.IsNullOrWhiteSpace(podUid))
 						{
 							if (i == 2)
 								continue;
 
 							if (i == 3)
-								kubernetesPodUid = podUid.Replace('_', '-');
-							else
-								kubernetesPodUid = podUid;
+								podUid = podUid.Replace('_', '-');
 
-							_logger.Debug()?.Log("Found Kubernetes pod UID: {podUid}", kubernetesPodUid);
+							_logger.Debug()?.Log("Found Kubernetes pod UID: {podUid}", podUid);
+							system.Kubernetes = new KubernetesMetadata { Pod = new Pod { Name = reportedHostName, Uid = podUid } };
 							break;
 						}
 					}
@@ -83,26 +74,20 @@ namespace Elastic.Apm.Helpers
 
 			// If the line matched the one of the kubernetes patterns, we assume that the last part is always the container ID.
 			// Otherwise we validate that it is a 64-length hex string
-			if (!string.IsNullOrWhiteSpace(kubernetesPodUid) || _containerUidRegex.IsMatch(idPart) || _shortenedUuidRegex.IsMatch(idPart))
-				return new Container { Id = idPart };
-
-			_logger.Info()?.Log("Could not parse container ID from '/proc/self/cgroup' line: {line}", line);
-			return null;
+			if (system.Kubernetes != null || _containerUidRegex.IsMatch(idPart) || _shortenedUuidRegex.IsMatch(idPart))
+				system.Container = new Container { Id = idPart };
+			else
+				_logger.Info()?.Log("Could not parse container ID from '/proc/self/cgroup' line: {line}", line);
 		}
 
 		internal Api.System ParseSystemInfo(string hostName)
 		{
-			var containerInfo = ParseContainerInfo();
 			var detectedHostName = GetHostName();
-			var kubernetesInfo = ParseKubernetesInfo(containerInfo, detectedHostName);
+			var system = new Api.System { DetectedHostName = detectedHostName, ConfiguredHostName = hostName };
+			ParseContainerInfo(system, string.IsNullOrEmpty(hostName) ? detectedHostName : hostName);
+			ParseKubernetesInfo(system);
 
-			return new Api.System
-			{
-				Container = containerInfo,
-				DetectedHostName = detectedHostName,
-				ConfiguredHostName = hostName,
-				Kubernetes = kubernetesInfo
-			};
+			return system;
 		}
 
 		internal string GetHostName()
@@ -119,7 +104,7 @@ namespace Elastic.Apm.Helpers
 			return null;
 		}
 
-		private Container ParseContainerInfo()
+		private void ParseContainerInfo(Api.System system, string reportedHostName)
 		{
 			try
 			{
@@ -128,16 +113,16 @@ namespace Elastic.Apm.Helpers
 				{
 					//just debug log, since this is normal on non-docker environments
 					_logger.Debug()?.Log("No /proc/self/cgroup found - the agent will not report container id");
-					return null;
+					return;
 				}
 
 				var line = sr.ReadLine();
 
 				while (line != null)
 				{
-					var res = ParseContainerId(line);
-					if (res != null)
-						return res;
+					ParseContainerId(system, reportedHostName, line);
+					if (system.Container != null)
+						return;
 
 					line = sr.ReadLine();
 				}
@@ -150,7 +135,6 @@ namespace Elastic.Apm.Helpers
 			_logger.Info()
 				?.Log(
 					"Failed parsing container id - the agent will not report container id. Likely the application is not running within a container");
-			return null;
 		}
 
 		protected virtual StreamReader GetCGroupAsStream()
@@ -161,27 +145,39 @@ namespace Elastic.Apm.Helpers
 		internal const string PodUid = "KUBERNETES_POD_UID";
 		internal const string NodeName = "KUBERNETES_NODE_NAME";
 
-		internal KubernetesMetadata ParseKubernetesInfo(Container containerInfo, string hostName)
+		internal void ParseKubernetesInfo(Api.System system)
 		{
-			var @namespace = Environment.GetEnvironmentVariable(Namespace);
-			var podName = Environment.GetEnvironmentVariable(PodName);
-			var podUid = Environment.GetEnvironmentVariable(PodUid);
-			var nodeName = Environment.GetEnvironmentVariable(NodeName);
-
-			if (@namespace == null && podName == null && podUid == null && nodeName == null)
+			try
 			{
-				// By default, Kubernetes will set the hostname of the pod containers to the pod name.
-				// Users that override the name should use the Downward API to override the pod name.
-				return containerInfo != null
-					? new KubernetesMetadata { Pod = new Pod { Uid = containerInfo.Id, Name = hostName } }
-					: null;
+				var @namespace = Environment.GetEnvironmentVariable(Namespace);
+				var podName = Environment.GetEnvironmentVariable(PodName);
+				var podUid = Environment.GetEnvironmentVariable(PodUid);
+				var nodeName = Environment.GetEnvironmentVariable(NodeName);
+
+				if (@namespace != null || podName != null || podUid != null || nodeName != null)
+				{
+					system.Kubernetes ??= new KubernetesMetadata();
+					system.Kubernetes.Namespace = @namespace;
+
+					if (nodeName != null)
+						system.Kubernetes.Node = new Api.Kubernetes.Node { Name = nodeName };
+
+					if (podUid != null || podName != null)
+					{
+						// retain existing pod values when environment variables are null
+						system.Kubernetes.Pod ??= new Pod();
+						if (podUid != null)
+							system.Kubernetes.Pod.Uid = podUid;
+
+						if (podName != null)
+							system.Kubernetes.Pod.Name = podName;
+					}
+				}
 			}
-
-			var kubernetesMetadata = new KubernetesMetadata { Namespace = @namespace };
-			if (podName != null || podUid != null) kubernetesMetadata.Pod = new Pod { Name = podName, Uid = podUid };
-			if (nodeName != null) kubernetesMetadata.Node = new Api.Kubernetes.Node { Name = nodeName };
-
-			return kubernetesMetadata;
+			catch (Exception e)
+			{
+				_logger.Warning()?.LogException(e, "Failed to read environment variables for Kubernetes Downward API discovery");
+			}
 		}
 	}
 }

--- a/test/Elastic.Apm.Docker.Tests/ContainerIdCalculationTests.cs
+++ b/test/Elastic.Apm.Docker.Tests/ContainerIdCalculationTests.cs
@@ -43,7 +43,7 @@ namespace Elastic.Apm.Docker.Tests
 			var noopLogger = new NoopLogger();
 			var systemInfoHelper = new TestSystemInfoHelper(noopLogger, cGroupContent);
 
-			var systemInfo = systemInfoHelper.ParseSystemInfo(null);
+			var systemInfo = systemInfoHelper.GetSystemInfo(null);
 			systemInfo.Should().NotBeNull();
 			systemInfo.Container.Should().NotBeNull();
 			systemInfo.Container.Id.Should().Be(expectedContainerId);
@@ -57,7 +57,7 @@ namespace Elastic.Apm.Docker.Tests
 			var noopLogger = new NoopLogger();
 			var systemInfoHelper = new TestSystemInfoHelper(noopLogger, "asdf:invalid-dockerid:243543");
 
-			var systemInfo = systemInfoHelper.ParseSystemInfo(null);
+			var systemInfo = systemInfoHelper.GetSystemInfo(null);
 
 			systemInfo.Container.Should().BeNull();
 		}

--- a/test/Elastic.Apm.Tests/BackendCommTests/CentralConfig/CentralConfigFetcherTests.cs
+++ b/test/Elastic.Apm.Tests/BackendCommTests/CentralConfig/CentralConfigFetcherTests.cs
@@ -197,7 +197,7 @@ namespace Elastic.Apm.Tests.BackendCommTests.CentralConfig
 			using (var agent = new ApmAgent(new TestAgentComponents(LoggerBase,
 				centralConfigFetcher: new CentralConfigFetcher(LoggerBase, configStore, service, handler),
 				payloadSender: new PayloadSenderV2(LoggerBase, configSnapshotFromReader, service,
-					new SystemInfoHelper(LoggerBase).ParseSystemInfo(null), MockApmServerInfo.Version710))))
+					new SystemInfoHelper(LoggerBase).GetSystemInfo(null), MockApmServerInfo.Version710))))
 			{
 				lastCentralConfigFetcher = (CentralConfigFetcher)agent.CentralConfigFetcher;
 				lastCentralConfigFetcher.IsRunning.Should().BeTrue();
@@ -242,7 +242,7 @@ namespace Elastic.Apm.Tests.BackendCommTests.CentralConfig
 					LoggerBase,
 					configSnapshotFromReader,
 					service,
-					new SystemInfoHelper(LoggerBase).ParseSystemInfo(null),
+					new SystemInfoHelper(LoggerBase).GetSystemInfo(null),
 					MockApmServerInfo.Version710);
 
 				var components = new TestAgentComponents(LoggerBase, centralConfigFetcher: centralConfigFetcher, payloadSender: payloadSender);

--- a/test/Elastic.Apm.Tests/SerializationTests.cs
+++ b/test/Elastic.Apm.Tests/SerializationTests.cs
@@ -450,7 +450,7 @@ namespace Elastic.Apm.Tests
 			var systemHelper = new SystemInfoHelper(new NoopLogger());
 
 			var hostName = "this_is_my_hostname";
-			var system = systemHelper.ParseSystemInfo(hostName);
+			var system = systemHelper.GetSystemInfo(hostName);
 
 			var json = _payloadItemSerializer.Serialize(system);
 			var jObject = JObject.Parse(json);

--- a/test/Elastic.Apm.Tests/SystemInfoHelperTests.cs
+++ b/test/Elastic.Apm.Tests/SystemInfoHelperTests.cs
@@ -23,7 +23,7 @@ namespace Elastic.Apm.Tests
 		public void ParseSystemInfo_Should_Use_HostName_For_ConfiguredHostName()
 		{
 			var hostName = "This_is_my_host";
-			var system = _systemInfoHelper.ParseSystemInfo(hostName);
+			var system = _systemInfoHelper.GetSystemInfo(hostName);
 
 #pragma warning disable 618
 			system.HostName.Should().Be(hostName);
@@ -78,23 +78,24 @@ namespace Elastic.Apm.Tests
 		public void ParseKubernetesInfo_ShouldUseContainerInfoAndHostName_WhenNoEnvironmentVariablesAreSet()
 		{
 			// Arrange
-			var containerId = "e9b90526-f47d-11e8-b2a5-080027b9f4fb";
+			var podId = "e9b90526-f47d-11e8-b2a5-080027b9f4fb";
 			var hostName = "hostName";
-			var line = $"1:name=systemd:/kubepods/besteffort/pod{containerId}/15aa6e53-b09a-40c7-8558-c6c31e36c88a";
+			var containerId = "15aa6e53-b09a-40c7-8558-c6c31e36c88a";
+			var line = $"1:name=systemd:/kubepods/besteffort/pod{podId}/{containerId}";
 
 			// Act
-			_systemInfoHelper.ParseSystemInfo(hostName);
-
 			var system = new Api.System();
 			_systemInfoHelper.ParseContainerId(system, hostName, line);
 			_systemInfoHelper.ParseKubernetesInfo(system);
 
 			// Assert
+			system.Container.Should().NotBeNull();
+			system.Container.Id.Should().Be(containerId);
 			system.Kubernetes.Should().NotBeNull();
 			system.Kubernetes.Node.Should().BeNull();
 			system.Kubernetes.Namespace.Should().BeNull();
 			system.Kubernetes.Pod.Should().NotBeNull();
-			system.Kubernetes.Pod.Uid.Should().Be(containerId);
+			system.Kubernetes.Pod.Uid.Should().Be(podId);
 			system.Kubernetes.Pod.Name.Should().Be(hostName);
 		}
 


### PR DESCRIPTION
This commit updates the creation of System info reported by the agent, to bring it
more in line with the Java agent implementation.

The implementation did not use the pod id determined from parsing lines in
/proc/self/cgroup file in the resulting Kubernetes metadata, instead using the container id
when Kubernetes environment variables are not set. This is now addressed.