### PR TITLE
Report profiler based agent

### DIFF
--- a/src/Elastic.Apm/Api/Service.cs
+++ b/src/Elastic.Apm/Api/Service.cs
@@ -87,7 +87,7 @@ namespace Elastic.Apm.Api
 		{
 			if (AppDomain.CurrentDomain.GetAssemblies().Where(n => n.GetName().Name
 			.Equals("Elastic.Apm.Profiler.Managed", StringComparison.OrdinalIgnoreCase)).Any())
-				service.Agent.Version += "p";
+				service.Agent.Version += "-p";
 		}
 
 		public class AgentC

--- a/src/Elastic.Apm/Api/Service.cs
+++ b/src/Elastic.Apm/Api/Service.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to Elasticsearch B.V under one or more agreements.
+// Licensed to Elasticsearch B.V under one or more agreements.
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
 
@@ -85,7 +85,9 @@ namespace Elastic.Apm.Api
 		/// <param name="service"></param>
 		private static void CheckIfProfiler(Service service)
 		{
-			if (AppDomain.CurrentDomain.GetAssemblies().Where(n => n.FullName == "Elastic.Apm.Profiler.Managed").Any()) service.Agent.Version += "p";
+			if (AppDomain.CurrentDomain.GetAssemblies().Where(n => n.GetName().Name
+			.Equals("Elastic.Apm.Profiler.Managed", StringComparison.OrdinalIgnoreCase)).Any())
+				service.Agent.Version += "p";
 		}
 
 		public class AgentC

--- a/src/Elastic.Apm/Api/Service.cs
+++ b/src/Elastic.Apm/Api/Service.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information
 
 using System;
+using System.Linq;
 using System.Reflection;
 using Elastic.Apm.Api.Constraints;
 using Elastic.Apm.Config;
@@ -63,6 +64,8 @@ namespace Elastic.Apm.Api
 				Node = new Node { ConfiguredName = configurationReader.ServiceNodeName }
 			};
 
+			CheckIfProfiler(service);
+
 			//see https://github.com/elastic/apm-agent-dotnet/issues/859
 			try
 			{
@@ -74,6 +77,15 @@ namespace Elastic.Apm.Api
 			}
 
 			return service;
+		}
+
+		/// <summary>
+		/// Checks if the profiler is loaded and if so, it adds a `p` suffix to Agent.Version
+		/// </summary>
+		/// <param name="service"></param>
+		private static void CheckIfProfiler(Service service)
+		{
+			if (AppDomain.CurrentDomain.GetAssemblies().Where(n => n.FullName == "Elastic.Apm.Profiler.Managed").Any()) service.Agent.Version += "p";
 		}
 
 		public class AgentC

--- a/test/Elastic.Apm.Profiler.Managed.Tests/BasicTests.cs
+++ b/test/Elastic.Apm.Profiler.Managed.Tests/BasicTests.cs
@@ -1,0 +1,61 @@
+// Licensed to Elasticsearch B.V under
+// one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Elastic.Apm.Tests.MockApmServer;
+using Elastic.Apm.Tests.Utilities;
+using FluentAssertions;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Elastic.Apm.Profiler.Managed.Tests;
+
+public class BasicTests
+{
+	private readonly ITestOutputHelper _output;
+
+	public BasicTests(ITestOutputHelper output) => _output = output;
+
+	/// <summary>
+	/// Makes sure Agent.Version is suffixed with `p` when the profiler is loaded
+	/// </summary>
+	[Fact]
+	public async Task AgentVersionTest()
+	{
+		var apmLogger = new InMemoryBlockingLogger(Logging.LogLevel.Error);
+		var apmServer = new MockApmServer(apmLogger, nameof(BasicTests));
+		var port = apmServer.FindAvailablePortToListen();
+		apmServer.RunInBackground(port);
+
+		using (var profiledApplication = new ProfiledApplication("SqliteSample"))
+		{
+			var environmentVariables = new Dictionary<string, string>
+			{
+				["ELASTIC_APM_SERVER_URL"] = $"http://localhost:{port}",
+				["ELASTIC_APM_DISABLE_METRICS"] = "*",
+				["ELASTIC_APM_PROFILER_LOG_TARGETS"] = "file;stdout",
+			};
+
+			profiledApplication.Start(
+				"net5.0",
+				TimeSpan.FromMinutes(2),
+				environmentVariables,
+				null,
+				line =>
+				{
+					_output.WriteLine(line.Line);
+				},
+				exception => _output.WriteLine($"{exception}"));
+		}
+
+		// Asserts that Agent.Version ends with `p`, signaling profiler based agent
+		apmServer.ReceivedData.Metadata.First().Service.Agent.Version.Should().EndWith("p");
+
+		await apmServer.StopAsync();
+	}
+}


### PR DESCRIPTION
Solves https://github.com/elastic/apm-agent-dotnet/issues/1572

With this PR, once the profiler is loaded, the agent will report `Agent.Version` with a `p` suffix. 