### PR TITLE
proxy support for outbound traffic

### DIFF
--- a/src/Elastic.Apm/BackendComm/BackendCommUtils.cs
+++ b/src/Elastic.Apm/BackendComm/BackendCommUtils.cs
@@ -176,7 +176,18 @@ namespace Elastic.Apm.BackendComm
 				};
 			}
 
-			return new HttpClientHandler { ServerCertificateCustomValidationCallback = serverCertificateCustomValidationCallback };
+			IWebProxy proxy = null;
+			if (configuration.ProxyUrl is not null)
+			{
+				proxy = new WebProxy(configuration.ProxyUrl);
+			}
+
+			return new HttpClientHandler
+			{
+				ServerCertificateCustomValidationCallback = serverCertificateCustomValidationCallback,
+				UseProxy = proxy is not null,
+				Proxy = proxy
+			};
 		}
 
 		internal static HttpClient BuildHttpClient(IApmLogger loggerArg, IConfiguration configuration, Service service, string dbgCallerDesc

--- a/src/Elastic.Apm/Config/IConfigurationReader.cs
+++ b/src/Elastic.Apm/Config/IConfigurationReader.cs
@@ -189,6 +189,11 @@ namespace Elastic.Apm.Config
 		int MaxQueueEventCount { get; }
 
 		double MetricsIntervalInMilliseconds { get; }
+		
+		/// <summary>
+		/// The Proxy URL for outbound traffic.
+		/// </summary>
+		Uri ProxyUrl { get; }
 
 		/// <summary>
 		/// Whether the agent is recording.


### PR DESCRIPTION
In this PR proxy support for outbound traffic is added to the HTTP Client Handler. This issue originated as our firm uses proxy for outbound traffic and the current .net Agent lacks this feature.