### PR TITLE
Test major.minor version only when asserting framework version

### DIFF
--- a/test/Elastic.Apm.AspNetCore.Tests/AspNetCoreBasicTests.cs
+++ b/test/Elastic.Apm.AspNetCore.Tests/AspNetCoreBasicTests.cs
@@ -241,8 +241,9 @@ namespace Elastic.Apm.AspNetCore.Tests
 
 			_agent.Service.Framework.Name.Should().Be("ASP.NET Core");
 
-			var aspNetCoreVersion = Assembly.Load("Microsoft.AspNetCore").GetName().Version.ToString();
-			_agent.Service.Framework.Version.Should().Be(aspNetCoreVersion);
+			// test major.minor values only
+			var aspNetCoreVersion = Assembly.Load("Microsoft.AspNetCore").GetName().Version.ToString(2);
+			_agent.Service.Framework.Version.Should().StartWith(aspNetCoreVersion);
 
 #if NET5_0
 			_agent.Service.Runtime.Name.Should().Be(Runtime.DotNetName + " 5");


### PR DESCRIPTION
This commit tests that the version captured for the agent service
framework when running under ASP.NET Core matches on major.minor version
only.

Fixes #1061