### PR TITLE
Update Jenkinsfile - bump rust version

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -180,7 +180,7 @@ pipeline {
                       unstash 'source'
                       dir("${BASE_DIR}"){
                         dotnet(){
-                          sh label: 'Rustup', script: 'rustup default 1.54.0'
+                          sh label: 'Rustup', script: 'rustup default 1.56.0'
                           sh label: 'Cargo make', script: 'cargo install --force cargo-make'
                           sh label: 'Build', script: './build.sh profiler-zip'
                           sh label: 'Test & coverage', script: '.ci/linux/test-profiler.sh'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -101,7 +101,7 @@ pipeline {
                           whenTrue(isPR()) {
                             // build nuget packages and profiler
                             sh(label: 'Package', script: '.ci/linux/release.sh true')
-                            sh label: 'Rustup', script: 'rustup default 1.54.0'
+                            sh label: 'Rustup', script: 'rustup default 1.56.0'
                             sh label: 'Cargo make', script: 'cargo install --force cargo-make'
                             sh(label: 'Build profiler', script: './build.sh profiler-zip')
                           }


### PR DESCRIPTION
Bump rust version to fix:

```
[2022-01-12T15:56:24.729Z] + cargo install --force cargo-make
[2022-01-12T15:56:24.729Z]     Updating crates.io index
[2022-01-12T15:56:56.866Z]  Downloading crates ...
[2022-01-12T15:56:56.866Z]   Downloaded cargo-make v0.35.8
[2022-01-12T15:56:57.129Z] error: failed to parse manifest at `/var/lib/jenkins/workspace/net_apm-agent-dotnet-mbp_PR-1600/apm-agent-dotnet/.cargo/registry/src/github.com-1ecc6299db9ec823/cargo-make-0.35.8/Cargo.toml`
[2022-01-12T15:56:57.129Z] 
[2022-01-12T15:56:57.129Z] Caused by:
[2022-01-12T15:56:57.129Z]   feature `edition2021` is required
[2022-01-12T15:56:57.129Z] 
[2022-01-12T15:56:57.129Z]   this Cargo does not support nightly features, but if you
[2022-01-12T15:56:57.129Z]   switch to nightly channel you can add
[2022-01-12T15:56:57.129Z]   `cargo-features = ["edition2021"]` to enable this feature
script returned exit code 101
```