### PR TITLE
Fix InvalidCastException in AspNetCoreDiagnosticListener

### DIFF
--- a/src/Elastic.Apm.AspNetCore/DiagnosticListener/AspNetCoreDiagnosticListener.cs
+++ b/src/Elastic.Apm.AspNetCore/DiagnosticListener/AspNetCoreDiagnosticListener.cs
@@ -22,6 +22,9 @@ namespace Elastic.Apm.AspNetCore.DiagnosticListener
 		private readonly PropertyFetcher _exceptionContextPropertyFetcher = new PropertyFetcher("Exception");
 		private readonly PropertyFetcher _httpContextPropertyFetcher = new PropertyFetcher("HttpContext");
 
+		private readonly PropertyFetcher _hostDefaultHttpContextFetcher = new PropertyFetcher("HttpContext");
+		private readonly PropertyFetcher _hostExceptionContextPropertyFetcher = new PropertyFetcher("Exception");
+
 		/// <summary>
 		/// Keeps track of ongoing transactions
 		/// </summary>
@@ -83,8 +86,8 @@ namespace Elastic.Apm.AspNetCore.DiagnosticListener
 
 					break;
 				case "Microsoft.AspNetCore.Hosting.UnhandledException": // Not called when exception handler registered
-					if (!(_defaultHttpContextFetcher.Fetch(kv.Value) is DefaultHttpContext httpContextUnhandledException)) return;
-					if (!(_exceptionContextPropertyFetcher.Fetch(kv.Value) is Exception exception)) return;
+					if (!(_hostDefaultHttpContextFetcher.Fetch(kv.Value) is DefaultHttpContext httpContextUnhandledException)) return;
+					if (!(_hostExceptionContextPropertyFetcher.Fetch(kv.Value) is Exception exception)) return;
 					if (!_processingRequests.TryGetValue(httpContextUnhandledException, out var iCurrentTransaction)) return;
 
 					if (iCurrentTransaction is Transaction currentTransaction)

--- a/test/Elastic.Apm.AspNetCore.Tests/AspNetCoreDiagnosticListenerTest.cs
+++ b/test/Elastic.Apm.AspNetCore.Tests/AspNetCoreDiagnosticListenerTest.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to Elasticsearch B.V under one or more agreements.
+// Licensed to Elasticsearch B.V under one or more agreements.
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
 
@@ -9,9 +9,12 @@ using System.Text;
 using System.Threading.Tasks;
 using Elastic.Apm.AspNetCore.DiagnosticListener;
 using Elastic.Apm.Config;
+using Elastic.Apm.DiagnosticSource;
 using Elastic.Apm.Model;
 using Elastic.Apm.Tests.Utilities;
 using FluentAssertions;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
 using SampleAspNetCoreApp;
 using Xunit;
@@ -19,7 +22,8 @@ using Xunit;
 namespace Elastic.Apm.AspNetCore.Tests
 {
 	/// <summary>
-	/// Tests the <see cref="AspNetCoreErrorDiagnosticListener" /> type.
+	/// Tests the <see cref="AspNetCoreDiagnosticListener" /> and
+	/// <see cref="AspNetCoreErrorDiagnosticListener" /> type.
 	/// </summary>
 	[Collection("DiagnosticListenerTest")] //To avoid tests from DiagnosticListenerTests running in parallel with this we add them to 1 collection.
 	public class AspNetCoreDiagnosticListenerTest : IClassFixture<WebApplicationFactory<Startup>>
@@ -112,6 +116,82 @@ namespace Elastic.Apm.AspNetCore.Tests
 				context?.Request.Body.Should().Be(body);
 				errorException?.Should().NotBeNull();
 				errorException?.Handled.Should().BeFalse();
+			}
+		}
+
+		[Fact]
+		public async Task CaptureDiagnosticAndHostingUnhandledExceptionEvent()
+		{
+			// Test that this exception does not reappear.
+			// System.InvalidCastException: 'Unable to cast object of type
+			// '<>f__AnonymousType1`3[ Microsoft.AspNetCore.Http.HttpContext, System.Int64, System.Exception ]' to type
+			// '<>f__AnonymousType0`2[ Microsoft.AspNetCore.Http.HttpContext, System.Exception ]'.'
+
+			var capturedPayload = new MockPayloadSender();
+			using ( var agent = new ApmAgent(new TestAgentComponents(payloadSender: capturedPayload, configuration: new MockConfiguration(exitSpanMinDuration: "0"))) )
+			{
+				// Based on Helper GetClient
+				var builder = _factory
+					.WithWebHostBuilder(n =>
+					{
+						n.Configure(app =>
+						{
+							var subs = new IDiagnosticsSubscriber[]
+							{
+								new AspNetCoreDiagnosticSubscriber()
+							};
+							agent.Subscribe(subs);
+
+							app.UseWhen(
+								ctx => !ctx.Request.Query.ContainsKey("skipUseDeveloperExceptionPage"),
+								app =>
+								{
+									app.UseDeveloperExceptionPage();
+								}
+							);
+
+							app.UseHttpsRedirection();
+							app.UseStaticFiles();
+							app.UseCookiePolicy();
+
+							Startup.ConfigureRoutingAndMvc(app);
+						});
+
+						n.ConfigureServices(Helper.ConfigureServices);
+					});
+
+				var client  = builder.CreateClient();
+
+				// Hits case Microsoft.AspNetCore.Diagnostics.UnhandledException
+				// Exception handled by UseDeveloperExceptionPage
+				await client.GetAsync("/Home/TriggerError");
+
+				// So far same as TestErrorInAspNetCore
+				capturedPayload.WaitForTransactions();
+				capturedPayload.Transactions.Should().ContainSingle();
+
+				capturedPayload.Clear();
+
+				// Hits case Microsoft.AspNetCore.Hosting.UnhandledException
+				Func<Task> act = async () => await client.GetAsync("/Home/TriggerError?skipUseDeveloperExceptionPage=true");
+				( await act.Should().ThrowAsync<Exception>() ).WithMessage("This is a test exception!");
+
+				capturedPayload?.WaitForTransactions();
+				capturedPayload?.Transactions.Should().ContainSingle();
+
+				capturedPayload?.WaitForErrors();
+				capturedPayload?.Errors.Should().NotBeEmpty();
+
+				var error = capturedPayload?.Errors.FirstOrDefault(e => e.Exception.Message == "This is a test exception!") as Error;
+				error.Should().NotBeNull();
+
+				error?.Exception.Message.Should().Be("This is a test exception!");
+				error?.Exception.Type.Should().Be(typeof(Exception).FullName);
+				error?.Exception.Handled.Should().BeFalse();
+
+				var context = error?.Context;
+				context?.Request.Url.Full.Should().Be("http://localhost/Home/TriggerError?skipUseDeveloperExceptionPage=true");
+				context?.Request.Method.Should().Be(HttpMethod.Get.Method);
 			}
 		}
 	}


### PR DESCRIPTION
Fixes ``System.InvalidCastException: 'Unable to cast object of type'<>f__AnonymousType1`3[ Microsoft.AspNetCore.Http.HttpContext, System.Int64, System.Exception ]' to type  '<>f__AnonymousType0`2[ Microsoft.AspNetCore.Http.HttpContext, System.Exception ]'.'``.
This exception happens when both `UnhandledException` cases are executed. One event has an anonymous type with two values, the other with three values. The anonymous type is cached in the `PropertyFetcher`.