### PR TITLE
Set span context destination service name and type to empty string

### DIFF
--- a/src/Elastic.Apm/Api/Destination.cs
+++ b/src/Elastic.Apm/Api/Destination.cs
@@ -73,8 +73,8 @@ namespace Elastic.Apm.Api
 			/// Identifier for the destination service (e.g. 'http://elastic.co', 'elasticsearch', 'rabbitmq')"
 			/// </summary>
 			[MaxLength]
-			[Obsolete("This field will be removed in future versions")]
-			public string Name { get; set; }
+			[Obsolete("This field is unused by Elastic APM and will be removed in a future version")]
+			public string Name { get; set; } = string.Empty;
 
 			/// <summary>
 			/// Identifier for the destination service resource being operated on (e.g. 'http://elastic.co:80', 'elasticsearch',
@@ -87,8 +87,8 @@ namespace Elastic.Apm.Api
 			/// Type of the destination service (e.g. 'db', 'elasticsearch'). Should typically be the same as span.type.
 			/// </summary>
 			[MaxLength]
-			[Obsolete("This field will be removed in future versions")]
-			public string Type { get; set; }
+			[Obsolete("This field is unused by Elastic APM and will be removed in a future version")]
+			public string Type { get; set; } = string.Empty;
 		}
 
 		/// <summary>

--- a/test/Elastic.Apm.Tests/SerializationTests.cs
+++ b/test/Elastic.Apm.Tests/SerializationTests.cs
@@ -463,6 +463,15 @@ namespace Elastic.Apm.Tests
 			detectedHostName.Should().NotBeNull();
 		}
 
+		[Fact]
+		public void SpanContext_Destination_Service_Should_Serialize_Name_And_Type_As_Empty_String_By_Default()
+		{
+			var destinationService = new Destination.DestinationService();
+
+			var json = _payloadItemSerializer.Serialize(destinationService);
+			json.Should().Contain("\"name\":\"\"").And.Contain("\"type\":\"\"");
+		}
+
 		/// <summary>
 		/// A dummy type for tests.
 		/// </summary>


### PR DESCRIPTION
This commit updates the Span context destination service name
and type to set them to empty string by default.

Both fields are marked as obsolete and will be removed in a
future version, but need to be sent as empty strings for
older APM server compatibility, which validates the presence
of these fields.

Fixes #1563