### PR TITLE
Prevent RanToCompletion in WorkingLoop when APM Server timeouts

### DIFF
--- a/src/Elastic.Apm/Helpers/ExceptionUtils.cs
+++ b/src/Elastic.Apm/Helpers/ExceptionUtils.cs
@@ -40,34 +40,5 @@ namespace Elastic.Apm.Helpers
 				logger.Error()?.LogException(ex, MethodExitingExceptionMsgFmt, dbgCallerMethodName);
 			}
 		}
-
-		internal static async Task DoSwallowingExceptions(IApmLogger loggerArg, Func<Task> asyncAction, bool shouldSwallowCancellation = true
-			, [CallerMemberName] string dbgCallerMethodName = null
-		)
-		{
-			var logger = loggerArg.Scoped($"{ThisClassName}.{nameof(DoSwallowingExceptions)}");
-			try
-			{
-				logger.Debug()?.Log(MethodStartingMsgFmt + ". Current thread: {ThreadDesc}", dbgCallerMethodName, DbgUtils.CurrentThreadDesc);
-				await asyncAction().ConfigureAwait(false);
-				logger.Debug()
-					?.Log(MethodExitingNormallyMsgFmt + ". Current thread: {ThreadDesc}", dbgCallerMethodName
-						, DbgUtils.CurrentThreadDesc);
-			}
-			catch (OperationCanceledException)
-			{
-				logger.Debug()
-					?.Log(MethodExitingCancelledMsgFmt + ". Current thread: {ThreadDesc}", dbgCallerMethodName
-						, DbgUtils.CurrentThreadDesc);
-
-				if (!shouldSwallowCancellation) throw;
-			}
-			catch (Exception ex)
-			{
-				logger.Error()
-					?.LogException(ex, MethodExitingExceptionMsgFmt + ". Current thread: {ThreadDesc}", dbgCallerMethodName
-						, DbgUtils.CurrentThreadDesc);
-			}
-		}
 	}
 }

--- a/test/Elastic.Apm.Tests/HelpersTests/ExceptionUtilsTests.cs
+++ b/test/Elastic.Apm.Tests/HelpersTests/ExceptionUtilsTests.cs
@@ -39,31 +39,5 @@ namespace Elastic.Apm.Tests.HelpersTests
 			var exitMsg = string.Format(exitMsgFmt.Replace("{MethodName}", "{0}"), DbgUtils.CurrentMethodName());
 			mockLogger.Lines.Should().Contain(line => line.Contains(exitMsg));
 		}
-
-		[Theory]
-		[MemberData(nameof(DoSwallowingExceptionsVariantsToTest))]
-		public async Task DoSwallowingExceptions_async_test(string exitMsgFmt, Action action)
-		{
-			var mockLogger = new TestLogger(LogLevel.Trace);
-			var sideEffect = 0;
-			await ExceptionUtils.DoSwallowingExceptions(mockLogger, PublicMethod);
-			sideEffect.Should().Be(1);
-			var startMsg = ExceptionUtils.MethodStartingMsgFmt.Replace("{MethodName}", DbgUtils.CurrentMethodName());
-			mockLogger.Lines.Should().Contain(line => line.Contains(startMsg));
-			var exitMsg = exitMsgFmt.Replace("{MethodName}", DbgUtils.CurrentMethodName());
-			mockLogger.Lines.Should().Contain(line => line.Contains(exitMsg));
-
-			async Task MethodImpl()
-			{
-				await Task.Yield();
-				++sideEffect;
-				action();
-			}
-
-			Task PublicMethod()
-			{
-				return MethodImpl();
-			}
-		}
 	}
 }

--- a/test/Elastic.Apm.Tests/WorkingLoopTests.cs
+++ b/test/Elastic.Apm.Tests/WorkingLoopTests.cs
@@ -1,0 +1,74 @@
+// Licensed to Elasticsearch B.V under
+// one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Elastic.Apm.Api;
+using Elastic.Apm.Logging;
+using Elastic.Apm.Report;
+using Elastic.Apm.Tests.Utilities;
+using FluentAssertions;
+using Xunit;
+
+namespace Elastic.Apm.Tests;
+
+public class WorkingLoopTests
+{
+	/// <summary>
+	/// See https://github.com/elastic/apm-agent-dotnet/pull/1630
+	/// Makes sure that the worker loop does not end when an OperationCanceledException happens during the HTTP request to APM Server.
+	/// Assert happens based on logging - we assume the PayloadSender prints a log line in the format of the current assert.
+	/// </summary>
+	[Fact]
+	public void RequestTimeoutTest()
+	{
+		var waitHandle = new ManualResetEvent(false);
+
+		using var localServer = LocalServer.Create(context =>
+		{
+			Thread.Sleep(500000);
+			context.Response.StatusCode = 200;
+		});
+
+		var iterCount = 0;
+		var handler = new MockHttpMessageHandler((r, c) =>
+		{
+			// 1. request times out
+			if (iterCount == 0)
+				throw new OperationCanceledException();
+
+			// 2. request returns OK
+			iterCount++;
+			waitHandle.Set();
+			return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK));
+		});
+
+
+		var config = new MockConfiguration(serverUrl: localServer.Uri, flushInterval: "1ms");
+		var logger = new InMemoryBlockingLogger(LogLevel.Trace);
+		var payloadSender = new PayloadSenderV2(logger, config,
+			Service.GetDefaultService(config, logger), new Api.System(), MockApmServerInfo.Version710, handler);
+
+		using var agent = new ApmAgent(new AgentComponents(payloadSender: payloadSender, configurationReader: config));
+
+		// This won't be sent due to timeout
+		agent.Tracer.CaptureTransaction("Test", "Test", t => { });
+
+		Thread.Sleep(50);
+
+		// This will be sent
+		agent.Tracer.CaptureTransaction("Test2", "Test", t => { });
+
+		Thread.Sleep(50);
+
+		waitHandle.WaitOne(TimeSpan.FromMilliseconds(1000));
+
+		logger.Lines.Should().Contain(l => l.Contains("{PayloadSenderV2} Serialized item to send: Transaction") && l.Contains("Name: Test2"));
+		logger.Lines.Should().NotContain(l => l.Contains("WorkLoop is about to exit because it was cancelled"));
+	}
+}


### PR DESCRIPTION
Solves the issue reported in https://github.com/elastic/apm-agent-dotnet/pull/1630 