### PR TITLE
Improve Performance counter handling

### DIFF
--- a/docs/metrics.asciidoc
+++ b/docs/metrics.asciidoc
@@ -22,6 +22,26 @@ The metrics will be stored in the `apm-*` index and have the `processor.event` p
 
 As of APM version 6.6, these metrics will be visualized in the APM app.
 
+[IMPORTANT]
+--
+System metrics are collected using Performance Counters on Windows. The account under which a traced
+application runs must be part of the **Performance Monitor Users** group to be able to access
+performance counter values.
+
+An account can be added to the **Performance Monitor Users** group from the command line
+
+[source,sh]
+----
+net localgroup "Performance Monitor Users" "<Account Name>" /add <1>
+----
+<1> `<Account Name>` is the account under which the traced application runs
+
+For applications running in IIS, 
+https://docs.microsoft.com/en-us/iis/manage/configuring-security/application-pool-identities[IIS application pool identities use _virtual_ accounts]
+with a name following the convention `IIS APPPOOL\<Application pool name>`. An individual application pool identity
+can be added to the **Performance Monitor Users** group.
+--
+
 For more system metrics, consider installing {metricbeat-ref}/index.html[metricbeat] on your hosts.
 
 *`system.cpu.total.norm.pct`*::

--- a/docs/metrics.asciidoc
+++ b/docs/metrics.asciidoc
@@ -24,7 +24,7 @@ As of APM version 6.6, these metrics will be visualized in the APM app.
 
 [IMPORTANT]
 --
-System metrics are collected using Performance Counters on Windows. The account under which a traced
+System CPU usage metric is collected using Performance Counters on Windows. The account under which a traced
 application runs must be part of the **Performance Monitor Users** group to be able to access
 performance counter values.
 
@@ -39,7 +39,7 @@ net localgroup "Performance Monitor Users" "<Account Name>" /add <1>
 For applications running in IIS, 
 https://docs.microsoft.com/en-us/iis/manage/configuring-security/application-pool-identities[IIS application pool identities use _virtual_ accounts]
 with a name following the convention `IIS APPPOOL\<Application pool name>`. An individual application pool identity
-can be added to the **Performance Monitor Users** group.
+can be added to the **Performance Monitor Users** group using the `net localgroup` command above.
 --
 
 For more system metrics, consider installing {metricbeat-ref}/index.html[metricbeat] on your hosts.

--- a/src/Elastic.Apm/Metrics/MetricsProvider/SystemTotalCpuProvider.cs
+++ b/src/Elastic.Apm/Metrics/MetricsProvider/SystemTotalCpuProvider.cs
@@ -10,7 +10,6 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
-using System.Security;
 using Elastic.Apm.Api;
 using Elastic.Apm.Helpers;
 using Elastic.Apm.Logging;
@@ -52,12 +51,12 @@ namespace Elastic.Apm.Metrics.MetricsProvider
 				}
 				catch (Exception e)
 				{
-					if (e is SecurityException)
+					if (e is UnauthorizedAccessException)
 					{
 						_logger.Error()
 							?.LogException(e, "Error instantiating '{CategoryName}' performance counter."
-								+ "- please make sure the current user has permissions to read performance counters. E.g. make sure the current user is member of "
-								+ "the 'Performance Monitor Users' group", categoryName);
+								+ " Process does not have permissions to read performance counters."
+								+ " See https://www.elastic.co/guide/en/apm/agent/dotnet/current/metrics.html#metrics-system to see how to configure.", categoryName);
 					}
 					else
 					{
@@ -65,6 +64,7 @@ namespace Elastic.Apm.Metrics.MetricsProvider
 							?.LogException(e, "Error instantiating '{CategoryName}' performance counter", categoryName);
 					}
 
+					_logger.Warning()?.Log("System metrics won't be collected");
 					_processorTimePerfCounter?.Dispose();
 					_processorTimePerfCounter = null;
 				}


### PR DESCRIPTION
This commit improves the handling of performance counters
used to get the total CPU % time on Windows. When
the "Processor" performance counter category does not exist,
try using the "Processor Information" category name.

Include information in the log message about checking permissions
only when a SecurityException is thrown.

Closes #1505