### PR TITLE
synchronize schema spec

### DIFF
--- a/src/Elastic.Apm.Specification/specs/error.json
+++ b/src/Elastic.Apm.Specification/specs/error.json
@@ -601,6 +601,29 @@
                 "string"
               ]
             },
+            "target": {
+              "description": "Target holds information about the outgoing service in case of an outgoing event",
+              "type": [
+                "null",
+                "object"
+              ],
+              "properties": {
+                "name": {
+                  "description": "Immutable name of the target service for the event",
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "type": {
+                  "description": "Immutable type of the target service for the event",
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                }
+              }
+            },
             "version": {
               "description": "Version of the monitored service.",
               "type": [

--- a/src/Elastic.Apm.Specification/specs/span.json
+++ b/src/Elastic.Apm.Specification/specs/span.json
@@ -516,6 +516,29 @@
                 "string"
               ]
             },
+            "target": {
+              "description": "Target holds information about the outgoing service in case of an outgoing event",
+              "type": [
+                "null",
+                "object"
+              ],
+              "properties": {
+                "name": {
+                  "description": "Immutable name of the target service for the event",
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "type": {
+                  "description": "Immutable type of the target service for the event",
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                }
+              }
+            },
             "version": {
               "description": "Version of the monitored service.",
               "type": [

--- a/src/Elastic.Apm.Specification/specs/transaction.json
+++ b/src/Elastic.Apm.Specification/specs/transaction.json
@@ -600,6 +600,29 @@
                 "string"
               ]
             },
+            "target": {
+              "description": "Target holds information about the outgoing service in case of an outgoing event",
+              "type": [
+                "null",
+                "object"
+              ],
+              "properties": {
+                "name": {
+                  "description": "Immutable name of the target service for the event",
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "type": {
+                  "description": "Immutable type of the target service for the event",
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                }
+              }
+            },
             "version": {
               "description": "Version of the monitored service.",
               "type": [


### PR DESCRIPTION
### What
  APM agent json schema automatic sync

  ### Why
  *Changeset*
* https://github.com/elastic/apm-server/commit/d1b5503a6 Extend intake API to accept info about target service (https://github.com/elastic/apm-server/pull/7870)