### PR TITLE
Use Environment.MachineName to get HostName

### DIFF
--- a/src/Elastic.Apm/Helpers/SystemInfoHelper.cs
+++ b/src/Elastic.Apm/Helpers/SystemInfoHelper.cs
@@ -94,7 +94,7 @@ namespace Elastic.Apm.Helpers
 		{
 			try
 			{
-				return Dns.GetHostName();
+				return Environment.MachineName;
 			}
 			catch (Exception e)
 			{


### PR DESCRIPTION
Solves https://github.com/elastic/apm-agent-dotnet/issues/1504

Other agents seem to do similar things based on https://github.com/elastic/apm/pull/517 what `Environment.MachineName` does internally.

On [Windows `Environment.MachineName` ends up in `GetComputerNameW`](https://github.com/dotnet/corert/blob/c6af4cfc8b625851b91823d9be746c4f7abdc667/src/Common/src/Interop/Windows/Kernel32/Interop.GetComputerName.cs), on [Unix](https://github.com/dotnet/corert/blob/master/src/System.Private.CoreLib/shared/System/Environment.Unix.cs#L57) it uses [`gethostname`](https://github.com/dotnet/corert/blob/c6af4cfc8b625851b91823d9be746c4f7abdc667/src/Common/src/Interop/Unix/System.Native/Interop.GetHostName.cs#L12). 