### PR TITLE
Update SystemTotalCpuProvider.cs

### DIFF
--- a/src/Elastic.Apm/Metrics/MetricsProvider/SystemTotalCpuProvider.cs
+++ b/src/Elastic.Apm/Metrics/MetricsProvider/SystemTotalCpuProvider.cs
@@ -22,54 +22,16 @@ namespace Elastic.Apm.Metrics.MetricsProvider
 
 		// ReSharper disable once PrivateFieldCanBeConvertedToLocalVariable
 		private readonly IApmLogger _logger;
-		private readonly PerformanceCounter _processorTimePerfCounter;
+		private PerformanceCounter _processorTimePerfCounter;
 		private readonly StreamReader _procStatStreamReader;
+
+		private bool _initializationStarted;
 
 		public SystemTotalCpuProvider(IApmLogger logger)
 		{
 			_logger = logger.Scoped(nameof(SystemTotalCpuProvider));
-			if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-			{
-				var categoryName = "Processor";
-				try
-				{
-					try
-					{
-						_processorTimePerfCounter = new PerformanceCounter(categoryName, "% Processor Time", "_Total");
-					}
-					catch (InvalidOperationException e)
-					{
-						_logger.Debug()?.LogException(e, "Error instantiating '{CategoryName}' performance counter.", categoryName);
-						_processorTimePerfCounter?.Dispose();
-						// If the Processor performance counter category does not exist, try Processor Information.
-						categoryName = "Processor Information";
-						_processorTimePerfCounter = new PerformanceCounter(categoryName, "% Processor Time", "_Total");
-					}
-
-					//The perf. counter API returns 0 the for the 1. call (probably because there is no delta in the 1. call) - so we just call it here first
-					_processorTimePerfCounter.NextValue();
-				}
-				catch (Exception e)
-				{
-					if (e is UnauthorizedAccessException)
-					{
-						_logger.Error()
-							?.LogException(e, "Error instantiating '{CategoryName}' performance counter."
-								+ " Process does not have permissions to read performance counters."
-								+ " See https://www.elastic.co/guide/en/apm/agent/dotnet/current/metrics.html#metrics-system to see how to configure.", categoryName);
-					}
-					else
-					{
-						_logger.Error()
-							?.LogException(e, "Error instantiating '{CategoryName}' performance counter", categoryName);
-					}
-
-					_logger.Warning()?.Log("System metrics won't be collected");
-					_processorTimePerfCounter?.Dispose();
-					_processorTimePerfCounter = null;
-				}
-			}
-			else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+			
+			if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
 			{
 				var (success, idle, total) = ReadProcStat();
 				if (!success) return;
@@ -128,6 +90,58 @@ namespace Elastic.Apm.Metrics.MetricsProvider
 
 		public IEnumerable<MetricSet> GetSamples()
 		{
+			if(!_initializationStarted)
+			{
+				// Ideally we'd do all this initialization in the .ctor
+				// The reason to move it here is the call to `new PerformanceCounter(...)`.
+				// That call causes a hang in some environments. See: https://github.com/elastic/apm-agent-dotnet/issues/1724
+				// MetricsCollector instantiates all the IMetricsProvider instances (this one as well).
+				// With moving the initialization of PerformanceCounter into GetSamples(),
+				// it's never called if this metric is disabled. Therefore at least by disabling  this metric can be used as a workaround.
+				_initializationStarted = true;
+				if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+				{
+					var categoryName = "Processor";
+					try
+					{
+						try
+						{
+							_processorTimePerfCounter = new PerformanceCounter(categoryName, "% Processor Time", "_Total");
+						}
+						catch (InvalidOperationException e)
+						{
+							_logger.Debug()?.LogException(e, "Error instantiating '{CategoryName}' performance counter.", categoryName);
+							_processorTimePerfCounter?.Dispose();
+							// If the Processor performance counter category does not exist, try Processor Information.
+							categoryName = "Processor Information";
+							_processorTimePerfCounter = new PerformanceCounter(categoryName, "% Processor Time", "_Total");
+						}
+
+						//The perf. counter API returns 0 the for the 1. call (probably because there is no delta in the 1. call) - so we just call it here first
+						_processorTimePerfCounter.NextValue();
+					}
+					catch (Exception e)
+					{
+						if (e is UnauthorizedAccessException)
+						{
+							_logger.Error()
+								?.LogException(e, "Error instantiating '{CategoryName}' performance counter."
+									+ " Process does not have permissions to read performance counters."
+									+ " See https://www.elastic.co/guide/en/apm/agent/dotnet/current/metrics.html#metrics-system to see how to configure.", categoryName);
+						}
+						else
+						{
+							_logger.Error()
+								?.LogException(e, "Error instantiating '{CategoryName}' performance counter", categoryName);
+						}
+
+						_logger.Warning()?.Log("System metrics won't be collected");
+						_processorTimePerfCounter?.Dispose();
+						_processorTimePerfCounter = null;
+					}
+				}
+			}
+
 			if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
 			{
 				if (_processorTimePerfCounter == null) return null;


### PR DESCRIPTION
Enables a workaround for https://github.com/elastic/apm-agent-dotnet/issues/1724.

Move `PerformanceCounter` initialization out from ctor into the `GetSamples()` method.

This was instantiation of `PerformanceCounter` does not happen when the metric is disabled. 