### PR TITLE
synchronize schema spec

### DIFF
--- a/src/Elastic.Apm.Specification/specs/error.json
+++ b/src/Elastic.Apm.Specification/specs/error.json
@@ -1096,6 +1096,14 @@
         "object"
       ],
       "properties": {
+        "name": {
+          "description": "Name is the generic designation of a transaction in the scope of a single service, eg: 'GET /users/:id'.",
+          "type": [
+            "null",
+            "string"
+          ],
+          "maxLength": 1024
+        },
         "sampled": {
           "description": "Sampled indicates whether or not the full information for a transaction is captured. If a transaction is unsampled no spans and less context information will be reported.",
           "type": [


### PR DESCRIPTION
### What
  APM agent json schema automatic sync

  ### Why
  *Changeset*
* https://github.com/elastic/apm-server/commit/fe1db82a1 Added support for transaction.name in an error object to the intake API (https://github.com/elastic/apm-server/pull/6539)