### PR TITLE
Update doc links

### DIFF
--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -550,7 +550,7 @@ your communications using HTTPS. Unless you do so, your API Key could be observe
 ==== `ApiKey` (added[1.4])
 
 A base64-encoded string used to ensure that only your agents can send data to your APM server.
-You must have created the API key using the APM server's {apm-server-ref-v}/api-key.html[command line tool].
+You must have created the API key using the APM server's {apm-guide-ref}/api-key.html[command line tool].
 
 NOTE: This feature is fully supported in the APM Server versions >= 7.6.
 
@@ -909,7 +909,7 @@ NOTE: Changing this configuration will overwrite the default value.
 [[config-use-elastic-apm-traceparent-header]]
 ==== `UseElasticTraceparentHeader` (added[1.3.0])
 
-To enable {apm-overview-ref-v}/distributed-tracing.html[distributed tracing], the agent adds trace context headers to outgoing HTTP requests made with the `HttpClient` type. These headers (`traceparent` and `tracestate`) are defined in the https://www.w3.org/TR/trace-context-1/[W3C Trace Context] specification.
+To enable {apm-guide-ref}/apm-distributed-tracing.html[distributed tracing], the agent adds trace context headers to outgoing HTTP requests made with the `HttpClient` type. These headers (`traceparent` and `tracestate`) are defined in the https://www.w3.org/TR/trace-context-1/[W3C Trace Context] specification.
 
 When this setting is `true`, the agent also adds the header `elasticapm-traceparent` for backwards compatibility with older versions of Elastic APM agents. Versions prior to `1.3.0` only read the `elasticapm-traceparent` header.
 

--- a/docs/intro.asciidoc
+++ b/docs/intro.asciidoc
@@ -30,6 +30,6 @@ You can then use the APM app in Kibana to gain insight into latency issues and e
 [float]
 [[additional-components]]
 === Additional Components
-APM Agents work in conjunction with the {apm-server-ref-v}/index.html[APM Server], {ref}/index.html[Elasticsearch], and {kibana-ref}/index.html[Kibana].
-The {apm-overview-ref-v}/index.html[APM Overview] provides details on how these components work together,
-and provides a matrix outlining {apm-overview-ref-v}/agent-server-compatibility.html[Agent and Server compatibility].
+APM Agents work in conjunction with the {apm-guide-ref}/index.html[APM Server], {ref}/index.html[Elasticsearch], and {kibana-ref}/index.html[Kibana].
+The {apm-guide-ref}/index.html[APM Overview] provides details on how these components work together,
+and provides a matrix outlining {apm-guide-ref}/agent-server-compatibility.html[Agent and Server compatibility].

--- a/docs/intro.asciidoc
+++ b/docs/intro.asciidoc
@@ -31,5 +31,5 @@ You can then use the APM app in Kibana to gain insight into latency issues and e
 [[additional-components]]
 === Additional Components
 APM Agents work in conjunction with the {apm-guide-ref}/index.html[APM Server], {ref}/index.html[Elasticsearch], and {kibana-ref}/index.html[Kibana].
-The {apm-guide-ref}/index.html[APM Overview] provides details on how these components work together,
+The {apm-guide-ref}/index.html[APM Guide] provides details on how these components work together,
 and provides a matrix outlining {apm-guide-ref}/agent-server-compatibility.html[Agent and Server compatibility].

--- a/docs/public-api.asciidoc
+++ b/docs/public-api.asciidoc
@@ -283,7 +283,7 @@ Agent.Tracer.CaptureErrorLog(errorLog);
 [[api-transaction]]
 == Transaction API
 //----------------------------
-A transaction describes an event captured by an Elastic APM agent monitoring a service. Transactions help combine multiple <<api-span,Spans>> into logical groups, and they are the first <<api-span,Span>> of a service. More information on Transactions and Spans is available in the {apm-overview-ref-v}/apm-data-model.html[APM data model] documentation.
+A transaction describes an event captured by an Elastic APM agent monitoring a service. Transactions help combine multiple <<api-span,Spans>> into logical groups, and they are the first <<api-span,Span>> of a service. More information on Transactions and Spans is available in the {apm-guide-ref}/data-model.html[APM data model] documentation.
 
 See <<api-current-transaction>> on how to get a reference of the current transaction.
 
@@ -378,7 +378,7 @@ A flat mapping of user-defined labels with string values.
 If the key contains any special characters (`.`,`*`, `"`), they will be replaced with underscores. For example `a.b` will be stored as `a_b`.
 
 TIP: Before using custom labels, ensure you understand the different types of
-{apm-overview-ref-v}/metadata.html[metadata] that are available.
+{apm-guide-ref}/data-model-metadata.html[metadata] that are available.
 
 WARNING: Avoid defining too many user-specified labels.
 Defining too many unique fields in an index is a condition that can lead to a
@@ -686,7 +686,7 @@ Similar to <<api-transaction-tags>> on the <<api-transaction>>: A flat mapping o
 If the key contains any special characters (`.`,`*`, `"`), they will be replaced with underscores. For example `a.b` will be stored as `a_b`.
 
 TIP: Before using custom labels, ensure you understand the different types of
-{apm-overview-ref-v}/metadata.html[metadata] that are available.
+{apm-guide-ref}/data-model-metadata.html[metadata] that are available.
 
 WARNING: Avoid defining too many user-specified labels.
 Defining too many unique fields in an index is a condition that can lead to a

--- a/docs/upgrading.asciidoc
+++ b/docs/upgrading.asciidoc
@@ -6,7 +6,7 @@ Upgrades that involve a major version bump often come with some backwards incomp
 Before upgrading the agent, be sure to review the:
 
 * <<release-notes,Agent release notes>>
-* {apm-overview-ref-v}/agent-server-compatibility.html[Agent and Server compatibility chart]
+* {apm-guide-ref}/agent-server-compatibility.html[Agent and Server compatibility chart]
 
 [float]
 [[end-of-life-dates]]


### PR DESCRIPTION
Links updated as per elastic/observability-docs#1385. The old links will break when 7.17 releases. This PR and all backports must be merged before the 7.17 release. Thanks!


### Backports

- [ ] 1.8: https://github.com/elastic/apm-agent-dotnet/pull/1615
- [ ] 1.9: https://github.com/elastic/apm-agent-dotnet/pull/1614
- [ ] 1.10: https://github.com/elastic/apm-agent-dotnet/pull/1613
- [ ] 1.11: https://github.com/elastic/apm-agent-dotnet/pull/1617
- [ ] 1.12: https://github.com/elastic/apm-agent-dotnet/pull/1616