### PR TITLE
ADO.NET instrumentation flags

### DIFF
--- a/src/Elastic.Apm/AgentComponents.cs
+++ b/src/Elastic.Apm/AgentComponents.cs
@@ -53,12 +53,16 @@ namespace Elastic.Apm
 					?? new PayloadSenderV2(Logger, ConfigStore.CurrentSnapshot, Service, system, ApmServerInfo,
 						isEnabled: ConfigurationReader.Enabled);
 
+				if (ConfigurationReader.Enabled)
+					breakdownMetricsProvider ??= new BreakdownMetricsProvider(Logger);
+
+				TracerInternal = new Tracer(Logger, Service, PayloadSender, ConfigStore,
+					currentExecutionSegmentsContainer ?? new CurrentExecutionSegmentsContainer(), ApmServerInfo, breakdownMetricsProvider);
+
 				HttpTraceConfiguration = new HttpTraceConfiguration();
 
 				if (ConfigurationReader.Enabled)
 				{
-					breakdownMetricsProvider ??= new BreakdownMetricsProvider(Logger);
-
 					CentralConfigFetcher = centralConfigFetcher ?? new CentralConfigFetcher(Logger, ConfigStore, Service);
 					MetricsCollector = metricsCollector ?? new MetricsCollector(Logger, PayloadSender, ConfigStore, breakdownMetricsProvider);
 					MetricsCollector.StartCollecting();
@@ -66,8 +70,6 @@ namespace Elastic.Apm
 				else
 					Logger.Info()?.Log("The Elastic APM .NET Agent is disabled - the agent won't capture traces and metrics.");
 
-				TracerInternal = new Tracer(Logger, Service, PayloadSender, ConfigStore,
-					currentExecutionSegmentsContainer ?? new CurrentExecutionSegmentsContainer(), ApmServerInfo, breakdownMetricsProvider);
 			}
 			catch (Exception e)
 			{

--- a/src/Elastic.Apm/Elastic.Apm.csproj
+++ b/src/Elastic.Apm/Elastic.Apm.csproj
@@ -52,6 +52,8 @@
     <InternalsVisibleTo Include="Elastic.Apm.Azure.CosmosDb.Tests" Key="$(ExposedPublicKey)" />
     <InternalsVisibleTo Include="Elastic.Apm.MongoDb" Key="$(ExposedPublicKey)" />
     <InternalsVisibleTo Include="Elastic.Apm.MongoDb.Tests" Key="$(ExposedPublicKey)" />
+    <InternalsVisibleTo Include="Elastic.Apm.Profiler.Managed" Key="$(ExposedPublicKey)" />
+    <InternalsVisibleTo Include="Elastic.Apm.Profiler.Managed.Tests" Key="$(ExposedPublicKey)" />
   </ItemGroup>
   <ItemGroup Condition="'$(DiagnosticSourceVersion)' == ''">
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="5.0.0" />

--- a/src/Elastic.Apm/Helpers/StringExtensions.cs
+++ b/src/Elastic.Apm/Helpers/StringExtensions.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information
 
 using System;
+using System.Runtime.CompilerServices;
 using System.Text;
 
 namespace Elastic.Apm.Helpers
@@ -28,8 +29,9 @@ namespace Elastic.Apm.Helpers
 		}
 
 		// Credit: https://stackoverflow.com/a/444818/973581
-		internal static bool ContainsOrdinalIgnoreCase(this string thisObj, string subStr) =>
-			thisObj.IndexOf(subStr, StringComparison.OrdinalIgnoreCase) >= 0;
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		internal static bool ContainsOrdinalIgnoreCase(this string s, string value) =>
+			s.IndexOf(value, StringComparison.OrdinalIgnoreCase) >= 0;
 
 		internal static string ToLog(this string thisObj) => "`" + thisObj + "'";
 

--- a/src/Elastic.Apm/Model/DbSpanCommon.cs
+++ b/src/Elastic.Apm/Model/DbSpanCommon.cs
@@ -28,10 +28,13 @@ namespace Elastic.Apm.Model
 			bool captureStackTraceOnStart = false
 		)
 		{
-			var spanName = dbCommand.CommandText.Replace(Environment.NewLine, " ");
+			var spanName = GetDbSpanName(dbCommand);
 			return ExecutionSegmentCommon.StartSpanOnCurrentExecutionSegment(agent, spanName, ApiConstants.TypeDb, subType, instrumentationFlag,
 				captureStackTraceOnStart);
 		}
+
+		internal static string GetDbSpanName(IDbCommand dbCommand) =>
+			dbCommand.CommandText.Replace(Environment.NewLine, " ");
 
 		internal void EndSpan(ISpan span, IDbCommand dbCommand, Outcome outcome, TimeSpan? duration = null)
 		{
@@ -47,7 +50,7 @@ namespace Elastic.Apm.Model
 				{
 					capturedSpan.Context.Db = new Database
 					{
-						Statement = dbCommand.CommandText.Replace(Environment.NewLine, " "),
+						Statement = GetDbSpanName(dbCommand),
 						Instance = dbCommand.Connection.Database,
 						Type = Database.TypeSql
 					};

--- a/src/Elastic.Apm/Model/ExecutionSegmentCommon.cs
+++ b/src/Elastic.Apm/Model/ExecutionSegmentCommon.cs
@@ -297,7 +297,7 @@ namespace Elastic.Apm.Model
 		{
 			var currentExecutionSegment = agent.GetCurrentExecutionSegment();
 
-			if (currentExecutionSegment == null)
+			if (currentExecutionSegment is null)
 				return null;
 
 			return currentExecutionSegment switch

--- a/src/Elastic.Apm/Model/InstrumentationFlag.cs
+++ b/src/Elastic.Apm/Model/InstrumentationFlag.cs
@@ -25,5 +25,10 @@ namespace Elastic.Apm.Model
 		AspNetClassic = 1 << 5,
 		Azure = 1 << 6,
 		Elasticsearch = 1 << 7,
+		Postgres = 1 << 8,
+		Oracle = 1 << 9,
+		MySql = 1 << 10,
+		Sqlite = 1 << 11,
+		AdoNet = 1 << 12,
 	}
 }


### PR DESCRIPTION
This commit

- adds instrumentation flags for ADO.NET
- creates the Tracer instance before creating and starting metrics or central configuration components.
- extracts Db span naming into an internal method to be in other assemblies