### PR TITLE
.net Agent support for outbound traffic using Proxy

### DIFF
--- a/src/Elastic.Apm/BackendComm/BackendCommUtils.cs
+++ b/src/Elastic.Apm/BackendComm/BackendCommUtils.cs
@@ -176,7 +176,18 @@ namespace Elastic.Apm.BackendComm
 				};
 			}
 
-			return new HttpClientHandler { ServerCertificateCustomValidationCallback = serverCertificateCustomValidationCallback };
+			IWebProxy proxy = null;
+			if (configuration.ProxyUrl is not null)
+			{
+				proxy = new WebProxy(configuration.ProxyUrl);
+			}
+
+			return new HttpClientHandler
+			{
+				ServerCertificateCustomValidationCallback = serverCertificateCustomValidationCallback,
+				UseProxy = proxy is not null,
+				Proxy = proxy
+			};
 		}
 
 		internal static HttpClient BuildHttpClient(IApmLogger loggerArg, IConfiguration configuration, Service service, string dbgCallerDesc

--- a/src/Elastic.Apm/BackendComm/BackendCommUtils.cs
+++ b/src/Elastic.Apm/BackendComm/BackendCommUtils.cs
@@ -177,7 +177,7 @@ namespace Elastic.Apm.BackendComm
 			}
 
 			IWebProxy proxy = null;
-			if (configuration.ProxyUrl is not null)
+			if (configuration.ProxyUrl != null)
 			{
 				proxy = new WebProxy(configuration.ProxyUrl);
 			}
@@ -185,7 +185,7 @@ namespace Elastic.Apm.BackendComm
 			return new HttpClientHandler
 			{
 				ServerCertificateCustomValidationCallback = serverCertificateCustomValidationCallback,
-				UseProxy = proxy is not null,
+				UseProxy = proxy != null,
 				Proxy = proxy
 			};
 		}

--- a/src/Elastic.Apm/BackendComm/CentralConfig/CentralConfigurationFetcher.cs
+++ b/src/Elastic.Apm/BackendComm/CentralConfig/CentralConfigurationFetcher.cs
@@ -277,6 +277,9 @@ namespace Elastic.Apm.BackendComm.CentralConfig
 			public int MaxQueueEventCount => _wrapped.MaxQueueEventCount;
 
 			public double MetricsIntervalInMilliseconds => _wrapped.MetricsIntervalInMilliseconds;
+
+			public Uri ProxyUrl  => _wrapped.ProxyUrl;
+
 			public bool Recording => _centralConfiguration.Recording ?? _wrapped.Recording;
 
 			public IReadOnlyList<WildcardMatcher> SanitizeFieldNames => _centralConfiguration.SanitizeFieldNames ?? _wrapped.SanitizeFieldNames;

--- a/src/Elastic.Apm/Config/AbstractConfigurationWithEnvFallbackReader.cs
+++ b/src/Elastic.Apm/Config/AbstractConfigurationWithEnvFallbackReader.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to Elasticsearch B.V under
+// Licensed to Elasticsearch B.V under
 // one or more agreements.
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
@@ -85,6 +85,9 @@ namespace Elastic.Apm.Config
 
 		public virtual double MetricsIntervalInMilliseconds =>
 			ParseMetricsInterval(Read(KeyNames.MetricsInterval, EnvVarNames.MetricsInterval));
+
+		public Uri ProxyUrl =>
+			ParseProxyUrl(Read( KeyNames.ProxyUrl, EnvVarNames.ProxyUrl ));
 
 		public bool Recording =>
 			ParseRecording(Read(KeyNames.Recording, EnvVarNames.Recording));

--- a/src/Elastic.Apm/Config/ConfigConsts.cs
+++ b/src/Elastic.Apm/Config/ConfigConsts.cs
@@ -162,6 +162,7 @@ namespace Elastic.Apm.Config
 			public const string TransactionSampleRate = Prefix + "TRANSACTION_SAMPLE_RATE";
 			public const string UseElasticTraceparentHeader = Prefix + "USE_ELASTIC_TRACEPARENT_HEADER";
 			public const string VerifyServerCert = Prefix + "VERIFY_SERVER_CERT";
