### PR TITLE
CgroupMetricsProvider: Only query on Linux, just log on other OSs

### DIFF
--- a/src/Elastic.Apm/Metrics/MetricsProvider/CgroupMetricsProvider.cs
+++ b/src/Elastic.Apm/Metrics/MetricsProvider/CgroupMetricsProvider.cs
@@ -79,6 +79,10 @@ namespace Elastic.Apm.Metrics.MetricsProvider
 			_collectStatsInactiveFileBytes = IsSystemProcessCgroupMemoryStatsInactiveFileBytesEnabled(disabledMetrics);
 			_logger = logger.Scoped(nameof(CgroupMetricsProvider));
 
+			_cGroupFiles = FindCGroupFiles(procSelfCGroup, mountInfo);
+
+			IsMetricAlreadyCaptured = true;
+
 			if (!RuntimeInformation.IsOSPlatform(OSPlatform.Linux) && !_ignoreOs)
 			{
 				_logger.Trace()
@@ -86,9 +90,6 @@ namespace Elastic.Apm.Metrics.MetricsProvider
 						+ " Cgroup metrics will not be reported", nameof(CgroupMetricsProvider));
 				return;
 			}
-			_cGroupFiles = FindCGroupFiles(procSelfCGroup, mountInfo);
-
-			IsMetricAlreadyCaptured = true;
 		}
 
 		public int ConsecutiveNumberOfFailedReads { get; set; }

--- a/src/Elastic.Apm/Metrics/MetricsProvider/CgroupMetricsProvider.cs
+++ b/src/Elastic.Apm/Metrics/MetricsProvider/CgroupMetricsProvider.cs
@@ -78,6 +78,14 @@ namespace Elastic.Apm.Metrics.MetricsProvider
 			_collectMemUsageBytes = IsSystemProcessCgroupMemoryMemUsageBytesEnabled(disabledMetrics);
 			_collectStatsInactiveFileBytes = IsSystemProcessCgroupMemoryStatsInactiveFileBytesEnabled(disabledMetrics);
 			_logger = logger.Scoped(nameof(CgroupMetricsProvider));
+
+			if (!RuntimeInformation.IsOSPlatform(OSPlatform.Linux) && !_ignoreOs)
+			{
+				_logger.Trace()
+					?.Log("{MetricsProviderName} detected a non Linux OS, therefore"
+						+ " Cgroup metrics will not be reported", nameof(CgroupMetricsProvider));
+				return;
+			}
 			_cGroupFiles = FindCGroupFiles(procSelfCGroup, mountInfo);
 
 			IsMetricAlreadyCaptured = true;
@@ -90,14 +98,6 @@ namespace Elastic.Apm.Metrics.MetricsProvider
 
 		private CgroupFiles FindCGroupFiles(string procSelfCGroup, string mountInfo)
 		{
-			if (!RuntimeInformation.IsOSPlatform(OSPlatform.Linux) && !_ignoreOs)
-			{
-				_logger.Trace()
-					?.Log("{MetricsProviderName} detected a non Linux OS, therefore"
-						+ " Cgroup metrics will not be reported", nameof(CgroupMetricsProvider));
-				return null;
-			}
-
 			if (!File.Exists(procSelfCGroup))
 			{
 				_logger.Debug()?.Log("{File} does not exist. Cgroup metrics will not be reported", procSelfCGroup);

--- a/src/Elastic.Apm/Metrics/MetricsProvider/CgroupMetricsProvider.cs
+++ b/src/Elastic.Apm/Metrics/MetricsProvider/CgroupMetricsProvider.cs
@@ -79,17 +79,17 @@ namespace Elastic.Apm.Metrics.MetricsProvider
 			_collectStatsInactiveFileBytes = IsSystemProcessCgroupMemoryStatsInactiveFileBytesEnabled(disabledMetrics);
 			_logger = logger.Scoped(nameof(CgroupMetricsProvider));
 
-			_cGroupFiles = FindCGroupFiles(procSelfCGroup, mountInfo);
-
-			IsMetricAlreadyCaptured = true;
-
 			if (!RuntimeInformation.IsOSPlatform(OSPlatform.Linux) && !_ignoreOs)
 			{
 				_logger.Trace()
 					?.Log("{MetricsProviderName} detected a non Linux OS, therefore"
 						+ " Cgroup metrics will not be reported", nameof(CgroupMetricsProvider));
+
 				return;
 			}
+
+			_cGroupFiles = FindCGroupFiles(procSelfCGroup, mountInfo);
+			IsMetricAlreadyCaptured = true;
 		}
 
 		public int ConsecutiveNumberOfFailedReads { get; set; }

--- a/test/Elastic.Apm.Tests/Metrics/CgroupMetricsProviderTests.cs
+++ b/test/Elastic.Apm.Tests/Metrics/CgroupMetricsProviderTests.cs
@@ -45,7 +45,7 @@ namespace Elastic.Apm.Tests.Metrics
 
 			using (tempFile)
 			{
-				var provider = new CgroupMetricsProvider(GetTestFilePath(selfCGroup), tempFile.Path, new NoopLogger(), new List<WildcardMatcher>());
+				var provider = new CgroupMetricsProvider(GetTestFilePath(selfCGroup), tempFile.Path, new NoopLogger(), new List<WildcardMatcher>(), ignoreOs: true);
 
 				var samples = provider.GetSamples().ToList();
 
@@ -146,7 +146,7 @@ namespace Elastic.Apm.Tests.Metrics
 			var tempFile = TempFile.CreateWithContents(
 				$"39 30 0:35 / {mountInfo} rw,nosuid,nodev,noexec,relatime shared:10 - {cgroup} rw,seclabel,memory\n");
 
-			return new CgroupMetricsProvider(GetTestFilePath(cGroupPath), tempFile.Path, new NoopLogger(), new List<WildcardMatcher>());
+			return new CgroupMetricsProvider(GetTestFilePath(cGroupPath), tempFile.Path, new NoopLogger(), new List<WildcardMatcher>(), true);
 		}
 	}
 }


### PR DESCRIPTION
Inspired by [a discuss entry](https://discuss.elastic.co/t/warning-metriccollector-net5-0-windows/).

`CgroupMetricsProvider` prior to this PR always tried to open `/proc/self/cgroup` and if it failed, it printed a warning. On non-Linux OSs, this always resulted in a warning because the file does not exist in that case. This PR adds an OS check and on non-Linux OSs it just prints a trace log and returns (so no more warning).