### PR TITLE
Capture spans for new Azure Storage SDKs

### DIFF
--- a/src/Elastic.Apm.Azure.Storage/AzureBlobStorageDiagnosticsSubscriber.cs
+++ b/src/Elastic.Apm.Azure.Storage/AzureBlobStorageDiagnosticsSubscriber.cs
@@ -20,8 +20,12 @@ namespace Elastic.Apm.Azure.Storage
 		public IDisposable Subscribe(IApmAgent agent)
 		{
 			var retVal = new CompositeDisposable();
+			var initializer = new DiagnosticInitializer(agent.Logger, new IDiagnosticListener[]
+				{
+					new AzureBlobStorageDiagnosticListener(agent),
+					new AzureCoreDiagnosticListener(agent)
+				});
 
-			var initializer = new DiagnosticInitializer(agent.Logger, new AzureBlobStorageDiagnosticListener(agent));
 			retVal.Add(initializer);
 
 			retVal.Add(DiagnosticListener
@@ -33,7 +37,7 @@ namespace Elastic.Apm.Azure.Storage
 				realAgent.HttpTraceConfiguration.AddTracer(new MicrosoftAzureBlobStorageTracer());
 
 				if (!realAgent.HttpTraceConfiguration.Subscribed)
-					realAgent.Subscribe(new HttpDiagnosticsSubscriber(false));
+					retVal.Add(realAgent.Subscribe(new HttpDiagnosticsSubscriber(false)));
 			}
 
 			return retVal;

--- a/src/Elastic.Apm.Azure.Storage/AzureCoreDiagnosticListener.cs
+++ b/src/Elastic.Apm.Azure.Storage/AzureCoreDiagnosticListener.cs
@@ -1,0 +1,94 @@
+// Licensed to Elasticsearch B.V under
+// one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using Elastic.Apm.DiagnosticSource;
+using Elastic.Apm.Model;
+
+namespace Elastic.Apm.Azure.Storage
+{
+	/// <summary>
+	/// Subscribes to Azure.Core events to set the url tag on parent activities.
+	/// </summary>
+	internal class AzureCoreDiagnosticListener : IDiagnosticListener
+	{
+		private readonly IApmAgent _agent;
+
+		public AzureCoreDiagnosticListener(IApmAgent agent) => _agent = agent;
+
+		public string Name => "Azure.Core";
+
+		public void OnCompleted() { }
+
+		public void OnError(Exception error) { }
+
+		public void OnNext(KeyValuePair<string, object> value)
+		{
+			if (value.Key == "Azure.Core.Http.Request.Start")
+			{
+				if (_agent.GetCurrentExecutionSegment() != null)
+				{
+					var currentActivity = Activity.Current;
+					if (currentActivity != null)
+					{
+						var targetActivity = FindTargetActivity(currentActivity);
+						if (targetActivity != null && string.IsNullOrEmpty(targetActivity.Tags.FirstOrDefault(t => t.Key == "url").Value))
+						{
+							var url = currentActivity.Tags.FirstOrDefault(t => t.Key == "http.url").Value;
+							if (!string.IsNullOrEmpty(url))
+								targetActivity.SetTag("url", url);
+						}
+					}
+				}
+			}
+		}
+
+		/// <summary>
+		/// Finds the target Azure activity to set the url tag on.
+		/// Some Azure SDK versions and methods fire two activities with the same operation name for the same operation e.g.
+		///
+		/// QueueClient.ReceiveMessage activity in package version 12.7.0 is started twice for QueueClient.ReceiveMessageAsync():
+		/// https://github.com/Azure/azure-sdk-for-net/blob/b0403de6fff3cfc961deba543e3c657287fc0626/sdk/storage/Azure.Storage.Queues/src/QueueClient.cs#L2343-L2347
+		/// and in the internal method call ReceiveMessagesInternal
+		/// https://github.com/Azure/azure-sdk-for-net/blob/b0403de6fff3cfc961deba543e3c657287fc0626/sdk/storage/Azure.Storage.Queues/src/QueueClient.cs#L2180-L2183
+		///
+		/// With regards to Elastic APM, we are only interested in the first QueueClient.ReceiveMessage activity, for which we will start a
+		/// transaction and start an APM transaction Activity. In this case, we end up with the following Activity chain:
+		///
+		/// QueueClient.ReceiveMessage activity (the activity we're interested in and want to set url tag on)
+		/// Apm Transaction activity
+		/// QueueClient.ReceiveMessage activity
+		/// Azure.Core.Http.Request activity (which contains the http.url tag with the url)
+		///
+		/// For other Azure SDK versions and methods, only a single activity might be started. This is the majority case and we will start a
+		/// span when this single activity is started. This ends up with the following Activity chain:
+		///
+		///
+		/// </summary>
+		/// <param name="activity"></param>
+		/// <returns></returns>
+		private static Activity FindTargetActivity(Activity activity)
+		{
+			var parentActivity = activity.Parent;
+			Activity transactionActivity = null;
+
+			while (parentActivity != null)
+			{
+				if (parentActivity.OperationName == Transaction.ApmTransactionActivityName)
+				{
+					transactionActivity = parentActivity;
+					break;
+				}
+
+				parentActivity = parentActivity.Parent;
+			}
+
+			return transactionActivity?.Parent ?? activity.Parent;
+		}
+	}
+}

--- a/src/Elastic.Apm.Azure.Storage/AzureQueueStorageDiagnosticListener.cs
+++ b/src/Elastic.Apm.Azure.Storage/AzureQueueStorageDiagnosticListener.cs
@@ -97,9 +97,8 @@ namespace Elastic.Apm.Azure.Storage
 			string destinationAddress = null;
 
 			var urlTag = activity.Tags.FirstOrDefault(t => t.Key == "url").Value;
-			if (!string.IsNullOrEmpty(urlTag) && Uri.TryCreate(urlTag, UriKind.Absolute, out var url))
+			if (QueueUrl.TryCreate(urlTag, out var queueUrl))
 			{
-				var queueUrl = new QueueUrl(url);
 				queueName = queueUrl.QueueName;
 				destinationAddress = queueUrl.FullyQualifiedNamespace;
 			}
@@ -115,16 +114,8 @@ namespace Elastic.Apm.Azure.Storage
 			if (span is Span realSpan)
 				realSpan.InstrumentationFlag = InstrumentationFlag.Azure;
 
-			span.Context.Destination = new Destination
-			{
-				Address = destinationAddress,
-				Service = new Destination.DestinationService
-				{
-					Name = AzureQueueStorage.SubType,
-					Resource = queueName is null ? AzureQueueStorage.SubType : $"{AzureQueueStorage.SubType}/{queueName}",
-					Type = ApiConstants.TypeMessaging
-				}
-			};
+			if (queueUrl != null)
+				SetDestination(span, destinationAddress, queueName);
 
 			if (!_processingSegments.TryAdd(activity.Id, span))
 			{
@@ -137,6 +128,18 @@ namespace Elastic.Apm.Azure.Storage
 			}
 		}
 
