### PR TITLE
Make sure Span.Composite is only instantiated for composite spans

### DIFF
--- a/src/Elastic.Apm/Model/Span.cs
+++ b/src/Elastic.Apm/Model/Span.cs
@@ -516,13 +516,12 @@ namespace Elastic.Apm.Model
 		{
 			if (!IsSameKind(sibling)) return false;
 
-			Composite = new Composite();
-
 			if (Name == sibling.Name)
 			{
 				if (Duration <= Configuration.SpanCompressionExactMatchMaxDuration
 					&& sibling.Duration <= Configuration.SpanCompressionExactMatchMaxDuration)
 				{
+					Composite ??= new Composite();
 					Composite.CompressionStrategy = "exact_match";
 					return true;
 				}
@@ -532,6 +531,7 @@ namespace Elastic.Apm.Model
 
 			if (Duration <= Configuration.SpanCompressionSameKindMaxDuration && sibling.Duration <= Configuration.SpanCompressionSameKindMaxDuration)
 			{
+				Composite ??= new Composite();
 				Composite.CompressionStrategy = "same_kind";
 				if(_context.IsValueCreated)
 					Name = "Calls to " + Context.Destination.Service.Resource;


### PR DESCRIPTION
Fixes https://github.com/elastic/apm-agent-dotnet/issues/1631 


The agent sent `composite":{"count":0,"sum":0.0}` which got rejected by APM Server. This PR fixes this and adds a test for a specific case when this happened. 