+			public const string ProxyUrl = Prefix + "PROXY_URL";
 		}
 
 		public static class KeyNames
@@ -191,6 +192,7 @@ namespace Elastic.Apm.Config
 			public const string MaxBatchEventCount = Prefix + nameof(MaxBatchEventCount);
 			public const string MaxQueueEventCount = Prefix + nameof(MaxQueueEventCount);
 			public const string MetricsInterval = Prefix + nameof(MetricsInterval);
+			public const string ProxyUrl = Prefix + nameof(ProxyUrl);
 			public const string Recording = Prefix + nameof(Recording);
 			public const string SanitizeFieldNames = Prefix + nameof(SanitizeFieldNames);
 			public const string SecretToken = Prefix + nameof(SecretToken);

--- a/src/Elastic.Apm/Config/ConfigurationSnapshotFromReader.cs
+++ b/src/Elastic.Apm/Config/ConfigurationSnapshotFromReader.cs
@@ -42,6 +42,7 @@ namespace Elastic.Apm.Config
 		public int MaxBatchEventCount => _content.MaxBatchEventCount;
 		public int MaxQueueEventCount => _content.MaxQueueEventCount;
 		public double MetricsIntervalInMilliseconds => _content.MetricsIntervalInMilliseconds;
+		public Uri ProxyUrl => _content.ProxyUrl;
 		public bool Recording => _content.Recording;
 		public IReadOnlyList<WildcardMatcher> SanitizeFieldNames => _content.SanitizeFieldNames;
 		public string SecretToken => _content.SecretToken;

--- a/src/Elastic.Apm/Config/EnvironmentConfigurationReader.cs
+++ b/src/Elastic.Apm/Config/EnvironmentConfigurationReader.cs
@@ -65,6 +65,9 @@ namespace Elastic.Apm.Config
 		public int MaxQueueEventCount => ParseMaxQueueEventCount(Read(ConfigConsts.EnvVarNames.MaxQueueEventCount));
 
 		public double MetricsIntervalInMilliseconds => ParseMetricsInterval(Read(ConfigConsts.EnvVarNames.MetricsInterval));
+
+		public Uri ProxyUrl => ParseProxyUrl(Read(ConfigConsts.EnvVarNames.ProxyUrl));
+
 		public bool Recording => ParseRecording(Read(ConfigConsts.EnvVarNames.Recording));
 
 		public IReadOnlyList<WildcardMatcher> SanitizeFieldNames => ParseSanitizeFieldNames(Read(ConfigConsts.EnvVarNames.SanitizeFieldNames));

--- a/src/Elastic.Apm/Config/IConfigurationReader.cs
+++ b/src/Elastic.Apm/Config/IConfigurationReader.cs
@@ -191,6 +191,11 @@ namespace Elastic.Apm.Config
 		double MetricsIntervalInMilliseconds { get; }
 
 		/// <summary>
+		/// The Proxy URL for outbound traffic.
+		/// </summary>
+		Uri ProxyUrl { get; }
+
+		/// <summary>
 		/// Whether the agent is recording.
 		/// When set to <c>true</c>. the agent instruments and capture requests, tracks errors, and
 		/// collects and sends metrics.

--- a/test/Elastic.Apm.Feature.Tests/TestConfiguration.cs
+++ b/test/Elastic.Apm.Feature.Tests/TestConfiguration.cs
@@ -40,6 +40,7 @@ namespace Elastic.Apm.Feature.Tests
 		public int MaxBatchEventCount { get; set; } = DefaultValues.MaxBatchEventCount;
 		public int MaxQueueEventCount { get; set; } = DefaultValues.MaxQueueEventCount;
 		public double MetricsIntervalInMilliseconds { get; set; } = DefaultValues.MetricsIntervalInMilliseconds;
+		public Uri ProxyUrl => null;
 		public bool Recording { get; set; } = true;
 		public IReadOnlyList<WildcardMatcher> SanitizeFieldNames { get; set; } = DefaultValues.SanitizeFieldNames;
 		public string SecretToken { get; set; }

