### PR TITLE
Handle HTTP404 with valid route data

### DIFF
--- a/sample/SampleAspNetCoreApp/Controllers/HomeController.cs
+++ b/sample/SampleAspNetCoreApp/Controllers/HomeController.cs
@@ -284,6 +284,10 @@ namespace SampleAspNetCoreApp.Controllers
 			return Ok();
 		}
 
+		[HttpGet]
+		[Route("api/Home/ReturnNotFound/{id}")]
+		public ActionResult ReturnNotFound(int id) => NotFound();
+
 		/// <summary>
 		/// From: https://github.com/elastic/apm-agent-dotnet/issues/1571#issuecomment-984520076
 		/// </summary>

--- a/src/Elastic.Apm.AspNetCore/WebRequestTransactionCreator.cs
+++ b/src/Elastic.Apm.AspNetCore/WebRequestTransactionCreator.cs
@@ -193,14 +193,14 @@ namespace Elastic.Apm.AspNetCore
 					//fixup Transaction.Name - e.g. /user/profile/1 -> /user/profile/{id}
 					var routeData = context.GetRouteData()?.Values;
 
-					if (routeData != null && context.Response.StatusCode != StatusCodes.Status404NotFound)
+					if (routeData.Count > 0)
 					{
 						logger?.Trace()?.Log("Calculating transaction name based on route data");
 						var name = Transaction.GetNameFromRouteContext(routeData);
 
 						if (!string.IsNullOrWhiteSpace(name)) transaction.Name = $"{context.Request.Method} {name}";
 					}
-					else if (context.Response.StatusCode == StatusCodes.Status404NotFound)
+					else
 					{
 						logger?.Trace()
 							?


### PR DESCRIPTION
Fixes https://github.com/elastic/apm-agent-dotnet/issues/1533.

According to spec, if a URL matches a valid route, then the transaction name should be this valid route (and not 'unknown route') even if the HTTP return code is 404.

Prior to this PR, the agent named such transactions 'unknown route', this PR fixes the behaviour and implements the spec.