### PR TITLE
Add auto instrumentation for RabbitMQ

### DIFF
--- a/ElasticApmAgent.sln
+++ b/ElasticApmAgent.sln
@@ -177,6 +177,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SqlClientSample", "sample\S
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "KafkaSample", "sample\KafkaSample\KafkaSample.csproj", "{2B23487A-B340-4F5C-A49B-9B829F437A5A}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RabbitMqSample", "sample\RabbitMqSample\RabbitMqSample.csproj", "{1D6B0C67-42C8-4AB4-A795-B6FF8EF7196E}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -459,6 +461,10 @@ Global
 		{2B23487A-B340-4F5C-A49B-9B829F437A5A}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{2B23487A-B340-4F5C-A49B-9B829F437A5A}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{2B23487A-B340-4F5C-A49B-9B829F437A5A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1D6B0C67-42C8-4AB4-A795-B6FF8EF7196E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1D6B0C67-42C8-4AB4-A795-B6FF8EF7196E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1D6B0C67-42C8-4AB4-A795-B6FF8EF7196E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1D6B0C67-42C8-4AB4-A795-B6FF8EF7196E}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -533,6 +539,7 @@ Global
 		{4E235C21-5637-4498-8335-134ACAA4884E} = {3734A52F-2222-454B-BF58-1BA5C1F29D77}
 		{456A8639-FE1B-426A-9C72-5252AB4D3AD5} = {3C791D9C-6F19-4F46-B367-2EC0F818762D}
 		{2B23487A-B340-4F5C-A49B-9B829F437A5A} = {3C791D9C-6F19-4F46-B367-2EC0F818762D}
