### PR TITLE
Fix handling of HttpClient client side timeouts

### DIFF
--- a/src/Elastic.Apm/BackendComm/CentralConfig/CentralConfigurationFetcher.cs
+++ b/src/Elastic.Apm/BackendComm/CentralConfig/CentralConfigurationFetcher.cs
@@ -94,7 +94,7 @@ namespace Elastic.Apm.BackendComm.CentralConfig
 		protected override async Task WorkLoopIteration()
 		{
 			++_dbgIterationsCount;
-			WaitInfoS waitInfo;
+			WaitInfoS waitInfo = default;
 			HttpRequestMessage httpRequest = null;
 			HttpResponseMessage httpResponse = null;
 			string httpResponseBody = null;
@@ -115,7 +115,10 @@ namespace Elastic.Apm.BackendComm.CentralConfig
 			}
 			catch (OperationCanceledException)
 			{
-				throw;
+				if (CancellationTokenSource.IsCancellationRequested)
+				{
+					throw;
+				}
 			}
 			catch (Exception ex)
 			{

--- a/src/Elastic.Apm/Report/PayloadSenderV2.cs
+++ b/src/Elastic.Apm/Report/PayloadSenderV2.cs
@@ -347,7 +347,10 @@ namespace Elastic.Apm.Report
 						, string.Join($",{Environment.NewLine}{TextUtils.Indentation}", queueItems));
 
 				// throw to allow Workloop to handle
-				throw;
+				if(CancellationTokenSource.IsCancellationRequested)
+				{
+					throw;
+				}
 			}
 			catch (Exception e)
 			{


### PR DESCRIPTION
Hello :)

We are using the apm-agent-dotnet in several of our applications, and have discovered that the agent will stop calling the endpoints  "intake/v2/events" and "config/v1/agents" if the response latency exceeds the HttpClient timeout. Therefore, if the APM server has higher latency than expected (and it can happen), our applications will no longer send their data and fetch their settings at all, because the logic  client side HTTP timeouts isn't handled.

This PR addresses this.

Perhaps the BackendCommComponentBase should actually handle the distinction between cancelled operations that short circuit the work loop iteration and those that don't, but the most straightforward fix was that to check if the CancellationToken is actually cancelled inside each implementation of BackendCommComponentBase.

Another possible solution is to drop the "servicePoint.ConnectionLeaseTimeout", and use a composite cancellation token comprised out of the current ".BackendCommComponentBase.CancellationTokenSource" property and a newly created one from a Task.Delay inside the "FetchConfigHttpResponseImplAsync"/"ProcessQueueItems" methods.