### PR TITLE
Add .NET6 to CI scripts

### DIFF
--- a/.ci/windows/dotnet.bat
+++ b/.ci/windows/dotnet.bat
@@ -16,4 +16,6 @@ dotnet sln remove test/Elastic.Apm.Profiler.Managed.Tests/Elastic.Apm.Profiler.M
 
 dotnet nuget locals all --clear
 
+dotnet nuget add source --name nuget.org https://api.nuget.org/v3/index.json
+
 dotnet build -c Release

--- a/.ci/windows/dotnet.bat
+++ b/.ci/windows/dotnet.bat
@@ -18,4 +18,5 @@ dotnet nuget locals all --clear
 
 dotnet nuget add source --name nuget.org https://api.nuget.org/v3/index.json
 
+:: Build solution. Add `--verbosity detailed` for more detailed logs
 dotnet build -c Release

--- a/.ci/windows/dotnet.bat
+++ b/.ci/windows/dotnet.bat
@@ -14,6 +14,6 @@ dotnet sln remove test/Elastic.Apm.StartupHook.Tests/Elastic.Apm.StartupHook.Tes
 :: Remove profiler tests, which are tested separately- require profiler to be built
 dotnet sln remove test/Elastic.Apm.Profiler.Managed.Tests/Elastic.Apm.Profiler.Managed.Tests.csproj
 
-dotnet --version
+dotnet nuget locals all --clear
 
 dotnet build -c Release

--- a/.ci/windows/dotnet.bat
+++ b/.ci/windows/dotnet.bat
@@ -14,4 +14,6 @@ dotnet sln remove test/Elastic.Apm.StartupHook.Tests/Elastic.Apm.StartupHook.Tes
 :: Remove profiler tests, which are tested separately- require profiler to be built
 dotnet sln remove test/Elastic.Apm.Profiler.Managed.Tests/Elastic.Apm.Profiler.Managed.Tests.csproj
 
-dotnet build -c Release --verbosity detailed
+dotnet --version
+
+dotnet build -c Release

--- a/.ci/windows/msbuild-tools.ps1
+++ b/.ci/windows/msbuild-tools.ps1
@@ -6,7 +6,7 @@ $ErrorActionPreference = "Stop"
 
 # Install visualstudio2019 and workloads needed to build ASP.NET and .NET Core apps
 Invoke-WebRequest -UseBasicParsing `
-    -Uri "https://download.visualstudio.microsoft.com/download/pr/cb1d5164-e767-4886-8955-2df3a7c816a8/b9ff67da6d68d6a653a612fd401283cc213b4ec4bae349dd3d9199659a7d9354/vs_BuildTools.exe" `
+    -Uri "https://download.visualstudio.microsoft.com/download/pr/ce8663b0-08ed-410a-9f5d-4f9469d1b2cb/73271b3d53a4e50e65e2e918a8c1100d2681c17bc418e03513c9f0554609ff8a/vs_BuildTools.exe" `
     -OutFile "C:\tools\vs_BuildTools.exe"
 
 Start-Process "C:\tools\vs_BuildTools.exe" -ArgumentList "--add", "Microsoft.VisualStudio.Component.NuGet", `

--- a/.ci/windows/msbuild.bat
+++ b/.ci/windows/msbuild.bat
@@ -2,7 +2,7 @@
 :: This script runs the msbuild
 ::
 echo "Prepare context for VsDevCmd.bat"
-call "C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\Common7\Tools\VsDevCmd.bat"
+call "C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\Common7\Tools\VsDevCmd.bat"
 
 dotnet nuget add source --name nuget.org https://api.nuget.org/v3/index.json
 nuget restore -verbosity detailed -NonInteractive

--- a/.ci/windows/test.bat
+++ b/.ci/windows/test.bat
@@ -16,6 +16,7 @@ dotnet sln remove test/Elastic.Apm.Profiler.Managed.Tests/Elastic.Apm.Profiler.M
 
 :: TODO: Test only - building this seems to fail
 dotnet sln remove test/Elastic.Apm.StaticImplicitInitialization.Tests/Elastic.Apm.StaticImplicitInitialization.Tests.csproj
+dotnet sln remove test/Elastic.Apm.StaticExplicitInitialization.Tests/Elastic.Apm.StaticExplicitInitialization.Tests.csproj
 
 ::
 :: This script runs the tests and stored them in an xml file defined in the