+		private static void SetDestination(ISpan span, string destinationAddress, string queueName) =>
+			span.Context.Destination = new Destination
+			{
+				Address = destinationAddress,
+				Service = new Destination.DestinationService
+				{
+					Name = AzureQueueStorage.SubType,
+					Resource = queueName is null ? AzureQueueStorage.SubType : $"{AzureQueueStorage.SubType}/{queueName}",
+					Type = ApiConstants.TypeMessaging
+				}
+			};
+
 		private void OnReceiveStart(KeyValuePair<string, object> kv)
 		{
 			if (!(kv.Value is Activity activity))
@@ -145,9 +148,28 @@ namespace Elastic.Apm.Azure.Storage
 				return;
 			}
 
+			// Newer versions of the Queue storage library fire two QueueClient.ReceiveMessage.Start events.
+			// In order to avoid creating two transactions, check if the parent activity is an APM transaction and if it is,
+			// check its parent activity to see if it is the same operation as this one. If it is, don't create a transaction
+			// for it.
+			Logger.Trace()?.Log($"current activity: {activity.Id}, parent: {activity.Parent?.Id}");
+
+			// if we're already processing this activity, ignore it.
+			if (_processingSegments.ContainsKey(activity.Id))
+				return;
+
+			var parentActivity = activity.Parent;
+			if (parentActivity != null &&
+				parentActivity.OperationName == Transaction.ApmTransactionActivityName)
+			{
+				parentActivity = parentActivity.Parent;
+				if (parentActivity != null && parentActivity.OperationName == activity.OperationName)
+					return;
+			}
+
 			var urlTag = activity.Tags.FirstOrDefault(t => t.Key == "url").Value;
