### PR TITLE
Documentation improvements

### DIFF
--- a/docs/integrations.asciidoc
+++ b/docs/integrations.asciidoc
@@ -2,52 +2,52 @@
 :nuget: https://www.nuget.org/packages
 
 |===
-|**Integration name** |**NuGet package version(s)** |**Assembly version(s)** 
-.2+| AdoNet
-| part of .NET
-| System.Data 4.0.0 - 4.{star}.{star}
+|Integration name |NuGet package version(s) |Assembly version(s) 
+.2+.^|AdoNet
+|part of .NET
+|System.Data 4.0.0 - 4.{star}.{star}
 
-| part of .NET
-| System.Data.Common 4.0.0 - 5.{star}.{star}
+|part of .NET
+|System.Data.Common 4.0.0 - 5.{star}.{star}
 
-.1+| AspNet
-| part of .NET Framework
-| System.Web 4.0.0 - 4.{star}.{star}
+.1+.^|AspNet
+|part of .NET Framework
+|System.Web 4.0.0 - 4.{star}.{star}
 
-.1+| Kafka
-| {nuget}/Confluent.Kafka[Confluent.Kafka 1.4.0 - 1.{star}.{star}]
-| Confluent.Kafka 1.4.0 - 1.{star}.{star}
+.1+.^|Kafka
+|{nuget}/Confluent.Kafka[Confluent.Kafka 1.4.0 - 1.{star}.{star}]
+|Confluent.Kafka 1.4.0 - 1.{star}.{star}
 
-.1+| MySqlCommand
-| {nuget}/MySql.Data[MySql.Data 6.7.0 - 8.{star}.{star}]
-| MySql.Data 6.7.0 - 8.{star}.{star}
+.1+.^|MySqlCommand
+|{nuget}/MySql.Data[MySql.Data 6.7.0 - 8.{star}.{star}]
+|MySql.Data 6.7.0 - 8.{star}.{star}
 
-.1+| NpgsqlCommand
-| {nuget}/Npgsql[Npgsql 4.0.0 - 5.{star}.{star}]
-| Npgsql 4.0.0 - 5.{star}.{star}
+.1+.^|NpgsqlCommand
+|{nuget}/Npgsql[Npgsql 4.0.0 - 5.{star}.{star}]
+|Npgsql 4.0.0 - 5.{star}.{star}
 
-.2+| OracleCommand
-| {nuget}/Oracle.ManagedDataAccess[Oracle.ManagedDataAccess 4.122.0 - 4.122.{star}]
-| Oracle.ManagedDataAccess 4.122.0 - 4.122.{star}
+.2+.^|OracleCommand
+|{nuget}/Oracle.ManagedDataAccess[Oracle.ManagedDataAccess 4.122.0 - 4.122.{star}]
+|Oracle.ManagedDataAccess 4.122.0 - 4.122.{star}
 
-| {nuget}/Oracle.ManagedDataAccess.Core[Oracle.ManagedDataAccess.Core 2.0.0 - 2.{star}.{star}]
-| Oracle.ManagedDataAccess 2.0.0 - 2.{star}.{star}
+|{nuget}/Oracle.ManagedDataAccess.Core[Oracle.ManagedDataAccess.Core 2.0.0 - 2.{star}.{star}]
+|Oracle.ManagedDataAccess 2.0.0 - 2.{star}.{star}
 
-.3+| SqlCommand
-| {nuget}/System.Data[System.Data 4.0.0 - 4.{star}.{star}]
-| System.Data 4.0.0 - 4.{star}.{star}
+.3+.^|SqlCommand
+|{nuget}/System.Data[System.Data 4.0.0 - 4.{star}.{star}]
+|System.Data 4.0.0 - 4.{star}.{star}
 
-| {nuget}/System.Data.SqlClient[System.Data.SqlClient 4.0.0 - 4.{star}.{star}]
-| System.Data.SqlClient 4.0.0 - 4.{star}.{star}
+|{nuget}/System.Data.SqlClient[System.Data.SqlClient 4.0.0 - 4.{star}.{star}]
+|System.Data.SqlClient 4.0.0 - 4.{star}.{star}
 
-| {nuget}/Microsoft.Data.SqlClient[Microsoft.Data.SqlClient 1.0.0 - 2.{star}.{star}]
-| Microsoft.Data.SqlClient 1.0.0 - 2.{star}.{star}
+|{nuget}/Microsoft.Data.SqlClient[Microsoft.Data.SqlClient 1.0.0 - 2.{star}.{star}]
+|Microsoft.Data.SqlClient 1.0.0 - 2.{star}.{star}
 
-.2+| SqliteCommand
-| {nuget}/Microsoft.Data.Sqlite[Microsoft.Data.Sqlite 2.0.0 - 5.{star}.{star}]
-| Microsoft.Data.Sqlite 2.0.0 - 5.{star}.{star}
+.2+.^|SqliteCommand
+|{nuget}/Microsoft.Data.Sqlite[Microsoft.Data.Sqlite 2.0.0 - 5.{star}.{star}]
+|Microsoft.Data.Sqlite 2.0.0 - 5.{star}.{star}
 
-| {nuget}/System.Data.SQLite[System.Data.SQLite 1.0.0 - 2.{star}.{star}]
-| System.Data.SQLite 1.0.0 - 2.{star}.{star}
+|{nuget}/System.Data.SQLite[System.Data.SQLite 1.0.0 - 2.{star}.{star}]
+|System.Data.SQLite 1.0.0 - 2.{star}.{star}
 
 |===

--- a/docs/integrations.asciidoc
+++ b/docs/integrations.asciidoc
@@ -1,52 +1,53 @@
 :star: *
+:nuget: https://www.nuget.org/packages
 
 |===
-|**Integration name** |**Assembly** |**Supported assembly version range**
+|**Integration name** |**NuGet package version(s)** |**Assembly version(s)** 
 .2+| AdoNet
-| System.Data
-| 4.0.0 - 4.{star}.{star}
+| part of .NET
+| System.Data 4.0.0 - 4.{star}.{star}
 
-| System.Data.Common
-| 4.0.0 - 5.{star}.{star}
+| part of .NET
+| System.Data.Common 4.0.0 - 5.{star}.{star}
 
 .1+| AspNet
-| System.Web
-| 4.0.0 - 4.{star}.{star}
+| part of .NET Framework
+| System.Web 4.0.0 - 4.{star}.{star}
 
 .1+| Kafka
-| Confluent.Kafka
-| 1.4.0 - 1.{star}.{star}
+| {nuget}/Confluent.Kafka[Confluent.Kafka 1.4.0 - 1.{star}.{star}]
+| Confluent.Kafka 1.4.0 - 1.{star}.{star}
 
 .1+| MySqlCommand
-| MySql.Data
-| 6.7.0 - 8.{star}.{star}
+| {nuget}/MySql.Data[MySql.Data 6.7.0 - 8.{star}.{star}]
+| MySql.Data 6.7.0 - 8.{star}.{star}
 
 .1+| NpgsqlCommand
-| Npgsql
-| 4.0.0 - 5.{star}.{star}
+| {nuget}/Npgsql[Npgsql 4.0.0 - 5.{star}.{star}]
+| Npgsql 4.0.0 - 5.{star}.{star}
 
 .2+| OracleCommand
-| Oracle.ManagedDataAccess
-| 4.122.0 - 4.122.{star}
+| {nuget}/Oracle.ManagedDataAccess[Oracle.ManagedDataAccess 4.122.0 - 4.122.{star}]
+| Oracle.ManagedDataAccess 4.122.0 - 4.122.{star}
 
-| Oracle.ManagedDataAccess
-| 2.0.0 - 2.{star}.{star}
+| {nuget}/Oracle.ManagedDataAccess.Core[Oracle.ManagedDataAccess.Core 2.0.0 - 2.{star}.{star}]
+| Oracle.ManagedDataAccess 2.0.0 - 2.{star}.{star}
 
 .3+| SqlCommand