--- a/.ci/windows/test.bat
+++ b/.ci/windows/test.bat
@@ -15,7 +15,7 @@ dotnet sln remove test/Elastic.Apm.StartupHook.Tests/Elastic.Apm.StartupHook.Tes
 dotnet sln remove test/Elastic.Apm.Profiler.Managed.Tests/Elastic.Apm.Profiler.Managed.Tests.csproj
 
 :: TODO: Test only - building this seems to fail
-dotnet sln remove test/Elastic.Apm.StaticImplicitInitialization.Tests.csproj
+dotnet sln remove test/Elastic.Apm.StaticImplicitInitialization.Tests/Elastic.Apm.StaticImplicitInitialization.Tests.csproj
 
 ::
 :: This script runs the tests and stored them in an xml file defined in the

--- a/.ci/windows/test.bat
+++ b/.ci/windows/test.bat
@@ -2,7 +2,7 @@
 :: This script runs the tests and stored them in an xml file defined in the
 :: LogFilePath property
 ::
-dotnet test -c Release --no-build ^
+dotnet test -c Release ^
  --verbosity normal ^
  --results-directory target ^
  --diag target\diag.log ^

--- a/.ci/windows/test.bat
+++ b/.ci/windows/test.bat
@@ -14,6 +14,9 @@ dotnet sln remove test/Elastic.Apm.StartupHook.Tests/Elastic.Apm.StartupHook.Tes
 :: Remove profiler tests, which are tested separately- require profiler to be built
 dotnet sln remove test/Elastic.Apm.Profiler.Managed.Tests/Elastic.Apm.Profiler.Managed.Tests.csproj
 
+:: TODO: Test only - building this seems to fail
+dotnet sln remove test/Elastic.Apm.StaticImplicitInitialization.Tests.csproj
+
 ::
 :: This script runs the tests and stored them in an xml file defined in the
 :: LogFilePath property

--- a/.ci/windows/test.bat
+++ b/.ci/windows/test.bat
@@ -1,4 +1,20 @@
 ::
+:: This script runs the dotnet build without the Full Framework projects
+::
+dotnet sln remove sample/AspNetFullFrameworkSampleApp/AspNetFullFrameworkSampleApp.csproj
+dotnet sln remove src/Elastic.Apm.AspNetFullFramework/Elastic.Apm.AspNetFullFramework.csproj
+dotnet sln remove test/Elastic.Apm.AspNetFullFramework.Tests/Elastic.Apm.AspNetFullFramework.Tests.csproj
+dotnet sln remove test/Elastic.Apm.SqlClient.Tests/Elastic.Apm.SqlClient.Tests.csproj
+dotnet sln remove test/Elastic.Apm.EntityFramework6.Tests/Elastic.Apm.EntityFramework6.Tests.csproj
+dotnet sln remove test/Elastic.Apm.MongoDb.Tests/Elastic.Apm.MongoDb.Tests.csproj
+
+:: Remove startup hooks tests, which are tested separately- require agent zip to be built
+dotnet sln remove test/Elastic.Apm.StartupHook.Tests/Elastic.Apm.StartupHook.Tests.csproj
+
+:: Remove profiler tests, which are tested separately- require profiler to be built
+dotnet sln remove test/Elastic.Apm.Profiler.Managed.Tests/Elastic.Apm.Profiler.Managed.Tests.csproj
+
+::
 :: This script runs the tests and stored them in an xml file defined in the
 :: LogFilePath property
 ::

--- a/.ci/windows/tools.ps1
+++ b/.ci/windows/tools.ps1
@@ -17,7 +17,7 @@ choco install dotnet-sdk -m -y --no-progress -r --version 5.0.100
 choco install dotnet-sdk -m -y --no-progress -r --version 6.0.100
 
 # Install NuGet Tool
-choco install nuget.commandline -y --no-progress -r --version 5.8.0
+choco install nuget.commandline -y --no-progress -r --version 6.0.0
 
 # Install vswhere
 choco install vswhere -y --no-progress -r --version 2.8.4

--- a/.ci/windows/tools.ps1
+++ b/.ci/windows/tools.ps1
@@ -14,7 +14,7 @@ choco install dotnetcore-sdk -m -y --no-progress -r --version 2.2.402
 choco install dotnetcore-sdk -m -y --no-progress -r --version 3.0.103
 choco install dotnetcore-sdk -m -y --no-progress -r --version 3.1.416
 choco install dotnet-sdk -m -y --no-progress -r --version 5.0.100