-			var queueName = !string.IsNullOrEmpty(urlTag) && Uri.TryCreate(urlTag, UriKind.Absolute, out var url)
-				? new QueueUrl(url).QueueName
+			var queueName = QueueUrl.TryCreate(urlTag, out var queueUrl)
+				? queueUrl.QueueName
 				: null;
 
 			if (MatchesIgnoreMessageQueues(queueName))
@@ -211,6 +233,38 @@ namespace Elastic.Apm.Azure.Storage
 				return;
 			}
 
+			if (segment is ISpan span && span.Context.Destination is null)
+			{
+				var urlTag = activity.Tags.FirstOrDefault(t => t.Key == "url").Value;
+				if (QueueUrl.TryCreate(urlTag, out var queueUrl))
+				{
+					if (!string.IsNullOrEmpty(queueUrl.QueueName))
+					{
+						span.Name += $" to {queueUrl.QueueName}";
+
+						// if destination wasn't set in the Start, we didn't get a chance to see if this
+						// is a queue that should be ignored, so check now.
+						if (MatchesIgnoreMessageQueues(queueUrl.QueueName))
+							return;
+					}
+
+					SetDestination(span, queueUrl.FullyQualifiedNamespace, queueUrl.QueueName);
+				}
+			}
+			else if (segment is ITransaction transaction && !transaction.Name.Contains("RECEIVE from "))
+			{
+				var urlTag = activity.Parent?.Tags.FirstOrDefault(t => t.Key == "url").Value;
+				if (QueueUrl.TryCreate(urlTag, out var queueUrl) && !string.IsNullOrEmpty(queueUrl.QueueName))
+				{
+					// if destination wasn't set in the Start, we didn't get a chance to see if this
+					// is a queue that should be ignored, so check now.
+					if (MatchesIgnoreMessageQueues(queueUrl.QueueName))
+						return;
+
+					transaction.Name += $" from {queueUrl.QueueName}";
+				}
+			}
+
 			segment.Outcome = Outcome.Success;
 			segment.End();
 		}
@@ -233,6 +287,38 @@ namespace Elastic.Apm.Azure.Storage
 				return;
 			}
 
+			if (segment is ISpan span && span.Context.Destination is null)
+			{
+				var urlTag = activity.Tags.FirstOrDefault(t => t.Key == "url").Value;
+				if (QueueUrl.TryCreate(urlTag, out var queueUrl))
+				{
+					if (!string.IsNullOrEmpty(queueUrl.QueueName))
+					{
+						span.Name += $" to {queueUrl.QueueName}";
+
+						// if destination wasn't set in the Start, we didn't get a chance to see if this
+						// is a queue that should be ignored, so check now.
+						if (MatchesIgnoreMessageQueues(queueUrl.QueueName))
+							return;
+					}
+
+					SetDestination(span, queueUrl.FullyQualifiedNamespace, queueUrl.QueueName);
+				}
+			}
+			else if (segment is ITransaction transaction && !transaction.Name.Contains("RECEIVE from "))
+			{
+				var urlTag = activity.Parent?.Tags.FirstOrDefault(t => t.Key == "url").Value;
+				if (QueueUrl.TryCreate(urlTag, out var queueUrl) && !string.IsNullOrEmpty(queueUrl.QueueName))
+				{
+					// if destination wasn't set in the Start, we didn't get a chance to see if this
+					// is a queue that should be ignored, so check now.
+					if (MatchesIgnoreMessageQueues(queueUrl.QueueName))
+						return;
+
+					transaction.Name += $" from {queueUrl.QueueName}";
+				}
+			}
+
 			if (kv.Value is Exception e)
 				segment.CaptureException(e);
 