-| System.Data
-| 4.0.0 - 4.{star}.{star}
+| {nuget}/System.Data[System.Data 4.0.0 - 4.{star}.{star}]
+| System.Data 4.0.0 - 4.{star}.{star}
 
-| System.Data.SqlClient
-| 4.0.0 - 4.{star}.{star}
+| {nuget}/System.Data.SqlClient[System.Data.SqlClient 4.0.0 - 4.{star}.{star}]
+| System.Data.SqlClient 4.0.0 - 4.{star}.{star}
 
-| Microsoft.Data.SqlClient
-| 1.0.0 - 2.{star}.{star}
+| {nuget}/Microsoft.Data.SqlClient[Microsoft.Data.SqlClient 1.0.0 - 2.{star}.{star}]
+| Microsoft.Data.SqlClient 1.0.0 - 2.{star}.{star}
 
 .2+| SqliteCommand
-| Microsoft.Data.Sqlite
-| 2.0.0 - 5.{star}.{star}
+| {nuget}/Microsoft.Data.Sqlite[Microsoft.Data.Sqlite 2.0.0 - 5.{star}.{star}]
+| Microsoft.Data.Sqlite 2.0.0 - 5.{star}.{star}
 
-| System.Data.SQLite
-| 1.0.0 - 2.{star}.{star}
+| {nuget}/System.Data.SQLite[System.Data.SQLite 1.0.0 - 2.{star}.{star}]
+| System.Data.SQLite 1.0.0 - 2.{star}.{star}
 
 |===

--- a/docs/integrations.asciidoc
+++ b/docs/integrations.asciidoc
@@ -27,14 +27,14 @@
 |Npgsql 4.0.0 - 5.{star}.{star}
 
 .2+.^|OracleCommand
-|{nuget}/Oracle.ManagedDataAccess[Oracle.ManagedDataAccess 4.122.0 - 4.122.{star}]
+|{nuget}/Oracle.ManagedDataAccess[Oracle.ManagedDataAccess 12.2.1100 - 21.*.*]
 |Oracle.ManagedDataAccess 4.122.0 - 4.122.{star}
 
 |{nuget}/Oracle.ManagedDataAccess.Core[Oracle.ManagedDataAccess.Core 2.0.0 - 2.{star}.{star}]
 |Oracle.ManagedDataAccess 2.0.0 - 2.{star}.{star}
 
 .3+.^|SqlCommand
-|{nuget}/System.Data[System.Data 4.0.0 - 4.{star}.{star}]
+|part of .NET
 |System.Data 4.0.0 - 4.{star}.{star}
 
 |{nuget}/System.Data.SqlClient[System.Data.SqlClient 4.0.0 - 4.{star}.{star}]

--- a/docs/packages.asciidoc
+++ b/docs/packages.asciidoc
@@ -66,7 +66,6 @@ A package containing instrumentation to capture spans for Azure Cosmos DB with
 
 A package containing instrumentation to capture transactions and spans for messages sent and received from Azure Service Bus with {nuget}/Microsoft.Azure.ServiceBus/[Microsoft.Azure.ServiceBus] and {nuget}/Azure.Messaging.ServiceBus/[Azure.Messaging.ServiceBus] packages.
 
-
 <<setup-azure-storage, **Elastic.Apm.Azure.Storage**>>::
 
 A package containing instrumentation to capture spans for interaction with Azure Storage with {nuget}/azure.storage.queues/[Azure.Storage.Queues], {nuget}/azure.storage.blobs/[Azure.Storage.Blobs] and {nuget}/azure.storage.files.shares/[Azure.Storage.Files.Shares] packages.

--- a/docs/packages.asciidoc
+++ b/docs/packages.asciidoc
@@ -11,13 +11,16 @@ by referencing one or more of these packages.
 [float]
 == Get started
 
-* <<setup-ef6>>
-* <<setup-sqlclient>>
-* <<setup-stackexchange-redis>>
 * <<setup-azure-cosmosdb>>
 * <<setup-azure-servicebus>>
 * <<setup-azure-storage>>
+* <<setup-ef6>>
+* <<setup-ef-core>>
+* <<setup-elasticsearch>>
+* <<setup-grpc>>
 * <<setup-mongo-db>>
+* <<setup-sqlclient>>
+* <<setup-stackexchange-redis>>
 
 [float]
 == Packages
@@ -42,7 +45,7 @@ In order to avoid adding unnecessary dependencies in applications that aren’t 
 A package for agent registration integration with `Microsoft.Extensions.Hosting.IHostBuilder` registration.
 
 [[setup-asp-net]]
-{nuget}/Elastic.Apm.AspNetCore[**Elastic.Apm.AspNetCore**]::
+<<setup-asp-net-core, Elastic.Apm.AspNetCore>>::
 
 A package for instrumenting ASP.NET Core applications. The main difference between this package and the `Elastic.Apm.NetCoreAll` package is that this package only instruments ASP.NET Core by default, whereas
 `Elastic.Apm.NetCoreAll` instruments all components that can be automatically configured, such as
@@ -50,46 +53,68 @@ Entity Framework Core, HTTP calls with `HttpClient`, database calls to SQL Serve
 Additional instrumentations can be added when using `Elastic.Apm.AspNetCore` by referencing the
 respective NuGet packages and including their configuration code in agent setup.
 
-{nuget}/Elastic.Apm.AspNetFullFramework[**Elastic.Apm.AspNetFullFramework**]::
+<<setup-asp-dot-net, **Elastic.Apm.AspNetFullFramework**>>::
 
 A package containing ASP.NET .NET Framework instrumentation.
 
-{nuget}/Elastic.Apm.EntityFrameworkCore[**Elastic.Apm.EntityFrameworkCore**]::
-
-A package containing Entity Framework Core instrumentation.
-
-{nuget}/Elastic.Apm.EntityFramework6[**Elastic.Apm.EntityFramework6**]::
-
-A package containing an interceptor to automatically create spans for database operations 
-executed by Entity Framework 6 on behalf of the application.
-
-{nuget}/Elastic.Apm.SqlClient[**Elastic.Apm.SqlClient**]::
-
-A package containing {nuget}/System.Data.SqlClient[System.Data.SqlClient] and {nuget}/Microsoft.Data.SqlClient[Microsoft.Data.SqlClient] instrumentation.
-
-{nuget}/Elastic.Apm.StackExchange.Redis[**Elastic.Apm.StackExchange.Redis**]::
-
-A package containing instrumentation to capture spans for commands sent to redis with {nuget}/StackExchange.Redis/[StackExchange.Redis] package.
-
-{nuget}/Elastic.Apm.Azure.CosmosDb[**Elastic.Apm.Azure.CosmosDb**]::
+<<setup-azure-cosmosdb, **Elastic.Apm.Azure.CosmosDb**>>::
 
 A package containing instrumentation to capture spans for Azure Cosmos DB with
 {nuget}/Microsoft.Azure.Cosmos[Microsoft.Azure.Cosmos], {nuget}/Microsoft.Azure.DocumentDb[Microsoft.Azure.DocumentDb], and {nuget}/Microsoft.Azure.DocumentDb.Core[Microsoft.Azure.DocumentDb.Core] packages.
 
-{nuget}/Elastic.Apm.Azure.ServiceBus[**Elastic.Apm.Azure.ServiceBus**]::
+<<setup-azure-servicebus, **Elastic.Apm.Azure.ServiceBus**>>::
 
 A package containing instrumentation to capture transactions and spans for messages sent and received from Azure Service Bus with {nuget}/Microsoft.Azure.ServiceBus/[Microsoft.Azure.ServiceBus] and {nuget}/Azure.Messaging.ServiceBus/[Azure.Messaging.ServiceBus] packages.
 
 
-{nuget}/Elastic.Apm.Azure.Storage[**Elastic.Apm.Azure.Storage**]::
+<<setup-azure-storage, **Elastic.Apm.Azure.Storage**>>::
 
 A package containing instrumentation to capture spans for interaction with Azure Storage with {nuget}/azure.storage.queues/[Azure.Storage.Queues], {nuget}/azure.storage.blobs/[Azure.Storage.Blobs] and {nuget}/azure.storage.files.shares/[Azure.Storage.Files.Shares] packages.
 
