### PR TITLE
Fix: handle `area:null` when creating transaction name based on routing

### DIFF
--- a/src/Elastic.Apm/Model/Transaction.cs
+++ b/src/Elastic.Apm/Model/Transaction.cs
@@ -749,7 +749,7 @@ namespace Elastic.Apm.Model
 			{
 				// Check for MVC areas
 				string areaString = null;
-				if (routeValues.TryGetValue("area", out var area))
+				if (routeValues.TryGetValue("area", out var area) && area != null)
 				{
 					count++;
 					areaString = area.ToString();

--- a/test/Elastic.Apm.AspNetCore.Tests/TransactionExtensionTests.cs
+++ b/test/Elastic.Apm.AspNetCore.Tests/TransactionExtensionTests.cs
@@ -1,0 +1,26 @@
+// Licensed to Elasticsearch B.V under
+// one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System.Collections.Generic;
+using Elastic.Apm.Model;
+using Xunit;
+
+namespace Elastic.Apm.AspNetCore.Tests;
+
+public class TransactionExtensionTests
+{
+	/// <summary>
+	/// Makes sure that area:null does not cause exception.
+	/// See: https://github.com/elastic/apm-agent-dotnet/issues/1681
+	/// </summary>
+	[Fact]
+	public void TestRouteWithAreaNull()
+	{
+		var data = new Dictionary<string, object>() { { "controller", "Home" }, { "area", null }, { "action", "Index" } };
+
+		var ex = Record.Exception(() => Transaction.GetNameFromRouteContext(data));
+		Assert.Null(ex);
+	}
+}


### PR DESCRIPTION
Solves https://github.com/elastic/apm-agent-dotnet/issues/1681 