### PR TITLE
Fix/assembly metadata culture

### DIFF
--- a/ElasticApmAgent.sln
+++ b/ElasticApmAgent.sln
@@ -181,6 +181,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RabbitMqSample", "sample\Ra
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OpenTelemetrySample", "sample\OpenTelemetrySample\OpenTelemetrySample.csproj", "{3D31589A-CA44-4D6D-9944-26CE9640A283}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SatelliteAssemblySample", "sample\SatelliteAssemblySample\SatelliteAssemblySample.csproj", "{2B62E740-A493-42D6-BE5E-709BD07F877E}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -471,6 +473,10 @@ Global
 		{3D31589A-CA44-4D6D-9944-26CE9640A283}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{3D31589A-CA44-4D6D-9944-26CE9640A283}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{3D31589A-CA44-4D6D-9944-26CE9640A283}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2B62E740-A493-42D6-BE5E-709BD07F877E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2B62E740-A493-42D6-BE5E-709BD07F877E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2B62E740-A493-42D6-BE5E-709BD07F877E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2B62E740-A493-42D6-BE5E-709BD07F877E}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -547,6 +553,7 @@ Global
 		{2B23487A-B340-4F5C-A49B-9B829F437A5A} = {3C791D9C-6F19-4F46-B367-2EC0F818762D}
 		{1D6B0C67-42C8-4AB4-A795-B6FF8EF7196E} = {3C791D9C-6F19-4F46-B367-2EC0F818762D}
 		{3D31589A-CA44-4D6D-9944-26CE9640A283} = {3C791D9C-6F19-4F46-B367-2EC0F818762D}
+		{2B62E740-A493-42D6-BE5E-709BD07F877E} = {3C791D9C-6F19-4F46-B367-2EC0F818762D}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {69E02FD9-C9DE-412C-AB6B-5B8BECC6BFA5}

--- a/sample/SatelliteAssemblySample/Program.cs
+++ b/sample/SatelliteAssemblySample/Program.cs
@@ -1,0 +1,16 @@
+﻿using System.Globalization;
+using Microsoft.FSharp.Collections;
+
+var germanCulture = new CultureInfo("de");
+CultureInfo.CurrentCulture = germanCulture;
+CultureInfo.CurrentUICulture = germanCulture;
+
+// Throw a localized ArgumentException
+try
+{
+	SeqModule.Head(SeqModule.Empty<int>());
+}
+catch (ArgumentException ex)
+{
+	Console.WriteLine($"Handled: {ex.Message}");
+}

--- a/sample/SatelliteAssemblySample/SatelliteAssemblySample.csproj
+++ b/sample/SatelliteAssemblySample/SatelliteAssemblySample.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+      <OutputType>Exe</OutputType>
+      <TargetFramework>net6.0</TargetFramework>
+      <ImplicitUsings>enable</ImplicitUsings>
+      <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="FSharp.Core" Version="6.0.2" />
+  </ItemGroup>
+
+</Project>

