### PR TITLE
Change unknown service.name to align with other agents

### DIFF
--- a/src/Elastic.Apm/Config/AbstractConfigurationReader.cs
+++ b/src/Elastic.Apm/Config/AbstractConfigurationReader.cs
@@ -622,7 +622,7 @@ namespace Elastic.Apm.Config
 			return null;
 		}
 
-		internal static string AdaptServiceName(string originalName) =>
+		private static string AdaptServiceName(string originalName) =>
 			originalName != null
 				? Regex.Replace(originalName, "[^a-zA-Z0-9 _-]", "_")
 				: null;

--- a/src/Elastic.Apm/Config/ConfigConsts.cs
+++ b/src/Elastic.Apm/Config/ConfigConsts.cs
@@ -38,7 +38,7 @@ namespace Elastic.Apm.Config
 			public const bool TraceContextIgnoreSampledFalse = false;
 			public const int TransactionMaxSpans = 500;
 			public const double TransactionSampleRate = 1.0;
-			public const string UnknownServiceName = "unknown";
+			public const string UnknownServiceName = "unknown-" + Consts.AgentName + "-service";
 			public const bool UseElasticTraceparentHeader = true;
 			public const bool VerifyServerCert = true;
 


### PR DESCRIPTION
Solves https://github.com/elastic/apm-agent-dotnet/issues/1585 

This is already covered by an existing test: `ConfigTests.UnknownServiceNameValueTest` - which automatically picks up and tests the new default fallback. So no test adaption needed.