### PR TITLE
Implement fallback to read hostname from environment variables

### DIFF
--- a/src/Elastic.Apm/Helpers/SystemInfoHelper.cs
+++ b/src/Elastic.Apm/Helpers/SystemInfoHelper.cs
@@ -98,7 +98,22 @@ namespace Elastic.Apm.Helpers
 			}
 			catch (Exception e)
 			{
-				_logger.Error()?.LogException(e, "Failed to get hostname");
+				_logger.Warning()?.LogException(e, "Failed to get hostname via Dns.GetHostName - revert to environment variables");
+
+				try
+				{
+					// try environment variables
+					var host = (Environment.GetEnvironmentVariable("COMPUTERNAME")
+						?? Environment.GetEnvironmentVariable("HOSTNAME"))
+						?? Environment.GetEnvironmentVariable("HOST");
+
+					if (host == null) _logger.Error()?.Log("Failed to get hostname via environment variables.");
+					return host;
+				}
+				catch (Exception exception)
+				{
+					_logger.Error()?.LogException(exception, "Failed to get hostname.");
+				}
 			}
 
 			return null;


### PR DESCRIPTION
Implement the [fallback logic from the Java agent](https://github.com/elastic/apm-agent-java/blob/f9267ff7fc7df619cb2272b8790fde618055c8f6/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/payload/SystemInfo.java#L228-L237)  to read hostname from environment variables. 