+<<setup-ef-core, **Elastic.Apm.EntityFrameworkCore**>>::
 
-{nuget}/Elastic.Apm.MongoDb[**Elastic.Apm.MongoDb**]::
+A package containing Entity Framework Core instrumentation.
+
+<<setup-ef6, **Elastic.Apm.EntityFramework6**>>::
+
+A package containing an interceptor to automatically create spans for database operations 
+executed by Entity Framework 6 on behalf of the application.
+
+<<setup-mongo-db, **Elastic.Apm.MongoDb**>>::
 
 A package containing support for {nuget}/MongoDB.Driver/[MongoDB.Driver].
 
+<<setup-sqlclient, **Elastic.Apm.SqlClient**>>::
+
+A package containing {nuget}/System.Data.SqlClient[System.Data.SqlClient] and {nuget}/Microsoft.Data.SqlClient[Microsoft.Data.SqlClient] instrumentation.
+
+<<setup-stackexchange-redis, **Elastic.Apm.StackExchange.Redis**>>::
+
+A package containing instrumentation to capture spans for commands sent to redis with {nuget}/StackExchange.Redis/[StackExchange.Redis] package.
+
+[[setup-ef-core]]
+=== Entity Framework Core
+
+[float]
+==== Quick start
+
+Instrumentation can be enabled for Entity Framework Core by referencing {nuget}/Elastic.Apm.EntityFrameworkCore[`Elastic.Apm.EntityFrameworkCore`] package
+and passing `EfCoreDiagnosticsSubscriber` to the `UseElasticApm` method in case of ASP.NET Core as following
+
+[source,csharp]
+----
+app.UseElasticApm(Configuration, new EfCoreDiagnosticsSubscriber()); <1>
+----
+<1> Configuration is the `IConfiguration` instance passed to your `Startup` type
+
+or passing `EfCoreDiagnosticsSubscriber` to the `Subscribe` method
+
+[source,csharp]
+----
+Agent.Subscribe(new EfCoreDiagnosticsSubscriber());
+----
+
+Instrumentation listens for diagnostic events raised by `Microsoft.EntityFrameworkCore` 2.x+, creating database spans for executed commands.
 
 [[setup-ef6]]
 === Entity Framework 6
@@ -121,9 +146,70 @@ DbInterception.Add(new Elastic.Apm.EntityFramework6.Ef6Interceptor());
 
 For example, in an ASP.NET application, you can place the above call in the `Application_Start` method.
 
-NOTE: Be careful not to execute `DbInterception.Add` for the same interceptor more than once,
-or you'll get additional interceptor instances.
-For example, if you add `Ef6Interceptor` interceptor twice, you'll see two spans for every SQL query.
+Instrumentation works with EntityFramework 6.2+ NuGet packages.
+
+NOTE: Be careful not to execute `DbInterception.Add` for the same interceptor type more than once,
+as this will register multiple instances, causing multiple database spans to be captured for every SQL command.
+
+[[setup-elasticsearch]]
+=== Elasticsearch
+
+[float]
+==== Quick start
+
+Instrumentation can be enabled for Elasticsearch when using the official Elasticsearch clients, Elasticsearch.Net and Nest, by referencing
+{nuget}/Elastic.Apm.Elasticsearch[`Elastic.Apm.Elasticsearch`] package and passing `ElasticsearchDiagnosticsSubscriber` to the `UseElasticApm` 
+method in case of ASP.NET Core as following
+
+[source,csharp]
+----
+app.UseElasticApm(Configuration, new ElasticsearchDiagnosticsSubscriber()); <1>
+----
+<1> Configuration is the `IConfiguration` instance passed to your `Startup` type
+
+or passing `ElasticsearchDiagnosticsSubscriber` to the `Subscribe` method
+
+
+[source,csharp]
+----
+Agent.Subscribe(new ElasticsearchDiagnosticsSubscriber());
+----
+
+Instrumentation listens for activities raised by `Elasticsearch.Net` and `Nest` 7.6.0+, creating spans for executed requests.
+
+[IMPORTANT]
+--
+If you're using `Elasticsearch.Net` and `Nest` 7.10.1 or 7.11.0, upgrade to at least 7.11.1 which fixes a bug in span capturing.
+--
+
+[[setup-grpc]]
+=== gRPC
+
+[float]
+==== Quick start
+
+Automatic instrumentation for gRPC can be enabled for both client-side and server-side gRPC calls.
+
+Automatic instrumentation for ASP.NET Core server-side is built in to <<setup-asp-net-core, NuGet package>>
+
+Automatic instrumentation can be enabled for the client-side by referencing {nuget}/Elastic.Apm.GrpcClient[`Elastic.Apm.GrpcClient`] package
+and passing `GrpcClientDiagnosticListener` to the `UseElasticApm` method in case of ASP.NET Core
+
+[source,csharp]
+----
+app.UseElasticApm(Configuration, new GrpcClientDiagnosticListener()); <1>
+----
+<1> Configuration is the `IConfiguration` instance passed to your `Startup` type
+
+or passing `GrpcClientDiagnosticListener` to the `Subscribe` method
+
+[source,csharp]
+----
+Agent.Subscribe(new GrpcClientDiagnosticListener());
+----
+
+Diagnostic events from `Grpc.Net.Client` are captured as spans.
+
 
 [[setup-sqlclient]]
 === SqlClient
@@ -136,16 +222,17 @@ and passing `SqlClientDiagnosticSubscriber` to the `UseElasticApm` method in cas
 
 [source,csharp]
 ----
-app.UseElasticApm(Configuration,
-	new SqlClientDiagnosticSubscriber());  /* Enable tracing of outgoing db requests */
+// Enable tracing of outgoing db requests
+app.UseElasticApm(Configuration, new SqlClientDiagnosticSubscriber()); <1>
 ----
+<1> Configuration is the `IConfiguration` instance passed to your `Startup` type
 
 or passing `SqlClientDiagnosticSubscriber` to the `Subscribe` method and make sure that the code is called only once, otherwise the same database call could be captured multiple times:
 
 [source,csharp]
 ----
-// you need add custom code to be sure that Subscribe called only once and in a thread-safe manner
-if (Agent.IsConfigured) Agent.Subscribe(new SqlClientDiagnosticSubscriber());  /* Enable tracing of outgoing db requests */
+// Enable tracing of outgoing db requests
+Agent.Subscribe(new SqlClientDiagnosticSubscriber());  
 ----
 
 [NOTE]
@@ -184,7 +271,7 @@ sent with `IConnectionMultiplexer`.
 [float]
 ==== Quick start
 
-Instrumentation can be enabled for Azure Cosmos DB by referencing https://www.nuget.org/packages/Elastic.Apm.Azure.CosmosDb[`Elastic.Apm.Azure.CosmosDb`]
+Instrumentation can be enabled for Azure Cosmos DB by referencing {nuget}/Elastic.Apm.Azure.CosmosDb[`Elastic.Apm.Azure.CosmosDb`]
 package and subscribing to diagnostic events.
 
 [source, csharp]
@@ -235,20 +322,20 @@ A new span is created when there is a current transaction, and when
 
 Instrumentation can be enabled for Azure Storage by referencing {nuget}/Elastic.Apm.Azure.Storage[`Elastic.Apm.Azure.Storage`] package and subscribing to diagnostic events using one of the subscribers:
 
-. If the agent is included by referencing the `Elastic.Apm.NetCoreAll` package, the subscribers will be automatically subscribed with the agent, and no further action is required.
-. If you're using `Azure.Storage.Blobs`, subscribe `AzureBlobStorageDiagnosticsSubscriber` with the agent
+* If the agent is included by referencing the `Elastic.Apm.NetCoreAll` package, the subscribers will be automatically subscribed with the agent, and no further action is required.
+* If you're using `Azure.Storage.Blobs`, subscribe `AzureBlobStorageDiagnosticsSubscriber` with the agent
 +
 [source, csharp]
 ----
 Agent.Subscribe(new AzureBlobStorageDiagnosticsSubscriber());
 ----
