### PR TITLE
Drop out of support netcoreapp2.1 and 3.0 from running on CI

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -623,8 +623,6 @@ def dotnet(Closure body){
     chmod ugo+rx dotnet-install.sh
 
     # Install .Net SDKs
-    ./dotnet-install.sh --install-dir "\${DOTNET_ROOT}" -version '2.1.505'
-    ./dotnet-install.sh --install-dir "\${DOTNET_ROOT}" -version '3.0.103'
     ./dotnet-install.sh --install-dir "\${DOTNET_ROOT}" -version '3.1.100'
     ./dotnet-install.sh --install-dir "\${DOTNET_ROOT}" -version '5.0.100'
     ./dotnet-install.sh --install-dir "\${DOTNET_ROOT}" -version '6.0.100'

--- a/sample/ApiSamples/ApiSamples.csproj
+++ b/sample/ApiSamples/ApiSamples.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.0;net5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.0;net5.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>

--- a/sample/Elastic.Apm.AdoNet/Elastic.Apm.AdoNet.csproj
+++ b/sample/Elastic.Apm.AdoNet/Elastic.Apm.AdoNet.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-      <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.0;netcoreapp3.1;net5.0;</TargetFrameworks>
+      <TargetFrameworks>net461;netcoreapp3.1;net5.0;</TargetFrameworks>
     </PropertyGroup>
 
     <ItemGroup>

--- a/sample/Elastic.Apm.StartupHook.Sample/Elastic.Apm.StartupHook.Sample.csproj
+++ b/sample/Elastic.Apm.StartupHook.Sample/Elastic.Apm.StartupHook.Sample.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.0;netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   

--- a/sample/ElasticsearchSample/ElasticsearchSample.csproj
+++ b/sample/ElasticsearchSample/ElasticsearchSample.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <LangVersion>latest</LangVersion>
     <UserSecretsId>bfb02fcb-6aa5-47e7-9c9e-5fb512708949</UserSecretsId>
   </PropertyGroup>

--- a/sample/HttpListenerSample/HttpListenerSample.csproj
+++ b/sample/HttpListenerSample/HttpListenerSample.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <LangVersion>7.1</LangVersion>
   </PropertyGroup>
 

--- a/sample/MySqlDataSample/MySqlDataSample.csproj
+++ b/sample/MySqlDataSample/MySqlDataSample.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <MySqlDataVersion Condition="'$(MySqlDataVersion)'==''">8.0.26</MySqlDataVersion>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.0;netcoreapp3.1;net5.0;</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp3.1;net5.0;</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/sample/NpgsqlSample/NpgsqlSample.csproj
+++ b/sample/NpgsqlSample/NpgsqlSample.csproj
@@ -3,7 +3,7 @@
     <PropertyGroup>
         <NpgsqlVersion Condition="'$(NpgsqlVersion)'==''">5.0.7</NpgsqlVersion>
         <OutputType>Exe</OutputType>
-        <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.0;netcoreapp3.1;net5.0;</TargetFrameworks>
+        <TargetFrameworks>net461;netcoreapp3.1;net5.0;</TargetFrameworks>
     </PropertyGroup>
 
     <ItemGroup>

--- a/sample/OracleManagedDataAccessCoreSample/OracleManagedDataAccessCoreSample.csproj
+++ b/sample/OracleManagedDataAccessCoreSample/OracleManagedDataAccessCoreSample.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <OracleManagedDataAccessCoreVersion Condition="'$(OracleManagedDataAccessCoreVersion)'==''">2.19.120</OracleManagedDataAccessCoreVersion>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.0;netcoreapp3.1;net5.0;</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp3.1;net5.0;</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/sample/SampleAspNetCoreApp/SampleAspNetCoreApp.csproj
+++ b/sample/SampleAspNetCoreApp/SampleAspNetCoreApp.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.0;netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/sample/SampleConsoleNetCoreApp/SampleConsoleNetCoreApp.csproj
+++ b/sample/SampleConsoleNetCoreApp/SampleConsoleNetCoreApp.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
+        <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
     </PropertyGroup>
 
     <ItemGroup>

--- a/sample/SqlClientSample/SqlClientSample.csproj
+++ b/sample/SqlClientSample/SqlClientSample.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <SqlVersion Condition="'$(SqlVersion)'==''">4.7.0</SqlVersion>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.0;netcoreapp3.1;net5.0;</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp3.1;net5.0;</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/sample/SqliteSample/SqliteSample.csproj
+++ b/sample/SqliteSample/SqliteSample.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <SqliteVersion Condition="'$(SqliteVersion)'==''">5.0.8</SqliteVersion>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.0;netcoreapp3.1;net5.0;</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp3.1;net5.0;</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/sample/WebApiSample/WebApiSample.csproj
+++ b/sample/WebApiSample/WebApiSample.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.0;netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/test/Elastic.Apm.AspNetCore.Static.Tests/Elastic.Apm.AspNetCore.Static.Tests.csproj
+++ b/test/Elastic.Apm.AspNetCore.Static.Tests/Elastic.Apm.AspNetCore.Static.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
     <PropertyGroup>
-      <TargetFrameworks>netcoreapp2.1;netcoreapp3.0;netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
+      <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
     </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="5.6.0" />

--- a/test/Elastic.Apm.AspNetCore.Tests/Elastic.Apm.AspNetCore.Tests.csproj
+++ b/test/Elastic.Apm.AspNetCore.Tests/Elastic.Apm.AspNetCore.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.0;netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
     <AssemblyName>Elastic.Apm.AspNetCore.Tests</AssemblyName>
     <RootNamespace>Elastic.Apm.AspNetCore.Tests</RootNamespace>
   </PropertyGroup>

--- a/test/Elastic.Apm.Benchmarks/Elastic.Apm.Benchmarks.csproj
+++ b/test/Elastic.Apm.Benchmarks/Elastic.Apm.Benchmarks.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <LangVersion>7.3</LangVersion>
     <IsTestProject>false</IsTestProject>
   </PropertyGroup>

--- a/test/Elastic.Apm.Docker.Tests/Elastic.Apm.Docker.Tests.csproj
+++ b/test/Elastic.Apm.Docker.Tests/Elastic.Apm.Docker.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Elastic.Apm.Elasticsearch.Tests/Elastic.Apm.Elasticsearch.Tests.csproj
+++ b/test/Elastic.Apm.Elasticsearch.Tests/Elastic.Apm.Elasticsearch.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/test/Elastic.Apm.EntityFrameworkCore.Tests/Elastic.Apm.EntityFrameworkCore.Tests.csproj
+++ b/test/Elastic.Apm.EntityFrameworkCore.Tests/Elastic.Apm.EntityFrameworkCore.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <RootNamespace>Elastic.Apm.EntityFrameworkCore.Tests</RootNamespace>
     <AssemblyName>Elastic.Apm.EntityFrameworkCore.Tests</AssemblyName>
   </PropertyGroup>

--- a/test/Elastic.Apm.SqlClient.Tests/Elastic.Apm.SqlClient.Tests.csproj
+++ b/test/Elastic.Apm.SqlClient.Tests/Elastic.Apm.SqlClient.Tests.csproj
@@ -1,10 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup Condition=" '$(OS)' != 'Windows_NT' ">
-    <TargetFrameworks>netcoreapp2.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(OS)' == 'Windows_NT' ">
-    <TargetFrameworks>net461;netcoreapp2.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/test/Elastic.Apm.StartupHook.Tests/StartupHookTests.cs
+++ b/test/Elastic.Apm.StartupHook.Tests/StartupHookTests.cs
@@ -29,7 +29,6 @@ namespace Elastic.Apm.StartupHook.Tests
 		/// <param name="targetFramework"></param>
 		/// <returns></returns>
 		[Theory]
-		[InlineData("netcoreapp3.0")]
 		[InlineData("netcoreapp3.1")]
 		[InlineData("net5.0")]
 		[InlineData("net6.0")]
@@ -72,7 +71,6 @@ namespace Elastic.Apm.StartupHook.Tests
 		}
 
 		[Theory]