-choco install dotnet-sdk -m -y --no-progress -r --version 6.0.100
+choco install dotnet-sdk -m -y --no-progress -r --version 6.0.101
 
 # Install NuGet Tool
 choco install nuget.commandline -y --no-progress -r --version 6.0.0

--- a/.ci/windows/tools.ps1
+++ b/.ci/windows/tools.ps1
@@ -14,6 +14,7 @@ choco install dotnetcore-sdk -m -y --no-progress -r --version 2.2.104
 choco install dotnetcore-sdk -m -y --no-progress -r --version 3.0.103
 choco install dotnetcore-sdk -m -y --no-progress -r --version 3.1.100
 choco install dotnet-sdk -m -y --no-progress -r --version 5.0.100
+choco install dotnet-sdk -m -y --no-progress -r --version 6.0.100
 
 # Install NuGet Tool
 choco install nuget.commandline -y --no-progress -r --version 5.8.0

--- a/.ci/windows/tools.ps1
+++ b/.ci/windows/tools.ps1
@@ -10,9 +10,9 @@ Add-WindowsFeature Web-Asp-Net45
 # Install .Net SDKs
 Write-Host "Install .Net SDKs"
 choco install dotnetcore-sdk -m -y --no-progress -r --version 2.1.505
-choco install dotnetcore-sdk -m -y --no-progress -r --version 2.2.104
+choco install dotnetcore-sdk -m -y --no-progress -r --version 2.2.402
 choco install dotnetcore-sdk -m -y --no-progress -r --version 3.0.103
-choco install dotnetcore-sdk -m -y --no-progress -r --version 3.1.100
+choco install dotnetcore-sdk -m -y --no-progress -r --version 3.1.416
 choco install dotnet-sdk -m -y --no-progress -r --version 5.0.100
 choco install dotnet-sdk -m -y --no-progress -r --version 6.0.100
 

--- a/.gitignore
+++ b/.gitignore
@@ -360,3 +360,4 @@ target/
 Cargo.lock
 expanded.rs
 
