### PR TITLE
Use checked in APM specs

### DIFF
--- a/src/Elastic.Apm.Specification/Elastic.Apm.Specification.csproj
+++ b/src/Elastic.Apm.Specification/Elastic.Apm.Specification.csproj
@@ -7,7 +7,7 @@
 
     <ItemGroup>
       <PackageReference Include="NJsonSchema" Version="10.2.2" />
-      <PackageReference Include="SharpZipLib" Version="1.3.0" />
+      <PackageReference Include="SharpZipLib" Version="1.3.3" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Elastic.Apm/Api/IError.cs
+++ b/src/Elastic.Apm/Api/IError.cs
@@ -11,7 +11,7 @@ namespace Elastic.Apm.Api
 	/// <summary>
 	/// Represents an error which was captured by the agent.
 	/// </summary>
-	[Specification("docs/spec/v2/error.json")]
+	[Specification("error.json")]
 	public interface IError
 	{
 		/// <summary>

--- a/src/Elastic.Apm/Api/IMetricSet.cs
+++ b/src/Elastic.Apm/Api/IMetricSet.cs
@@ -11,7 +11,7 @@ namespace Elastic.Apm.Api
 	/// <summary>
 	/// Data captured by the agent representing a metric occurring in a monitored service
 	/// </summary>
-	[Specification("docs/spec/v2/metricset.json")]
+	[Specification("metricset.json")]
 	public interface IMetricSet
 	{
 		/// <summary>

--- a/src/Elastic.Apm/Api/ISpan.cs
+++ b/src/Elastic.Apm/Api/ISpan.cs
@@ -9,7 +9,7 @@ namespace Elastic.Apm.Api
 	/// <summary>
 	/// An event captured by an agent occurring in a monitored service
 	/// </summary>
-	[Specification("docs/spec/v2/span.json")]
+	[Specification("span.json")]
 	public interface ISpan : IExecutionSegment
 	{
 		/// <summary>

--- a/src/Elastic.Apm/Api/ITransaction.cs
+++ b/src/Elastic.Apm/Api/ITransaction.cs
@@ -17,7 +17,7 @@ namespace Elastic.Apm.Api
 	/// This interface is the public contract for a transaction. It is not intended to be used by a consumer of the agent to
 	/// provide different transaction implementations.
 	/// </remarks>
-	[Specification("docs/spec/v2/transaction.json")]
+	[Specification("transaction.json")]
 	public interface ITransaction : IExecutionSegment
 	{
 		/// <summary>

--- a/src/Elastic.Apm/Model/Metadata.cs
+++ b/src/Elastic.Apm/Model/Metadata.cs
@@ -8,7 +8,7 @@ using Elastic.Apm.Helpers;
 
 namespace Elastic.Apm.Model
 {
-	[Specification("docs/spec/v2/metadata.json")]
+	[Specification("metadata.json")]
 	internal class Metadata
 	{
 		/// <inheritdoc cref="Api.Cloud"/>

--- a/test/Elastic.Apm.Tests.MockApmServer/ErrorDto.cs
+++ b/test/Elastic.Apm.Tests.MockApmServer/ErrorDto.cs
@@ -12,7 +12,7 @@ using FluentAssertions;
 
 namespace Elastic.Apm.Tests.MockApmServer
 {
-	[Specification("docs/spec/v2/error.json")]
+	[Specification("error.json")]
 	internal class ErrorDto : ITimestampedDto
 	{
 		public ContextDto Context { get; set; }

--- a/test/Elastic.Apm.Tests.MockApmServer/MetadataDto.cs
+++ b/test/Elastic.Apm.Tests.MockApmServer/MetadataDto.cs
@@ -13,7 +13,7 @@ using Elastic.Apm.Helpers;
 
 namespace Elastic.Apm.Tests.MockApmServer
 {
-	[Specification("docs/spec/v2/metadata.json")]
+	[Specification("metadata.json")]
 	internal class MetadataDto : IDto
 	{
 		public Service Service { get; set; }

--- a/test/Elastic.Apm.Tests.MockApmServer/MetricSetDto.cs
+++ b/test/Elastic.Apm.Tests.MockApmServer/MetricSetDto.cs
@@ -14,7 +14,7 @@ using Elastic.Apm.Metrics;
 
 namespace Elastic.Apm.Tests.MockApmServer
 {
-	[Specification("docs/spec/v2/metricset.json")]
+	[Specification("metricset.json")]
 	internal class MetricSetDto : ITimestampedDto
 	{
 		public Dictionary<string, MetricSampleDto> Samples { get; set; }

--- a/test/Elastic.Apm.Tests.MockApmServer/SpanDto.cs
+++ b/test/Elastic.Apm.Tests.MockApmServer/SpanDto.cs
@@ -13,7 +13,7 @@ using Elastic.Apm.Libraries.Newtonsoft.Json;
 
 namespace Elastic.Apm.Tests.MockApmServer
 {
-	[Specification("docs/spec/v2/span.json")]
+	[Specification("span.json")]
 	internal class SpanDto : ITimedDto
 	{
 		public string Action { get; set; }

--- a/test/Elastic.Apm.Tests.MockApmServer/Startup.cs
+++ b/test/Elastic.Apm.Tests.MockApmServer/Startup.cs
@@ -23,16 +23,7 @@ namespace Elastic.Apm.Tests.MockApmServer
 		{
 			services.AddMvc().AddApplicationPart(typeof(MockApmServer).Assembly);
 			services.AddControllers();
-
-
-			var contentRootDir = _configuration.GetValue<string>(WebHostDefaults.ContentRootKey);
-			var specBranch = "7.x";
-			var validator = new Validator(specBranch, Path.Combine(contentRootDir, "specs"));
-			// not ideal to wait on async inside sync startup configuration, but do for now.
-			// Force the specs to work with to be downloaded now, to avoid race conditions with
-			// downloading for the first time.
-			validator.DownloadAsync(specBranch, true).Wait();
-			services.AddSingleton(validator);
+			services.AddSingleton(new Validator());
 		}
 
 		// This method gets called by the runtime. Use this method to configure the HTTP request pipeline.

--- a/test/Elastic.Apm.Tests.MockApmServer/TransactionDto.cs
+++ b/test/Elastic.Apm.Tests.MockApmServer/TransactionDto.cs
@@ -12,7 +12,7 @@ using FluentAssertions;
 
 namespace Elastic.Apm.Tests.MockApmServer
 {
-	[Specification("docs/spec/v2/transaction.json")]
+	[Specification("transaction.json")]
 	internal class TransactionDto : ITimedDto
 	{
 		public ContextDto Context { get; set; }

--- a/test/Elastic.Apm.Tests/SpecTests.cs
+++ b/test/Elastic.Apm.Tests/SpecTests.cs
@@ -41,13 +41,7 @@ namespace Elastic.Apm.Tests
 					where type.IsClass && specInterfaces.Any(i => i.IsAssignableFrom(type))
 					select type).ToList();
 
-			var specBranch = "master";
-
-			_validator = new Validator(specBranch, downloadDir);
-
-			// force tests to always get the latest spec on the branch
-			_validator.DownloadAsync(specBranch, true).Wait();
-
+			_validator = new Validator();
 			_output = output;
 		}
 


### PR DESCRIPTION
This commit updates the validator to use the checked in
APM specs. The download method is now exposed as a static
method, to allow testing other branches in future.

Closes elastic/apm-agent-dotnet#1214