### PR TITLE
[1.10] Pin docs to 7.15 stack version

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -1,4 +1,4 @@
-include::{asciidoc-dir}/../../shared/versions/stack/current.asciidoc[]
+include::{asciidoc-dir}/../../shared/versions/stack/7.15.asciidoc[]
 include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 
 ifdef::env-github[]


### PR DESCRIPTION
This pins an older version of the docs to the stack so we don't ever have to worry about broken links again.