--- a/test/Elastic.Apm.Tests.Utilities/MockConfiguration.cs
+++ b/test/Elastic.Apm.Tests.Utilities/MockConfiguration.cs
@@ -38,6 +38,7 @@ namespace Elastic.Apm.Tests.Utilities
 		private readonly string _maxBatchEventCount;
 		private readonly string _maxQueueEventCount;
 		private readonly string _metricsInterval;
+		private readonly string _proxyUrl;
 		private readonly string _recording;
 		private readonly string _sanitizeFieldNames;
 		private readonly string _secretToken;
@@ -83,6 +84,7 @@ namespace Elastic.Apm.Tests.Utilities
 			string flushInterval = null,
 			string maxBatchEventCount = null,
 			string maxQueueEventCount = null,
+			string proxyUrl = null,
 			string sanitizeFieldNames = null,
 			string globalLabels = null,
 			string disableMetrics = null,
@@ -127,6 +129,7 @@ namespace Elastic.Apm.Tests.Utilities
 			_flushInterval = flushInterval;
 			_maxBatchEventCount = maxBatchEventCount;
 			_maxQueueEventCount = maxQueueEventCount;
+			_proxyUrl = proxyUrl;
 			_sanitizeFieldNames = sanitizeFieldNames;
 			_globalLabels = globalLabels;
 			_disableMetrics = disableMetrics;
@@ -191,6 +194,7 @@ namespace Elastic.Apm.Tests.Utilities
 		public int MaxBatchEventCount => ParseMaxBatchEventCount(Kv(EnvVarNames.MaxBatchEventCount, _maxBatchEventCount, Origin));
 		public int MaxQueueEventCount => ParseMaxQueueEventCount(Kv(EnvVarNames.MaxQueueEventCount, _maxQueueEventCount, Origin));
 		public double MetricsIntervalInMilliseconds => ParseMetricsInterval(Kv(EnvVarNames.MetricsInterval, _metricsInterval, Origin));
+		public Uri ProxyUrl => ParseProxyUrl(Kv(EnvVarNames.ProxyUrl, _proxyUrl, Origin));
 		public bool Recording => ParseRecording(Kv(KeyNames.Recording, _recording, Origin));
 
 		public IReadOnlyList<WildcardMatcher> SanitizeFieldNames =>
@@ -200,17 +204,12 @@ namespace Elastic.Apm.Tests.Utilities
 
 		public string ServerCert => ParseServerCert(Kv(EnvVarNames.ServerCert, _serverCert, Origin));
 
-		public Uri ServerUrl
-		{
-			get
-			{
-				return _serverUrl != null
+		public Uri ServerUrl => _serverUrl != null
 					? ParseServerUrl(Kv(EnvVarNames.ServerUrl, _serverUrl, Origin))
 #pragma warning disable 618
 					: ServerUrls[0];
 #pragma warning restore 618
-			}
-		}
+
 
 		[Obsolete("Use ServerUrl")]
 		public IReadOnlyList<Uri> ServerUrls => ParseServerUrls(_serverUrls != null

--- a/test/Elastic.Apm.Tests/ConstructorTests.cs
+++ b/test/Elastic.Apm.Tests/ConstructorTests.cs
@@ -40,6 +40,7 @@ namespace Elastic.Apm.Tests
 
 			// ReSharper disable UnassignedGetOnlyAutoProperty
 			public string CaptureBody => ConfigConsts.DefaultValues.CaptureBody;
+			public Uri ProxyUrl { get; }
 			public bool Recording { get; }
 			public IReadOnlyList<WildcardMatcher> SanitizeFieldNames => ConfigConsts.DefaultValues.SanitizeFieldNames;
 			public List<string> CaptureBodyContentTypes { get; }


### PR DESCRIPTION
In this PR proxy support for outbound traffic is added to the HTTP Client Handler. This issue originated as our firm uses proxy for outbound traffic and the current .net Agent lacks this feature.