### PR TITLE
Check for nul when constructing UTF16 string

### DIFF
--- a/src/elastic_apm_profiler/src/interfaces/imetadata_assembly_import.rs
+++ b/src/elastic_apm_profiler/src/interfaces/imetadata_assembly_import.rs
@@ -334,12 +334,12 @@ impl IMetaDataAssemblyImport {
     // Other Rust abstractions
 
     fn get_locale(&self, assembly_metadata: &mut ASSEMBLYMETADATA) -> Option<String> {
-        if assembly_metadata.szLocale.is_null() {
+        if assembly_metadata.szLocale.is_null() || assembly_metadata.cbLocale == 0 {
             None
         } else {
             unsafe {
                 Some(
-                    U16CString::from_ptr(
+                    U16CString::from_ptr_with_nul(
                         assembly_metadata.szLocale,
                         assembly_metadata.cbLocale as usize,
                     )


### PR DESCRIPTION
This commit fixes a bug where the construction of a UTF-16 string
from a pointer and length should check for a nul-termination.

Fixes #1635