### PR TITLE
Handle transaction Name with 404

### DIFF
--- a/src/Elastic.Apm.AspNetCore/WebRequestTransactionCreator.cs
+++ b/src/Elastic.Apm.AspNetCore/WebRequestTransactionCreator.cs
@@ -200,7 +200,7 @@ namespace Elastic.Apm.AspNetCore
 
 						if (!string.IsNullOrWhiteSpace(name)) transaction.Name = $"{context.Request.Method} {name}";
 					}
-					else
+					else if (context.Response.StatusCode == StatusCodes.Status404NotFound)
 					{
 						logger?.Trace()
 							?


### PR DESCRIPTION
Integration tests are failing - after https://github.com/elastic/apm-agent-dotnet/pull/1715 the expected transaction names don't match.

This PR fixes it.