@@ -245,7 +331,19 @@ namespace Elastic.Apm.Azure.Storage
 		/// </summary>
 		private class QueueUrl : StorageUrl
 		{
-			public QueueUrl(Uri url) : base(url) =>
+			public static bool TryCreate(string url, out QueueUrl queueUrl)
+			{
+				if (Uri.TryCreate(url, UriKind.Absolute, out var uri))
+				{
+					queueUrl = new QueueUrl(uri);
+					return true;
+				}
+
+				queueUrl = null;
+				return false;
+			}
+
+			private QueueUrl(Uri url) : base(url) =>
 				QueueName = url.Segments.Length > 1
 					? url.Segments[1].TrimEnd('/')
 					: null;

--- a/src/Elastic.Apm.Azure.Storage/AzureQueueStorageDiagnosticsSubscriber.cs
+++ b/src/Elastic.Apm.Azure.Storage/AzureQueueStorageDiagnosticsSubscriber.cs
@@ -20,8 +20,12 @@ namespace Elastic.Apm.Azure.Storage
 		public IDisposable Subscribe(IApmAgent agent)
 		{
 			var retVal = new CompositeDisposable();
+			var initializer = new DiagnosticInitializer(agent.Logger, new IDiagnosticListener[]
+				{
+					new AzureQueueStorageDiagnosticListener(agent),
+					new AzureCoreDiagnosticListener(agent)
+				});
 
-			var initializer = new DiagnosticInitializer(agent.Logger, new AzureQueueStorageDiagnosticListener(agent));
 			retVal.Add(initializer);
 
 			retVal.Add(DiagnosticListener

--- a/src/Elastic.Apm.Azure.Storage/BlobUrl.cs
+++ b/src/Elastic.Apm.Azure.Storage/BlobUrl.cs
@@ -9,11 +9,19 @@ namespace Elastic.Apm.Azure.Storage
 {
 	internal class BlobUrl : StorageUrl
 	{
-		public BlobUrl(Uri url) : base(url) => ResourceName = url.AbsolutePath.TrimStart('/');
-
-		public BlobUrl(string url) : this(new Uri(url))
+		public static bool TryCreate(string url, out BlobUrl blobUrl)
 		{
+			if (Uri.TryCreate(url, UriKind.Absolute, out var uri))
+			{
+				blobUrl = new BlobUrl(uri);
+				return true;
+			}
+
+			blobUrl = null;
+			return false;
 		}
+
+		public BlobUrl(Uri url) : base(url) => ResourceName = url.AbsolutePath.TrimStart('/');
 
 		public string ResourceName { get; }
 	}

--- a/src/Elastic.Apm.Azure.Storage/FileShareStorageTracer.cs
+++ b/src/Elastic.Apm.Azure.Storage/FileShareStorageTracer.cs
@@ -1,0 +1,115 @@
+// Licensed to Elasticsearch B.V under
+// one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System;
+using Elastic.Apm.Api;
+using Elastic.Apm.DiagnosticListeners;
+using Elastic.Apm.Model;
+
+namespace Elastic.Apm.Azure.Storage
+{
+	internal class FileShareStorageTracer : IHttpSpanTracer
+	{
+		public bool IsMatch(string method, Uri requestUrl, Func<string, string> headerGetter) =>
+			requestUrl.Host.EndsWith(".file.core.windows.net", StringComparison.Ordinal) ||
+			requestUrl.Host.EndsWith(".file.core.usgovcloudapi.net", StringComparison.Ordinal) ||
+			requestUrl.Host.EndsWith(".file.core.chinacloudapi.cn", StringComparison.Ordinal) ||
+			requestUrl.Host.EndsWith(".file.core.cloudapi.de", StringComparison.Ordinal);
+
+		public ISpan StartSpan(IApmAgent agent, string method, Uri requestUrl, Func<string, string> headerGetter)
+		{
+			var fileShareUrl = new FileShareUrl(requestUrl);
+			string action = null;
+
+			switch (method)
+			{
+				case "DELETE":
+					action = "Delete";
+					break;
+				case "GET":
+					if (requestUrl.Query.Contains("comp=metadata"))
+						action = "GetMetadata";
+					else if (requestUrl.Query.Contains("comp=list"))
+						action = "List";
+					else if (requestUrl.Query.Contains("comp=properties") || requestUrl.Query.Contains("restype=share"))
+						action = "GetProperties";
+					else if (requestUrl.Query.Contains("comp=acl"))
+						action = "GetAcl";
+					else if (requestUrl.Query.Contains("comp=stats"))
+						action = "Stats";
+					else if (requestUrl.Query.Contains("comp=filepermission"))
+						action = "GetPermission";
+					else if (requestUrl.Query.Contains("comp=listhandles"))
+						action = "ListHandles";
+					else if (requestUrl.Query.Contains("comp=rangelist"))
+						action = "ListRanges";
+					else
+						action = "Download";
+					break;
+				case "HEAD":
+					if (requestUrl.Query.Contains("comp=metadata"))
+						action = "GetMetadata";
+					else if (requestUrl.Query.Contains("comp=acl"))
+						action = "GetAcl";
+					else
+						action = "GetProperties";
+					break;
+				case "PUT":
+					if (!string.IsNullOrEmpty(headerGetter("x-ms-copy-source")))
+						action = "Copy";
+					else if (!string.IsNullOrEmpty(headerGetter("x-ms-copy-action:abort")) && requestUrl.Query.Contains("comp=copy"))
+						action = "Abort";
+					else if (requestUrl.Query.Contains("comp=metadata"))
+						action = "SetMetadata";
+					else if (requestUrl.Query.Contains("comp=acl"))
+						action = "SetAcl";
+					else if (requestUrl.Query.Contains("comp=properties"))
+						action = "SetProperties";
+					else if (requestUrl.Query.Contains("comp=lease"))
+						action = "Lease";
+					else if (requestUrl.Query.Contains("comp=snapshot"))
+						action = "Snapshot";
+					else if (requestUrl.Query.Contains("comp=undelete"))
+						action = "Undelete";
+					else if (requestUrl.Query.Contains("comp=filepermission"))
+						action = "SetPermission";
+					else if (requestUrl.Query.Contains("comp=forceclosehandles"))
+						action = "CloseHandles";
+					else if (requestUrl.Query.Contains("comp=range"))
+						action = "Upload";
+					else
+						action = "Create";
+
+					break;
+				case "OPTIONS":
+					action = "Preflight";
+					break;
+			}
+
+			if (action is null)
+				return null;
+
+			var name = $"{AzureFileStorage.SpanName} {action} {fileShareUrl.ResourceName}";
+			var span = ExecutionSegmentCommon.StartSpanOnCurrentExecutionSegment(agent, name,
+				ApiConstants.TypeStorage, AzureFileStorage.SubType, InstrumentationFlag.Azure, true);
+			span.Action = action;
+			span.Context.Destination = new Destination
+			{
+				Address = fileShareUrl.FullyQualifiedNamespace,
+				Service = new Destination.DestinationService
+				{
+					Name = AzureFileStorage.SubType,
+					Resource = $"{AzureFileStorage.SubType}/{fileShareUrl.StorageAccountName}",
+					Type = ApiConstants.TypeStorage
+				}
+			};
+
+			if (span is Span realSpan)
+				realSpan.InstrumentationFlag = InstrumentationFlag.Azure;
+
+			return span;
+		}
+	}
+}

--- a/src/Elastic.Apm.Azure.Storage/FileShareUrl.cs
+++ b/src/Elastic.Apm.Azure.Storage/FileShareUrl.cs
@@ -1,0 +1,28 @@
+// Licensed to Elasticsearch B.V under
+// one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System;
+
+namespace Elastic.Apm.Azure.Storage
+{
+	internal class FileShareUrl : StorageUrl
+	{
+		public static bool TryCreate(string url, out FileShareUrl fileShareUrl)
+		{
+			if (Uri.TryCreate(url, UriKind.Absolute, out var uri))
+			{
+				fileShareUrl = new FileShareUrl(uri);
+				return true;
+			}
+
+			fileShareUrl = null;
+			return false;
+		}
+
+		public FileShareUrl(Uri url) : base(url) => ResourceName = url.AbsolutePath.TrimStart('/');
+
+		public string ResourceName { get; }
+	}
+}

--- a/src/Elastic.Apm/Agent.cs
+++ b/src/Elastic.Apm/Agent.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information
 
 using System;
+using System.Collections.Generic;
 using Elastic.Apm.Api;
 using Elastic.Apm.BackendComm.CentralConfig;
 using Elastic.Apm.Config;

--- a/src/Elastic.Apm/DiagnosticSource/DiagnosticInitializer.cs
+++ b/src/Elastic.Apm/DiagnosticSource/DiagnosticInitializer.cs
@@ -65,14 +65,12 @@ namespace Elastic.Apm.DiagnosticSource
 
 			if (!subscribedAny)
 			{
-				var listenerTypes = _listener != null
-					? _listener.GetType().FullName
-					: string.Join(", ", _listeners.Select(listener => listener.GetType().FullName));
-
 				_logger.Trace()
 					?.Log(
 						"There are no listeners in the current batch ({DiagnosticListeners}) that would like to subscribe to `{DiagnosticListenerName}' events source",
-						listenerTypes,
+						_listener != null
+							? _listener.GetType().FullName
+							: string.Join(", ", _listeners.Select(listener => listener.GetType().FullName)),
 						value.Name);
 			}
 		}

--- a/src/Elastic.Apm/Model/Transaction.cs
+++ b/src/Elastic.Apm/Model/Transaction.cs
@@ -24,7 +24,7 @@ namespace Elastic.Apm.Model
 {
 	internal class Transaction : ITransaction
 	{
-		private static readonly string ApmTransactionActivityName = "ElasticApm.Transaction";
+		internal static readonly string ApmTransactionActivityName = "ElasticApm.Transaction";
 
 		internal readonly TraceState _traceState;
 

--- a/test/Elastic.Apm.Azure.Storage.Tests/AzureFileShareStorageDiagnosticListenerTests.cs
+++ b/test/Elastic.Apm.Azure.Storage.Tests/AzureFileShareStorageDiagnosticListenerTests.cs
@@ -17,7 +17,7 @@ using Xunit.Abstractions;
 namespace Elastic.Apm.Azure.Storage.Tests
 {
 	[Collection("AzureStorage")]
-	public class AzureFileShareStorageDiagnosticListenerTests
+	public class AzureFileShareStorageDiagnosticListenerTests : IDisposable
 	{
 		private readonly AzureStorageTestEnvironment _environment;
 		private readonly MockPayloadSender _sender;
@@ -181,5 +181,7 @@ namespace Elastic.Apm.Azure.Storage.Tests
 			destination.Service.Resource.Should().Be($"{AzureFileStorage.SubType}/{_environment.StorageAccountConnectionStringProperties.AccountName}");
 			destination.Service.Type.Should().Be(ApiConstants.TypeStorage);
 		}
+
+		public void Dispose() => _agent?.Dispose();
 	}
 }

--- a/test/Elastic.Apm.Azure.Storage.Tests/AzureQueueStorageDiagnosticListenerTests.cs
+++ b/test/Elastic.Apm.Azure.Storage.Tests/AzureQueueStorageDiagnosticListenerTests.cs
@@ -1,7 +1,10 @@
 ﻿using System;
+using System.Diagnostics;
+using System.Linq;
 using System.Threading.Tasks;
 using Azure.Storage.Queues;
 using Elastic.Apm.Api;
+using Elastic.Apm.DiagnosticListeners;
 using Elastic.Apm.Logging;
 using Elastic.Apm.Tests.Utilities;
 using Elastic.Apm.Tests.Utilities.Azure;
@@ -13,20 +16,24 @@ using Xunit.Abstractions;
 namespace Elastic.Apm.Azure.Storage.Tests
 {
 	[Collection("AzureStorage")]
-	public class AzureQueueStorageDiagnosticListenerTests
+	public class AzureQueueStorageDiagnosticListenerTests : IDisposable
 	{
 		private readonly AzureStorageTestEnvironment _environment;
 		private readonly MockPayloadSender _sender;
 		private readonly ApmAgent _agent;
+		private readonly IDisposable _subscription;
+		private readonly ITestOutputHelper _output
+			;
 
 		public AzureQueueStorageDiagnosticListenerTests(AzureStorageTestEnvironment environment, ITestOutputHelper output)
 		{
 			_environment = environment;
+			_output = output;
 
 			var logger = new XUnitLogger(LogLevel.Trace, output);
 			_sender = new MockPayloadSender(logger);
 			_agent = new ApmAgent(new TestAgentComponents(logger: logger, payloadSender: _sender));
-			_agent.Subscribe(new AzureQueueStorageDiagnosticsSubscriber());
+			_subscription = _agent.Subscribe(new AzureQueueStorageDiagnosticsSubscriber());
 		}
 
 		[AzureCredentialsFact]
@@ -74,7 +81,10 @@ namespace Elastic.Apm.Azure.Storage.Tests
 		private void AssertTransaction(string action, string queueName)
 		{
 			if (!_sender.WaitForTransactions())
-				throw new Exception("No transaction received in timeout");
+			{
+				_sender.SignalEndTransactions();
+				throw new Exception($"No transaction received within timeout. (already received {_sender.Transactions.Count} transactions)");
+			}
 
 			_sender.Transactions.Should().HaveCount(1);
 			var transaction = _sender.FirstTransaction;
@@ -102,6 +112,12 @@ namespace Elastic.Apm.Azure.Storage.Tests
 			destination.Service.Name.Should().Be(AzureQueueStorage.SubType);
 			destination.Service.Resource.Should().Be($"{AzureQueueStorage.SubType}/{queueName}");
 			destination.Service.Type.Should().Be(ApiConstants.TypeMessaging);
+		}
+
+		public void Dispose()
+		{
+			_subscription.Dispose();
+			_agent.Dispose();
 		}
 	}
 }

--- a/test/Elastic.Apm.Azure.Storage.Tests/BlobStorageTestsBase.cs
+++ b/test/Elastic.Apm.Azure.Storage.Tests/BlobStorageTestsBase.cs
@@ -13,7 +13,7 @@ using Xunit.Abstractions;
 
 namespace Elastic.Apm.Azure.Storage.Tests
 {
-	public abstract class BlobStorageTestsBase
+	public abstract class BlobStorageTestsBase : IDisposable
 	{
 		private readonly MockPayloadSender _sender;
 		protected IApmAgent Agent { get; }
@@ -49,5 +49,6 @@ namespace Elastic.Apm.Azure.Storage.Tests
 			destination.Service.Type.Should().Be(ApiConstants.TypeStorage);
 		}
 
+		public void Dispose() => ((ApmAgent)Agent).Dispose();
 	}
 }

--- a/test/Elastic.Apm.Azure.Storage.Tests/Elastic.Apm.Azure.Storage.Tests.csproj
+++ b/test/Elastic.Apm.Azure.Storage.Tests/Elastic.Apm.Azure.Storage.Tests.csproj
@@ -7,10 +7,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Storage.Queues" Version="12.6.0" />
-    <PackageReference Include="Azure.Storage.Blobs" Version="12.8.0" />
+    <PackageReference Include="Azure.Storage.Queues" Version="12.7.0" />
+    <PackageReference Include="Azure.Storage.Blobs" Version="12.9.1" />
     <PackageReference Include="Microsoft.Azure.Storage.Blob" Version="11.2.2" />
-    <PackageReference Include="Azure.Storage.Files.Shares" Version="12.6.0" />
+    <PackageReference Include="Azure.Storage.Files.Shares" Version="12.7.0" />
     <PackageReference Include="Proc" Version="0.6.2" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
     <PackageReference Include="FluentAssertions" Version="5.6.0" />


### PR DESCRIPTION
Still a work in progress, but opening for early review.

I'm seeing an issue with Queue storage receive related tests.  Diagnostic listener subscriptions to `DiagnosticListener.AllListeners` seem to be polluting across tests, causing multiple transactions to be created when a message is received from queue storage. This requires further investigation.

Fixes #1352