### PR TITLE
Change log level in CentralConfigurationFetcher.cs

### DIFF
--- a/src/Elastic.Apm/BackendComm/CentralConfig/CentralConfigurationFetcher.cs
+++ b/src/Elastic.Apm/BackendComm/CentralConfig/CentralConfigurationFetcher.cs
@@ -152,7 +152,7 @@ namespace Elastic.Apm.BackendComm.CentralConfig
 				httpResponse?.Dispose();
 			}
 
-			_logger.Info()?.Log("Waiting {WaitInterval}... {WaitReason}. dbgIterationsCount: {dbgIterationsCount}."
+			_logger.Trace()?.Log("Waiting {WaitInterval}... {WaitReason}. dbgIterationsCount: {dbgIterationsCount}."
 					, waitInfo.Interval.ToHms(), waitInfo.Reason, _dbgIterationsCount);
 			await _agentTimer.Delay(_agentTimer.Now + waitInfo.Interval, CancellationTokenSource.Token).ConfigureAwait(false);
 		}


### PR DESCRIPTION
From [discuss](https://discuss.elastic.co/t/loglevel-changed-in-centralconfigfetcher/284413). 

The log line changes here is printed in every round - prior to https://github.com/elastic/apm-agent-dotnet/pull/1471 if everything went well, we printed this log as a trace log and https://github.com/elastic/apm-agent-dotnet/pull/1471 changed it to info. Since we log this in every round I think it'd be better to keep this in trace. Regarding https://github.com/elastic/apm-agent-dotnet/pull/1471: that changes the log around the exception, even if an exception happens I'd say this log line is still fine on trace - no info related to the exception is printed in this line. 