### PR TITLE
Build startuphook zip containing DiagnosticSource 6.x

### DIFF
--- a/build/scripts/ReleaseNotes.fs
+++ b/build/scripts/ReleaseNotes.fs
@@ -53,7 +53,7 @@ module ReleaseNotes =
             ("uncategorized", "Uncategorized")
         ]
         uncategorized = "uncategorized"
-    };
+    }
         
     let private groupByLabel (config: Config) (items: List<GitHubItem>) =
         let dict = Dictionary<string, GitHubItem list>()     

--- a/sample/Elastic.Apm.StartupHook.Sample/Elastic.Apm.StartupHook.Sample.csproj
+++ b/sample/Elastic.Apm.StartupHook.Sample/Elastic.Apm.StartupHook.Sample.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.0;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.0;netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   

--- a/sample/Elastic.Apm.StartupHook.Sample/Startup.cs
+++ b/sample/Elastic.Apm.StartupHook.Sample/Startup.cs
@@ -21,7 +21,7 @@ namespace Elastic.Apm.StartupHook.Sample
 		// This method gets called by the runtime. Use this method to add services to the container.
 		public void ConfigureServices(IServiceCollection services)
 		{
-#if NET5_0
+#if NET5_0 || NET6_0
 			services.AddControllersWithViews();
 #else
 			services.AddMvc();

--- a/src/Elastic.Apm/Elastic.Apm.csproj
+++ b/src/Elastic.Apm/Elastic.Apm.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net5.0;net461;net6.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net5.0;net6.0;net461</TargetFrameworks>
     <IsPackable>true</IsPackable>
   </PropertyGroup>
   <PropertyGroup>
@@ -55,11 +55,13 @@
     <InternalsVisibleTo Include="Elastic.Apm.Profiler.Managed" Key="$(ExposedPublicKey)" />
     <InternalsVisibleTo Include="Elastic.Apm.Profiler.Managed.Tests" Key="$(ExposedPublicKey)" />
   </ItemGroup>
-  <ItemGroup Condition="'$(DiagnosticSourceVersion)' == '' and '$(TargetFramework)' == 'net6.0'">
-    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="6.0.0" />
-  </ItemGroup>
+<!--  <ItemGroup Condition="'$(DiagnosticSourceVersion)' == '' and '$(TargetFramework)' == 'net6.0'">-->
+<!--    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="6.0.0" />-->
+<!--  </ItemGroup>-->
 
-  <ItemGroup Condition="'$(DiagnosticSourceVersion)' == '' and '$(TargetFramework)' != 'net6.0'">
+<!--  <ItemGroup Condition="'$(DiagnosticSourceVersion)' == '' and '$(TargetFramework)' != 'net6.0'">-->
+    
+  <ItemGroup Condition="'$(DiagnosticSourceVersion)' == ''">
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="5.0.0" />
   </ItemGroup>
   <!-- DiagnosticSourceVersion MsBuild property can be used to compile the agent against a specific version of

--- a/src/Elastic.Apm/Elastic.Apm.csproj
+++ b/src/Elastic.Apm/Elastic.Apm.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net5.0;net461</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net5.0;net461;net6.0</TargetFrameworks>
     <IsPackable>true</IsPackable>
   </PropertyGroup>
   <PropertyGroup>
@@ -55,7 +55,11 @@
     <InternalsVisibleTo Include="Elastic.Apm.Profiler.Managed" Key="$(ExposedPublicKey)" />
     <InternalsVisibleTo Include="Elastic.Apm.Profiler.Managed.Tests" Key="$(ExposedPublicKey)" />
   </ItemGroup>
-  <ItemGroup Condition="'$(DiagnosticSourceVersion)' == ''">
+  <ItemGroup Condition="'$(DiagnosticSourceVersion)' == '' and '$(TargetFramework)' == 'net6.0'">
+    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="6.0.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(DiagnosticSourceVersion)' == '' and '$(TargetFramework)' != 'net6.0'">
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="5.0.0" />
   </ItemGroup>
   <!-- DiagnosticSourceVersion MsBuild property can be used to compile the agent against a specific version of
@@ -68,7 +72,7 @@
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="System.Diagnostics.PerformanceCounter" Version="4.5.0" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'net5.0'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net5.0' or '$(TargetFramework)' == 'net6.0'">
     <PackageReference Include="System.Diagnostics.PerformanceCounter" Version="4.5.0" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Elastic.Apm/Libraries/Newtonsoft.Json/Serialization/DefaultContractResolver.cs
+++ b/src/Elastic.Apm/Libraries/Newtonsoft.Json/Serialization/DefaultContractResolver.cs
@@ -1260,7 +1260,7 @@ namespace Elastic.Apm.Libraries.Newtonsoft.Json.Serialization
 			// warning - this method use to cause errors with Intellitrace. Retest in VS Ultimate after changes
 			IValueProvider valueProvider;
 
-#if !(PORTABLE40 || PORTABLE || DOTNET || NETSTANDARD2_0 || NET5_0)
+#if !(PORTABLE40 || PORTABLE || DOTNET || NETSTANDARD2_0 || NET5_0 || NET6_0)
             if (DynamicCodeGeneration)
             {
                 valueProvider = new DynamicValueProvider(member);

--- a/src/Elastic.Apm/Libraries/Newtonsoft.Json/Serialization/JsonTypeReflector.cs
+++ b/src/Elastic.Apm/Libraries/Newtonsoft.Json/Serialization/JsonTypeReflector.cs
@@ -468,7 +468,7 @@ namespace Elastic.Apm.Libraries.Newtonsoft.Json.Serialization
 		{
 			get
 			{
-#if !(PORTABLE40 || PORTABLE || DOTNET || NETSTANDARD2_0 || NET5_0)
+#if !(PORTABLE40 || PORTABLE || DOTNET || NETSTANDARD2_0 || NET5_0 || NET6_0)
                 if (DynamicCodeGeneration)
                 {
                     return DynamicReflectionDelegateFactory.Instance;

--- a/src/Elastic.Apm/OpenTelemetry/ElasticActivityListener.cs
+++ b/src/Elastic.Apm/OpenTelemetry/ElasticActivityListener.cs
@@ -3,7 +3,7 @@
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
 
-#if NET5_0
+#if NET5_0 || NET6_0
 
 using System;
 using System.Collections.Concurrent;

--- a/test/Elastic.Apm.StartupHook.Tests/Elastic.Apm.StartupHook.Tests.csproj
+++ b/test/Elastic.Apm.StartupHook.Tests/Elastic.Apm.StartupHook.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net5.0</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>

--- a/test/Elastic.Apm.StartupHook.Tests/StartupHookTests.cs
+++ b/test/Elastic.Apm.StartupHook.Tests/StartupHookTests.cs
@@ -32,6 +32,7 @@ namespace Elastic.Apm.StartupHook.Tests
 		[InlineData("netcoreapp3.0")]
 		[InlineData("netcoreapp3.1")]
 		[InlineData("net5.0")]
+		[InlineData("net6.0")]
 		public async Task Auto_Instrument_With_StartupHook_Should_Capture_Transaction(string targetFramework)
 		{
 			var apmLogger = new InMemoryBlockingLogger(LogLevel.Error);
@@ -74,6 +75,7 @@ namespace Elastic.Apm.StartupHook.Tests
 		[InlineData("netcoreapp3.0")]
 		[InlineData("netcoreapp3.1")]
 		[InlineData("net5.0")]
+		[InlineData("net6.0")]
 		public async Task Auto_Instrument_With_StartupHook_Should_Capture_Error(string targetFramework)
 		{
 			var apmLogger = new InMemoryBlockingLogger(LogLevel.Error);
@@ -126,6 +128,7 @@ namespace Elastic.Apm.StartupHook.Tests
 		[InlineData("netcoreapp3.0", ".NET Core", "3.0.0.0")]
 		[InlineData("netcoreapp3.1", ".NET Core", "3.1.0.0")]
 		[InlineData("net5.0", ".NET 5", "5.0.0.0")]
+		[InlineData("net6.0", ".NET 6", "6.0.0.0")]
 		public async Task Auto_Instrument_With_StartupHook_Should_Capture_Metadata(
 			string targetFramework,
 			string expectedRuntimeName,
@@ -176,9 +179,11 @@ namespace Elastic.Apm.StartupHook.Tests
 		[InlineData("webapp", "WebApp30", "netcoreapp3.0", "")]
 		[InlineData("webapp", "WebApp31", "netcoreapp3.1", "")]
 		[InlineData("webapp", "WebApp50", "net5.0", "")]
+		[InlineData("webapp", "WebApp60", "net6.0", "")]
 		[InlineData("mvc", "Mvc30", "netcoreapp3.0", "")]
 		[InlineData("mvc", "Mvc31", "netcoreapp3.1", "")]
 		[InlineData("mvc", "Mvc50", "net5.0", "")]
+		[InlineData("mvc", "Mvc60", "net6.0", "")]
 		public async Task Auto_Instrument_With_StartupHook(string template, string name, string targetFramework, string path)
 		{
 			var apmLogger = new InMemoryBlockingLogger(LogLevel.Trace);


### PR DESCRIPTION
Solves: https://github.com/elastic/apm-agent-dotnet/issues/1590 


### Root cause of the bug

The zip file with the agent prior to this PR contained 2 folders with 2 different versions of `System.Diagnostics.DiagnosticSource`. One with version `4.0.0`, the other one with version `5.0.0`. During startup the agent decided from which folder to load the agent based on the loaded version of this assembly (logic [here](https://github.com/elastic/apm-agent-dotnet/blob/master/src/ElasticApmAgentStartupHook/StartupHook.cs#L98)). The issue is, .NET 6 ships with a new version (`6.0.0`) of this dll, therefore the `StartupHook` implementation tried to load the agent from the `6.0.0` which did not exits.

### Solution

This PR adds specifically building the agent for .NET6 as well with `System.Diagnostics.DiagnosticSource` v `6.0.0`. It also updates the release scripts to ship a `6.0.0` folder based on the output of the .NET6 build. 

### Alternative 

It'd be also possible to force the agent to load from the `5.0.0` folder which is built agains `System.Diagnostics.DiagnosticSource` v5. Likely this would work, reasons not to do this is: 1) we may use some `Activity` API later that are only present in .NET6, 2) if we know the app is built agains DiagnosticSource 6, I think it's safer to load a version of the agent which was built agains v6 as well. 