### PR TITLE
Remove deprecated Socket.Encrypted

### DIFF
--- a/src/Elastic.Apm.AspNetCore/WebRequestTransactionCreator.cs
+++ b/src/Elastic.Apm.AspNetCore/WebRequestTransactionCreator.cs
@@ -108,7 +108,7 @@ namespace Elastic.Apm.AspNetCore
 
 				transaction.Context.Request = new Request(context.Request.Method, url)
 				{
-					Socket = new Socket { Encrypted = context.Request.IsHttps, RemoteAddress = context.Connection?.RemoteIpAddress?.ToString() },
+					Socket = new Socket { RemoteAddress = context.Connection?.RemoteIpAddress?.ToString() },
 					HttpVersion = GetHttpVersion(context.Request.Protocol),
 					Headers = GetHeaders(context.Request.Headers, transaction.ConfigSnapshot)
 				};

--- a/src/Elastic.Apm.AspNetFullFramework/ElasticApmModule.cs
+++ b/src/Elastic.Apm.AspNetFullFramework/ElasticApmModule.cs
@@ -227,7 +227,7 @@ namespace Elastic.Apm.AspNetFullFramework
 
 			transaction.Context.Request = new Request(request.HttpMethod, url)
 			{
-				Socket = new Socket { Encrypted = request.IsSecureConnection, RemoteAddress = request.UserHostAddress },
+				Socket = new Socket { RemoteAddress = request.UserHostAddress },
 				HttpVersion = GetHttpVersion(request.ServerVariables["SERVER_PROTOCOL"]),
 				Headers = _isCaptureHeadersEnabled
 					? ConvertHeaders(request.Unvalidated.Headers, (transaction as Transaction)?.ConfigSnapshot)

--- a/src/Elastic.Apm/Api/Request.cs
+++ b/src/Elastic.Apm/Api/Request.cs
@@ -57,15 +57,13 @@ namespace Elastic.Apm.Api
 
 	public class Socket
 	{
-		public bool Encrypted { get; set; }
-
 		[JsonProperty("remote_address")]
 		public string RemoteAddress { get; set; }
 
 		internal Socket DeepCopy() => (Socket)MemberwiseClone();
 
 		public override string ToString() =>
-			new ToStringBuilder(nameof(Socket)) { { "Encrypted", Encrypted }, { "RemoteAddress", RemoteAddress } }.ToString();
+			new ToStringBuilder(nameof(Socket)) { { "RemoteAddress", RemoteAddress } }.ToString();
 	}
 
 	public class Url

--- a/test/Elastic.Apm.AspNetCore.Tests/AspNetCoreBasicTests.cs
+++ b/test/Elastic.Apm.AspNetCore.Tests/AspNetCoreBasicTests.cs
@@ -147,9 +147,6 @@ namespace Elastic.Apm.AspNetCore.Tests
 				transaction.Context.Request.Headers.Should().ContainKeys(headerKey);
 				transaction.Context.Request.Headers[headerKey].Should().Be(headerValue);
 			}
-
-			//test transaction.context.request.encrypted
-			transaction.Context.Request.Socket.Encrypted.Should().BeFalse();
 		}
 
 		/// <summary>
@@ -303,9 +300,6 @@ namespace Elastic.Apm.AspNetCore.Tests
 				transaction.Context.Request.Headers.Should().ContainKeys(headerKey);
 				transaction.Context.Request.Headers[headerKey].Should().Be(headerValue);
 			}
-
-			//test transaction.context.request.encrypted
-			transaction.Context.Request.Socket.Encrypted.Should().BeFalse();
 		}
 
 		/// <summary>

--- a/test/Elastic.Apm.AspNetFullFramework.Tests/TestsBase.cs
+++ b/test/Elastic.Apm.AspNetFullFramework.Tests/TestsBase.cs
@@ -731,8 +731,6 @@ namespace Elastic.Apm.AspNetFullFramework.Tests
 		private static void FullFwAssertValid(Socket socket)
 		{
 			socket.Should().NotBeNull();
-
-			socket.Encrypted.Should().BeFalse();
 			socket.RemoteAddress.Should().BeOneOf("::1", "127.0.0.1");
 		}
 

--- a/test/Elastic.Apm.Tests/ApiTests/ConvenientApiTransactionTests.cs
+++ b/test/Elastic.Apm.Tests/ApiTests/ConvenientApiTransactionTests.cs
@@ -526,7 +526,7 @@ namespace Elastic.Apm.Tests.ApiTests
 								new Url { Full = "https://elastic.co", Raw = "https://elastic.co", HostName = "elastic", Protocol = "HTTP" })
 							{
 								HttpVersion = "2.0",
-								Socket = new Socket { Encrypted = true, RemoteAddress = "127.0.0.1" },
+								Socket = new Socket { RemoteAddress = "127.0.0.1" },
 								Body = "123"
 							};
 					});
@@ -536,7 +536,6 @@ namespace Elastic.Apm.Tests.ApiTests
 			payloadSender.FirstTransaction.Context.Request.Url.Protocol.Should().Be("HTTP");
 
 			payloadSender.FirstTransaction.Context.Request.HttpVersion.Should().Be("2.0");
-			payloadSender.FirstTransaction.Context.Request.Socket.Encrypted.Should().BeTrue();
 			payloadSender.FirstTransaction.Context.Request.Url.Full.Should().Be("https://elastic.co");
 			payloadSender.FirstTransaction.Context.Request.Url.Raw.Should().Be("https://elastic.co");
 			payloadSender.FirstTransaction.Context.Request.Socket.RemoteAddress.Should().Be("127.0.0.1");


### PR DESCRIPTION
Follow up from https://github.com/elastic/apm-agent-dotnet/pull/1491.
APM Server will remove this field.