### PR TITLE
sample: add an end to end webapi demo

### DIFF
--- a/sample/WebApiQuickStart/AspNetCore.Demo/AspNetCore.Demo.csproj
+++ b/sample/WebApiQuickStart/AspNetCore.Demo/AspNetCore.Demo.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Elastic.Apm.AspNetCore" Version="1.14.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.2.3" />
+  </ItemGroup>
+
+</Project>

--- a/sample/WebApiQuickStart/AspNetCore.Demo/Controllers/WeatherForecastController.cs
+++ b/sample/WebApiQuickStart/AspNetCore.Demo/Controllers/WeatherForecastController.cs
@@ -1,0 +1,32 @@
+using Microsoft.AspNetCore.Mvc;
+
+namespace AspNetCore.Demo.Controllers;
+
+[ApiController]
+[Route("[controller]")]
+public class WeatherForecastController : ControllerBase
+{
+    private static readonly string[] Summaries = new[]
+    {
+        "Freezing", "Bracing", "Chilly", "Cool", "Mild", "Warm", "Balmy", "Hot", "Sweltering", "Scorching"
+    };
+
+    private readonly ILogger<WeatherForecastController> _logger;
+
+    public WeatherForecastController(ILogger<WeatherForecastController> logger)
+    {
+        _logger = logger;
+    }
+
+    [HttpGet(Name = "GetWeatherForecast")]
+    public IEnumerable<WeatherForecast> Get()
+    {
+        return Enumerable.Range(1, 5).Select(index => new WeatherForecast
+        {
+            Date = DateTime.Now.AddDays(index),
+            TemperatureC = Random.Shared.Next(-20, 55),
+            Summary = Summaries[Random.Shared.Next(Summaries.Length)]
+        })
+        .ToArray();
+    }
+}

--- a/sample/WebApiQuickStart/AspNetCore.Demo/Program.cs
+++ b/sample/WebApiQuickStart/AspNetCore.Demo/Program.cs
@@ -1,0 +1,28 @@
+using Elastic.Apm.AspNetCore;
+using Elastic.Apm.DiagnosticSource;
+
+var builder = WebApplication.CreateBuilder(args);
+
+// Add services to the container.
+
+builder.Services.AddControllers();
+// Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
+builder.Services.AddEndpointsApiExplorer();
+builder.Services.AddSwaggerGen();
+
+var app = builder.Build();
+
+// Configure the HTTP request pipeline.
+if (app.Environment.IsDevelopment())
+{
+	app.UseSwagger();
+	app.UseSwaggerUI();
+}
+
+app.UseElasticApm(builder.Configuration, new HttpDiagnosticsSubscriber());
+
+app.UseAuthorization();
+
+app.MapControllers();
+
+app.Run();

--- a/sample/WebApiQuickStart/AspNetCore.Demo/WeatherForecast.cs
+++ b/sample/WebApiQuickStart/AspNetCore.Demo/WeatherForecast.cs
@@ -1,0 +1,12 @@
+namespace AspNetCore.Demo;
+
+public class WeatherForecast
+{
+    public DateTime Date { get; set; }
+
+    public int TemperatureC { get; set; }
+
+    public int TemperatureF => 32 + (int)(TemperatureC / 0.5556);
+
+    public string? Summary { get; set; }
+}

--- a/sample/WebApiQuickStart/AspNetCore.Demo/appsettings.Development.json
+++ b/sample/WebApiQuickStart/AspNetCore.Demo/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/sample/WebApiQuickStart/AspNetCore.Demo/appsettings.json
+++ b/sample/WebApiQuickStart/AspNetCore.Demo/appsettings.json
@@ -1,0 +1,14 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*",
+  "ElasticApm": {
+    "SecretToken": "",
+    "ServerUrls": "http://localhost:8200",
+    "ServiceName": "AspNetCoreDemo"
+  }
+}

--- a/sample/WebApiQuickStart/README.md
+++ b/sample/WebApiQuickStart/README.md
@@ -1,6 +1,6 @@
 # End to End WebApi QuickStart
 
