### PR TITLE
Add trace log with callstack in Agent.Setup

### DIFF
--- a/src/Elastic.Apm/Agent.cs
+++ b/src/Elastic.Apm/Agent.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using Elastic.Apm.Api;
 using Elastic.Apm.BackendComm.CentralConfig;
 using Elastic.Apm.Config;
@@ -162,8 +163,12 @@ namespace Elastic.Apm
 		public static void Setup(AgentComponents agentComponents)
 		{
 			if (LazyApmAgent.IsValueCreated)
-				agentComponents?.Logger?.Error()?.Log("The singleton APM agent has" +
-					" already been instantiated and can no longer be configured. Reusing existing instance");
+				agentComponents?.Logger?.Error()
+					?.Log("The singleton APM agent has" +
+						" already been instantiated and can no longer be configured. Reusing existing instance");
+
+			agentComponents?.Logger?.Trace()
+				?.Log("Initialization - Agent.Setup called. Callstack: {callstack}", new StackTrace().ToString());
 
 			Components = agentComponents;
 			_isConfigured = true;


### PR DESCRIPTION
This could help us diagnose double initialization issues better. This will we'll know the callstack of the first initialization.