### PR TITLE
Ignore duplicate Diagnostic listener subscriptions

### DIFF
--- a/src/Elastic.Apm.AspNetCore/DiagnosticListener/AspNetCoreDiagnosticSubscriber.cs
+++ b/src/Elastic.Apm.AspNetCore/DiagnosticListener/AspNetCoreDiagnosticSubscriber.cs
@@ -15,7 +15,7 @@ namespace Elastic.Apm.AspNetCore.DiagnosticListener
 			if (!agent.ConfigurationReader.Enabled)
 				return retVal;
 
-			var subscriber = new DiagnosticInitializer(agent.Logger, new AspNetCoreDiagnosticListener(agent as ApmAgent));
+			var subscriber = new DiagnosticInitializer(agent, new AspNetCoreDiagnosticListener(agent as ApmAgent));
 			retVal.Add(subscriber);
 
 			retVal.Add(System.Diagnostics.DiagnosticListener

--- a/src/Elastic.Apm.AspNetCore/DiagnosticListener/AspNetCoreErrorDiagnosticsSubscriber.cs
+++ b/src/Elastic.Apm.AspNetCore/DiagnosticListener/AspNetCoreErrorDiagnosticsSubscriber.cs
@@ -23,7 +23,7 @@ namespace Elastic.Apm.AspNetCore.DiagnosticListener
 			if (!agent.ConfigurationReader.Enabled)
 				return retVal;
 
-			var subscriber = new DiagnosticInitializer(agent.Logger, new AspNetCoreErrorDiagnosticListener(agent));
+			var subscriber = new DiagnosticInitializer(agent, new AspNetCoreErrorDiagnosticListener(agent));
 			retVal.Add(subscriber);
 
 			retVal.Add(System.Diagnostics.DiagnosticListener

--- a/src/Elastic.Apm.Azure.ServiceBus/AzureMessagingServiceBusDiagnosticsSubscriber.cs
+++ b/src/Elastic.Apm.Azure.ServiceBus/AzureMessagingServiceBusDiagnosticsSubscriber.cs
@@ -21,7 +21,7 @@ namespace Elastic.Apm.Azure.ServiceBus
 		{
 			var retVal = new CompositeDisposable();
 
-			var initializer = new DiagnosticInitializer(agent.Logger, new AzureMessagingServiceBusDiagnosticListener(agent));
+			var initializer = new DiagnosticInitializer(agent, new AzureMessagingServiceBusDiagnosticListener(agent));
 			retVal.Add(initializer);
 
 			retVal.Add(DiagnosticListener

--- a/src/Elastic.Apm.Azure.ServiceBus/MicrosoftAzureServiceBusDiagnosticsSubscriber.cs
+++ b/src/Elastic.Apm.Azure.ServiceBus/MicrosoftAzureServiceBusDiagnosticsSubscriber.cs
@@ -21,7 +21,7 @@ namespace Elastic.Apm.Azure.ServiceBus
 		{
 			var retVal = new CompositeDisposable();
 
-			var initializer = new DiagnosticInitializer(agent.Logger, new MicrosoftAzureServiceBusDiagnosticListener(agent));
+			var initializer = new DiagnosticInitializer(agent, new MicrosoftAzureServiceBusDiagnosticListener(agent));
 			retVal.Add(initializer);
 
 			retVal.Add(DiagnosticListener

--- a/src/Elastic.Apm.Azure.Storage/AzureBlobStorageDiagnosticsSubscriber.cs
+++ b/src/Elastic.Apm.Azure.Storage/AzureBlobStorageDiagnosticsSubscriber.cs
@@ -20,7 +20,7 @@ namespace Elastic.Apm.Azure.Storage
 		public IDisposable Subscribe(IApmAgent agent)
 		{
 			var retVal = new CompositeDisposable();
-			var initializer = new DiagnosticInitializer(agent.Logger, new IDiagnosticListener[]
+			var initializer = new DiagnosticInitializer(agent, new IDiagnosticListener[]
 				{
 					new AzureBlobStorageDiagnosticListener(agent),
 					new AzureCoreDiagnosticListener(agent)

--- a/src/Elastic.Apm.Azure.Storage/AzureCoreDiagnosticListener.cs
+++ b/src/Elastic.Apm.Azure.Storage/AzureCoreDiagnosticListener.cs
@@ -23,6 +23,8 @@ namespace Elastic.Apm.Azure.Storage
 
 		public string Name => "Azure.Core";
 
+		public bool AllowDuplicates { get; }
+
 		public void OnCompleted() { }
 
 		public void OnError(Exception error) { }

--- a/src/Elastic.Apm.Azure.Storage/AzureFileShareStorageDiagnosticsSubscriber.cs
+++ b/src/Elastic.Apm.Azure.Storage/AzureFileShareStorageDiagnosticsSubscriber.cs
@@ -20,7 +20,7 @@ namespace Elastic.Apm.Azure.Storage
 		public IDisposable Subscribe(IApmAgent agent)
 		{
 			var retVal = new CompositeDisposable();
-			var initializer = new DiagnosticInitializer(agent.Logger, new IDiagnosticListener[]
+			var initializer = new DiagnosticInitializer(agent, new IDiagnosticListener[]
 				{
 					new AzureFileShareStorageDiagnosticListener(agent),
 					new AzureCoreDiagnosticListener(agent)

--- a/src/Elastic.Apm.Azure.Storage/AzureQueueStorageDiagnosticsSubscriber.cs
+++ b/src/Elastic.Apm.Azure.Storage/AzureQueueStorageDiagnosticsSubscriber.cs
@@ -20,7 +20,7 @@ namespace Elastic.Apm.Azure.Storage
 		public IDisposable Subscribe(IApmAgent agent)
 		{
 			var retVal = new CompositeDisposable();
-			var initializer = new DiagnosticInitializer(agent.Logger, new IDiagnosticListener[]
+			var initializer = new DiagnosticInitializer(agent, new IDiagnosticListener[]
 				{
 					new AzureQueueStorageDiagnosticListener(agent),
 					new AzureCoreDiagnosticListener(agent)

--- a/src/Elastic.Apm.Elasticsearch/ElasticsearchDiagnosticsSubscriber.cs
+++ b/src/Elastic.Apm.Elasticsearch/ElasticsearchDiagnosticsSubscriber.cs
@@ -23,7 +23,7 @@ namespace Elastic.Apm.Elasticsearch
 			if (!agentComponents.ConfigurationReader.Enabled)
 				return composite;
 
-			var subscriber = new DiagnosticInitializer(agentComponents.Logger, new IDiagnosticListener[]
+			var subscriber = new DiagnosticInitializer(agentComponents, new IDiagnosticListener[]
 			{
 				new AuditDiagnosticsListener(agentComponents),
 				new RequestPipelineDiagnosticsListener(agentComponents),

--- a/src/Elastic.Apm.EntityFrameworkCore/EfCoreDiagnosticListener.cs
+++ b/src/Elastic.Apm.EntityFrameworkCore/EfCoreDiagnosticListener.cs
@@ -19,6 +19,8 @@ namespace Elastic.Apm.EntityFrameworkCore
 
 		public EfCoreDiagnosticListener(IApmAgent agent) : base(agent) => _agent = agent as ApmAgent;
 
+		public override bool AllowDuplicates => true;
+
 		public override string Name => "Microsoft.EntityFrameworkCore";
 
 		protected override void HandleOnNext(KeyValuePair<string, object> kv)

--- a/src/Elastic.Apm.EntityFrameworkCore/EfCoreDiagnosticsSubscriber.cs
+++ b/src/Elastic.Apm.EntityFrameworkCore/EfCoreDiagnosticsSubscriber.cs
@@ -22,7 +22,7 @@ namespace Elastic.Apm.EntityFrameworkCore
 			if (!agentComponents.ConfigurationReader.Enabled)
 				return retVal;
 
-			var subscriber = new DiagnosticInitializer(agentComponents.Logger, new EfCoreDiagnosticListener(agentComponents));
+			var subscriber = new DiagnosticInitializer(agentComponents, new EfCoreDiagnosticListener(agentComponents));
 			retVal.Add(subscriber);
 
 			retVal.Add(DiagnosticListener

--- a/src/Elastic.Apm.GrpcClient/GrpcClientDiagnosticSubscriber.cs
+++ b/src/Elastic.Apm.GrpcClient/GrpcClientDiagnosticSubscriber.cs
@@ -21,7 +21,7 @@ namespace Elastic.Apm.GrpcClient
 				return retVal;
 
 			Listener = new GrpcClientDiagnosticListener(agent as ApmAgent);
-			var subscriber = new DiagnosticInitializer(agent.Logger, Listener);
+			var subscriber = new DiagnosticInitializer(agent, Listener);
 			retVal.Add(subscriber);
 
 			retVal.Add(DiagnosticListener

--- a/src/Elastic.Apm.MongoDb/MongoDbDiagnosticsSubscriber.cs
+++ b/src/Elastic.Apm.MongoDb/MongoDbDiagnosticsSubscriber.cs
@@ -28,8 +28,7 @@ namespace Elastic.Apm.MongoDb
 			if (!components.ConfigurationReader.Enabled)
 				return retVal;
 
-			var initializer = new DiagnosticInitializer(components.Logger,
-				new[] { new MongoDiagnosticListener(components) });
+			var initializer = new DiagnosticInitializer(components, new MongoDiagnosticListener(components));
 
 			retVal.Add(initializer);
 

--- a/src/Elastic.Apm.SqlClient/SqlClientDiagnosticListener.cs
+++ b/src/Elastic.Apm.SqlClient/SqlClientDiagnosticListener.cs
@@ -27,6 +27,8 @@ namespace Elastic.Apm.SqlClient
 
 		public SqlClientDiagnosticListener(IApmAgent apmAgent) : base(apmAgent) => _agent = apmAgent as ApmAgent;
 
+		public override bool AllowDuplicates => true;
+
 		public override string Name => "SqlClientDiagnosticListener";
 
 		// prefix - Microsoft.Data.SqlClient. or System.Data.SqlClient.

--- a/src/Elastic.Apm.SqlClient/SqlClientDiagnosticSubscriber.cs
+++ b/src/Elastic.Apm.SqlClient/SqlClientDiagnosticSubscriber.cs
@@ -24,7 +24,7 @@ namespace Elastic.Apm.SqlClient
 
 			if (PlatformDetection.IsDotNetCore || PlatformDetection.IsDotNet5)
 			{
-				var initializer = new DiagnosticInitializer(agentComponents.Logger, new SqlClientDiagnosticListener(agentComponents));
+				var initializer = new DiagnosticInitializer(agentComponents, new SqlClientDiagnosticListener(agentComponents));
 
 				retVal.Add(initializer);
 

--- a/src/Elastic.Apm/Agent.cs
+++ b/src/Elastic.Apm/Agent.cs
@@ -44,6 +44,7 @@ namespace Elastic.Apm
 		public ITracer Tracer => Components.Tracer;
 		internal Tracer TracerInternal => Components.TracerInternal;
 		internal HttpTraceConfiguration HttpTraceConfiguration => Components.HttpTraceConfiguration;
+		internal HashSet<Type> SubscribedListeners => Components.SubscribedListeners;
 
 		public void Dispose()
 		{

--- a/src/Elastic.Apm/AgentComponents.cs
+++ b/src/Elastic.Apm/AgentComponents.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information
 
 using System;
+using System.Collections.Generic;
 using Elastic.Apm.Api;
 using Elastic.Apm.BackendComm.CentralConfig;
 using Elastic.Apm.Config;
@@ -57,6 +58,7 @@ namespace Elastic.Apm
 					breakdownMetricsProvider ??= new BreakdownMetricsProvider(Logger);
 
 				HttpTraceConfiguration = new HttpTraceConfiguration();
+				SubscribedListeners = new HashSet<Type>();
 
 				// initialize the tracer before central configuration or metric collection is started
 				TracerInternal = new Tracer(Logger, Service, PayloadSender, ConfigurationStore,
@@ -92,6 +94,8 @@ namespace Elastic.Apm
 		internal IApmServerInfo ApmServerInfo { get; }
 
 		internal HttpTraceConfiguration HttpTraceConfiguration { get; }
+
+		internal HashSet<Type> SubscribedListeners { get; }
 
 		/// <summary>
 		/// Identifies the monitored service. If this remains unset the agent

--- a/src/Elastic.Apm/DiagnosticListeners/DiagnosticListenerBase.cs
+++ b/src/Elastic.Apm/DiagnosticListeners/DiagnosticListenerBase.cs
@@ -40,6 +40,8 @@ namespace Elastic.Apm.DiagnosticListeners
 
 		public abstract string Name { get; }
 
+		public virtual bool AllowDuplicates { get; }
+
 		public virtual void OnCompleted() { }
 
 		public virtual void OnError(Exception error) { }

--- a/src/Elastic.Apm/DiagnosticSource/DiagnosticInitializer.cs
+++ b/src/Elastic.Apm/DiagnosticSource/DiagnosticInitializer.cs
@@ -46,7 +46,7 @@ namespace Elastic.Apm.DiagnosticSource
 				if (value.Name == _listener.Name)
 				{
 					var listenerType = _listener.GetType();
-					if (_agent is null || _agent.SubscribedListeners.Add(listenerType))
+					if (_agent is null || _agent.SubscribedListeners.Add(listenerType) || _listener.AllowDuplicates)
 					{
 						_sourceSubscription = new SubscribedListenerDisposable(value.Subscribe(_listener), () => _agent.SubscribedListeners.Remove(listenerType));
 						_logger.Debug()
@@ -68,7 +68,7 @@ namespace Elastic.Apm.DiagnosticSource
 					if (value.Name == listener.Name)
 					{
 						var listenerType = listener.GetType();
-						if (_agent is null || _agent.SubscribedListeners.Add(listenerType))
+						if (_agent is null || _agent.SubscribedListeners.Add(listenerType) || listener.AllowDuplicates)
 						{
 							_sourceSubscription ??= new CompositeDisposable();
 							((CompositeDisposable)_sourceSubscription).Add(

--- a/src/Elastic.Apm/DiagnosticSource/DiagnosticInitializer.cs
+++ b/src/Elastic.Apm/DiagnosticSource/DiagnosticInitializer.cs
@@ -71,7 +71,9 @@ namespace Elastic.Apm.DiagnosticSource
 						if (_agent is null || _agent.SubscribedListeners.Add(listenerType))
 						{
 							_sourceSubscription ??= new CompositeDisposable();
-							((CompositeDisposable)_sourceSubscription).Add(new SubscribedListenerDisposable(value.Subscribe(listener), () => _agent.SubscribedListeners.Remove(listenerType)));
+							((CompositeDisposable)_sourceSubscription).Add(
+								new SubscribedListenerDisposable(value.Subscribe(listener),
+								() => _agent.SubscribedListeners.Remove(listenerType)));
 							_logger.Debug()
 								?.Log("Subscribed {DiagnosticListenerType} to `{DiagnosticListenerName}' events source",
 									listenerType.FullName, value.Name);

--- a/src/Elastic.Apm/DiagnosticSource/HttpDiagnosticsSubscriber.cs
+++ b/src/Elastic.Apm/DiagnosticSource/HttpDiagnosticsSubscriber.cs
@@ -41,7 +41,7 @@ namespace Elastic.Apm.DiagnosticSource
 				configuration.Subscribed = true;
 			}
 
-			var initializer = new DiagnosticInitializer(agent.Logger, HttpDiagnosticListener.New(agent));
+			var initializer = new DiagnosticInitializer(agent, HttpDiagnosticListener.New(agent));
 
 			retVal.Add(initializer);
 

--- a/src/Elastic.Apm/DiagnosticSource/IDiagnosticListener.cs
+++ b/src/Elastic.Apm/DiagnosticSource/IDiagnosticListener.cs
@@ -18,5 +18,12 @@ namespace Elastic.Apm.DiagnosticSource
 		/// </summary>
 		/// <value>The name.</value>
 		string Name { get; }
+
+		/// <summary>
+		/// Allow duplicate diagnostic listeners of the same type to be registered. There may be
+		/// more than one diagnostic listener (source) with the same name for which events
+		/// should be listened.
+		/// </summary>
+		bool AllowDuplicates { get; }
 	}
 }

--- a/test/Elastic.Apm.Tests/DiagnosticSource/DiagnosticListenerTests.cs
+++ b/test/Elastic.Apm.Tests/DiagnosticSource/DiagnosticListenerTests.cs
@@ -1,0 +1,66 @@
+// Licensed to Elasticsearch B.V under
+// one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using Elastic.Apm.DiagnosticListeners;
+using Elastic.Apm.DiagnosticSource;
+using Elastic.Apm.Helpers;
+using Elastic.Apm.Logging;
+using Elastic.Apm.Tests.Utilities;
+using FluentAssertions;
+using Xunit;
+
+namespace Elastic.Apm.Tests.DiagnosticSource
+{
+	public class DiagnosticListenerTests
+	{
+		internal class TestSubscriber : IDiagnosticsSubscriber
+		{
+			public IDisposable Subscribe(IApmAgent agent)
+			{
+				var retVal = new CompositeDisposable();
+
+				var initializer = new DiagnosticInitializer(agent, new TestListener(agent));
+
+				retVal.Add(initializer);
+				retVal.Add(DiagnosticListener
+					.AllListeners
+					.Subscribe(initializer));
+
+				return retVal;
+			}
+		}
+
+		internal class TestListener : DiagnosticListenerBase
+		{
+			public TestListener(IApmAgent apmAgent) : base(apmAgent) { }
+
+			protected override void HandleOnNext(KeyValuePair<string, object> kv)
+			{
+			}
+
+			public override string Name { get; } = "Test";
+		}
+
+		[Fact]
+		public void SubscribeDuplicateDiagnosticListenerTypesShouldOnlySubscribeSingle()
+		{
+			using (var listener = new DiagnosticListener("Test"))
+			{
+				var logger = new InMemoryBlockingLogger(LogLevel.Debug);
+				using var agent = new ApmAgent(new TestAgentComponents(logger: logger));
+
+				agent.Subscribe(new TestSubscriber());
+				agent.Subscribe(new TestSubscriber());
+
+				logger.Lines.Should().Contain(line => line.Contains($"Subscribed {typeof(TestListener).FullName} to `Test' events source"));
+				logger.Lines.Should().Contain(line => line.Contains($"already subscribed to `Test' events source"));
+				agent.SubscribedListeners.Should().HaveCount(1).And.Contain(typeof(TestListener));
+			}
+		}
+	}
+}

--- a/test/Elastic.Apm.Tests/DiagnosticSource/DiagnosticListenerTests.cs
+++ b/test/Elastic.Apm.Tests/DiagnosticSource/DiagnosticListenerTests.cs
@@ -8,7 +8,6 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using Elastic.Apm.DiagnosticListeners;
 using Elastic.Apm.DiagnosticSource;
-using Elastic.Apm.Helpers;
 using Elastic.Apm.Logging;
 using Elastic.Apm.Tests.Utilities;
 using FluentAssertions;
@@ -60,6 +59,24 @@ namespace Elastic.Apm.Tests.DiagnosticSource
 				logger.Lines.Should().Contain(line => line.Contains($"Subscribed {typeof(TestListener).FullName} to `Test' events source"));
 				logger.Lines.Should().Contain(line => line.Contains($"already subscribed to `Test' events source"));
 				agent.SubscribedListeners.Should().HaveCount(1).And.Contain(typeof(TestListener));
+			}
+		}
+
+		[Fact]
+		public void DisposeSubscriptionShouldRemoveFromSubscribedListeners()
+		{
+			using (var listener = new DiagnosticListener("Test"))
+			{
+				var logger = new InMemoryBlockingLogger(LogLevel.Debug);
+				using var agent = new ApmAgent(new TestAgentComponents(logger: logger));
+
+				using (agent.Subscribe(new TestSubscriber()))
+				{
+					logger.Lines.Should().Contain(line => line.Contains($"Subscribed {typeof(TestListener).FullName} to `Test' events source"));
+					agent.SubscribedListeners.Should().HaveCount(1).And.Contain(typeof(TestListener));
+				}
+
+				agent.SubscribedListeners.Should().BeEmpty();
 			}
 		}
 	}


### PR DESCRIPTION
This commit ignores duplicate subscriptions of the same
diagnostic listener type.

Closes #1119