-. If you're using `Azure.Storage.Queues`, subscribe `AzureQueueStorageDiagnosticsSubscriber` with the agent
+* If you're using `Azure.Storage.Queues`, subscribe `AzureQueueStorageDiagnosticsSubscriber` with the agent
 +
 [source, csharp]
 ----
 Agent.Subscribe(new AzureQueueStorageDiagnosticsSubscriber());
 ----
-. If you're using `Azure.Storage.Files.Shares`, subscribe `AzureFileShareStorageDiagnosticsSubscriber` with the agent
+* If you're using `Azure.Storage.Files.Shares`, subscribe `AzureFileShareStorageDiagnosticsSubscriber` with the agent
 +
 [source, csharp]
 ----
@@ -260,25 +347,20 @@ For Azure Queue storage,
 * A new transaction is created when one or more messages are received from a queue
 * A new span is created when there is a current transaction, and when a message is sent to a queue
 
-For Azure Blob storage, a new span is created when there is a current transaction and when
+For Azure Blob storage, a new span is created when there is a current transaction and when a request
+is made to blob storage.
 
-* A container is created, enumerated, or deleted
-* A page blob is created, uploaded, downloaded, or deleted
-* A block blob is created, copied, uploaded, downloaded or deleted
-
-For Azure File Share storage, a new span is crated when there is a current transaction and when
-
-* A share is created or deleted
-* A directory is created or deleted
-* A file is created, uploaded, or deleted.
+For Azure File Share storage, a new span is crated when there is a current transaction and when a request
+is made to file storage.
 
 [[setup-mongo-db]]
-=== MongoDB.Driver
+=== MongoDB
 
 [float]
 ==== Quick start
 
-A prerequisite for auto instrumentation with [`MongoDb.Driver`] is to configure the `MongoClient` with `MongoDbEventSubscriber`:
+Instrumentation for MongoDB works with the official MongoDb.Driver 2.4.4+ driver packages.
+A prerequisite for auto instrumentation is to configure the `MongoClient` with `MongoDbEventSubscriber`:
 
 [source,csharp]
 ----