+		{1D6B0C67-42C8-4AB4-A795-B6FF8EF7196E} = {3C791D9C-6F19-4F46-B367-2EC0F818762D}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {69E02FD9-C9DE-412C-AB6B-5B8BECC6BFA5}

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -47,6 +47,11 @@ args = ["build", "-c", "${DOTNET_CONFIG}", "./sample/${SAMPLE_APP}/${SAMPLE_APP}
 
 [tasks.generate-integrations]
 description = "Generates integrations.yml file"
+dependencies = ["build-integrations", "generate-integrations-yml", "generate-integrations-asciidoc"]
+
+[tasks.generate-integrations-yml]
+description = "Generates integrations.yml file"
+private = true
 command = "dotnet"
 args = [
     "run",
@@ -55,6 +60,19 @@ args = [
     "-i", "./src/Elastic.Apm.Profiler.Managed/bin/Release/netstandard2.0/Elastic.Apm.Profiler.Managed.dll",
     "-o", "./src/Elastic.Apm.Profiler.Managed",
     "-f", "yml"]
+dependencies = ["build-integrations"]
+
+[tasks.generate-integrations-asciidoc]
+description = "Generates integrations documentation"
+private = true
+command = "dotnet"
+args = [
+    "run",
+    "--project", "./src/Elastic.Apm.Profiler.IntegrationsGenerator/Elastic.Apm.Profiler.IntegrationsGenerator.csproj",
+    "--",
+    "-i", "./src/Elastic.Apm.Profiler.Managed/bin/Release/netstandard2.0/Elastic.Apm.Profiler.Managed.dll",
+    "-o", "./docs",
+    "-f", "asciidoc"]
 dependencies = ["build-integrations"]
 
 [tasks.expand]

--- a/docs/integrations.asciidoc
+++ b/docs/integrations.asciidoc
@@ -34,6 +34,10 @@
 | Oracle.ManagedDataAccess
 | 2.0.0 - 2.{star}.{star}
 
+| RabbitMQ
+| RabbitMQ.Client
+| 3.6.9 - 6.{star}.{star}
+
 | SqlCommand
 | System.Data
 | 4.0.0 - 4.{star}.{star}

--- a/sample/RabbitMqSample/Program.cs
+++ b/sample/RabbitMqSample/Program.cs
@@ -1,0 +1,226 @@
+﻿// Licensed to Elasticsearch B.V under
+// one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+//
+// Based on https://github.com/DataDog/dd-trace-dotnet/blob/a72b74fc8e67d8d8a6430628fe8643b3a693d2bc/tracer/test/test-applications/integrations/Samples.RabbitMQ/Program.cs
+// Licensed under Apache 2.0
+
+using System;
+using System.Text;
+using System.Threading;
+using Elastic.Apm;
+using Elastic.Apm.Api;
+using RabbitMQ.Client;
+using RabbitMQ.Client.Events;
+
+namespace RabbitMqSample
+{
+	internal class Program
+    {
+		private static volatile int MessageCount = 0;
+		private static readonly AutoResetEvent SendFinished = new(false);
+
+		private const string IgnoreExchangeName = "test-ignore-exchange-name";
+		private const string IgnoreQueueName = "test-ignore-queue-name";
+		private const string IgnoreRoutingKey = "test-ignore-routing-key";
+
+		private const string ExchangeName = "test-exchange-name";
+		private const string RoutingKey = "test-routing-key";
+		private const string QueueName = "test-queue-name";
+
+		private static string Host() =>
+			Environment.GetEnvironmentVariable("RABBITMQ_HOST") ??
+			throw new ArgumentException("RABBITMQ_HOST environment variable must be specified");
+
+		public static void Main(string[] args)
+		{
+			var ignoreMessageQueues = Environment.GetEnvironmentVariable("ELASTIC_APM_IGNORE_MESSAGE_QUEUES");
+
+			// only run the ignore publish and get if the agent has been configured with the ignore exchange and queue.
+			if (!string.IsNullOrEmpty(ignoreMessageQueues) &&
+				ignoreMessageQueues.Contains(IgnoreExchangeName) &&
+				ignoreMessageQueues.Contains(IgnoreQueueName))
+				PublishAndGet("PublishAndGetIgnore", IgnoreExchangeName, IgnoreQueueName, IgnoreRoutingKey);
+
+			PublishAndGet("PublishAndGet", ExchangeName, QueueName, RoutingKey);
+			PublishAndGetDefault();
+
+			var sendThread = new Thread(Send);
+			sendThread.Start();
+
+			var receiveThread = new Thread(Receive);
+			receiveThread.Start();
+
+			sendThread.Join();
+			receiveThread.Join();
+
+			// Allow time for the agent to send data
+			Thread.Sleep(TimeSpan.FromSeconds(30));
+			Console.WriteLine("finished");
+        }
+
+        private static void PublishAndGet(string name, string exchange, string queue, string routingKey)
+        {
+            // Configure and send to RabbitMQ queue
+            var factory = new ConnectionFactory { Uri = new Uri(Host()) };
+
+            using (var connection = factory.CreateConnection())
+            using (var channel = connection.CreateModel())
+			{
+				Agent.Tracer.CaptureTransaction(name, "messaging", () =>
+				{
+					channel.ExchangeDeclare(exchange, "direct");
+					channel.QueueDeclare(queue: queue,
+						durable: false,
+						exclusive: false,
+						autoDelete: false,
+						arguments: null);
+					channel.QueueBind(queue, exchange, routingKey);
+					channel.QueuePurge(queue); // Ensure there are no more messages in this queue
+
+					// Test an empty BasicGetResult
+					channel.BasicGet(queue, true);
+
+					// Send message to the exchange
+					var message = $"{name} - Message";
+					var body = Encoding.UTF8.GetBytes(message);
+
+					channel.BasicPublish(exchange: exchange,
+						routingKey: routingKey,
+						basicProperties: null,
+						body: body);
+					Console.WriteLine($"[{name}] BasicPublish - Sent message: {message}");
+
+					var result = channel.BasicGet(queue, true);
+#if RABBITMQ_6_0
+					var resultMessage = Encoding.UTF8.GetString(result.Body.ToArray());
+#else
+					var resultMessage = Encoding.UTF8.GetString(result.Body);
+#endif
+					Console.WriteLine($"[{name}] BasicGet - Received message: {resultMessage}");
+				});
+			}
+        }
+
+        private static void PublishAndGetDefault()
+        {
+            // Configure and send to RabbitMQ queue
+            var factory = new ConnectionFactory() { Uri = new Uri(Host()) };
+
+            using (var connection = factory.CreateConnection())
+            using (var channel = connection.CreateModel())
+            {
+                string defaultQueueName;
+
+				Agent.Tracer.CaptureTransaction("PublishAndGetDefault", "messaging", () =>
+				{
+					defaultQueueName = channel.QueueDeclare().QueueName;
+					channel.QueuePurge(QueueName); // Ensure there are no more messages in this queue
+
+					// Test an empty BasicGetResult
+					channel.BasicGet(defaultQueueName, true);
+
+					// Send message to the default exchange and use new queue as the routingKey
+					var message = "PublishAndGetDefault - Message";
+					var body = Encoding.UTF8.GetBytes(message);
+					channel.BasicPublish(exchange: "",
+						routingKey: defaultQueueName,
+						basicProperties: null,
+						body: body);
+					Console.WriteLine($"[PublishAndGetDefault] BasicPublish - Sent message: {message}");
+
+					var result = channel.BasicGet(defaultQueueName, true);
+#if RABBITMQ_6_0
+					var resultMessage = Encoding.UTF8.GetString(result.Body.ToArray());
+#else
+					var resultMessage = Encoding.UTF8.GetString(result.Body);
+#endif
+
+					Console.WriteLine($"[PublishAndGetDefault] BasicGet - Received message: {resultMessage}");
+				});
+			}
+        }
+
+        private static void Send()
+        {
+            // Configure and send to RabbitMQ queue
+            var factory = new ConnectionFactory() { Uri = new Uri(Host()) };
+            using(var connection = factory.CreateConnection())
+            using(var channel = connection.CreateModel())
+            {
+                channel.QueueDeclare(queue: "hello",
+                                        durable: false,
+                                        exclusive: false,
+                                        autoDelete: false,
+                                        arguments: null);
+                channel.QueuePurge("hello"); // Ensure there are no more messages in this queue
+
+                for (var i = 0; i < 3; i++)
+				{
+					Agent.Tracer.CaptureTransaction("PublishToConsumer", "messaging", () =>
+					{
+						var message = $"Send - Message #{i}";
+						var body = Encoding.UTF8.GetBytes(message);
+
+						channel.BasicPublish(exchange: "",
+							routingKey: "hello",
+							basicProperties: null,
+							body: body);
+						Console.WriteLine("[Send] - [x] Sent \"{0}\"", message);
+						Interlocked.Increment(ref MessageCount);
+					});
+				}
+            }
+
+            SendFinished.Set();
+            Console.WriteLine("[Send] Exiting Thread.");
+        }
+
+        private static void Receive()
+        {
+            // Let's just wait for all sending activity to finish before doing any work
+            SendFinished.WaitOne();
+
+            // Configure and listen to RabbitMQ queue
+            var factory = new ConnectionFactory { Uri = new Uri(Host()) };
+            using(var connection = factory.CreateConnection())
+            using(var channel = connection.CreateModel())
+            {
+                channel.QueueDeclare(queue: "hello",
+                                    durable: false,
+                                    exclusive: false,
+                                    autoDelete: false,
+                                    arguments: null);
+
+                var consumer = new EventingBasicConsumer(channel);
+                consumer.Received += (model, ea) =>
+                {
+					var transaction = Agent.Tracer.CurrentTransaction;
+					var span = transaction?.StartSpan("Consume message", ApiConstants.TypeMessaging);
+
+#if RABBITMQ_6_0
+                    var body = ea.Body.ToArray();
+#else
+                    var body = ea.Body;
+#endif
+
+                    var message = Encoding.UTF8.GetString(body);
+                    Console.WriteLine("[Receive] - [x] Received {0}", message);
+
+					Interlocked.Decrement(ref MessageCount);
+					span?.End();
+                };
+
+                channel.BasicConsume("hello",
+                                    true,
+                                    consumer);
+
+                while (MessageCount != 0)
+					Thread.Sleep(1000);
+
+				Console.WriteLine("[Receive] Exiting Thread.");
+            }
+        }
+    }
+}

--- a/sample/RabbitMqSample/RabbitMqSample.csproj
+++ b/sample/RabbitMqSample/RabbitMqSample.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <RabbitMqVersion Condition="'$(RabbitMqVersion)' == ''">6.2.2</RabbitMqVersion>
+    <DefineConstants Condition="$(RabbitMqVersion) &gt;= 6.0.0">$(DefineConstants);RABBITMQ_6_0</DefineConstants>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net5.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="RabbitMQ.Client" Version="$(RabbitMqVersion)" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Elastic.Apm\Elastic.Apm.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Elastic.Apm.Profiler.Managed/ExecutionSegmentExtensions.cs
+++ b/src/Elastic.Apm.Profiler.Managed/ExecutionSegmentExtensions.cs
@@ -1,0 +1,26 @@
+// Licensed to Elasticsearch B.V under
+// one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System;
+using System.Runtime.CompilerServices;
+using Elastic.Apm.Api;
+
+namespace Elastic.Apm.Profiler.Managed
+{
+	internal static class ExecutionSegmentExtensions
+	{
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		public static void EndCapturingException(this IExecutionSegment segment, Exception exception)
+		{
+			if (segment is not null)
+			{
+				if (exception is not null)
+					segment.CaptureException(exception);
+
+				segment.End();
+			}
+		}
+	}
+}

--- a/src/Elastic.Apm.Profiler.Managed/Integrations/RabbitMq/BasicDeliverIntegration.cs
+++ b/src/Elastic.Apm.Profiler.Managed/Integrations/RabbitMq/BasicDeliverIntegration.cs
@@ -1,0 +1,120 @@
+// Licensed to Elasticsearch B.V under
+// one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+//
+// <copyright file="BasicDeliverIntegration.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System;
+using System.ComponentModel;
+using System.Linq;
+using Elastic.Apm.Api;
+using Elastic.Apm.DistributedTracing;
+using Elastic.Apm.Helpers;
+using Elastic.Apm.Logging;
+using Elastic.Apm.Profiler.Managed.CallTarget;
+using Elastic.Apm.Profiler.Managed.Core;
+
+namespace Elastic.Apm.Profiler.Managed.Integrations.RabbitMq
+{
+    /// <summary>
+    /// RabbitMQ.Client BasicDeliver calltarget instrumentation
+    /// </summary>
+    [Instrument(
+        Assembly = "RabbitMQ.Client",
+        Type = "RabbitMQ.Client.Events.EventingBasicConsumer",
+        Method = "HandleBasicDeliver",
+        ReturnType = ClrTypeNames.Void,
+        ParameterTypes = new[] { ClrTypeNames.String, ClrTypeNames.UInt64, ClrTypeNames.Bool, ClrTypeNames.String, ClrTypeNames.String, RabbitMqIntegration.IBasicPropertiesTypeName, ClrTypeNames.Ignore },
+        MinimumVersion = "3.6.9",
+        MaximumVersion = "6.*.*",
+        Group = RabbitMqIntegration.Name)]
+    [Browsable(false)]
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public class BasicDeliverIntegration
+    {
+		/// <summary>
+        /// OnMethodBegin callback
+        /// </summary>
+        /// <typeparam name="TTarget">Type of the target</typeparam>
+        /// <typeparam name="TBasicProperties">Type of the message properties</typeparam>
+        /// <typeparam name="TBody">Type of the message body</typeparam>
+        /// <param name="instance">Instance value, aka `this` of the instrumented method.</param>
+        /// <param name="consumerTag">The original consumerTag argument</param>
+        /// <param name="deliveryTag">The original deliveryTag argument</param>
+        /// <param name="redelivered">The original redelivered argument</param>
+        /// <param name="exchange">Name of the exchange.</param>
+        /// <param name="routingKey">The routing key.</param>
+        /// <param name="basicProperties">The message properties.</param>
+        /// <param name="body">The message body.</param>
+        /// <returns>Calltarget state value</returns>
+        public static CallTargetState OnMethodBegin<TTarget, TBasicProperties, TBody>(TTarget instance, string consumerTag, ulong deliveryTag, bool redelivered, string exchange, string routingKey, TBasicProperties basicProperties, TBody body)
+            where TBasicProperties : IBasicProperties
+            where TBody : IBody // ReadOnlyMemory<byte> body in 6.0.0
+		{
+			var agent = Agent.Instance;
+			if (agent.Tracer.CurrentTransaction is not null)
+				return default;
+
+			var matcher = WildcardMatcher.AnyMatch(agent.ConfigurationStore.CurrentSnapshot.IgnoreMessageQueues, exchange);
+			if (matcher != null)
+			{
+				agent.Logger.Trace()
+					?.Log(
+						"Not tracing message from {Queue} because it matched IgnoreMessageQueues pattern {Matcher}",
+						exchange,
+						matcher.GetMatcher());
+
+				return default;
+			}
+
+            // try to extract propagated context values from headers
+			DistributedTracingData distributedTracingData = null;
+            if (basicProperties?.Headers != null)
+            {
+                try
+                {
+					var traceParent = string.Join(",", ContextPropagation.HeadersGetter(basicProperties.Headers, TraceContext.TraceParentHeaderName));
+					var traceState = ContextPropagation.HeadersGetter(basicProperties.Headers, TraceContext.TraceStateHeaderName).FirstOrDefault();
+					distributedTracingData = TraceContext.TryExtractTracingData(traceParent, traceState);
+				}
+                catch (Exception ex)
+                {
+                    Logger.Error(ex, "Error extracting propagated RabbitMQ headers.");
+                }
+            }
+
+			var normalizedExchange = RabbitMqIntegration.NormalizeExchangeName(exchange);
+
+			var transaction = agent.Tracer.StartTransaction(
+				$"{RabbitMqIntegration.Name} RECEIVE from {normalizedExchange}",
+				ApiConstants.TypeMessaging,
+				distributedTracingData);
+
+			transaction.Context.Message = new Message { Queue = new Queue { Name = exchange } };
+
+			if (!string.IsNullOrEmpty(routingKey))
+				transaction.Context.Message.RoutingKey = routingKey;
+
+			transaction.SetLabel("message_size", body?.Length ?? 0);
+			return new CallTargetState(transaction);
+        }
+
+        /// <summary>
+        /// OnMethodEnd callback
+        /// </summary>
+        /// <typeparam name="TTarget">Type of the target</typeparam>
+        /// <param name="instance">Instance value, aka `this` of the instrumented method.</param>
+        /// <param name="exception">Exception instance in case the original code threw an exception.</param>
+        /// <param name="state">Calltarget state value</param>
+        /// <returns>A default CallTargetReturn to satisfy the CallTarget contract</returns>
+        public static CallTargetReturn OnMethodEnd<TTarget>(TTarget instance, Exception exception, CallTargetState state)
+        {
+            state.Segment.EndCapturingException(exception);
+            return CallTargetReturn.GetDefault();
+        }
+    }
+}

--- a/src/Elastic.Apm.Profiler.Managed/Integrations/RabbitMq/BasicGetIntegration.cs
+++ b/src/Elastic.Apm.Profiler.Managed/Integrations/RabbitMq/BasicGetIntegration.cs
@@ -1,0 +1,124 @@
+// Licensed to Elasticsearch B.V under
+// one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+//
+// <copyright file="BasicGetIntegration.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System;
+using System.ComponentModel;
+using Elastic.Apm.Api;
+using Elastic.Apm.Helpers;
+using Elastic.Apm.Logging;
+using Elastic.Apm.Model;
+using Elastic.Apm.Profiler.Managed.CallTarget;
+using Elastic.Apm.Profiler.Managed.Core;
+using Elastic.Apm.Profiler.Managed.DuckTyping;
+
+namespace Elastic.Apm.Profiler.Managed.Integrations.RabbitMq
+{
+    /// <summary>
+    /// RabbitMQ.Client BasicGet calltarget instrumentation
+    /// </summary>
+    [Instrument(
+        Assembly = "RabbitMQ.Client",
+        Type = "RabbitMQ.Client.Impl.ModelBase",
+        Method = "BasicGet",
+        ReturnType = "RabbitMQ.Client.BasicGetResult",
+        ParameterTypes = new[] { ClrTypeNames.String, ClrTypeNames.Bool },
+        MinimumVersion = "3.6.9",
+        MaximumVersion = "6.*.*",
+        Group = RabbitMqIntegration.Name)]
+    [Browsable(false)]
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public class BasicGetIntegration
+    {
+		/// <summary>
+        /// OnMethodBegin callback
+        /// </summary>
+        /// <typeparam name="TTarget">Type of the target</typeparam>
+        /// <param name="instance">Instance value, aka `this` of the instrumented method.</param>
+        /// <param name="queue">The queue name of the message</param>
+        /// <param name="autoAck">The original autoAck argument</param>
+        /// <returns>Calltarget state value</returns>
+        public static CallTargetState OnMethodBegin<TTarget>(TTarget instance, string queue, bool autoAck) =>
+			new CallTargetState(segment: null, state: queue, startTime: DateTimeOffset.UtcNow);
+
+		/// <summary>
+        /// OnMethodEnd callback
+        /// </summary>
+        /// <typeparam name="TTarget">Type of the target</typeparam>
+        /// <typeparam name="TResult">Type of the BasicGetResult</typeparam>
+        /// <param name="instance">Instance value, aka `this` of the instrumented method.</param>
+        /// <param name="basicGetResult">BasicGetResult instance</param>
+        /// <param name="exception">Exception instance in case the original code threw an exception.</param>
+        /// <param name="state">Calltarget state value</param>
+        /// <returns>A default CallTargetReturn to satisfy the CallTarget contract</returns>
+        public static CallTargetReturn<TResult> OnMethodEnd<TTarget, TResult>(TTarget instance, TResult basicGetResult, Exception exception, CallTargetState state)
+            where TResult : IBasicGetResult, IDuckType
+        {
+            var queue = (string)state.State;
+            var startTime = state.StartTime;
+			var agent = Agent.Instance;
+			var transaction = agent.Tracer.CurrentTransaction;
+			if (transaction is null)
+				return new CallTargetReturn<TResult>(basicGetResult);
+
+			var matcher = WildcardMatcher.AnyMatch(transaction.Configuration.IgnoreMessageQueues, queue);
+			if (matcher != null)
+			{
+				agent.Logger.Trace()
+					?.Log(
+						"Not tracing message from {Queue} because it matched IgnoreMessageQueues pattern {Matcher}",
+						queue,
+						matcher.GetMatcher());
+
+				return new CallTargetReturn<TResult>(basicGetResult);
+			}
+
+			// check if there is an actual instance of the duck-typed type. RabbitMQ client can return null when the server
+			// answers that there are no messages available
+			var instanceNotNull = basicGetResult.Instance != null;
+			if (instanceNotNull)
+			{
+				var normalizedExchange = RabbitMqIntegration.NormalizeExchangeName(basicGetResult.Exchange);
+				matcher = WildcardMatcher.AnyMatch(transaction.Configuration.IgnoreMessageQueues, normalizedExchange);
+				if (matcher != null)
+				{
+					agent.Logger.Trace()
+						?.Log(
+							"Not tracing message from {Queue} because it matched IgnoreMessageQueues pattern {Matcher}",
+							normalizedExchange,
+							matcher.GetMatcher());
+
+					return new CallTargetReturn<TResult>(basicGetResult);
+				}
+			}
+
+			var normalizedQueue = RabbitMqIntegration.NormalizeQueueName(queue);
+			var span = agent.Tracer.CurrentExecutionSegment().StartSpan(
+				$"{RabbitMqIntegration.Name} POLL from {normalizedQueue}",
+				ApiConstants.TypeMessaging,
+				RabbitMqIntegration.Subtype);
+
+			if (startTime.HasValue && span is Span realSpan)
+				realSpan.Timestamp = TimeUtils.ToTimestamp(startTime.Value);
+
+			span.Context.Message = new Message { Queue = new Queue { Name = queue } };
+
+			if (instanceNotNull)
+			{
+				span.SetLabel("message_size", basicGetResult.Body?.Length ?? 0);
+
+				if (!string.IsNullOrEmpty(basicGetResult.RoutingKey))
+					span.Context.Message.RoutingKey = basicGetResult.RoutingKey;
+			}
+
+			span.EndCapturingException(exception);
+			return new CallTargetReturn<TResult>(basicGetResult);
+        }
+	}
+}

--- a/src/Elastic.Apm.Profiler.Managed/Integrations/RabbitMq/BasicPublishIntegration.cs
+++ b/src/Elastic.Apm.Profiler.Managed/Integrations/RabbitMq/BasicPublishIntegration.cs
@@ -1,0 +1,122 @@
+// Licensed to Elasticsearch B.V under
+// one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+//
+// <copyright file="BasicPublishIntegration.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using Elastic.Apm.Api;
+using Elastic.Apm.DistributedTracing;
+using Elastic.Apm.Helpers;
+using Elastic.Apm.Logging;
+using Elastic.Apm.Profiler.Managed.CallTarget;
+using Elastic.Apm.Profiler.Managed.Core;
+using Elastic.Apm.Profiler.Managed.DuckTyping;
+
+namespace Elastic.Apm.Profiler.Managed.Integrations.RabbitMq
+{
+    /// <summary>
+    /// RabbitMQ.Client BasicPublish calltarget instrumentation
+    /// </summary>
+    [Instrument(
+        Assembly = "RabbitMQ.Client",
+        Type = "RabbitMQ.Client.Framing.Impl.Model",
+        Method = "_Private_BasicPublish",
+        ReturnType = ClrTypeNames.Void,
+        ParameterTypes = new[] { ClrTypeNames.String, ClrTypeNames.String, ClrTypeNames.Bool, RabbitMqIntegration.IBasicPropertiesTypeName, ClrTypeNames.Ignore },
+        MinimumVersion = "3.6.9",
+        MaximumVersion = "6.*.*",
+        Group = RabbitMqIntegration.Name)]
+    [Browsable(false)]
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public class BasicPublishIntegration
+    {
+		private static readonly string[] DeliveryModeStrings = { null, "1", "2" };
+
+        /// <summary>
+        /// OnMethodBegin callback
+        /// </summary>
+        /// <typeparam name="TTarget">Type of the target</typeparam>
+        /// <typeparam name="TBasicProperties">Type of the message properties</typeparam>
+        /// <typeparam name="TBody">Type of the message body</typeparam>
+        /// <param name="instance">Instance value, aka `this` of the instrumented method.</param>
+        /// <param name="exchange">Name of the exchange.</param>
+        /// <param name="routingKey">The routing key.</param>
+        /// <param name="mandatory">The mandatory routing flag.</param>
+        /// <param name="basicProperties">The message properties.</param>
+        /// <param name="body">The message body.</param>
+        /// <returns>Calltarget state value</returns>
+        public static CallTargetState OnMethodBegin<TTarget, TBasicProperties, TBody>(TTarget instance, string exchange, string routingKey, bool mandatory, TBasicProperties basicProperties, TBody body)
+            where TBasicProperties : IBasicProperties, IDuckType
+            where TBody : IBody, IDuckType // Versions < 6.0.0: TBody is byte[] // Versions >= 6.0.0: TBody is ReadOnlyMemory<byte>
+		{
+			var agent = Agent.Instance;
+			var transaction = agent.Tracer.CurrentTransaction;
+			if (transaction is null)
+				return default;
+
+			var matcher = WildcardMatcher.AnyMatch(transaction.Configuration.IgnoreMessageQueues, exchange);
+			if (matcher != null)
+			{
+				agent.Logger.Trace()
+					?.Log(
+						"Not tracing message to {Queue} because it matched IgnoreMessageQueues pattern {Matcher}",
+						exchange,
+						matcher.GetMatcher());
+
+				return default;
+			}
+
+			var normalizedExchange = RabbitMqIntegration.NormalizeExchangeName(exchange);
+			var span = agent.Tracer.CurrentExecutionSegment()
+				.StartSpan($"{RabbitMqIntegration.Name} SEND to {normalizedExchange}", ApiConstants.TypeMessaging, RabbitMqIntegration.Subtype, isExitSpan: true);
+
+			span.Context.Message = new Message { Queue = new Queue { Name = exchange } };
+
+			if (!string.IsNullOrEmpty(routingKey))
+				span.Context.Message.RoutingKey = routingKey;
+
+			span.SetLabel("message_size", body.Instance != null ? body.Length : 0);
+
+			if (basicProperties.Instance != null)
+            {
+				if (basicProperties.IsDeliveryModePresent())
+				{
+					var deliveryMode = DeliveryModeStrings[0x3 & basicProperties.DeliveryMode];
+					if (deliveryMode != null)
+						span.SetLabel("delivery_mode", deliveryMode);
+				}
+
+				// add distributed tracing headers to the message
+                basicProperties.Headers ??= new Dictionary<string, object>();
+				var distributedTracingData = span.OutgoingDistributedTracingData;
+				ContextPropagation.HeadersSetter(basicProperties.Headers, TraceContext.TraceParentHeaderName,
+					distributedTracingData.SerializeToString());
+				ContextPropagation.HeadersSetter(basicProperties.Headers, TraceContext.TraceStateHeaderName,
+					distributedTracingData.TraceState.ToTextHeader());
+			}
+
+			return new CallTargetState(span);
+        }
+
+        /// <summary>
+        /// OnMethodEnd callback
+        /// </summary>
+        /// <typeparam name="TTarget">Type of the target</typeparam>
+        /// <param name="instance">Instance value, aka `this` of the instrumented method.</param>
+        /// <param name="exception">Exception instance in case the original code threw an exception.</param>
+        /// <param name="state">Calltarget state value</param>
+        /// <returns>A default CallTargetReturn to satisfy the CallTarget contract</returns>
+        public static CallTargetReturn OnMethodEnd<TTarget>(TTarget instance, Exception exception, CallTargetState state)
+        {
+            state.Segment.EndCapturingException(exception);
+            return CallTargetReturn.GetDefault();
+        }
+    }
+}

--- a/src/Elastic.Apm.Profiler.Managed/Integrations/RabbitMq/ContextPropagation.cs
+++ b/src/Elastic.Apm.Profiler.Managed/Integrations/RabbitMq/ContextPropagation.cs
@@ -1,0 +1,32 @@
+// Licensed to Elasticsearch B.V under
+// one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+//
+// <copyright file="ContextPropagation.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Elastic.Apm.Profiler.Managed.Integrations.RabbitMq
+{
+    internal static class ContextPropagation
+    {
+		public static Action<IDictionary<string, object>, string, string> HeadersSetter = (carrier, key, value) =>
+        {
+            carrier[key] = Encoding.UTF8.GetBytes(value);
+        };
+
+        public static Func<IDictionary<string, object>, string, IEnumerable<string>> HeadersGetter = ((carrier, key) =>
+		{
+			return carrier.TryGetValue(key, out var value) && value is byte[] bytes
+				? new[] { Encoding.UTF8.GetString(bytes) }
+				: Enumerable.Empty<string>();
+		});
+    }
+}

--- a/src/Elastic.Apm.Profiler.Managed/Integrations/RabbitMq/IBasicGetResult.cs
+++ b/src/Elastic.Apm.Profiler.Managed/Integrations/RabbitMq/IBasicGetResult.cs
@@ -1,0 +1,42 @@
+// Licensed to Elasticsearch B.V under
+// one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+//
+// <copyright file="IBasicGetResult.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System.ComponentModel;
+
+namespace Elastic.Apm.Profiler.Managed.Integrations.RabbitMq
+{
+    /// <summary>
+    /// BasicGetResult interface for ducktyping
+    /// </summary>
+    [Browsable(false)]
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public interface IBasicGetResult
+    {
+        /// <summary>
+        /// Gets the message body of the result
+        /// </summary>
+        IBody Body { get; }
+
+        /// <summary>
+        /// Gets the message properties
+        /// </summary>
+        IBasicProperties BasicProperties { get; }
+
+		/// <summary>
+		/// Retrieve the exchange this message was published to.
+		/// </summary>
+		string Exchange { get; }
+
+		/// <summary>
+		/// Retrieve the routing key with which this message was published.
+		/// </summary>
+		public string RoutingKey { get; }
+    }
+}

--- a/src/Elastic.Apm.Profiler.Managed/Integrations/RabbitMq/IBasicProperties.cs
+++ b/src/Elastic.Apm.Profiler.Managed/Integrations/RabbitMq/IBasicProperties.cs
@@ -1,0 +1,35 @@
+// <copyright file="IBasicProperties.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System.Collections.Generic;
+using System.ComponentModel;
+
+namespace Elastic.Apm.Profiler.Managed.Integrations.RabbitMq
+{
+    /// <summary>
+    /// BasicProperties interface for ducktyping
+    /// </summary>
+    [Browsable(false)]
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public interface IBasicProperties
+    {
+        /// <summary>
+        /// Gets or sets the headers of the message
+        /// </summary>
+        /// <returns>Message headers</returns>
+        IDictionary<string, object> Headers { get; set; }
+
+        /// <summary>
+        /// Gets the delivery mode of the message
+        /// </summary>
+        byte DeliveryMode { get; }
+
+        /// <summary>
+        /// Returns true if the DeliveryMode property is present
+        /// </summary>
+        /// <returns>true if the DeliveryMode property is present</returns>
+        bool IsDeliveryModePresent();
+    }
+}

--- a/src/Elastic.Apm.Profiler.Managed/Integrations/RabbitMq/IBody.cs
+++ b/src/Elastic.Apm.Profiler.Managed/Integrations/RabbitMq/IBody.cs
@@ -1,0 +1,27 @@
+// Licensed to Elasticsearch B.V under
+// one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+//
+// <copyright file="IBody.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System.ComponentModel;
+
+namespace Elastic.Apm.Profiler.Managed.Integrations.RabbitMq
+{
+    /// <summary>
+    /// Body interface for ducktyping
+    /// </summary>
+    [Browsable(false)]
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public interface IBody
+    {
+        /// <summary>
+        /// Gets the length of the message body
+        /// </summary>
+        int Length { get; }
+    }
+}

--- a/src/Elastic.Apm.Profiler.Managed/Integrations/RabbitMq/RabbitMQIntegration.cs
+++ b/src/Elastic.Apm.Profiler.Managed/Integrations/RabbitMq/RabbitMQIntegration.cs
@@ -1,0 +1,36 @@
+// Licensed to Elasticsearch B.V under
+// one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+//
+// <copyright file="RabbitMQConstants.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+namespace Elastic.Apm.Profiler.Managed.Integrations.RabbitMq
+{
+    internal static class RabbitMqIntegration
+    {
+        internal const string Name = "RabbitMQ";
+		// ReSharper disable once InconsistentNaming
+		internal const string IBasicPropertiesTypeName = "RabbitMQ.Client.IBasicProperties";
+		internal const string Subtype = "rabbitmq";
+
+		internal static string NormalizeExchangeName(string exchange) =>
+			exchange switch
+			{
+				null => "<unknown>",
+				_ when exchange.Length == 0 => "<default>",
+				_ => exchange
+			};
+
+		internal static string NormalizeQueueName(string queue) =>
+			queue switch
+			{
+				null => "<unknown>",
+				_ when queue.StartsWith("amq.gen-") => "amq.gen-*",
+				_ => queue
+			};
+	}
+}

--- a/src/Elastic.Apm.Profiler.Managed/Logger.cs
+++ b/src/Elastic.Apm.Profiler.Managed/Logger.cs
@@ -54,6 +54,10 @@ namespace Elastic.Apm.Profiler.Managed
 
 		public static void Debug(string message, params object[] args) => Log(LogLevel.Debug, message, args);
 
+		public static void Error(Exception exception, string message, params object[] args) => Log(LogLevel.Error, exception, message, args);
+
+		public static void Error(string message, params object[] args) => Log(LogLevel.Error, message, args);
+
 		public static void Log(LogLevel level, string message, params object[] args)
 		{
 			if (Level > level)

--- a/src/Elastic.Apm.Profiler.Managed/integrations.yml
+++ b/src/Elastic.Apm.Profiler.Managed/integrations.yml
@@ -819,6 +819,58 @@
       assembly: Elastic.Apm.Profiler.Managed, Version=1.11.1.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteScalarWithBehaviorIntegration
       action: CallTargetModification
+- name: RabbitMQ
+  method_replacements:
+  - target:
+      assembly: RabbitMQ.Client
+      type: RabbitMQ.Client.Events.EventingBasicConsumer
+      method: HandleBasicDeliver
+      signature_types:
+      - System.Void
+      - System.String
+      - System.UInt64
+      - System.Boolean
+      - System.String
+      - System.String
+      - RabbitMQ.Client.IBasicProperties
+      - _
+      minimum_version: 3.6.9
+      maximum_version: 6.*.*
+    wrapper:
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.11.1.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      type: Elastic.Apm.Profiler.Managed.Integrations.RabbitMq.BasicDeliverIntegration
+      action: CallTargetModification
+  - target:
+      assembly: RabbitMQ.Client
+      type: RabbitMQ.Client.Impl.ModelBase
+      method: BasicGet
+      signature_types:
+      - RabbitMQ.Client.BasicGetResult
+      - System.String
+      - System.Boolean
+      minimum_version: 3.6.9
+      maximum_version: 6.*.*
+    wrapper:
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.11.1.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      type: Elastic.Apm.Profiler.Managed.Integrations.RabbitMq.BasicGetIntegration
+      action: CallTargetModification
+  - target:
+      assembly: RabbitMQ.Client
+      type: RabbitMQ.Client.Framing.Impl.Model
+      method: _Private_BasicPublish
+      signature_types:
+      - System.Void
+      - System.String
+      - System.String
+      - System.Boolean
+      - RabbitMQ.Client.IBasicProperties
+      - _
+      minimum_version: 3.6.9
+      maximum_version: 6.*.*
+    wrapper:
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.11.1.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      type: Elastic.Apm.Profiler.Managed.Integrations.RabbitMq.BasicPublishIntegration
+      action: CallTargetModification
 - name: SqlCommand
   method_replacements:
   - target:

--- a/src/Elastic.Apm/Helpers/TimeUtils.cs
+++ b/src/Elastic.Apm/Helpers/TimeUtils.cs
@@ -35,6 +35,8 @@ namespace Elastic.Apm.Helpers
 			return RoundTimeValue((dateTimeToConvert - UnixEpochDateTime).TotalMilliseconds * 1000);
 		}
 
+		internal static long ToTimestamp(DateTimeOffset dateTimeToConvert) => ToTimestamp(dateTimeToConvert.UtcDateTime);
+
 		internal static DateTime ToDateTime(long timestamp) => UnixEpochDateTime + TimeSpan.FromTicks(timestamp * 10);
 
 		internal static string FormatTimestampForLog(long timestamp) => ToDateTime(timestamp).FormatForLog();

--- a/src/Elastic.Apm/Model/Span.cs
+++ b/src/Elastic.Apm/Model/Span.cs
@@ -221,8 +221,6 @@ namespace Elastic.Apm.Model
 		[MaxLength]
 		public string Subtype { get; set; }
 
-		//public decimal Start { get; set; }
-
 		/// <summary>
 		/// Recorded time of the event, UTC based and formatted as microseconds since Unix epoch
 		/// </summary>

--- a/test/Elastic.Apm.Profiler.Managed.Tests/RabbitMq/RabbitMqFixture.cs
+++ b/test/Elastic.Apm.Profiler.Managed.Tests/RabbitMq/RabbitMqFixture.cs
@@ -1,0 +1,41 @@
+// Licensed to Elasticsearch B.V under
+// one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System.Threading.Tasks;
+using DotNet.Testcontainers.Builders;
+using DotNet.Testcontainers.Configurations;
+using DotNet.Testcontainers.Containers;
+using Elastic.Apm.Tests.Utilities;
+using Xunit;
+
+namespace Elastic.Apm.Profiler.Managed.Tests.RabbitMq
+{
+	[CollectionDefinition("RabbitMq")]
+	public class RabbitMqCollection : ICollectionFixture<RabbitMqFixture>
+	{
+	}
+
+	public class RabbitMqFixture : IAsyncLifetime
+	{
+		private readonly RabbitMqTestcontainer _builder;
+
+		public RabbitMqFixture() =>
+			_builder = new TestcontainersBuilder<RabbitMqTestcontainer>()
+				.WithMessageBroker(new RabbitMqTestcontainerConfiguration { Username = "rabbitmq", Password = "rabbitmq" })
+				.Build();
+
+
+		public async Task InitializeAsync()
+		{
+			await _builder.StartAsync();
+
+			ConnectionString = _builder.ConnectionString;
+		}
+
+		public string ConnectionString { get; private set; }
+
+		public async Task DisposeAsync() => await _builder.DisposeAsync();
+	}
+}

--- a/test/Elastic.Apm.Profiler.Managed.Tests/RabbitMq/RabbitMqTests.cs
+++ b/test/Elastic.Apm.Profiler.Managed.Tests/RabbitMq/RabbitMqTests.cs
@@ -66,16 +66,16 @@ namespace Elastic.Apm.Profiler.Managed.Tests.RabbitMq
 			spans.Where(s => s.TransactionId == ignoreTransaction.Id).Should().BeEmpty();
 
 			var publishAndGetTransaction = transactions.Single(t => t.Name == "PublishAndGet");
-			spans.Where(s => s.TransactionId == publishAndGetTransaction.Id).Should().HaveCount(3);
+			spans.Where(s => s.TransactionId == publishAndGetTransaction.Id).Should().HaveCount(3, "PublishAndGet");
 
 			var publishAndGetDefaultTransaction = transactions.Single(t => t.Name == "PublishAndGetDefault");
-			spans.Where(s => s.TransactionId == publishAndGetDefaultTransaction.Id).Should().HaveCount(3);
+			spans.Where(s => s.TransactionId == publishAndGetDefaultTransaction.Id).Should().HaveCount(3, "PublishAndGetDefault");
 
 			var senderTransactions = transactions.Where(t => t.Name == "PublishToConsumer").ToList();
-			senderTransactions.Should().HaveCount(3);
+			senderTransactions.Should().HaveCount(3, "PublishToConsumer");
 
 			var consumeTransactions = transactions.Where(t => t.Name.StartsWith("RabbitMQ RECEIVE from")).ToList();
-			consumeTransactions.Should().HaveCount(3);
+			consumeTransactions.Should().HaveCount(3, "RabbitMQ RECEIVE from");
 
 			foreach (var senderTransaction in senderTransactions)
 			{

--- a/test/Elastic.Apm.Profiler.Managed.Tests/RabbitMq/RabbitMqTests.cs
+++ b/test/Elastic.Apm.Profiler.Managed.Tests/RabbitMq/RabbitMqTests.cs
@@ -1,0 +1,96 @@
+// Licensed to Elasticsearch B.V under
+// one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Elastic.Apm.Profiler.Managed.Tests.Kafka;
+using Elastic.Apm.Tests.MockApmServer;
+using Elastic.Apm.Tests.Utilities;
+using Elastic.Apm.Tests.Utilities.Docker;
+using FluentAssertions;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Elastic.Apm.Profiler.Managed.Tests.RabbitMq
+{
+	[Collection("RabbitMq")]
+	public class RabbitMqTests
+	{
+		private readonly RabbitMqFixture _fixture;
+		private readonly ITestOutputHelper _output;
+
+		public RabbitMqTests(RabbitMqFixture fixture, ITestOutputHelper output)
+		{
+			_fixture = fixture;
+			_output = output;
+		}
+
+		[DockerTheory]
+		[InlineData("net5.0")]
+		public async Task CaptureAutoInstrumentedSpans(string targetFramework)
+		{
+			var apmLogger = new InMemoryBlockingLogger(Logging.LogLevel.Error);
+			var apmServer = new MockApmServer(apmLogger, nameof(CaptureAutoInstrumentedSpans));
+			var port = apmServer.FindAvailablePortToListen();
+			apmServer.RunInBackground(port);
+
+			using (var profiledApplication = new ProfiledApplication("RabbitMqSample"))
+			{
+				IDictionary<string, string> environmentVariables = new Dictionary<string, string>
+				{
+					["RABBITMQ_HOST"] = _fixture.ConnectionString,
+					["ELASTIC_APM_SERVER_URL"] = $"http://localhost:{port}",
+					["ELASTIC_APM_DISABLE_METRICS"] = "*",
+					["ELASTIC_APM_IGNORE_MESSAGE_QUEUES"] = "test-ignore-exchange-name,test-ignore-queue-name"
+				};
+
+				profiledApplication.Start(
+					targetFramework,
+					TimeSpan.FromMinutes(2),
+					environmentVariables,
+					line => _output.WriteLine(line.Line),
+					exception => _output.WriteLine($"{exception}"));
+			}
+
+			var transactions = apmServer.ReceivedData.Transactions;
+			var spans = apmServer.ReceivedData.Spans;
+
+			transactions.Should().HaveCount(9);
+
+			var ignoreTransaction = transactions.Single(t => t.Name == "PublishAndGetIgnore");
+			// don't capture any spans for ignored queues and messages
+			spans.Where(s => s.TransactionId == ignoreTransaction.Id).Should().BeEmpty();
+
+			var publishAndGetTransaction = transactions.Single(t => t.Name == "PublishAndGet");
+			spans.Where(s => s.TransactionId == publishAndGetTransaction.Id).Should().HaveCount(3);
+
+			var publishAndGetDefaultTransaction = transactions.Single(t => t.Name == "PublishAndGetDefault");
+			spans.Where(s => s.TransactionId == publishAndGetDefaultTransaction.Id).Should().HaveCount(3);
+
+			var senderTransactions = transactions.Where(t => t.Name == "PublishToConsumer").ToList();
+			senderTransactions.Should().HaveCount(3);
+
+			var consumeTransactions = transactions.Where(t => t.Name.StartsWith("RabbitMQ RECEIVE from")).ToList();
+			consumeTransactions.Should().HaveCount(3);
+
+			foreach (var senderTransaction in senderTransactions)
+			{
+				var senderSpan = spans.FirstOrDefault(s => s.TransactionId == senderTransaction.Id);
+				senderSpan.Should().NotBeNull();
+
+				var tracingTransaction = consumeTransactions.FirstOrDefault(t => t.TraceId == senderTransaction.TraceId);
+				tracingTransaction.Should().NotBeNull();
+				tracingTransaction.ParentId.Should().Be(senderSpan.Id);
+			}
+
+			foreach (var consumeTransaction in consumeTransactions)
+				spans.Where(s => s.TransactionId == consumeTransaction.Id).Should().HaveCount(1);
+
+			await apmServer.StopAsync();
+		}
+	}
+}

--- a/test/Elastic.Apm.Tests.MockApmServer/AssertValidExtensions.cs
+++ b/test/Elastic.Apm.Tests.MockApmServer/AssertValidExtensions.cs
@@ -260,8 +260,7 @@ namespace Elastic.Apm.Tests.MockApmServer
 		{
 			thisObj.Should().NotBeNull();
 
-			thisObj.Address.Should().NotBeNullOrEmpty();
-			thisObj.Address.AssertValid();
+			thisObj.Address?.AssertValid();
 			thisObj.Port?.Should().BeGreaterOrEqualTo(0);
 		}
 


### PR DESCRIPTION
This commit adds profiler auto instrumentation for RabbitMQ. The instrumentation follows the messaging spec and aligns with the Elastic APM Java agent implementation.

The following RabbitMQ.Client operations are instrumented:

- BasicGet

  Creates POLL spans if there is an active transaction

- BasicPublish

  Creates SEND spans if there is an active transaction

- HandleBasicDeliver in EventingBasicConsumer

  Creates RECEIVE transactions around the message processing flow

Trace Context is propagated through message headers for distributed tracing.

Closes #1223