-This End to End demo will introduce APM stack + APM dotnet webapi agent for test and development purpose
+This End to End demo will introduce APM stack + APM dotnet webapi agent for test and development purpose (do not use it for production)
 
 The full csharp webapi demo is available under AspNetCore.Demo folder
 

--- a/sample/WebApiQuickStart/README.md
+++ b/sample/WebApiQuickStart/README.md
@@ -18,7 +18,7 @@ curl -L -O https://raw.githubusercontent.com/elastic/apm-server/main/docker-comp
 
 ### Or using a lighter one
 
-A copy of the apm-server project with less services (for development and test only)
+A copy of the apm-server `docker-compose.yml` project with less services (for development and test only)
 
 ```bash
 docker compose up -d && docker compose logs -f

--- a/sample/WebApiQuickStart/README.md
+++ b/sample/WebApiQuickStart/README.md
@@ -80,4 +80,4 @@ After the first call to this api, the apm service `AspNetCoreDemo` will become a
 
 ### Open the APM kibana dashboard
 
-Open In your favorite browser open the [kibana apm services dashboard](http://localhost:5601/app/apm/services)
+Open In your favorite browser the [kibana apm services dashboard](http://localhost:5601/app/apm/services)

--- a/sample/WebApiQuickStart/README.md
+++ b/sample/WebApiQuickStart/README.md
@@ -1,0 +1,83 @@
+# End to End WebApi QuickStart
+
+This End to End demo will introduce APM stack + APM dotnet webapi agent for test and development purpose
+
+The full csharp webapi demo is available under AspNetCore.Demo folder
+
+## Setup an apm-server
+
+This part will setup APM stack (apm-server + elasticsearch + apm-server) locally for development and test purpose to enable end to end AspNetCore quick demo.
+
+### By using the latest version
+
+The docker file from the [apm-server project](https://github.com/elastic/apm-server)
+
+```bash
+curl -L -O https://raw.githubusercontent.com/elastic/apm-server/main/docker-compose.yml && docker compose up -d && docker compose logs -f
+```
+
+### Or using a lighter one
+
+A copy of the apm-server project with less services (for development and test only)
+
+```bash
+docker compose up -d && docker compose logs -f
+```
+
+## Create a WebApiDemo
+
+A full demo is available under AspNetCore.Demo folder.
+
+The AspNetCore.Demo has been built following those steps
+
+### Create the webapi project + reference Elastic.Apm.AspNetCore package
+
+```bash
+dotnet new webapi --name AspNetCore.Demo
+dotnet add AspNetCore.Demo package Elastic.Apm.AspNetCore
+```
+
+### Configure the app
+
+This configuration is well explained under the [apm-quickstart](https://www.elastic.co/guide/en/apm/guide/current/apm-quick-start.html)
+
+open the file Properties>launchSettings.json and add the following configuration
+
+```json
+{
+  "ElasticApm": {
+    "SecretToken": "",
+    "ServerUrls": "http://localhost:8200",
+    "ServiceName": "AspNetCoreDemo"
+}
+```
+
+The ElasticApm ServerUrls `http://localhost:8200`: the `apm-server` docker compose service
+
+### Enable the Agent
+
+Program.cs
+
+```csharp
+using Elastic.Apm.AspNetCore;
+using Elastic.Apm.DiagnosticSource;
+// ...
+app.UseElasticApm(builder.Configuration, new HttpDiagnosticsSubscriber());
+// ...
+```
+
+### Run the application
+
+```
+dotnet run
+```
+
+### Test your application
+
+By default the webapi dotnet template uses a fake weatherapi
+Right after running the AspNetCore.Demo webapi, test the api at `http://localhost:5264/weatherforecast`
+After the first call to this api, the apm service `AspNetCoreDemo` will become available by following the next step.
+
+### Open the APM kibana dashboard
+
+Open In your favorite browser open the [kibana apm services dashboard](http://localhost:5601/app/apm/services)

--- a/sample/WebApiQuickStart/README.md
+++ b/sample/WebApiQuickStart/README.md
@@ -6,7 +6,7 @@ The full csharp webapi demo is available under AspNetCore.Demo folder
 
 ## Setup an apm-server
 
-This part will setup APM stack (apm-server + elasticsearch + apm-server) locally for development and test purpose to enable end to end AspNetCore quick demo.
+This part will setup APM stack (apm-server + elasticsearch + kibana) locally for development and test purpose to enable end to end AspNetCore quick demo.
 
 ### By using the latest version
 

--- a/sample/WebApiQuickStart/docker-compose.yml
+++ b/sample/WebApiQuickStart/docker-compose.yml
@@ -1,0 +1,75 @@
+version: '2.2'
+services:
+  apm-server:
+    image: docker.elastic.co/apm/apm-server:7.15.2
+    depends_on:
+      elasticsearch:
+        condition: service_healthy
+      kibana:
+        condition: service_healthy
+    cap_add: ["CHOWN", "DAC_OVERRIDE", "SETGID", "SETUID"]
+    cap_drop: ["ALL"]
+    ports:
+    - 8200:8200
+    networks:
+    - elastic
+    command: >
+       apm-server -e
+         -E apm-server.rum.enabled=true
+         -E setup.kibana.host=kibana:5601
+         -E setup.template.settings.index.number_of_replicas=0
+         -E apm-server.kibana.enabled=true
+         -E apm-server.kibana.host=kibana:5601
+         -E output.elasticsearch.hosts=["elasticsearch:9200"]
+    healthcheck:
+      interval: 10s
+      retries: 12
+      test: curl --write-out 'HTTP %{http_code}' --fail --silent --output /dev/null http://localhost:8200/
+
+  elasticsearch:
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.15.2
+    environment:
+    - bootstrap.memory_lock=true
+    - cluster.name=docker-cluster
+    - cluster.routing.allocation.disk.threshold_enabled=false
+    - discovery.type=single-node
+    - ES_JAVA_OPTS=-XX:UseAVX=2 -Xms1g -Xmx1g
+    ulimits:
+      memlock:
+        hard: -1
+        soft: -1
+    volumes:
+    - esdata:/usr/share/elasticsearch/data
+    ports:
+    - 9200:9200
+    networks:
+    - elastic
+    healthcheck:
+      interval: 20s
+      retries: 10
+      test: curl -s http://localhost:9200/_cluster/health | grep -vq '"status":"red"'
+
+  kibana:
+    image: docker.elastic.co/kibana/kibana:7.15.2
+    depends_on:
+      elasticsearch:
+        condition: service_healthy
+    environment:
+      ELASTICSEARCH_URL: http://elasticsearch:9200
+      ELASTICSEARCH_HOSTS: http://elasticsearch:9200
+    ports:
+    - 5601:5601
+    networks:
+    - elastic
+    healthcheck:
+      interval: 10s
+      retries: 20
+      test: curl --write-out 'HTTP %{http_code}' --fail --silent --output /dev/null http://localhost:5601/api/status
+
+volumes:
+  esdata:
+    driver: local
+
+networks:
+  elastic:
+    driver: bridge


### PR DESCRIPTION
I am starting with the apm-agent-dotnet where I find it very useful.
While setting up my environment for the first time, I find the documentation very useful but at different locations here:
- [apm-quick-start](https://www.elastic.co/guide/en/apm/guide/current/apm-quick-start.html): which describes how to configure the apm server url on dotnet project
- [setup-asp-net-core](https://www.elastic.co/guide/en/apm/agent/dotnet/current/setup-asp-net-core.html) where there is all the code porcelain and plumbing but without mentioning how to configure the apm server url 

Lastly, the samples folder is great for introducing different use cases but I feel that having an end to end sample would be useful by having at one place the apm-server and the webapi demo at the same place.

I hope you will find my contribution useful.