@@ -288,10 +370,19 @@ settings.ClusterConfigurator = builder => builder.Subscribe(new MongoDbEventSubs
 var mongoClient = new MongoClient(settings);
 ----
 
-Once the above configuration is in place, and if the agent is included by referencing the `Elastic.Apm.NetCoreAll` package, it will automatically capture calls to MongoDB on every active transaction.
-Otherwise, you can manually activate auto instrumentation from the `Elastic.Apm.MongoDb` package by calling
+Once the above configuration is in place
+
+* if the agent is included by referencing the `Elastic.Apm.NetCoreAll` package, it will automatically capture 
+calls to MongoDB on every active transaction, and no further action is required.
+* you can manually activate auto instrumentation from the `Elastic.Apm.MongoDb` package by calling
 
 [source,csharp]
 ----
 Agent.Subscribe(new MongoDbDiagnosticsSubscriber());
 ----
+
+[IMPORTANT]
+--
+MongoDB integration is currently supported on .NET Core and newer. Due to MongoDb.Driver assemblies not
+being strongly named, they cannot be used with Elastic APM's strongly named assemblies on .NET Framework.
+--

--- a/docs/public-api.asciidoc
+++ b/docs/public-api.asciidoc
@@ -51,15 +51,22 @@ With the `Elastic.Apm.Agent.Subscribe(params IDiagnosticsSubscriber[] subscriber
 
 In the case of ASP.NET Core, when you turn on the agent with the `UseAllElasticApm` method, the agent will do this automatically.
 
-With a typical console application, you need to do this manually.
+With a typical console application, you need to do this manually by
+calling `Elastic.Apm.Agent.Subscribe(params IDiagnosticsSubscriber[] subscribers)` method somewhere in your application, ideally in
+the startup code.
 
 `IDiagnosticsSubscriber` implementations are offered by the agent and they subscribe to diagnostic source events or other data sources in order to capture events automatically.
 
 Some examples:
 
-- `HttpDiagnosticsSubscriber`: captures HTTP calls through `HttpClient`
-- `EfCoreDiagnosticsSubscriber`: captures database calls through Entity Framework Core
-- `SqlClientDiagnosticSubscriber`: captures database calls through `SqlClient` 
+* [[setup-http]]`HttpDiagnosticsSubscriber`: captures HTTP calls through `HttpClient` and `HttpWebRequest`
++
+[source,csharp]
+----
+Agent.Subscribe(new HttpDiagnosticsSubscriber());
+----
+* `EfCoreDiagnosticsSubscriber`: captures database calls through Entity Framework Core
+* `SqlClientDiagnosticSubscriber`: captures database calls through `SqlClient` 
 
 [NOTE]
 --

--- a/docs/setup-auto-instrumentation.asciidoc
+++ b/docs/setup-auto-instrumentation.asciidoc
@@ -330,7 +330,7 @@ environment variable.
 `ELASTIC_APM_PROFILER_EXCLUDE_INTEGRATIONS` _(optional)_::
 
 A semi-colon separated list of integrations to exclude from auto-instrumentation.
-Valid values are those defined in the `Integration` column in the integrations
+Valid values are those defined in the `Integration name` column in the integrations
 table above.
 
 `ELASTIC_APM_PROFILER_EXCLUDE_PROCESSES` _(optional)_::
@@ -343,8 +343,8 @@ applications that should not be.
 `ELASTIC_APM_PROFILER_EXCLUDE_SERVICE_NAMES` _(optional)_::
 
 A semi-colon separated list of APM service names to exclude from auto-instrumentation.
-Values defined are checked against the value of `ELASTIC_APM_SERVICE_NAME` environment
-variable.
+Values defined are checked against the value of <<config-service-name,`ELASTIC_APM_SERVICE_NAME`>>
+environment variable.
 
 `ELASTIC_APM_PROFILER_LOG` _(optional)_::
 

--- a/docs/setup-auto-instrumentation.asciidoc
+++ b/docs/setup-auto-instrumentation.asciidoc
@@ -36,12 +36,9 @@ and instruments the following assemblies
 
 include::integrations.asciidoc[]
 
-Note that NuGet package versions do not necessarily align with the version of assemblies contained therein. 
-https://nuget.info/packages[NuGet package explorer] can be used to inspect the assembly version of assemblies within a NuGet package.
-
 [IMPORTANT]
 --
-The .NET CLR Profiling API allows only one profiler to be attached to a .NET process. In light of this limitation, only one
+**The .NET CLR Profiling API allows only one profiler to be attached to a .NET process**. In light of this limitation, only one
 solution that uses the .NET CLR profiling API should be used by an application.
 
 Auto instrumentation using the .NET CLR Profiling API can be used in conjunction with 
@@ -188,7 +185,7 @@ Set-ItemProperty HKLM:SYSTEM\CurrentControlSet\Services\<service-name> -Name Env
 was unzipped
 <2> `<service-name>` is the name of the Windows service.
 
-With PowerShell
+The service must then be restarted for the change to take effect. With PowerShell
 
 [source,powershell]
 ----
@@ -209,12 +206,13 @@ pool using https://docs.microsoft.com/en-us/iis/get-started/getting-started-with
 ----
 $appcmd = "$($env:systemroot)\system32\inetsrv\AppCmd.exe"
 $appPool = "<application-pool>" <1>
+$profilerHomeDir = "<unzipped directory>" <2>
 $environment = @{
   COR_ENABLE_PROFILING = "1"
   COR_PROFILER = "{FA65FE15-F085-4681-9B20-95E04F6C03CC}"
-  COR_PROFILER_PATH = "<unzipped directory>\elastic_apm_profiler.dll" <2>
-  ELASTIC_APM_PROFILER_HOME = "<unzipped directory>"
-  ELASTIC_APM_PROFILER_INTEGRATIONS = "<unzipped directory>\integrations.yml"
+  COR_PROFILER_PATH = "$profilerHomeDir\elastic_apm_profiler.dll"
+  ELASTIC_APM_PROFILER_HOME = "$profilerHomeDir"
+  ELASTIC_APM_PROFILER_INTEGRATIONS = "$profilerHomeDir\integrations.yml"
   COMPlus_LoaderOptimization = "1" <3>
 }
 
@@ -222,8 +220,8 @@ $environment.Keys | ForEach-Object {
   & $appcmd set config -section:system.applicationHost/applicationPools /+"[name='$appPool'].environmentVariables.[name='$_',value='$($environment[$_])']"  
 }
 ----
-<1> `<application-pool>` is the name of the Application Pool your application uses
-<2> `<unzipped directory>` is the directory to which the zip file
+<1> `<application-pool>` is the name of the Application Pool your application uses. For example, `IIS APPPOOL\DefaultAppPool`
+<2> `<unzipped directory>` is the full path to the directory in which the zip file
 was unzipped
 <3> Forces assemblies **not** to be loaded domain-neutral. There is currently a limitation
 where Profiler auto-instrumentation cannot instrument assemblies when they are loaded
@@ -235,20 +233,21 @@ around by setting this environment variable. See the https://docs.microsoft.com/
 ----
 $appcmd = "$($env:systemroot)\system32\inetsrv\AppCmd.exe"
 $appPool = "<application-pool>" <1>
+$profilerHomeDir = "<unzipped directory>" <2>
 $environment = @{
   CORECLR_ENABLE_PROFILING = "1"
   CORECLR_PROFILER = "{FA65FE15-F085-4681-9B20-95E04F6C03CC}"
-  CORECLR_PROFILER_PATH = "<unzipped directory>\elastic_apm_profiler.dll" <2>
-  ELASTIC_APM_PROFILER_HOME = "<unzipped directory>"
-  ELASTIC_APM_PROFILER_INTEGRATIONS = "<unzipped directory>\integrations.yml"
+  CORECLR_PROFILER_PATH = "$profilerHomeDir\elastic_apm_profiler.dll"
+  ELASTIC_APM_PROFILER_HOME = "$profilerHomeDir"
+  ELASTIC_APM_PROFILER_INTEGRATIONS = "$profilerHomeDir\integrations.yml"
 }
 
 $environment.Keys | ForEach-Object {
   & $appcmd set config -section:system.applicationHost/applicationPools /+"[name='$appPool'].environmentVariables.[name='$_',value='$($environment[$_])']"  
 }
 ----
-<1> `<application-pool>` is the name of the Application Pool your application uses
-<2> `<unzipped directory>` is the directory to which the zip file
+<1> `<application-pool>` is the name of the Application Pool your application uses. For example, `IIS APPPOOL\DefaultAppPool`
+<2> `<unzipped directory>` is the full path to the directory in which the zip file
 was unzipped
 
 [IMPORTANT]
@@ -302,14 +301,24 @@ systemctl reload-or-restart <service>
 ----
 
 [float]
+[[profiler-configuration]]
 === Profiler environment variables
 
 The profiler auto instrumentation has its own set of environment variables to manage
-the instrumentation
+the instrumentation. These are used in addition to <<configuration, agent configuration>> 
+through environment variables.
+
 
 `ELASTIC_APM_PROFILER_HOME`::
 
-The home directory of the profiler auto instrumentation.
+The home directory of the profiler auto instrumentation. The home directory typically 
+contains 
+
+* platform specific profiler assemblies
+* a directory for each compatible target framework, where each directory contains
+supporting managed assemblies for auto instrumentation.
+* an integrations.yml file that determines which methods to target for
+auto instrumentation
 
 `ELASTIC_APM_PROFILER_INTEGRATIONS` _(optional)_::
 
@@ -362,3 +371,13 @@ The directory in which to write profiler log files. If unset, defaults to
 If the default directory cannot be written to for some reason, the profiler
 will try to write log files to a `logs` directory in the home directory specified 
 by `ELASTIC_APM_PROFILER_HOME` environment variable.
+
+`ELASTIC_APM_PROFILER_LOG_TARGETS` _(optional)_::
+
+A semi-colon separated list of targets for profiler logs. Valid values are
+
+* file
+* stdout
+
+The default value is `file`, which logs to the directory specified by
+`ELASTIC_APM_PROFILER_LOG_DIR` environment variable.

--- a/docs/supported-technologies.asciidoc
+++ b/docs/supported-technologies.asciidoc
@@ -28,7 +28,7 @@ the agent will not capture transactions.
 === .NET versions
 
 The agent works on every .NET flavor and version that supports .NET Standard 2.0.
-This means .NET Core 2.0 (or newer) and .NET Framework 4.6.1 (or newer).
+This means .NET Core 2.0 or newer, and .NET Framework 4.6.1 or newer.
 
 [float]
 [[supported-web-frameworks]]
@@ -37,18 +37,22 @@ This means .NET Core 2.0 (or newer) and .NET Framework 4.6.1 (or newer).
 Automatic instrumentation for a web framework means
 a transaction is automatically created for each incoming request and it is named after the registered route.
 
-We support automatic instrumentation for the following web frameworks.
+Automatic instrumentation is supported for the following web frameworks
 
 |===
-|Framework |Supported versions |Supported since agent's version
+|Framework |Supported versions |Integration
 
-|ASP.NET Core
-|2.1 and later
-|1.0
+| ASP.NET Core added[1.0]
+| 2.1+
+| <<setup-asp-net-core, NuGet package>>
 
-|ASP.NET (.NET Framework) on IIS
-|4.6.1 or newer (IIS 7.0 or newer)
-|1.1
+| ASP.NET (.NET Framework) in IIS  added[1.1]
+| 4.6.1+ (IIS 7.0 or newer)
+| <<setup-auto-instrumentation, Profiler auto instrumentation>>
+
+  _or_
+
+  <<setup-asp-dot-net, NuGet package>>
 
 |===
 
@@ -58,49 +62,100 @@ We support automatic instrumentation for the following web frameworks.
 
 The agent supports gRPC on .NET Core both on the client and the server side. Every gRPC call is automatically captured by the agent. 
 
-Streaming is not supported. In practice this means for streaming use-cases the agent does not create transactions and spans automatically.
+Streaming is not supported; for streaming use-cases, the agent does not create transactions and spans automatically.
 
 |===
-|Framework |Supported versions |Supported since agent's version
+|Framework |Supported versions |Integration
 
-|gRPC on .NET Core
-|2.23.2+
-|1.7
+.2+| gRPC added[1.7]
+| Grpc.Net.Client 2.23.2+ _(client side)_
+| <<setup-grpc, NuGet package>>
+| ASP.NET Core 2.1+ _(server side)_
+| <<setup-asp-net-core, NuGet package>>
+
 |===
 
 [float]
 [[supported-data-access-technologies]]
 === Data access technologies
 
-We support automatic instrumentation for the following data access technologies.
+Automatic instrumentation is supported for the following data access technologies
 
 |===
-|Data access technology |Supported versions |Notes |Supported since agent's version
+|Data access technology |Supported versions |Integration
 
-| Entity Framework (EF) Core
-| 2.x+
-| A DB span is automatically created for each access to underlying database performed by Entity Framework Core.
-| 1.0
+.3+| Azure CosmosDB added[1.11]
+| Microsoft.Azure.Cosmos 3.0.0+
+| Microsoft.Azure.DocumentDB.Core 2.4.1+
+| Microsoft.Azure.DocumentDB 2.4.1+
+.3+| <<setup-azure-cosmosdb, NuGet package>>
 
-| Entity Framework (EF) 6
-| 6.2+
-| A DB span is automatically created for each access to underlying database performed by Entity Framework 6.
-| 1.2
+| Entity Framework Core added[1.0]
+| Microsoft.EntityFrameworkCore 2.x+
+| <<setup-ef-core, NuGet package>>
 
-| Elasticsearch (Elasticsearch.Net and NEST)
-| 7.6.0+
-| __If you're using 7.10.1 or 7.11.0, upgrade to at least 7.11.1 which fixes a bug in capture__
-| 1.6
+| Entity Framework 6 added[1.2]
+| EntityFramework 6.2+
+| <<setup-ef6, NuGet package>>
 
-| MongoDb (MongoDB.Driver)
-| 2.4.4+
-| A DB span is automatically created for each profiled call to MongoDB.
-| 1.9
+| Elasticsearch added[1.6]
+| Elasticsearch.Net 7.6.0+
+  NEST 7.6.0+
+| <<setup-elasticsearch, NuGet package>>
 
-| Redis (StackExchange.Redis)
-| 2.0.495+
-| A DB span is automatically created for each profiled redis command performed by StackExchange.Redis 
-| 1.8
+| MySQL added[1.12]
+| see profiler documentation
+| <<setup-auto-instrumentation, Profiler auto instrumentation>>
+
+| MongoDB added[1.9]
+| MongoDB.Driver 2.4.4+
+| <<setup-mongo-db, NuGet package>>
+
+| Oracle added[1.12]
+| see profiler documentation
+| <<setup-auto-instrumentation, Profiler auto instrumentation>>
+
+| PostgreSQL added[1.12]
+| see profiler documentation
+| <<setup-auto-instrumentation, Profiler auto instrumentation>>
+
+| Redis added[1.8]
+| StackExchange.Redis 2.0.495+
+| <<setup-stackexchange-redis, NuGet package>>
+
+.2+| SqlClient
+| System.Data.SqlClient 2.0.495+ added[1.8]
+| <<setup-sqlclient, NuGet package>>
+| see profiler documentation added[1.12]
+| <<setup-auto-instrumentation, Profiler auto instrumentation>>
+
+| SQLite added[1.12]
+| see profiler documentation
+| <<setup-auto-instrumentation, Profiler auto instrumentation>>
+
+|===
+
+[float]
+[[supported-messaging-systems]]
+=== Messaging systems
+
+We support automatic instrumentation for the following messaging systems
+
+|===
+|Messaging system |Supported versions |Integration
+
+.2+| Azure Service Bus added[1.10]
+| Microsoft.Azure.ServiceBus 3.0.0+
+| Azure.Messaging.ServiceBus 7.0.0+
+.2+| <<setup-azure-servicebus, NuGet package>>
+
+| Azure Queue Storage added[1.10]
+| Azure.Storage.Queues 12.6.0+
+| <<setup-azure-storage, NuGet package>>
+
+| Kafka added[1.12]
+| see profiler documentation
+| <<setup-auto-instrumentation, Profiler auto instrumentation>>
 
 |===
 
@@ -110,18 +165,17 @@ We support automatic instrumentation for the following data access technologies.
 
 Automatic instrumentation for networking client-side technology means
 an HTTP span is automatically created for each outgoing HTTP request and tracing headers are propagated. 
-The spans are named after the schema `<method> <host>`, for example `GET elastic.co`.
 
 |===
-|Framework |Supported versions |Supported since agent's version
+|Framework |Supported versions |Integration
 
-|System.Net.Http.HttpClient on .NET Core
-|
-|1.0
+| System.Net.Http.HttpClient added[1.0]
+| _built-in_
+| _built-in_
 
-|System.Net.Http.HttpClient on .NET Framework
-|
-|1.1
+| System.Net.HttpWebRequest added[1.1]
+| _built-in_
+| _built-in_
 
 |===
 
@@ -132,26 +186,23 @@ The spans are named after the schema `<method> <host>`, for example `GET elastic
 Automatic instrumentation for the following cloud services
 
 |===
-| Cloud services | Supported versions | Notes | Supported since agent's version
+|Cloud service |Supported versions |Integration
 
-| Azure Service Bus
-| 3.0.0+ for Microsoft.Azure.ServiceBus,
-  7.0.0+ for Azure.Messaging.ServiceBus
-| A new transaction is created for received and
-receive deferred messages. A new span is created for sent and scheduled messages if there's a current transaction.
-| 1.10
+.3+| Azure CosmosDB added[1.11]
+| Microsoft.Azure.Cosmos 3.0.0+
+| Microsoft.Azure.DocumentDB.Core 2.4.1+
+| Microsoft.Azure.DocumentDB 2.4.1+
+.3+| <<setup-azure-cosmosdb, NuGet package>>
 
-| Azure Storage
-| 12.8.0+ for Azure.Storage.Blobs
-  12.6.0+ for Azure.Storage.Queues and Azure.Storage.Files.Shares
-| 
-| 1.10
+.2+| Azure Service Bus added[1.10]
+| Microsoft.Azure.ServiceBus 3.0.0+
+| Azure.Messaging.ServiceBus 7.0.0+
+.2+| <<setup-azure-servicebus, NuGet package>>
 
-| Azure Cosmos DB
-| 3.0.0+ for Microsoft.Azure.Cosmos
-  2.4.1+ for Microsoft.Azure.DocumentDB.Core
-  2.4.1+ for Microsoft.Azure.DocumentDB
-| 
-| 1.11
+.3+| Azure Storage added[1.10]
+| Azure.Storage.Blobs 12.6.0+
+| Azure.Storage.Queues 12.6.0+
+| Azure.Storage.Files.Shares 12.6.0+
+.3+| <<setup-azure-storage, NuGet package>>
 
 |===

--- a/docs/supported-technologies.asciidoc
+++ b/docs/supported-technologies.asciidoc
@@ -42,17 +42,17 @@ Automatic instrumentation is supported for the following web frameworks
 |===
 |Framework |Supported versions |Integration
 
-| ASP.NET Core added[1.0]
-| 2.1+
-| <<setup-asp-net-core, NuGet package>>
+|ASP.NET Core added[1.0]
+|2.1+
+|<<setup-asp-net-core, NuGet package>>
 
-| ASP.NET (.NET Framework) in IIS  added[1.1]
-| 4.6.1+ (IIS 7.0 or newer)
-| <<setup-auto-instrumentation, Profiler auto instrumentation>>
+|ASP.NET (.NET Framework) in IIS  added[1.1]
+|4.6.1+ (IIS 7.0 or newer)
+|<<setup-auto-instrumentation, Profiler auto instrumentation>>
 
-  _or_
+_or_
 
-  <<setup-asp-dot-net, NuGet package>>
+<<setup-asp-dot-net, NuGet package>>
 
 |===
 
@@ -67,11 +67,11 @@ Streaming is not supported; for streaming use-cases, the agent does not create t
 |===
 |Framework |Supported versions |Integration
 
-.2+| gRPC added[1.7]
-| Grpc.Net.Client 2.23.2+ _(client side)_
-| <<setup-grpc, NuGet package>>
-| ASP.NET Core 2.1+ _(server side)_
-| <<setup-asp-net-core, NuGet package>>
+.2+.^| gRPC added[1.7]
+|Grpc.Net.Client 2.23.2+ _(client side)_
+|<<setup-grpc, NuGet package>>
+|ASP.NET Core 2.1+ _(server side)_
+|<<setup-asp-net-core, NuGet package>>
 
 |===
 
@@ -84,54 +84,54 @@ Automatic instrumentation is supported for the following data access technologie
 |===
 |Data access technology |Supported versions |Integration
 
-.3+| Azure CosmosDB added[1.11]
-| Microsoft.Azure.Cosmos 3.0.0+
-| Microsoft.Azure.DocumentDB.Core 2.4.1+
-| Microsoft.Azure.DocumentDB 2.4.1+
-.3+| <<setup-azure-cosmosdb, NuGet package>>
+.3+.^|Azure CosmosDB added[1.11]
+|Microsoft.Azure.Cosmos 3.0.0+
+.3+.^|<<setup-azure-cosmosdb, NuGet package>>
+|Microsoft.Azure.DocumentDB.Core 2.4.1+
+|Microsoft.Azure.DocumentDB 2.4.1+
 
-| Entity Framework Core added[1.0]
-| Microsoft.EntityFrameworkCore 2.x+
-| <<setup-ef-core, NuGet package>>
+|Entity Framework Core added[1.0]
+|Microsoft.EntityFrameworkCore 2.x+
+|<<setup-ef-core, NuGet package>>
 
-| Entity Framework 6 added[1.2]
-| EntityFramework 6.2+
-| <<setup-ef6, NuGet package>>
+|Entity Framework 6 added[1.2]
+|EntityFramework 6.2+
+|<<setup-ef6, NuGet package>>
 
-| Elasticsearch added[1.6]
-| Elasticsearch.Net 7.6.0+
-  NEST 7.6.0+
-| <<setup-elasticsearch, NuGet package>>
+.2+.^|Elasticsearch added[1.6]
+|Elasticsearch.Net 7.6.0+
+.2+.^|<<setup-elasticsearch, NuGet package>>
+|NEST 7.6.0+
 
-| MySQL added[1.12]
-| see profiler documentation
-| <<setup-auto-instrumentation, Profiler auto instrumentation>>
+|MySQL added[1.12]
+|See profiler documentation
+|<<setup-auto-instrumentation, Profiler auto instrumentation>>
 
-| MongoDB added[1.9]
-| MongoDB.Driver 2.4.4+
-| <<setup-mongo-db, NuGet package>>
+|MongoDB added[1.9]
+|MongoDB.Driver 2.4.4+
+|<<setup-mongo-db, NuGet package>>
 
-| Oracle added[1.12]
-| see profiler documentation
-| <<setup-auto-instrumentation, Profiler auto instrumentation>>
+|Oracle added[1.12]
+|See profiler documentation
+|<<setup-auto-instrumentation, Profiler auto instrumentation>>
 
-| PostgreSQL added[1.12]
-| see profiler documentation
-| <<setup-auto-instrumentation, Profiler auto instrumentation>>
+|PostgreSQL added[1.12]
+|See profiler documentation
+|<<setup-auto-instrumentation, Profiler auto instrumentation>>
 
-| Redis added[1.8]
-| StackExchange.Redis 2.0.495+
-| <<setup-stackexchange-redis, NuGet package>>
+|Redis added[1.8]
+|StackExchange.Redis 2.0.495+
+|<<setup-stackexchange-redis, NuGet package>>
 
-.2+| SqlClient
-| System.Data.SqlClient 2.0.495+ added[1.8]
-| <<setup-sqlclient, NuGet package>>
-| see profiler documentation added[1.12]
-| <<setup-auto-instrumentation, Profiler auto instrumentation>>
+.2+|SqlClient
+|System.Data.SqlClient 2.0.495+ added[1.8]
+|<<setup-sqlclient, NuGet package>>
+|See profiler documentation added[1.12]
+|<<setup-auto-instrumentation, Profiler auto instrumentation>>
 
-| SQLite added[1.12]
-| see profiler documentation
-| <<setup-auto-instrumentation, Profiler auto instrumentation>>
+|SQLite added[1.12]
+|See profiler documentation
+|<<setup-auto-instrumentation, Profiler auto instrumentation>>
 
 |===
 
@@ -144,18 +144,18 @@ We support automatic instrumentation for the following messaging systems
 |===
 |Messaging system |Supported versions |Integration
 
-.2+| Azure Service Bus added[1.10]
-| Microsoft.Azure.ServiceBus 3.0.0+
-| Azure.Messaging.ServiceBus 7.0.0+
-.2+| <<setup-azure-servicebus, NuGet package>>
+.2+.^|Azure Service Bus added[1.10]
+|Microsoft.Azure.ServiceBus 3.0.0+
+.2+.^| <<setup-azure-servicebus, NuGet package>>
+|Azure.Messaging.ServiceBus 7.0.0+
 
-| Azure Queue Storage added[1.10]
-| Azure.Storage.Queues 12.6.0+
-| <<setup-azure-storage, NuGet package>>
+|Azure Queue Storage added[1.10]
+|Azure.Storage.Queues 12.6.0+
+|<<setup-azure-storage, NuGet package>>
 
-| Kafka added[1.12]
-| see profiler documentation
-| <<setup-auto-instrumentation, Profiler auto instrumentation>>
+|Kafka added[1.12]
+|See profiler documentation
+|<<setup-auto-instrumentation, Profiler auto instrumentation>>
 
 |===
 
@@ -169,13 +169,10 @@ an HTTP span is automatically created for each outgoing HTTP request and tracing
 |===
 |Framework |Supported versions |Integration
 
-| System.Net.Http.HttpClient added[1.0]
-| _built-in_
-| _built-in_
-
-| System.Net.HttpWebRequest added[1.1]
-| _built-in_
-| _built-in_
+|System.Net.Http.HttpClient added[1.0]
+.2+.^|_built-in_
+.2+.^|<<setup-http,part of Elastic.Apm>>
+|System.Net.HttpWebRequest added[1.1]
 
 |===
 
@@ -188,21 +185,21 @@ Automatic instrumentation for the following cloud services
 |===
 |Cloud service |Supported versions |Integration
 
-.3+| Azure CosmosDB added[1.11]
-| Microsoft.Azure.Cosmos 3.0.0+
-| Microsoft.Azure.DocumentDB.Core 2.4.1+
-| Microsoft.Azure.DocumentDB 2.4.1+
-.3+| <<setup-azure-cosmosdb, NuGet package>>
+.3+.^|Azure CosmosDB added[1.11]
+|Microsoft.Azure.Cosmos 3.0.0+
+.3+.^| <<setup-azure-cosmosdb, NuGet package>>
+|Microsoft.Azure.DocumentDB.Core 2.4.1+
+|Microsoft.Azure.DocumentDB 2.4.1+
 
-.2+| Azure Service Bus added[1.10]
-| Microsoft.Azure.ServiceBus 3.0.0+
-| Azure.Messaging.ServiceBus 7.0.0+
-.2+| <<setup-azure-servicebus, NuGet package>>
+.2+.^|Azure Service Bus added[1.10]
+|Microsoft.Azure.ServiceBus 3.0.0+
+.2+.^| <<setup-azure-servicebus, NuGet package>>
+|Azure.Messaging.ServiceBus 7.0.0+
 
-.3+| Azure Storage added[1.10]
-| Azure.Storage.Blobs 12.6.0+
-| Azure.Storage.Queues 12.6.0+
-| Azure.Storage.Files.Shares 12.6.0+
-.3+| <<setup-azure-storage, NuGet package>>
+.3+.^|Azure Storage added[1.10]
+|Azure.Storage.Blobs 12.8.0+
+.3+.^| <<setup-azure-storage, NuGet package>>
+|Azure.Storage.Queues 12.6.0+
+|Azure.Storage.Files.Shares 12.6.0+
 
 |===

--- a/src/Elastic.Apm.Profiler.IntegrationsGenerator/Program.cs
+++ b/src/Elastic.Apm.Profiler.IntegrationsGenerator/Program.cs
@@ -60,6 +60,7 @@ namespace Elastic.Apm.Profiler.IntegrationsGenerator
 							{
 								Target = new Target
 								{
+									Nuget = item.attribute.Nuget,
 									Assembly = item.attribute.Assembly,
 									Type = item.attribute.Type,
 									Method = item.attribute.Method,
@@ -109,24 +110,34 @@ namespace Elastic.Apm.Profiler.IntegrationsGenerator
 			var builder = new StringBuilder();
 			builder
 				.AppendLine(":star: *")
+				.AppendLine(":nuget: https://www.nuget.org/packages")
 				.AppendLine()
 				.AppendLine("|===")
-				.AppendLine("|**Integration name** |**Assembly** |**Supported assembly version range**");
+				.AppendLine("|**Integration name** |**NuGet package version(s)** |**Assembly version(s)** ");
 
 			foreach (var integration in integrations)
 			{
 				var integrationMethods =
 					integration.MethodReplacements
-						.GroupBy(m => (m.Target.Assembly, m.Target.MinimumVersion, m.Target.MaximumVersion))
+						.GroupBy(m => (m.Target.Nuget, m.Target.Assembly, m.Target.MinimumVersion, m.Target.MaximumVersion))
 						.ToList();
 
 				builder.AppendLine($".{integrationMethods.Count}+| {integration.Name}");
 
 				foreach (var integrationMethod in integrationMethods)
 				{
-					builder.AppendLine($"| {integrationMethod.Key.Assembly}")
-						.AppendLine($"| {integrationMethod.Key.MinimumVersion.Replace("*", "{star}")} - "
-							+ $"{integrationMethod.Key.MaximumVersion.Replace("*", "{star}")}")
+					var versionRange = $"{integrationMethod.Key.MinimumVersion.Replace("*", "{star}")} - "
+						+ $"{integrationMethod.Key.MaximumVersion.Replace("*", "{star}")}";
+
+					var nuget = integrationMethod.Key.Nuget is not null
+						? integrationMethod.Key.Nuget.StartsWith("part of")
+							? integrationMethod.Key.Nuget
+							: $"{{nuget}}/{integrationMethod.Key.Nuget}[{integrationMethod.Key.Nuget} {versionRange}]"
+						: $"{{nuget}}/{integrationMethod.Key.Assembly}[{integrationMethod.Key.Assembly} {versionRange}]";
+
+					builder
+						.AppendLine($"| {nuget}")
+						.AppendLine($"| {integrationMethod.Key.Assembly} {versionRange}")
 						.AppendLine();
 				}
 			}

--- a/src/Elastic.Apm.Profiler.IntegrationsGenerator/Program.cs
+++ b/src/Elastic.Apm.Profiler.IntegrationsGenerator/Program.cs
@@ -113,7 +113,7 @@ namespace Elastic.Apm.Profiler.IntegrationsGenerator
 				.AppendLine(":nuget: https://www.nuget.org/packages")
 				.AppendLine()
 				.AppendLine("|===")
-				.AppendLine("|**Integration name** |**NuGet package version(s)** |**Assembly version(s)** ");
+				.AppendLine("|Integration name |NuGet package version(s) |Assembly version(s) ");
 
 			foreach (var integration in integrations)
 			{
@@ -122,7 +122,7 @@ namespace Elastic.Apm.Profiler.IntegrationsGenerator
 						.GroupBy(m => (m.Target.Nuget, m.Target.Assembly, m.Target.MinimumVersion, m.Target.MaximumVersion))
 						.ToList();
 
-				builder.AppendLine($".{integrationMethods.Count}+| {integration.Name}");
+				builder.AppendLine($".{integrationMethods.Count}+.^|{integration.Name}");
 
 				foreach (var integrationMethod in integrationMethods)
 				{
@@ -136,8 +136,8 @@ namespace Elastic.Apm.Profiler.IntegrationsGenerator
 						: $"{{nuget}}/{integrationMethod.Key.Assembly}[{integrationMethod.Key.Assembly} {versionRange}]";
 
 					builder
-						.AppendLine($"| {nuget}")
-						.AppendLine($"| {integrationMethod.Key.Assembly} {versionRange}")
+						.AppendLine($"|{nuget}")
+						.AppendLine($"|{integrationMethod.Key.Assembly} {versionRange}")
 						.AppendLine();
 				}
 			}

--- a/src/Elastic.Apm.Profiler.IntegrationsGenerator/Target.cs
+++ b/src/Elastic.Apm.Profiler.IntegrationsGenerator/Target.cs
@@ -3,10 +3,14 @@
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
 
+using YamlDotNet.Serialization;
+
 namespace Elastic.Apm.Profiler.IntegrationsGenerator
 {
 	public class Target
 	{
+		[YamlIgnore]
+		public string Nuget { get; set; }
 		public string Assembly { get; set; }
 		public string Type { get; set; }
 		public string Method { get; set; }

--- a/src/Elastic.Apm.Profiler.Managed.Core/InstrumentAttribute.cs
+++ b/src/Elastic.Apm.Profiler.Managed.Core/InstrumentAttribute.cs
@@ -23,6 +23,13 @@ namespace Elastic.Apm.Profiler.Managed.Core
 		public string Assembly { get; set; }
 
 		/// <summary>
+		/// The name of the nuget package containing the assembly to instrument.
+		/// Used for documentation. If unspecified, will use <see cref="Assembly"/> value.
+		/// Values starting with "part of" are specially treated.
+		/// </summary>
+		public string Nuget { get; set; }
+
+		/// <summary>
 		/// The fully qualified name of the type containing the target method to instrument
 		/// </summary>
 		public string Type { get; set; }

--- a/src/Elastic.Apm.Profiler.Managed/Integrations/AdoNet/AdoNetTypeNames.cs
+++ b/src/Elastic.Apm.Profiler.Managed/Integrations/AdoNet/AdoNetTypeNames.cs
@@ -47,6 +47,7 @@ namespace Elastic.Apm.Profiler.Managed.Integrations.AdoNet
 	{
 		public InstrumentOracleManagedDataAccessCoreAttribute()
 		{
+			Nuget = "Oracle.ManagedDataAccess.Core";
 			Assembly = "Oracle.ManagedDataAccess";
 			Type = "Oracle.ManagedDataAccess.Client.OracleCommand";
 			MinimumVersion = "2.0.0";
@@ -119,6 +120,7 @@ namespace Elastic.Apm.Profiler.Managed.Integrations.AdoNet
 	{
 		public InstrumentSystemDataAttribute()
 		{
+			Nuget = "part of .NET";
 			Assembly = "System.Data";
 			Type = "System.Data.Common.DbCommand";
 			MinimumVersion = "4.0.0";
@@ -131,6 +133,7 @@ namespace Elastic.Apm.Profiler.Managed.Integrations.AdoNet
 	{
 		public InstrumentSystemDataCommonAttribute()
 		{
+			Nuget = "part of .NET";
 			Assembly = "System.Data.Common";
 			Type = "System.Data.Common.DbCommand";
 			MinimumVersion = "4.0.0";

--- a/src/Elastic.Apm.Profiler.Managed/Integrations/AdoNet/AdoNetTypeNames.cs
+++ b/src/Elastic.Apm.Profiler.Managed/Integrations/AdoNet/AdoNetTypeNames.cs
@@ -35,6 +35,7 @@ namespace Elastic.Apm.Profiler.Managed.Integrations.AdoNet
 	{
 		public InstrumentOracleManagedDataAccessAttribute()
 		{
+			Nuget = "Oracle.ManagedDataAccess 12.2.1100 - 21.*.*";
 			Assembly = "Oracle.ManagedDataAccess";
 			Type = "Oracle.ManagedDataAccess.Client.OracleCommand";
 			MinimumVersion = "4.122.0";
@@ -84,6 +85,7 @@ namespace Elastic.Apm.Profiler.Managed.Integrations.AdoNet
 	{
 		public InstrumentSystemDataSqlAttribute()
 		{
+			Nuget = "part of .NET";
 			Assembly = "System.Data";
 			Type = "System.Data.SqlClient.SqlCommand";
 			MinimumVersion = "4.0.0";

--- a/src/Elastic.Apm.Profiler.Managed/Integrations/AspNet/ElasticApmModuleIntegration.cs
+++ b/src/Elastic.Apm.Profiler.Managed/Integrations/AspNet/ElasticApmModuleIntegration.cs
@@ -23,6 +23,7 @@ namespace Elastic.Apm.Profiler.Managed.Integrations.AspNet
     /// System.Web.Compilation.BuildManager.InvokePreStartInitMethodsCore calltarget instrumentation
     /// </summary>
     [Instrument(
+		Nuget = "part of .NET Framework",
         Assembly = "System.Web",
         Type = "System.Web.Compilation.BuildManager",
         Method = "InvokePreStartInitMethodsCore",


### PR DESCRIPTION
This commit improves the documentation by

- Adding NuGet package information to Profiler auto instrumentation.
Assembly versions supported don't always align with NuGet package
versions.
- linking each supported technology to the relevant integration section
- Moving agent added versions to tags
- Adding missing sections for NuGet packages