### PR TITLE
Sanitize *auth* instead of authorization (implementation)

### DIFF
--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -474,7 +474,7 @@ See https://www.owasp.org/index.php/Information_exposure_through_query_strings_i
 [options="header"]
 |============
 | Default | Type
-| `password, passwd, pwd, secret, *key, *token*, *session*, *credit*, *card*, authorization, set-cookie` | Comma separated string
+| `password, passwd, pwd, secret, *key, *token*, *session*, *credit*, *card*, *auth*, set-cookie` | Comma separated string
 |============
 
 [float]

--- a/src/Elastic.Apm/Config/ConfigConsts.cs
+++ b/src/Elastic.Apm/Config/ConfigConsts.cs
@@ -86,7 +86,7 @@ namespace Elastic.Apm.Config
 							 "*session*",
 							 "*credit*",
 							 "*card*",
-							 "authorization",
+							 "*auth*",
 							 "set-cookie"
 						 })
 					SanitizeFieldNames.Add(WildcardMatcher.ValueOf(item));

--- a/test/Elastic.Apm.AspNetCore.Tests/SanitizeFieldNamesTests.cs
+++ b/test/Elastic.Apm.AspNetCore.Tests/SanitizeFieldNamesTests.cs
@@ -84,7 +84,9 @@ namespace Elastic.Apm.AspNetCore.Tests
 					testData.Add(new object[] { "creditcardnumber" }); //*card
 					break;
 				case Tests.DefaultsWithKnownHeaders:
-					testData.Add(new object[] { "authorization", "Authorization" });
+					testData.Add(new object[] { "authorization", "Authorization" }); // *auth*
+					testData.Add(new object[] { "authority", "authority" }); // *auth*
+					testData.Add(new object[] { "auth", "auth" }); // *auth*
 					testData.Add(new object[] { "set-cookie", "Set-Cookie" });
 					break;
 				case Tests.DefaultWithRequestBodyNoError:


### PR DESCRIPTION
Solves https://github.com/elastic/apm-agent-dotnet/issues/1588