-		[InlineData("netcoreapp3.0")]
 		[InlineData("netcoreapp3.1")]
 		[InlineData("net5.0")]
 		[InlineData("net6.0")]
@@ -125,7 +123,6 @@ namespace Elastic.Apm.StartupHook.Tests
 		}
 
 		[Theory]
-		[InlineData("netcoreapp3.0", ".NET Core", "3.0.0.0")]
 		[InlineData("netcoreapp3.1", ".NET Core", "3.1.0.0")]
 		[InlineData("net5.0", ".NET 5", "5.0.0.0")]
 		[InlineData("net6.0", ".NET 6", "6.0.0.0")]
@@ -173,14 +170,11 @@ namespace Elastic.Apm.StartupHook.Tests
 		}
 
 		[Theory]
-		[InlineData("webapi", "WebApi30", "netcoreapp3.0", "weatherforecast")]
 		[InlineData("webapi", "WebApi31", "netcoreapp3.1", "weatherforecast")]
 		[InlineData("webapi", "WebApi50", "net5.0", "weatherforecast")]
-		[InlineData("webapp", "WebApp30", "netcoreapp3.0", "")]
 		[InlineData("webapp", "WebApp31", "netcoreapp3.1", "")]
 		[InlineData("webapp", "WebApp50", "net5.0", "")]
 		[InlineData("webapp", "WebApp60", "net6.0", "")]
-		[InlineData("mvc", "Mvc30", "netcoreapp3.0", "")]
 		[InlineData("mvc", "Mvc31", "netcoreapp3.1", "")]
 		[InlineData("mvc", "Mvc50", "net5.0", "")]
 		[InlineData("mvc", "Mvc60", "net6.0", "")]

--- a/test/Elastic.Apm.Tests/Elastic.Apm.Tests.csproj
+++ b/test/Elastic.Apm.Tests/Elastic.Apm.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.0;netcoreapp3.1;net461;net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net461;net5.0;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
End of support for .NET Core 2.1 was August 21, 2021.
End of support for .NET Core 3.0 was March 03, 2020.

This PR removes running test code and support in sample code for those versions. Those versions were mainly targeted by .NET Standard 2.0 which we'll keep and none of the agent code and target framework of agent code is changed here. So no change on the agent side, but we won't run tests against those versions anymore. 