--- a/src/elastic_apm_profiler/src/ffi/mod.rs
+++ b/src/elastic_apm_profiler/src/ffi/mod.rs
@@ -615,6 +615,8 @@ pub struct ASSEMBLYMETADATA {
 }
 impl Default for ASSEMBLYMETADATA {
     fn default() -> Self {
+        // NOTE: null_mut() default values on ASSEMBLYMETADATA will not be populated.
+        // This is not an issue now, but would be if AssemblyMetaData were to expose these values
         Self {
             usMajorVersion: 0,
             usMinorVersion: 0,

--- a/src/elastic_apm_profiler/src/interfaces/icor_profiler_info.rs
+++ b/src/elastic_apm_profiler/src/interfaces/icor_profiler_info.rs
@@ -793,7 +793,6 @@ impl ICorProfilerInfo {
         let mut base_load_address = MaybeUninit::uninit();
         let name_buffer_length = unsafe { name_buffer_length.assume_init() };
         let mut name_buffer = Vec::<WCHAR>::with_capacity(name_buffer_length as usize);
-        unsafe { name_buffer.set_len(name_buffer_length as usize) };
         let mut name_length = MaybeUninit::uninit();
         let mut assembly_id = MaybeUninit::uninit();
         let hr = unsafe {
@@ -809,6 +808,7 @@ impl ICorProfilerInfo {
         match hr {
             S_OK => {
                 let base_load_address = unsafe { base_load_address.assume_init() };
+                unsafe { name_buffer.set_len(name_buffer_length as usize) };
                 let file_name = U16CString::from_vec_with_nul(name_buffer)
                     .unwrap()
                     .to_string_lossy();
@@ -922,7 +922,6 @@ impl ICorProfilerInfo {
 
         let name_buffer_length = unsafe { name_buffer_length.assume_init() };
         let mut name_buffer = Vec::<WCHAR>::with_capacity(name_buffer_length as usize);
-        unsafe { name_buffer.set_len(name_buffer_length as usize) };
         let mut name_length = MaybeUninit::uninit();
         let mut process_id = MaybeUninit::uninit();
         let hr = unsafe {
@@ -936,6 +935,7 @@ impl ICorProfilerInfo {
         };
         match hr {
             S_OK => {
+                unsafe { name_buffer.set_len(name_buffer_length as usize) };
                 let name = U16CString::from_vec_with_nul(name_buffer)
                     .unwrap()
                     .to_string_lossy();
@@ -1034,7 +1034,6 @@ impl ICorProfilerInfo {
 
         let map_buffer_length = unsafe { map_buffer_length.assume_init() };
         let mut map = Vec::<COR_DEBUG_IL_TO_NATIVE_MAP>::with_capacity(map_buffer_length as usize);
-        unsafe { map.set_len(map_buffer_length as usize) };
         let mut map_length = MaybeUninit::uninit();
         let hr = unsafe {
             self.GetILToNativeMapping(
@@ -1068,8 +1067,6 @@ impl ICorProfilerInfo3 {
 
         let file_name_buffer_length = unsafe { file_name_buffer_length.assume_init() };
         let mut file_name_buffer = Vec::<WCHAR>::with_capacity(file_name_buffer_length as usize);
-        unsafe { file_name_buffer.set_len(file_name_buffer_length as usize) };
-
         let mut base_load_address = MaybeUninit::uninit();
         let mut file_name_length = MaybeUninit::uninit();
         let mut assembly_id = MaybeUninit::uninit();
@@ -1092,6 +1089,7 @@ impl ICorProfilerInfo3 {
                 let assembly_id = unsafe { assembly_id.assume_init() };
                 let module_flags = unsafe { module_flags.assume_init() };
                 let module_flags = COR_PRF_MODULE_FLAGS::from_bits(module_flags).unwrap();
+                unsafe { file_name_buffer.set_len(file_name_buffer_length as usize) };
                 let file_name = U16CString::from_vec_with_nul(file_name_buffer)
                     .unwrap()
                     .to_string_lossy();
@@ -1125,8 +1123,6 @@ impl ICorProfilerInfo3 {
         let version_string_buffer_length = unsafe { version_string_buffer_length.assume_init() };
         let mut version_string_buffer =
             Vec::<WCHAR>::with_capacity(version_string_buffer_length as usize);
-        unsafe { version_string_buffer.set_len(version_string_buffer_length as usize) };
-
         let mut clr_instance_id = MaybeUninit::uninit();
         let mut runtime_type = MaybeUninit::uninit();
         let mut major_version = MaybeUninit::uninit();
@@ -1156,6 +1152,7 @@ impl ICorProfilerInfo3 {
                 let minor_version = unsafe { minor_version.assume_init() };
                 let build_number = unsafe { build_number.assume_init() };
                 let qfe_version = unsafe { qfe_version.assume_init() };
+                unsafe { version_string_buffer.set_len(version_string_buffer_length as usize) };
                 let version_string = U16CString::from_vec_with_nul(version_string_buffer)
                     .unwrap()
                     .to_string_lossy();

--- a/src/elastic_apm_profiler/src/interfaces/imetadata_assembly_import.rs
+++ b/src/elastic_apm_profiler/src/interfaces/imetadata_assembly_import.rs
@@ -272,12 +272,9 @@ impl IMetaDataAssemblyImport {
         let mut name_buffer = Vec::<WCHAR>::with_capacity(MAX_LENGTH as usize);
         let mut name_length = 0;
         let mut public_key = MaybeUninit::uninit();
-        // NOTE: null_mut() default values on ASSEMBLYMETADATA will not populated.
-        // This is not an issue now, but would be if AssemblyMetaData were to expose these values
         let mut assembly_metadata = ASSEMBLYMETADATA::default();
-        let mut sz_locale: *mut WCHAR = ptr::null_mut();
-        assembly_metadata.szLocale = (&mut sz_locale as *mut *mut WCHAR) as *mut WCHAR;
-
+        let sz_locale = U16CString::default();
+        assembly_metadata.szLocale = sz_locale.into_raw();
         let mut public_key_length = 0;
         let mut assembly_flags = 0;
 
@@ -307,6 +304,7 @@ impl IMetaDataAssemblyImport {
 
         let public_key = self.get_public_key(public_key, public_key_length as usize);
         let assembly_flags = CorAssemblyFlags::from_bits(assembly_flags).unwrap();
+        let _ = unsafe { U16CString::from_raw(assembly_metadata.szLocale) };
         let locale = self.get_locale(&mut assembly_metadata);
 
         Ok(AssemblyMetaData {

--- a/src/elastic_apm_profiler/src/profiler/calltarget_tokens.rs
+++ b/src/elastic_apm_profiler/src/profiler/calltarget_tokens.rs
@@ -491,7 +491,7 @@ impl CallTargetTokens {
         let mut signature = Vec::with_capacity(2 + method_argument_signature.len());
         signature.push(CorCallingConvention::IMAGE_CEE_CS_CALLCONV_GENERICINST.bits());
         signature.push(1);
-        signature.extend_from_slice(&method_argument_signature);
+        signature.extend_from_slice(method_argument_signature);
 
         let default_method_spec = module_metadata
             .emit

--- a/src/elastic_apm_profiler/src/profiler/env.rs
+++ b/src/elastic_apm_profiler/src/profiler/env.rs
@@ -65,7 +65,7 @@ pub static IS_AZURE_APP_SERVICE: Lazy<bool> = Lazy::new(|| {
 pub fn check_if_running_in_azure_app_service() -> Result<(), HRESULT> {
     if *IS_AZURE_APP_SERVICE {
         log::info!("Initialize: detected Azure App Service context");
-        if let Some(app_pool_id) = std::env::var(APP_POOL_ID_ENV_VAR).ok() {
+        if let Ok(app_pool_id) = std::env::var(APP_POOL_ID_ENV_VAR) {
             if app_pool_id.starts_with('~') {
                 log::info!(
                     "Initialize: {} environment variable value {} suggests \
@@ -77,7 +77,7 @@ pub fn check_if_running_in_azure_app_service() -> Result<(), HRESULT> {
             }
         }
 
-        if let Some(cli_telemetry) = std::env::var(DOTNET_CLI_TELEMETRY_PROFILE_ENV_VAR).ok() {
+        if let Ok(cli_telemetry) = std::env::var(DOTNET_CLI_TELEMETRY_PROFILE_ENV_VAR) {
             if &cli_telemetry == "AzureKudu" {
                 log::info!(
                     "Initialize: {} environment variable value {} suggests \
@@ -101,9 +101,9 @@ pub fn get_env_vars() -> String {
             if key.starts_with("ELASTIC_")
                 || key.starts_with("CORECLR_")
                 || key.starts_with("COR_")
-                || &key == APP_POOL_ID_ENV_VAR
-                || &key == DOTNET_CLI_TELEMETRY_PROFILE_ENV_VAR
-                || &key == COMPLUS_LOADEROPTIMIZATION
+                || key == APP_POOL_ID_ENV_VAR
+                || key == DOTNET_CLI_TELEMETRY_PROFILE_ENV_VAR
+                || key == COMPLUS_LOADEROPTIMIZATION
             {
                 let value = if key.contains("SECRET") || key.contains("API_KEY") {
                     "[REDACTED]"
@@ -321,15 +321,15 @@ pub fn initialize_logging(process_name: &str) -> Handle {
         // try to create the log directory ahead of time so that we can determine if it's a valid
         // directory. if the directory can't be created, try the default log directory or home directory
         // before bailing and not setting up the file logger.
-        if let Err(_) = std::fs::create_dir_all(&log_dir) {
+        if std::fs::create_dir_all(&log_dir).is_err() {
             let default_log_dir = get_default_log_dir();
             if log_dir != default_log_dir {
                 log_dir = default_log_dir;
-                if let Err(_) = std::fs::create_dir_all(&log_dir) {
+                if std::fs::create_dir_all(&log_dir).is_err() {
                     let home_log_dir = get_home_log_dir();
                     if log_dir != home_log_dir {
                         log_dir = home_log_dir;
-                        if let Err(e) = std::fs::create_dir_all(&log_dir) {
+                        if std::fs::create_dir_all(&log_dir).is_err() {
                             valid_log_dir = false;
                         }
                     } else {
@@ -338,7 +338,7 @@ pub fn initialize_logging(process_name: &str) -> Handle {
                 }
             } else {
                 log_dir = get_home_log_dir();
-                if let Err(e) = std::fs::create_dir_all(&log_dir) {
+                if std::fs::create_dir_all(&log_dir).is_err() {
                     valid_log_dir = false;
                 }
             }
@@ -346,12 +346,10 @@ pub fn initialize_logging(process_name: &str) -> Handle {
 
         if valid_log_dir {
             let log_file_name = log_dir
-                .clone()
                 .join(format!("elastic_apm_profiler_{}_{}.log", process_name, pid))
                 .to_string_lossy()
                 .to_string();
             let rolling_log_file_name = log_dir
-                .clone()
                 .join(format!(
                     "elastic_apm_profiler_{}_{}_{{}}.log",
                     process_name, pid
@@ -442,16 +440,13 @@ pub fn load_integrations() -> Result<Vec<Integration>, HRESULT> {
     );
 
     // Now filter integrations
-    match std::env::var(ELASTIC_APM_PROFILER_EXCLUDE_INTEGRATIONS_ENV_VAR) {
-        Ok(val) => {
-            let exclude_integrations = val.split(';');
-            for exclude_integration in exclude_integrations {
-                log::trace!("exclude integrations that match {}", exclude_integration);
-                integrations
-                    .retain(|i| i.name.to_lowercase() != exclude_integration.to_lowercase());
-            }
+    if let Ok(val) = std::env::var(ELASTIC_APM_PROFILER_EXCLUDE_INTEGRATIONS_ENV_VAR) {
+        let exclude_integrations = val.split(';');
+        for exclude_integration in exclude_integrations {
+            log::trace!("exclude integrations that match {}", exclude_integration);
+            integrations
+                .retain(|i| i.name.to_lowercase() != exclude_integration.to_lowercase());
         }
-        Err(_) => (),
     };
 
     Ok(integrations)

--- a/src/elastic_apm_profiler/src/profiler/mod.rs
+++ b/src/elastic_apm_profiler/src/profiler/mod.rs
@@ -703,7 +703,7 @@ impl Profiler {
                 E_FAIL
             })?;
 
-        let assembly_metadata: AssemblyMetaData = metadata_assembly_import.get_assembly_metadata()?;
+        let assembly_metadata = metadata_assembly_import.get_assembly_metadata()?;
         let is_managed_profiler_assembly = assembly_info.name == MANAGED_PROFILER_ASSEMBLY;
 
         log::debug!(

--- a/src/elastic_apm_profiler/src/profiler/mod.rs
+++ b/src/elastic_apm_profiler/src/profiler/mod.rs
@@ -703,13 +703,14 @@ impl Profiler {
                 E_FAIL
             })?;
 
-        let assembly_metadata = metadata_assembly_import.get_assembly_metadata()?;
+        let assembly_metadata: AssemblyMetaData = metadata_assembly_import.get_assembly_metadata()?;
         let is_managed_profiler_assembly = assembly_info.name == MANAGED_PROFILER_ASSEMBLY;
 
         log::debug!(
-            "AssemblyLoadFinished: name={}, version={}",
+            "AssemblyLoadFinished: name={}, version={}, culture={}",
             &assembly_metadata.name,
-            &assembly_metadata.version
+            &assembly_metadata.version,
+            &assembly_metadata.locale.as_deref().unwrap_or("neutral")
         );
 
         if is_managed_profiler_assembly {

--- a/src/elastic_apm_profiler/src/profiler/process.rs
+++ b/src/elastic_apm_profiler/src/profiler/process.rs
@@ -151,7 +151,7 @@ pub fn process_replacement_calls(
                     log::warn!(
                         "JITCompilationStarted failed to obtain wrapper method ref for {}.{}(). function_id={}, function_token={}, name={}()",
                         &wrapper.type_name,
-                        wrapper.method_name.as_ref().map_or("", |m| m.as_str()),
+                        wrapper.method_name.as_deref().unwrap_or(""),
                         function_id,
                         function_token,
                         caller.full_name()
@@ -585,7 +585,7 @@ pub fn get_wrapper_method_ref(
             log::warn!(
                 "JITCompilationStarted: failed to store wrapper method ref for {}.{}()",
                 &wrapper.type_name,
-                wrapper.method_name.as_ref().map_or("", |m| m.as_str())
+                wrapper.method_name.as_deref().unwrap_or("")
             );
             e
         })?;

--- a/src/elastic_apm_profiler/src/profiler/process.rs
+++ b/src/elastic_apm_profiler/src/profiler/process.rs
@@ -455,7 +455,7 @@ pub fn process_replacement_calls(
 
             if wrapper_method_signature.return_type_is_object() {
                 if let Some(type_token) = return_type_is_value_type_or_generic(
-                    &module_metadata,
+                    module_metadata,
                     target.id,
                     &target.signature,
                 ) {
@@ -591,7 +591,7 @@ pub fn get_wrapper_method_ref(
         })?;
 
     let method_ref = module_wrapper_tokens
-        .get_wrapper_member_ref(&wrapper_method_key)
+        .get_wrapper_member_ref(wrapper_method_key)
         .unwrap_or(mdMemberRefNil);
     let type_ref = module_wrapper_tokens
         .get_wrapper_parent_type_ref(&wrapper_type_key)

--- a/src/elastic_apm_profiler/src/profiler/sig.rs
+++ b/src/elastic_apm_profiler/src/profiler/sig.rs
@@ -41,7 +41,7 @@ fn parse_optional_custom_mods(signature: &[u8]) -> Option<usize> {
         if let Some(cor_element_type) = CorElementType::from_u8(signature[idx]) {
             match cor_element_type {
                 CorElementType::ELEMENT_TYPE_CMOD_OPT | CorElementType::ELEMENT_TYPE_CMOD_REQD => {
-                    if let Some(mod_idx) = parse_custom_mod(&signature) {
+                    if let Some(mod_idx) = parse_custom_mod(signature) {
                         idx += mod_idx;
                     } else {
                         return None;
@@ -103,7 +103,7 @@ pub fn parse_number(signature: &[u8]) -> Option<(ULONG, usize)> {
 }
 
 fn parse_return_type(signature: &[u8]) -> Option<usize> {
-    if let Some(mut idx) = parse_optional_custom_mods(&signature) {
+    if let Some(mut idx) = parse_optional_custom_mods(signature) {
         if let Some(cor_element_type) = CorElementType::from_u8(signature[idx]) {
             match cor_element_type {
                 CorElementType::ELEMENT_TYPE_TYPEDBYREF | CorElementType::ELEMENT_TYPE_VOID => {
@@ -173,7 +173,7 @@ fn parse_method(signature: &[u8]) -> Option<usize> {
 }
 
 fn parse_param(signature: &[u8]) -> Option<usize> {
-    if let Some(mut idx) = parse_optional_custom_mods(&signature) {
+    if let Some(mut idx) = parse_optional_custom_mods(signature) {
         if let Some(cor_element_type) = CorElementType::from_u8(signature[idx]) {
             match cor_element_type {
                 CorElementType::ELEMENT_TYPE_TYPEDBYREF => {

--- a/src/elastic_apm_profiler/src/profiler/types.rs
+++ b/src/elastic_apm_profiler/src/profiler/types.rs
@@ -315,10 +315,9 @@ impl WrapperMethodReference {
 
     pub fn get_method_cache_key(&self) -> String {
         format!(
-            "[{}]{}.{}",
+            "[{}]{}",
             &self.assembly.name,
-            &self.type_name,
-            self.method_name.as_ref().map_or("", |m| m.as_str()),
+            self.full_name(),
         )
     }
 
@@ -326,7 +325,7 @@ impl WrapperMethodReference {
         format!(
             "{}.{}",
             &self.type_name,
-            self.method_name.as_ref().map_or("", |m| m.as_str())
+            self.method_name.as_deref().unwrap_or("")
         )
     }
 }

--- a/src/elastic_apm_profiler/src/profiler/types.rs
+++ b/src/elastic_apm_profiler/src/profiler/types.rs
@@ -389,11 +389,11 @@ impl TargetMethodReference {
     }
 
     pub fn signature_types(&self) -> Option<&[String]> {
-        self.signature_types.as_ref().map(|s| s.as_slice())
+        self.signature_types.as_deref()
     }
 
     pub fn is_valid_for_assembly(&self, assembly_name: &str, version: &Version) -> bool {
-        if &self.assembly != assembly_name {
+        if self.assembly != assembly_name {
             return false;
         }
 
@@ -1363,10 +1363,10 @@ pub struct PublicKey {
 }
 
 impl PublicKey {
-    pub fn new(bytes: Vec<u8>, hash_algorithm: u32) -> Self {
+    pub fn new(bytes: Vec<u8>, hash_algorithm: Option<HashAlgorithmType>) -> Self {
         Self {
             bytes,
-            hash_algorithm: HashAlgorithmType::from_u32(hash_algorithm),
+            hash_algorithm,
         }
     }
 

--- a/test/Elastic.Apm.Profiler.Managed.Tests/SatelliteAssemblyTests.cs
+++ b/test/Elastic.Apm.Profiler.Managed.Tests/SatelliteAssemblyTests.cs
@@ -1,0 +1,64 @@
+﻿// Licensed to Elasticsearch B.V under
+// one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Elastic.Apm.Tests.MockApmServer;
+using Elastic.Apm.Tests.Utilities;
+using FluentAssertions;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Elastic.Apm.Profiler.Managed.Tests;
+
+public class SatelliteAssemblyTests
+{
+	private readonly ITestOutputHelper _output;
+
+	public SatelliteAssemblyTests(ITestOutputHelper output) => _output = output;
+
+	[Fact]
+	public async Task CorrectlyReadSatelliteAssemblyMetadata()
+	{
+		var apmLogger = new InMemoryBlockingLogger(Logging.LogLevel.Error);
+		var apmServer = new MockApmServer(apmLogger, nameof(BasicTests));
+		var port = apmServer.FindAvailablePortToListen();
+		apmServer.RunInBackground(port);
+		var builder = new StringBuilder();
+
+		using (var profiledApplication = new ProfiledApplication("SatelliteAssemblySample"))
+		{
+			var environmentVariables = new Dictionary<string, string>
+			{
+				["ELASTIC_APM_SERVER_URL"] = $"http://localhost:{port}",
+				["ELASTIC_APM_DISABLE_METRICS"] = "*",
+				["ELASTIC_APM_PROFILER_LOG_TARGETS"] = "file;stdout",
+				["ELASTIC_APM_PROFILER_LOG"] = "debug",
+			};
+
+			profiledApplication.Start(
+				"net6.0",
+				TimeSpan.FromMinutes(2),
+				environmentVariables,
+				null,
+				line =>
+				{
+					_output.WriteLine(line.Line);
+					builder.Append(line.Line);
+				},
+				exception =>
+				{
+					_output.WriteLine($"{exception}");
+					builder.Append(exception);
+				});
+		}
+
+		builder.ToString().Should().Contain("AssemblyLoadFinished: name=FSharp.Core.resources, version=6.0.0.0, culture=de");
+		await apmServer.StopAsync();
+	}
+}


### PR DESCRIPTION
This PR fixes an issue with retrieving the assembly metadata locale.

In https://github.com/elastic/apm-agent-dotnet/pull/1708, the check for a nul terminating UTF-16 string was fixed, however,
 the locale was not correctly passed across the FFI boundary. This addresses that.