### PR TITLE
Update Elastic.Apm.AspNetCore.csproj

### DIFF
--- a/src/Elastic.Apm.AspNetCore/Elastic.Apm.AspNetCore.csproj
+++ b/src/Elastic.Apm.AspNetCore/Elastic.Apm.AspNetCore.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AssemblyName>Elastic.Apm.AspNetCore</AssemblyName>
     <RootNamespace>Elastic.Apm.AspNetCore</RootNamespace>
@@ -35,7 +35,6 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="5.0.0" />
-    <ProjectReference Include="..\Elastic.Apm.OpenTelemetry\Elastic.Apm.OpenTelemetry.csproj" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Elastic.Apm.Extensions.Hosting\Elastic.Apm.Extensions.Hosting.csproj" />


### PR DESCRIPTION
Remove `Elastic.Apm.OpenTelemetry.csproj` -  we ended up not using a separate project, that code lives in `Elastic.Apm`. 

Solves https://github.com/elastic/apm-agent-dotnet/issues/1595.