### PR TITLE
Use ConditionalWeakTable in AspNetCoreDiagnosticListener

### DIFF
--- a/test/Elastic.Apm.AspNetCore.Tests/TransactionQueueTests.cs
+++ b/test/Elastic.Apm.AspNetCore.Tests/TransactionQueueTests.cs
@@ -1,0 +1,44 @@
+// Licensed to Elasticsearch B.V under
+// one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using Elastic.Apm.AspNetCore.DiagnosticListener;
+using Elastic.Apm.Tests.Utilities;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Xunit;
+
+namespace Elastic.Apm.AspNetCore.Tests;
+
+public class TransactionQueueTests
+{
+	/// <summary>
+	/// Makes sure <see cref="AspNetCoreDiagnosticListener"/> does not keep references to GCed <see cref="HttpContext"/> instances.
+	/// </summary>
+	[Fact]
+	public void WeakReferenceTest()
+	{
+		using var agent = new ApmAgent(new TestAgentComponents());
+		var listener = new AspNetCoreDiagnosticListener(agent);
+
+		AddItem(listener);
+
+		listener.ProcessingRequests.Count().Should().Be(1);
+		GC.Collect();
+		Thread.Sleep(10);
+		GC.Collect();
+		foreach (var item in listener.ProcessingRequests) { }
+
+		listener.ProcessingRequests.Count().Should().Be(0);
+	}
+
+	[MethodImpl(MethodImplOptions.NoInlining)]
+	private static void AddItem(AspNetCoreDiagnosticListener listener) =>
+		listener.OnNext(new KeyValuePair<string, object>("Microsoft.AspNetCore.Hosting.HttpRequestIn.Start", new DefaultHttpContext()));
+}


### PR DESCRIPTION
Likely solves https://github.com/elastic/apm-agent-dotnet/issues/1676

The original code used `ConcurrentDictionary` and assumed we get both the `.Start` and the `.Stop` event and we removed items from the `ConcurrentDictionary` in `.Stop`. With this it was in theory possible that we never remove items from the queue (if we don't receive the `Stop` event.).

This PR makes a change to use `ConditionalWeakTable` with the given `HttpContext` as a key instead of `ConcurrentDictionary`. This way, once the `HttpContext` is GCed, the item will be removed automatically, even if we don't receive the `.Stop` event. 