+test/Elastic.Apm.Feature.Tests/SpecFlow/userid

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -358,9 +358,6 @@ pipeline {
                       unstash 'source'
                       dir("${BASE_DIR}"){
                         powershell label: 'Install test tools', script: '.ci\\windows\\test-tools.ps1'
-                        retry(3) {
-                          bat label: 'Build', script: '.ci/windows/dotnet.bat'
-                        }
                         withAzureCredentials(path: "${HOME}", credentialsFile: '.credentials.json') {
                           bat label: 'Test & coverage', script: '.ci/windows/test.bat'
                         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -624,6 +624,7 @@ def dotnet(Closure body){
     ./dotnet-install.sh --install-dir "\${DOTNET_ROOT}" -version '3.0.103'
     ./dotnet-install.sh --install-dir "\${DOTNET_ROOT}" -version '3.1.100'
     ./dotnet-install.sh --install-dir "\${DOTNET_ROOT}" -version '5.0.100'
+    ./dotnet-install.sh --install-dir "\${DOTNET_ROOT}" -version '6.0.100'
     """)
     withAzureCredentials(path: "${homePath}", credentialsFile: '.credentials.json') {
       withTerraform(){

--- a/build/scripts/ReleaseNotes.fs
+++ b/build/scripts/ReleaseNotes.fs
@@ -53,7 +53,7 @@ module ReleaseNotes =
             ("uncategorized", "Uncategorized")
         ]
         uncategorized = "uncategorized"
-    };
+    }
         
     let private groupByLabel (config: Config) (items: List<GitHubItem>) =
         let dict = Dictionary<string, GitHubItem list>()     

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "5.0.100",
+    "version": "6.0.100",
     "rollForward": "latestFeature",
     "allowPrerelease": false
   }

--- a/sample/SampleAspNetCoreApp/SampleAspNetCoreApp.csproj
+++ b/sample/SampleAspNetCoreApp/SampleAspNetCoreApp.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.0;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.0;netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   
@@ -25,6 +25,14 @@
     <PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="5.0.0" />
     <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.0.0-rc6"/>
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.0.0-rc6"/>
+  </ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="6.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="6.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="6.0.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.0.0-rc6"/>
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.0.0-rc6"/>
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />

--- a/sample/SampleAspNetCoreApp/Startup.cs
+++ b/sample/SampleAspNetCoreApp/Startup.cs
@@ -56,7 +56,7 @@ namespace SampleAspNetCoreApp
 		}
 
 		// This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
-#if NETCOREAPP3_0 || NETCOREAPP3_1 || NET5_0
+#if NETCOREAPP3_0 || NETCOREAPP3_1 || NET5_0 || NET6_0
 		public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
 #else
 		public void Configure(IApplicationBuilder app, IHostingEnvironment env)
@@ -79,7 +79,7 @@ namespace SampleAspNetCoreApp
 
 		public static void ConfigureRoutingAndMvc(IApplicationBuilder app)
 		{
-#if NETCOREAPP3_0 || NETCOREAPP3_1 || NET5_0
+#if NETCOREAPP3_0 || NETCOREAPP3_1 || NET5_0 || NET6_0
 			app.UseRouting();
 
 			app.UseAuthentication();

--- a/sample/WebApiSample/Startup.cs
+++ b/sample/WebApiSample/Startup.cs
@@ -23,7 +23,7 @@ namespace WebApiSample
 
 
 		// This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
-#if NETCOREAPP3_0 || NETCOREAPP3_1 || NET5_0
+#if NETCOREAPP3_0 || NETCOREAPP3_1 || NET5_0 || NET6_0
 		public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
 #else
 		public void Configure(IApplicationBuilder app, IHostingEnvironment env)
@@ -39,7 +39,7 @@ namespace WebApiSample
 
 			app.UseHttpsRedirection();
 
-#if NETCOREAPP3_0 || NETCOREAPP3_1 || NET5_0
+#if NETCOREAPP3_0 || NETCOREAPP3_1 || NET5_0 || NET6_0
 			app.UseRouting();
 
 			app.UseEndpoints(endpoints => { endpoints.MapControllers(); });

--- a/sample/WebApiSample/WebApiSample.csproj
+++ b/sample/WebApiSample/WebApiSample.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.0;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.0;netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/src/Elastic.Apm/Elastic.Apm.csproj
+++ b/src/Elastic.Apm/Elastic.Apm.csproj
@@ -9,7 +9,7 @@
     <PackageId>Elastic.Apm</PackageId>
     <Description>Elastic APM .NET Agent base package. This package provides core functionality for transmitting of all Elastic APM types and is a dependent package for all other Elastic APM package. Additionally this package contains the public Agent API that allows you to manually capture transactions and spans. Please install the platform specific package for the best experience. See: https://github.com/elastic/apm-agent-dotnet/tree/master/docs</Description>
     <PackageTags>apm, monitoring, elastic, elasticapm, analytics, sdk</PackageTags>
-    <LangVersion>latest</LangVersion>
+    <LangVersion>9</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <InternalsVisibleTo Include="DynamicProxyGenAssembly2" Key="0024000004800000940000000602000000240000525341310004000001000100c547cac37abd99c8db225ef2f6c8a3602f3b3606cc9891605d02baa56104f4cfc0734aa39b93bf7852f7d9266654753cc297e7d2edfe0bac1cdcf9f717241550e0a7b191195b7667bb4f64bcb8e2121380fd1d9d46ad2d92d2d15605093924cceaf74c4861eff62abf69b9291ed0a340e113be11e6a7d3113e92484cf7045cc7" />

--- a/test/Elastic.Apm.AspNetCore.Static.Tests/Elastic.Apm.AspNetCore.Static.Tests.csproj
+++ b/test/Elastic.Apm.AspNetCore.Static.Tests/Elastic.Apm.AspNetCore.Static.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
     <PropertyGroup>
-      <TargetFrameworks>netcoreapp2.1;netcoreapp3.0;netcoreapp3.1;net5.0</TargetFrameworks>
+      <TargetFrameworks>netcoreapp2.1;netcoreapp3.0;netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
     </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="5.6.0" />

--- a/test/Elastic.Apm.AspNetCore.Static.Tests/Elastic.Apm.AspNetCore.Static.Tests.csproj
+++ b/test/Elastic.Apm.AspNetCore.Static.Tests/Elastic.Apm.AspNetCore.Static.Tests.csproj
@@ -27,6 +27,10 @@
   <ItemGroup Condition=" '$(TargetFramework)' == 'net5.0' ">
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="5.0.0" />
   </ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Configuration" Version="6.0.0" />
+  </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\Elastic.Apm.AspNetCore\Elastic.Apm.AspNetCore.csproj" />
     <ProjectReference Include="..\..\src\Elastic.Apm\Elastic.Apm.csproj" />

--- a/test/Elastic.Apm.AspNetCore.Tests/AspNetCoreBasicTests.cs
+++ b/test/Elastic.Apm.AspNetCore.Tests/AspNetCoreBasicTests.cs
@@ -98,10 +98,12 @@ namespace Elastic.Apm.AspNetCore.Tests
 			_agent.Service.Framework.Version.Should().Be(aspNetCoreVersion);
 #if NET5_0
 			_agent.Service.Runtime.Name.Should().Be(Runtime.DotNetName + " 5");
+#elif NET6_0
+			_agent.Service.Runtime.Name.Should().Be(Runtime.DotNetName + " 6");
 #else
 			_agent.Service.Runtime.Name.Should().Be(Runtime.DotNetCoreName);
 #endif
-			_agent.Service.Runtime.Version.Should().Be(Directory.GetParent(typeof(object).Assembly.Location).Name);
+			_agent.Service.Runtime.Version.Should().StartWith(Directory.GetParent(typeof(object).Assembly.Location).Name);
 
 			var transaction = _capturedPayload.FirstTransaction;
 			var transactionName = $"{response.RequestMessage.Method} Home/SimplePage";
@@ -125,7 +127,7 @@ namespace Elastic.Apm.AspNetCore.Tests
 			}
 
 			//test transaction.context.request
-#if NET5_0
+#if NET5_0 || NET6_0
 			transaction.Context.Request.HttpVersion.Should().Be("1.1");
 #elif NETCOREAPP3_0 || NETCOREAPP3_1
 			transaction.Context.Request.HttpVersion.Should().Be("2");
@@ -247,11 +249,13 @@ namespace Elastic.Apm.AspNetCore.Tests
 
 #if NET5_0
 			_agent.Service.Runtime.Name.Should().Be(Runtime.DotNetName + " 5");
+#elif NET6_0
+			_agent.Service.Runtime.Name.Should().Be(Runtime.DotNetName + " 6");
 #else
 			_agent.Service.Runtime.Name.Should().Be(Runtime.DotNetCoreName);
 #endif
 
-			_agent.Service.Runtime.Version.Should().Be(Directory.GetParent(typeof(object).Assembly.Location).Name);
+			_agent.Service.Runtime.Version.Should().StartWith(Directory.GetParent(typeof(object).Assembly.Location).Name);
 
 
 			_capturedPayload.Transactions.Should().ContainSingle();
@@ -279,7 +283,7 @@ namespace Elastic.Apm.AspNetCore.Tests
 			}
 
 			//test transaction.context.request
-#if NET5_0
+#if NET5_0 || NET6_0
 			transaction.Context.Request.HttpVersion.Should().Be("1.1");
 #elif NETCOREAPP3_0 || NETCOREAPP3_1
 			transaction.Context.Request.HttpVersion.Should().Be("2");

--- a/test/Elastic.Apm.AspNetCore.Tests/DistributedTracingAspNetCoreTests.cs
+++ b/test/Elastic.Apm.AspNetCore.Tests/DistributedTracingAspNetCoreTests.cs
@@ -323,7 +323,7 @@ namespace Elastic.Apm.AspNetCore.Tests
 		/// <returns></returns>
 		private async Task ExecuteAndCheckDistributedCall(bool startActivityBeforeHttpCall = true)
 		{
-#if NET5_0
+#if NET5_0 || NET6_0
 			// .NET 5 has built-in W3C TraceContext support and Activity uses the W3C id format by default (pre .NET 5 it was opt-in)
 			// This means if there is no active activity, the outgoing HTTP request on HttpClient will add the traceparent header with
 			// a flag recorded=false. The agent would pick this up on the incoming call and start an unsampled transaction.

--- a/test/Elastic.Apm.AspNetCore.Tests/Elastic.Apm.AspNetCore.Tests.csproj
+++ b/test/Elastic.Apm.AspNetCore.Tests/Elastic.Apm.AspNetCore.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.0;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.0;netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
     <AssemblyName>Elastic.Apm.AspNetCore.Tests</AssemblyName>
     <RootNamespace>Elastic.Apm.AspNetCore.Tests</RootNamespace>
   </PropertyGroup>
@@ -35,6 +35,11 @@
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net5.0' ">
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="5.0.0" />
+  </ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Configuration" Version="6.0.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\Elastic.Apm.AspNetCore\Elastic.Apm.AspNetCore.csproj" />

--- a/test/Elastic.Apm.Extensions.Hosting.Tests/Elastic.Apm.Extensions.Hosting.Tests.csproj
+++ b/test/Elastic.Apm.Extensions.Hosting.Tests/Elastic.Apm.Extensions.Hosting.Tests.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>
@@ -26,6 +26,10 @@
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net5.0'">
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="5.0.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0'">
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.0" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1'">

--- a/test/Elastic.Apm.Extensions.Logging.Tests/Elastic.Apm.Extensions.Logging.Tests.csproj
+++ b/test/Elastic.Apm.Extensions.Logging.Tests/Elastic.Apm.Extensions.Logging.Tests.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>
@@ -26,6 +26,10 @@
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net5.0'">
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="5.0.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0'">
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.0" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1'">

--- a/test/Elastic.Apm.SqlClient.Tests/EfCoreWithMsSqlTests.cs
+++ b/test/Elastic.Apm.SqlClient.Tests/EfCoreWithMsSqlTests.cs
@@ -56,8 +56,8 @@ namespace Elastic.Apm.SqlClient.Tests
 			_apmAgent.Tracer.CaptureTransaction("transaction", "type", transaction =>
 			{
 				// ReSharper disable once AccessToDisposedClosure
-				var firstItemInDb = context.SampleTable.First();
-				Debug.WriteLine(firstItemInDb.StrField);
+				var firstItemInDb = context.SampleTable.FirstOrDefault();
+				Debug.WriteLine(firstItemInDb?.StrField);
 			});
 
 			_payloadSender.SpansOnFirstTransaction.Should().HaveCount(1);

--- a/test/Elastic.Apm.SqlClient.Tests/Elastic.Apm.SqlClient.Tests.csproj
+++ b/test/Elastic.Apm.SqlClient.Tests/Elastic.Apm.SqlClient.Tests.csproj
@@ -1,10 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup Condition=" '$(OS)' != 'Windows_NT' ">
-    <TargetFrameworks>netcoreapp2.1;net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;net5.0</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(OS)' == 'Windows_NT' ">
-    <TargetFrameworks>net461;netcoreapp2.1;net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp2.1;net5.0</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/test/Elastic.Apm.SqlClient.Tests/Elastic.Apm.SqlClient.Tests.csproj
+++ b/test/Elastic.Apm.SqlClient.Tests/Elastic.Apm.SqlClient.Tests.csproj
@@ -1,10 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup Condition=" '$(OS)' != 'Windows_NT' ">
-    <TargetFrameworks>netcoreapp2.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;net5.0;net6.0</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(OS)' == 'Windows_NT' ">
-    <TargetFrameworks>net461;netcoreapp2.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp2.1;net5.0;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/test/Elastic.Apm.StaticExplicitInitialization.Tests/Elastic.Apm.StaticExplicitInitialization.Tests.csproj
+++ b/test/Elastic.Apm.StaticExplicitInitialization.Tests/Elastic.Apm.StaticExplicitInitialization.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Elastic.Apm.StaticImplicitInitialization.Tests/Elastic.Apm.StaticImplicitInitialization.Tests.csproj
+++ b/test/Elastic.Apm.StaticImplicitInitialization.Tests/Elastic.Apm.StaticImplicitInitialization.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Elastic.Apm.Tests/ConfigTests.cs
+++ b/test/Elastic.Apm.Tests/ConfigTests.cs
@@ -323,7 +323,7 @@ namespace Elastic.Apm.Tests
 			var payloadSender = new MockPayloadSender();
 			using (var agent = new ApmAgent(new TestAgentComponents(payloadSender: payloadSender, configuration: new EnvironmentConfigurationReader())))
 			{
-#if !NETCOREAPP3_0 && !NETCOREAPP3_1 && !NET5_0
+#if !NETCOREAPP3_0 && !NETCOREAPP3_1 && !NET5_0 && !NET6_0
 				agent.ConfigurationReader.ServerUrls.First().Should().NotBe(serverUrlsWithSpace);
 				agent.ConfigurationReader.ServerUrl.Should().NotBe(serverUrlsWithSpace);
 #endif

--- a/test/Elastic.Apm.Tests/Elastic.Apm.Tests.csproj
+++ b/test/Elastic.Apm.Tests/Elastic.Apm.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.0;netcoreapp3.1;net461;net5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.0;netcoreapp3.1;net461;net5.0;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
Solves https://github.com/elastic/apm-agent-dotnet/issues/1566

- Adding .NET 6 in CI
- Installing the VS2022 version of vs BuildTools
- Running all tests on .NET 6 as well (where applicable)
