### PR TITLE
Deactivate Flaky tests in CentralConfigFetcherTests.cs

### DIFF
--- a/test/Elastic.Apm.Tests/BackendCommTests/CentralConfig/CentralConfigFetcherTests.cs
+++ b/test/Elastic.Apm.Tests/BackendCommTests/CentralConfig/CentralConfigFetcherTests.cs
@@ -72,51 +72,52 @@ namespace Elastic.Apm.Tests.BackendCommTests.CentralConfig
 				.And.NotContain(serverUrl);
 		}
 
-		[Fact]
-		public void Should_Update_Logger_That_Is_ILogLevelSwitchable()
-		{
-			var logLevel = LogLevel.Trace;
-			var testLogger = new ConsoleLogger(logLevel);
-
-			var configSnapshotFromReader = new MockConfiguration(testLogger, logLevel: "Trace");
-			var configStore = new ConfigurationStore(configSnapshotFromReader, testLogger);
-			var service = Service.GetDefaultService(configSnapshotFromReader, testLogger);
-
-			var waitHandle = new ManualResetEvent(false);
-			var handler = new MockHttpMessageHandler();
-			var configUrl = BackendCommUtils.ApmServerEndpoints
-				.BuildGetConfigAbsoluteUrl(configSnapshotFromReader.ServerUrl, service);
-
-			handler.When(configUrl.AbsoluteUri)
-				.Respond(_ =>
-				{
-					waitHandle.Set();
-					return new HttpResponseMessage(HttpStatusCode.OK)
-					{
-						Headers = { ETag = new EntityTagHeaderValue("\"etag\"") },
-						Content = new StringContent("{ \"log_level\": \"error\" }", Encoding.UTF8)
-					};
-				});
-
-			var centralConfigFetcher = new CentralConfigurationFetcher(testLogger, configStore, service, handler);
-
-			using var agent = new ApmAgent(new TestAgentComponents(testLogger,
-				centralConfigurationFetcher: centralConfigFetcher,
-				payloadSender: new NoopPayloadSender()));
-
-			centralConfigFetcher.IsRunning.Should().BeTrue();
-			waitHandle.WaitOne();
-
-			// wait up to 60 seconds for the log level to change. Change can often be slower in CI
-			var count = 0;
-			while (count < 60 && testLogger.LogLevelSwitch.Level == logLevel)
-			{
-				count++;
-				Thread.Sleep(TimeSpan.FromSeconds(1));
-			}
-
-			testLogger.LogLevelSwitch.Level.Should().Be(LogLevel.Error);
-		}
+		// Flaky test, issue: https://github.com/elastic/apm-agent-dotnet/issues/1360
+		// [Fact]
+		// public void Should_Update_Logger_That_Is_ILogLevelSwitchable()
+		// {
+		// 	var logLevel = LogLevel.Trace;
+		// 	var testLogger = new ConsoleLogger(logLevel);
+		//
+		// 	var configSnapshotFromReader = new MockConfiguration(testLogger, logLevel: "Trace");
+		// 	var configStore = new ConfigurationStore(configSnapshotFromReader, testLogger);
+		// 	var service = Service.GetDefaultService(configSnapshotFromReader, testLogger);
+		//
+		// 	var waitHandle = new ManualResetEvent(false);
+		// 	var handler = new MockHttpMessageHandler();
+		// 	var configUrl = BackendCommUtils.ApmServerEndpoints
+		// 		.BuildGetConfigAbsoluteUrl(configSnapshotFromReader.ServerUrl, service);
+		//
+		// 	handler.When(configUrl.AbsoluteUri)
+		// 		.Respond(_ =>
+		// 		{
+		// 			waitHandle.Set();
+		// 			return new HttpResponseMessage(HttpStatusCode.OK)
+		// 			{
+		// 				Headers = { ETag = new EntityTagHeaderValue("\"etag\"") },
+		// 				Content = new StringContent("{ \"log_level\": \"error\" }", Encoding.UTF8)
+		// 			};
+		// 		});
+		//
+		// 	var centralConfigFetcher = new CentralConfigurationFetcher(testLogger, configStore, service, handler);
+		//
+		// 	using var agent = new ApmAgent(new TestAgentComponents(testLogger,
+		// 		centralConfigurationFetcher: centralConfigFetcher,
+		// 		payloadSender: new NoopPayloadSender()));
+		//
+		// 	centralConfigFetcher.IsRunning.Should().BeTrue();
+		// 	waitHandle.WaitOne();
+		//
+		// 	// wait up to 60 seconds for the log level to change. Change can often be slower in CI
+		// 	var count = 0;
+		// 	while (count < 60 && testLogger.LogLevelSwitch.Level == logLevel)
+		// 	{
+		// 		count++;
+		// 		Thread.Sleep(TimeSpan.FromSeconds(1));
+		// 	}
+		//
+		// 	testLogger.LogLevelSwitch.Level.Should().Be(LogLevel.Error);
+		// }
 
 		/// <summary>
 		/// logger that has a log level switch but does not implement <see cref="ILogLevelSwitchable"/>


### PR DESCRIPTION
These 2 tests are flaky and often makes our CI fail:
- `Should_Update_Logger_That_Is_ILogLevelSwitchable`
- `Should_Update_IgnoreMessageQueues_Configuration`

Deactivate tests for now. Issue remains open: https://github.com/elastic/apm-agent-dotnet/issues/1360