### PR TITLE
Turn on AspNetCoreDiagnosticSubscriber with profiler

### DIFF
--- a/sample/SampleAspNetCoreApp/SampleAspNetCoreApp.csproj
+++ b/sample/SampleAspNetCoreApp/SampleAspNetCoreApp.csproj
@@ -3,47 +3,48 @@
   <PropertyGroup>
     <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
+    <PlatformTarget>AnyCPU</PlatformTarget>
   </PropertyGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.1' ">
-    <PackageReference Include="Microsoft.AspNetCore.App"/>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="2.1.4"/>
+    <PackageReference Include="Microsoft.AspNetCore.App" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="2.1.4" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.0' ">
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="3.0.0"/>
-    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="3.0.0"/>
-    <PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="3.0.0"/>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="3.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="3.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="3.0.0" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1' ">
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="3.1.0"/>
-    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="3.1.0"/>
-    <PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="3.1.0"/>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="3.1.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="3.1.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="3.1.0" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net5.0' ">
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="5.0.0"/>
-    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="5.0.0"/>
-    <PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="5.0.0"/>
-    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.0.0-rc6"/>
-    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.0.0-rc6"/>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="5.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="5.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="5.0.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.0.0-rc6" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.0.0-rc6" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="6.0.0"/>
-    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="6.0.0"/>
-    <PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="6.0.0"/>
-    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.0.0-rc6"/>
-    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.0.0-rc6"/>
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0"/>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="6.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="6.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="6.0.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.0.0-rc6" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.0.0-rc6" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1"/>
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
   <ItemGroup>
-    <Folder Include="Data\"/>
-    <Folder Include="Data\HistoricalData"/>
-    <Folder Include="Migrations"/>
+    <Folder Include="Data\" />
+    <Folder Include="Data\HistoricalData" />
+    <Folder Include="Migrations" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\src\Elastic.Apm.NetCoreAll\Elastic.Apm.NetCoreAll.csproj"/>
+    <ProjectReference Include="..\..\src\Elastic.Apm.NetCoreAll\Elastic.Apm.NetCoreAll.csproj" />
   </ItemGroup>
   <ItemGroup>
     <Content Update="Views\Home\Index.cshtml">

--- a/sample/SampleAspNetCoreApp/Startup.cs
+++ b/sample/SampleAspNetCoreApp/Startup.cs
@@ -2,6 +2,7 @@
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
 
+using System;
 using Elastic.Apm;
 using Elastic.Apm.EntityFrameworkCore;
 using Elastic.Apm.NetCoreAll;
@@ -12,7 +13,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
-#if  NET5_0
+#if NET5_0
 using OpenTelemetry;
 using OpenTelemetry.Trace;
 #endif
@@ -62,7 +63,9 @@ namespace SampleAspNetCoreApp
 		public void Configure(IApplicationBuilder app, IHostingEnvironment env)
 #endif
 		{
-			app.UseAllElasticApm(Configuration);
+			if (string.IsNullOrEmpty(Environment.GetEnvironmentVariable("SKIP_AGENT_REGISTRATION")))
+				app.UseAllElasticApm(Configuration);
+
 			ConfigureAllExceptAgent(app);
 		}
 

--- a/sample/SampleAspNetCoreApp/Startup.cs
+++ b/sample/SampleAspNetCoreApp/Startup.cs
@@ -73,7 +73,6 @@ namespace SampleAspNetCoreApp
 		{
 			app.UseDeveloperExceptionPage();
 
-			app.UseHttpsRedirection();
 			app.UseStaticFiles();
 			app.UseCookiePolicy();
 

--- a/src/Elastic.Apm.AspNetCore/DiagnosticListener/AspNetCoreDiagnosticSubscriber.cs
+++ b/src/Elastic.Apm.AspNetCore/DiagnosticListener/AspNetCoreDiagnosticSubscriber.cs
@@ -1,5 +1,6 @@
 using System;
 using Elastic.Apm.DiagnosticSource;
+using Elastic.Apm.Logging;
 
 namespace Elastic.Apm.AspNetCore.DiagnosticListener
 {
@@ -11,6 +12,8 @@ namespace Elastic.Apm.AspNetCore.DiagnosticListener
 	{
 		public IDisposable Subscribe(IApmAgent agent)
 		{
+			agent.Logger.Debug()?.Log($"{nameof(AspNetCoreDiagnosticSubscriber)} starting to subscribe");
+
 			var retVal = new CompositeDisposable();
 			if (!agent.ConfigurationReader.Enabled)
 				return retVal;
@@ -21,6 +24,8 @@ namespace Elastic.Apm.AspNetCore.DiagnosticListener
 			retVal.Add(System.Diagnostics.DiagnosticListener
 				.AllListeners
 				.Subscribe(subscriber));
+
+			agent.Logger.Debug()?.Log($"{nameof(AspNetCoreDiagnosticSubscriber)} subscribed");
 
 			return retVal;
 		}

--- a/src/Elastic.Apm.AspNetCore/Elastic.Apm.AspNetCore.csproj
+++ b/src/Elastic.Apm.AspNetCore/Elastic.Apm.AspNetCore.csproj
@@ -5,7 +5,7 @@
     <PackageId>Elastic.Apm.AspNetCore</PackageId>
     <Description>Elastic APM for ASP.NET Core. This package contains auto instrumentation for ASP.NET Core. See: https://github.com/elastic/apm-agent-dotnet/tree/main/docs</Description>
     <PackageTags>apm, monitoring, elastic, elasticapm, analytics, aspnetcore</PackageTags>
-    <TargetFrameworks>netstandard2.0;netcoreapp3.0;net5.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netcoreapp3.0;netcoreapp3.1;net5.0</TargetFrameworks>
     <IsPackable>true</IsPackable>
   </PropertyGroup>
   <ItemGroup>
@@ -29,6 +29,12 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="3.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.0.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="3.0.0" />
+  </ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1' ">
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="3.1.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="3.1.0" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net5.0' ">
     <FrameworkReference Include="Microsoft.AspNetCore.App" />

--- a/src/Elastic.Apm.Profiler.Managed.Loader/Startup.cs
+++ b/src/Elastic.Apm.Profiler.Managed.Loader/Startup.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to Elasticsearch B.V under the Apache 2.0 License.
+// Licensed to Elasticsearch B.V under the Apache 2.0 License.
 // Elasticsearch B.V licenses this file, including any modifications, to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 //

--- a/src/Elastic.Apm.Profiler.Managed/AutoInstrumentation.cs
+++ b/src/Elastic.Apm.Profiler.Managed/AutoInstrumentation.cs
@@ -44,7 +44,12 @@ namespace Elastic.Apm.Profiler.Managed
 #endif
 				// ensure global instance is created if it's not already
 				if (!skipInstantiation)
+				{
 					_ = Agent.Instance;
+
+					Agent.Subscribe(new Elastic.Apm.AspNetCore.DiagnosticListener.AspNetCoreDiagnosticSubscriber());
+				//	Agent.Subscribe(new AspNetCoreDiagnosticSubscriber());
+				}
 			}
 			catch
 			{

--- a/src/Elastic.Apm.Profiler.Managed/AutoInstrumentation.cs
+++ b/src/Elastic.Apm.Profiler.Managed/AutoInstrumentation.cs
@@ -46,9 +46,9 @@ namespace Elastic.Apm.Profiler.Managed
 				if (!skipInstantiation)
 				{
 					_ = Agent.Instance;
-
+#if !NETFRAMEWORK
 					Agent.Subscribe(new Elastic.Apm.AspNetCore.DiagnosticListener.AspNetCoreDiagnosticSubscriber());
-				//	Agent.Subscribe(new AspNetCoreDiagnosticSubscriber());
+#endif
 				}
 			}
 			catch

--- a/src/Elastic.Apm.Profiler.Managed/AutoInstrumentation.cs
+++ b/src/Elastic.Apm.Profiler.Managed/AutoInstrumentation.cs
@@ -47,6 +47,8 @@ namespace Elastic.Apm.Profiler.Managed
 				{
 					_ = Agent.Instance;
 #if !NETFRAMEWORK
+
+					Logger.Log(LogLevel.Debug, "Activate Elastic.Apm.AspNetCore.DiagnosticListener.AspNetCoreDiagnosticSubscriber");
 					Agent.Subscribe(new Elastic.Apm.AspNetCore.DiagnosticListener.AspNetCoreDiagnosticSubscriber());
 #endif
 				}

--- a/src/Elastic.Apm.Profiler.Managed/AutoInstrumentation.cs
+++ b/src/Elastic.Apm.Profiler.Managed/AutoInstrumentation.cs
@@ -51,6 +51,8 @@ namespace Elastic.Apm.Profiler.Managed
 					Logger.Log(LogLevel.Debug, "Activate Elastic.Apm.AspNetCore.DiagnosticListener.AspNetCoreDiagnosticSubscriber");
 					Agent.Subscribe(new Elastic.Apm.AspNetCore.DiagnosticListener.AspNetCoreDiagnosticSubscriber());
 #endif
+					Logger.Log(LogLevel.Debug, "Activate Elastic.Apm.DiagnosticSource.HttpDiagnosticsSubscriber");
+					Agent.Subscribe(new Elastic.Apm.DiagnosticSource.HttpDiagnosticsSubscriber());
 				}
 			}
 			catch

--- a/src/Elastic.Apm.Profiler.Managed/Elastic.Apm.Profiler.Managed.csproj
+++ b/src/Elastic.Apm.Profiler.Managed/Elastic.Apm.Profiler.Managed.csproj
@@ -1,28 +1,32 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-    <PropertyGroup>
-      <TargetFrameworks>net461;netstandard2.0;netcoreapp3.1</TargetFrameworks>
-      <IsPackable>false</IsPackable>
-    </PropertyGroup>
-    
-    <ItemGroup Condition="'$(TargetFramework)' != 'net461'">
-      <PackageReference Include="System.Reflection.Emit" Version="4.3.0" />
-      <PackageReference Include="System.Reflection.Emit.Lightweight" Version="4.3.0" />
-    </ItemGroup>
-  
-    <!-- ASP.NET integration -->
-    <ItemGroup Condition="'$(TargetFramework)' == 'net461'">
-      <ProjectReference Include="..\Elastic.Apm.AspNetFullFramework\Elastic.Apm.AspNetFullFramework.csproj" />
-      <Reference Include="System.Web" />
-    </ItemGroup>
+  <PropertyGroup>
+    <TargetFrameworks>net461;netstandard2.0;netcoreapp3.1</TargetFrameworks>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
 
-    <ItemGroup>
-      <ProjectReference Include="..\Elastic.Apm.Profiler.Managed.Core\Elastic.Apm.Profiler.Managed.Core.csproj" />
-      <ProjectReference Include="..\Elastic.Apm\Elastic.Apm.csproj" />
-    </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' != 'net461'">
+    <PackageReference Include="System.Reflection.Emit" Version="4.3.0" />
+    <PackageReference Include="System.Reflection.Emit.Lightweight" Version="4.3.0" />
+  </ItemGroup>
 
-    <ItemGroup>
-      <InternalsVisibleTo Include="Elastic.Apm.Profiler.Managed.Tests" Key="$(ExposedPublicKey)" />
-    </ItemGroup>
+  <!-- ASP.NET integration -->
+  <ItemGroup Condition="'$(TargetFramework)' == 'net461'">
+    <ProjectReference Include="..\Elastic.Apm.AspNetFullFramework\Elastic.Apm.AspNetFullFramework.csproj" />
+    <Reference Include="System.Web" />
+  </ItemGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\Elastic.Apm.AspNetCore\Elastic.Apm.AspNetCore.csproj" />
+    <ProjectReference Include="..\Elastic.Apm.Profiler.Managed.Core\Elastic.Apm.Profiler.Managed.Core.csproj" />
+    <ProjectReference Include="..\Elastic.Apm\Elastic.Apm.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="Elastic.Apm.Profiler.Managed.Tests" Key="$(ExposedPublicKey)" />
+  </ItemGroup>
+
+  <ItemGroup  Condition="'$(TargetFramework)' != 'net461'">
+    <ProjectReference Include="..\Elastic.Apm.AspNetCore\Elastic.Apm.AspNetCore.csproj" />
+  </ItemGroup>
 </Project>

--- a/src/Elastic.Apm.Profiler.Managed/integrations.yml
+++ b/src/Elastic.Apm.Profiler.Managed/integrations.yml
@@ -10,7 +10,7 @@
       minimum_version: 4.0.0
       maximum_version: 4.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.14.1.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.15.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteNonQueryAsyncIntegration
       action: CallTargetModification
   - target:
@@ -23,7 +23,7 @@
       minimum_version: 4.0.0
       maximum_version: 5.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.14.1.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.15.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteNonQueryAsyncIntegration
       action: CallTargetModification
   - target:
@@ -37,7 +37,7 @@
       minimum_version: 4.0.0
       maximum_version: 4.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.14.1.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.15.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteReaderWithBehaviorAsyncIntegration
       action: CallTargetModification
   - target:
@@ -51,7 +51,7 @@
       minimum_version: 4.0.0
       maximum_version: 5.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.14.1.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.15.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteReaderWithBehaviorAsyncIntegration
       action: CallTargetModification
   - target:
@@ -64,7 +64,7 @@
       minimum_version: 4.0.0
       maximum_version: 4.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.14.1.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.15.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteScalarAsyncIntegration
       action: CallTargetModification
   - target:
@@ -77,7 +77,7 @@
       minimum_version: 4.0.0
       maximum_version: 5.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.14.1.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.15.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteScalarAsyncIntegration
       action: CallTargetModification
 - name: AspNet
@@ -93,7 +93,7 @@
       minimum_version: 4.0.0
       maximum_version: 4.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.14.1.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.15.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AspNet.ElasticApmModuleIntegration
       action: CallTargetModification
 - name: Kafka
@@ -107,7 +107,7 @@
       minimum_version: 1.4.0
       maximum_version: 1.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.14.1.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.15.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.Kafka.KafkaConsumerCloseIntegration
       action: CallTargetModification
   - target:
@@ -120,7 +120,7 @@
       minimum_version: 1.4.0
       maximum_version: 1.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.14.1.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.15.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.Kafka.KafkaConsumerConsumeIntegration
       action: CallTargetModification
   - target:
@@ -132,7 +132,7 @@
       minimum_version: 1.4.0
       maximum_version: 1.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.14.1.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.15.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.Kafka.KafkaConsumerDisposeIntegration
       action: CallTargetModification
   - target:
@@ -144,7 +144,7 @@
       minimum_version: 1.4.0
       maximum_version: 1.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.14.1.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.15.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.Kafka.KafkaConsumerUnsubscribeIntegration
       action: CallTargetModification
   - target:
@@ -159,7 +159,7 @@
       minimum_version: 1.4.0
       maximum_version: 1.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.14.1.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.15.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.Kafka.KafkaProduceAsyncIntegration
       action: CallTargetModification
   - target:
@@ -175,7 +175,7 @@
       minimum_version: 1.4.0
       maximum_version: 1.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.14.1.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.15.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.Kafka.KafkaProduceSyncDeliveryHandlerIntegration
       action: CallTargetModification
   - target:
@@ -190,7 +190,7 @@
       minimum_version: 1.4.0
       maximum_version: 1.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.14.1.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.15.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.Kafka.KafkaProduceSyncIntegration
       action: CallTargetModification
 - name: MySqlCommand
@@ -205,7 +205,7 @@
       minimum_version: 6.7.0
       maximum_version: 8.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.14.1.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.15.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteNonQueryAsyncIntegration
       action: CallTargetModification
   - target:
@@ -217,7 +217,7 @@
       minimum_version: 6.7.0
       maximum_version: 8.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.14.1.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.15.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteNonQueryIntegration
       action: CallTargetModification
   - target:
@@ -230,7 +230,7 @@
       minimum_version: 6.7.0
       maximum_version: 8.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.14.1.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.15.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteNonQueryWithBehaviorIntegration
       action: CallTargetModification
   - target:
@@ -243,7 +243,7 @@
       minimum_version: 6.7.0
       maximum_version: 8.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.14.1.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.15.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteReaderAsyncIntegration
       action: CallTargetModification
   - target:
@@ -255,7 +255,7 @@
       minimum_version: 6.7.0
       maximum_version: 8.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.14.1.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.15.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteReaderIntegration
       action: CallTargetModification
   - target:
@@ -269,7 +269,7 @@
       minimum_version: 6.7.0
       maximum_version: 8.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.14.1.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.15.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteReaderWithBehaviorAsyncIntegration
       action: CallTargetModification
   - target:
@@ -283,7 +283,7 @@
       minimum_version: 6.7.0
       maximum_version: 8.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.14.1.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.15.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteReaderWithBehaviorAsyncIntegration
       action: CallTargetModification
   - target:
@@ -296,7 +296,7 @@
       minimum_version: 6.7.0
       maximum_version: 8.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.14.1.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.15.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteReaderWithBehaviorIntegration
       action: CallTargetModification
   - target:
@@ -309,7 +309,7 @@
       minimum_version: 6.7.0
       maximum_version: 8.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.14.1.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.15.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteReaderWithBehaviorIntegration
       action: CallTargetModification
   - target:
@@ -322,7 +322,7 @@
       minimum_version: 6.7.0
       maximum_version: 8.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.14.1.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.15.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteScalarAsyncIntegration
       action: CallTargetModification
   - target:
@@ -334,7 +334,7 @@
       minimum_version: 6.7.0
       maximum_version: 8.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.14.1.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.15.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteScalarIntegration
       action: CallTargetModification
   - target:
@@ -347,7 +347,7 @@
       minimum_version: 6.7.0
       maximum_version: 8.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.14.1.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.15.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteScalarWithBehaviorIntegration
       action: CallTargetModification
 - name: NpgsqlCommand
@@ -362,7 +362,7 @@
       minimum_version: 4.0.0
       maximum_version: 6.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.14.1.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.15.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteNonQueryAsyncIntegration
       action: CallTargetModification
   - target:
@@ -374,7 +374,7 @@
       minimum_version: 4.0.0
       maximum_version: 6.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.14.1.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.15.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteNonQueryIntegration
       action: CallTargetModification
   - target:
@@ -387,7 +387,7 @@
       minimum_version: 4.0.0
       maximum_version: 6.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.14.1.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.15.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteNonQueryWithBehaviorIntegration
       action: CallTargetModification
   - target:
@@ -400,7 +400,7 @@
       minimum_version: 4.0.0
       maximum_version: 6.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.14.1.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.15.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteReaderAsyncIntegration
       action: CallTargetModification
   - target:
@@ -412,7 +412,7 @@
       minimum_version: 4.0.0
       maximum_version: 6.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.14.1.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.15.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteReaderIntegration
       action: CallTargetModification
   - target:
@@ -426,7 +426,7 @@
       minimum_version: 4.0.0
       maximum_version: 6.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.14.1.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.15.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteReaderWithBehaviorAsyncIntegration
       action: CallTargetModification
   - target:
@@ -440,7 +440,7 @@
       minimum_version: 4.0.0
       maximum_version: 6.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.14.1.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.15.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteReaderWithBehaviorAsyncIntegration
       action: CallTargetModification
   - target:
@@ -453,7 +453,7 @@
       minimum_version: 4.0.0
       maximum_version: 6.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.14.1.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.15.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteReaderWithBehaviorIntegration
       action: CallTargetModification
   - target:
@@ -466,7 +466,7 @@
       minimum_version: 4.0.0
       maximum_version: 6.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.14.1.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.15.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteReaderWithBehaviorIntegration
       action: CallTargetModification
   - target:
@@ -479,7 +479,7 @@
       minimum_version: 4.0.0
       maximum_version: 6.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.14.1.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.15.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteScalarAsyncIntegration
       action: CallTargetModification
   - target:
@@ -491,7 +491,7 @@
       minimum_version: 4.0.0
       maximum_version: 6.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.14.1.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.15.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteScalarIntegration
       action: CallTargetModification
   - target:
@@ -504,7 +504,7 @@
       minimum_version: 4.0.0
       maximum_version: 6.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.14.1.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.15.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteScalarWithBehaviorIntegration
       action: CallTargetModification
 - name: OracleCommand
@@ -519,7 +519,7 @@
       minimum_version: 4.122.0
       maximum_version: 4.122.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.14.1.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.15.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteNonQueryAsyncIntegration
       action: CallTargetModification
   - target:
@@ -532,7 +532,7 @@
       minimum_version: 2.0.0
       maximum_version: 2.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.14.1.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.15.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteNonQueryAsyncIntegration
       action: CallTargetModification
   - target:
@@ -544,7 +544,7 @@
       minimum_version: 4.122.0
       maximum_version: 4.122.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.14.1.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.15.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteNonQueryIntegration
       action: CallTargetModification
   - target:
@@ -556,7 +556,7 @@
       minimum_version: 2.0.0
       maximum_version: 2.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.14.1.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.15.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteNonQueryIntegration
       action: CallTargetModification
   - target:
@@ -569,7 +569,7 @@
       minimum_version: 4.122.0
       maximum_version: 4.122.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.14.1.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.15.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteNonQueryWithBehaviorIntegration
       action: CallTargetModification
   - target:
@@ -582,7 +582,7 @@
       minimum_version: 2.0.0
       maximum_version: 2.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.14.1.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.15.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteNonQueryWithBehaviorIntegration
       action: CallTargetModification
   - target:
@@ -595,7 +595,7 @@
       minimum_version: 4.122.0
       maximum_version: 4.122.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.14.1.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.15.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteReaderAsyncIntegration
       action: CallTargetModification
   - target:
@@ -608,7 +608,7 @@
       minimum_version: 2.0.0
       maximum_version: 2.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.14.1.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.15.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteReaderAsyncIntegration
       action: CallTargetModification
   - target:
@@ -620,7 +620,7 @@
       minimum_version: 4.122.0
       maximum_version: 4.122.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.14.1.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.15.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteReaderIntegration
       action: CallTargetModification
   - target:
@@ -632,7 +632,7 @@
       minimum_version: 2.0.0
       maximum_version: 2.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.14.1.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.15.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteReaderIntegration
       action: CallTargetModification
   - target:
@@ -646,7 +646,7 @@
       minimum_version: 4.122.0
       maximum_version: 4.122.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.14.1.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.15.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteReaderWithBehaviorAsyncIntegration
       action: CallTargetModification
   - target:
@@ -660,7 +660,7 @@
       minimum_version: 2.0.0
       maximum_version: 2.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.14.1.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.15.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteReaderWithBehaviorAsyncIntegration
       action: CallTargetModification
   - target:
@@ -674,7 +674,7 @@
       minimum_version: 4.122.0
       maximum_version: 4.122.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.14.1.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.15.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteReaderWithBehaviorAsyncIntegration
       action: CallTargetModification
   - target:
@@ -688,7 +688,7 @@
       minimum_version: 2.0.0
       maximum_version: 2.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.14.1.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.15.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteReaderWithBehaviorAsyncIntegration
       action: CallTargetModification
   - target:
@@ -701,7 +701,7 @@
       minimum_version: 4.122.0
       maximum_version: 4.122.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.14.1.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.15.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteReaderWithBehaviorIntegration
       action: CallTargetModification
   - target:
@@ -714,7 +714,7 @@
       minimum_version: 2.0.0
       maximum_version: 2.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.14.1.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.15.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteReaderWithBehaviorIntegration
       action: CallTargetModification
   - target:
@@ -727,7 +727,7 @@
       minimum_version: 4.122.0
       maximum_version: 4.122.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.14.1.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.15.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteReaderWithBehaviorIntegration
       action: CallTargetModification
   - target:
@@ -740,7 +740,7 @@
       minimum_version: 2.0.0
       maximum_version: 2.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.14.1.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.15.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteReaderWithBehaviorIntegration
       action: CallTargetModification
   - target:
@@ -753,7 +753,7 @@
       minimum_version: 4.122.0
       maximum_version: 4.122.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.14.1.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.15.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteScalarAsyncIntegration
       action: CallTargetModification
   - target:
@@ -766,7 +766,7 @@
       minimum_version: 2.0.0
       maximum_version: 2.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.14.1.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.15.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteScalarAsyncIntegration
       action: CallTargetModification
   - target:
@@ -778,7 +778,7 @@
       minimum_version: 4.122.0
       maximum_version: 4.122.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.14.1.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.15.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteScalarIntegration
       action: CallTargetModification
   - target:
@@ -790,7 +790,7 @@
       minimum_version: 2.0.0
       maximum_version: 2.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.14.1.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.15.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteScalarIntegration
       action: CallTargetModification
   - target:
@@ -803,7 +803,7 @@
       minimum_version: 4.122.0
       maximum_version: 4.122.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.14.1.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.15.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteScalarWithBehaviorIntegration
       action: CallTargetModification
   - target:
@@ -816,7 +816,7 @@
       minimum_version: 2.0.0
       maximum_version: 2.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.14.1.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.15.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteScalarWithBehaviorIntegration
       action: CallTargetModification
 - name: RabbitMQ
@@ -837,7 +837,7 @@
       minimum_version: 3.6.9
       maximum_version: 6.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.14.1.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.15.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.RabbitMq.BasicDeliverIntegration
       action: CallTargetModification
   - target:
@@ -851,7 +851,7 @@
       minimum_version: 3.6.9
       maximum_version: 6.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.14.1.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.15.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.RabbitMq.BasicGetIntegration
       action: CallTargetModification
   - target:
@@ -868,7 +868,7 @@
       minimum_version: 3.6.9
       maximum_version: 6.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.14.1.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.15.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.RabbitMq.BasicPublishIntegration
       action: CallTargetModification
 - name: SqlCommand
@@ -883,7 +883,7 @@
       minimum_version: 4.0.0
       maximum_version: 4.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.14.1.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.15.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteNonQueryAsyncIntegration
       action: CallTargetModification
   - target:
@@ -896,7 +896,7 @@
       minimum_version: 4.0.0
       maximum_version: 4.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.14.1.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.15.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteNonQueryAsyncIntegration
       action: CallTargetModification
   - target:
@@ -909,7 +909,7 @@
       minimum_version: 1.0.0
       maximum_version: 2.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.14.1.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.15.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteNonQueryAsyncIntegration
       action: CallTargetModification
   - target:
@@ -921,7 +921,7 @@
       minimum_version: 4.0.0
       maximum_version: 4.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.14.1.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.15.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteNonQueryIntegration
       action: CallTargetModification
   - target:
@@ -933,7 +933,7 @@
       minimum_version: 4.0.0
       maximum_version: 4.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.14.1.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.15.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteNonQueryIntegration
       action: CallTargetModification
   - target:
@@ -945,7 +945,7 @@
       minimum_version: 1.0.0
       maximum_version: 2.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.14.1.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.15.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteNonQueryIntegration
       action: CallTargetModification
   - target:
@@ -958,7 +958,7 @@
       minimum_version: 4.0.0
       maximum_version: 4.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.14.1.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.15.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteNonQueryWithBehaviorIntegration
       action: CallTargetModification
   - target:
@@ -971,7 +971,7 @@
       minimum_version: 4.0.0
       maximum_version: 4.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.14.1.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.15.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteNonQueryWithBehaviorIntegration
       action: CallTargetModification
   - target:
@@ -984,7 +984,7 @@
       minimum_version: 1.0.0
       maximum_version: 2.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.14.1.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.15.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteNonQueryWithBehaviorIntegration
       action: CallTargetModification
   - target:
@@ -997,7 +997,7 @@
       minimum_version: 4.0.0
       maximum_version: 4.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.14.1.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.15.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteReaderAsyncIntegration
       action: CallTargetModification
   - target:
@@ -1010,7 +1010,7 @@
       minimum_version: 4.0.0
       maximum_version: 4.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.14.1.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.15.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteReaderAsyncIntegration
       action: CallTargetModification
   - target:
@@ -1023,7 +1023,7 @@
       minimum_version: 1.0.0
       maximum_version: 2.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.14.1.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.15.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteReaderAsyncIntegration
       action: CallTargetModification
   - target:
@@ -1035,7 +1035,7 @@
       minimum_version: 4.0.0
       maximum_version: 4.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.14.1.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.15.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteReaderIntegration
       action: CallTargetModification
   - target:
@@ -1047,7 +1047,7 @@
       minimum_version: 4.0.0
       maximum_version: 4.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.14.1.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.15.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteReaderIntegration
       action: CallTargetModification
   - target:
@@ -1059,7 +1059,7 @@
       minimum_version: 1.0.0
       maximum_version: 2.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.14.1.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.15.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteReaderIntegration
       action: CallTargetModification
   - target:
@@ -1073,7 +1073,7 @@
       minimum_version: 4.0.0
       maximum_version: 4.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.14.1.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.15.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteReaderWithBehaviorAsyncIntegration
       action: CallTargetModification
   - target:
@@ -1087,7 +1087,7 @@
       minimum_version: 4.0.0
       maximum_version: 4.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.14.1.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.15.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteReaderWithBehaviorAsyncIntegration
       action: CallTargetModification
   - target:
@@ -1101,7 +1101,7 @@
       minimum_version: 1.0.0
       maximum_version: 2.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.14.1.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.15.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteReaderWithBehaviorAsyncIntegration
       action: CallTargetModification
   - target:
@@ -1115,7 +1115,7 @@
       minimum_version: 4.0.0
       maximum_version: 4.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.14.1.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.15.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteReaderWithBehaviorAsyncIntegration
       action: CallTargetModification
   - target:
@@ -1129,7 +1129,7 @@
       minimum_version: 4.0.0
       maximum_version: 4.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.14.1.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.15.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteReaderWithBehaviorAsyncIntegration
       action: CallTargetModification
   - target:
@@ -1143,7 +1143,7 @@
       minimum_version: 1.0.0
       maximum_version: 2.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.14.1.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.15.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteReaderWithBehaviorAsyncIntegration
       action: CallTargetModification
   - target:
@@ -1156,7 +1156,7 @@
       minimum_version: 4.0.0
       maximum_version: 4.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.14.1.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.15.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteReaderWithBehaviorIntegration
       action: CallTargetModification
   - target:
@@ -1169,7 +1169,7 @@
       minimum_version: 4.0.0
       maximum_version: 4.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.14.1.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.15.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteReaderWithBehaviorIntegration
       action: CallTargetModification
   - target:
@@ -1182,7 +1182,7 @@
       minimum_version: 1.0.0
       maximum_version: 2.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.14.1.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.15.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteReaderWithBehaviorIntegration
       action: CallTargetModification
   - target:
@@ -1195,7 +1195,7 @@
       minimum_version: 4.0.0
       maximum_version: 4.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.14.1.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.15.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteReaderWithBehaviorIntegration
       action: CallTargetModification
   - target:
@@ -1208,7 +1208,7 @@
       minimum_version: 4.0.0
       maximum_version: 4.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.14.1.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.15.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteReaderWithBehaviorIntegration
       action: CallTargetModification
   - target:
@@ -1221,7 +1221,7 @@
       minimum_version: 1.0.0
       maximum_version: 2.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.14.1.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.15.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteReaderWithBehaviorIntegration
       action: CallTargetModification
   - target:
@@ -1234,7 +1234,7 @@
       minimum_version: 4.0.0
       maximum_version: 4.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.14.1.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.15.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteScalarAsyncIntegration
       action: CallTargetModification
   - target:
@@ -1247,7 +1247,7 @@
       minimum_version: 4.0.0
       maximum_version: 4.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.14.1.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.15.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteScalarAsyncIntegration
       action: CallTargetModification
   - target:
@@ -1260,7 +1260,7 @@
       minimum_version: 1.0.0
       maximum_version: 2.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.14.1.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.15.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteScalarAsyncIntegration
       action: CallTargetModification
   - target:
@@ -1272,7 +1272,7 @@
       minimum_version: 4.0.0
       maximum_version: 4.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.14.1.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.15.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteScalarIntegration
       action: CallTargetModification
   - target:
@@ -1284,7 +1284,7 @@
       minimum_version: 4.0.0
       maximum_version: 4.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.14.1.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.15.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteScalarIntegration
       action: CallTargetModification
   - target:
@@ -1296,7 +1296,7 @@
       minimum_version: 1.0.0
       maximum_version: 2.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.14.1.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.15.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteScalarIntegration
       action: CallTargetModification
   - target:
@@ -1309,7 +1309,7 @@
       minimum_version: 4.0.0
       maximum_version: 4.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.14.1.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.15.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteScalarWithBehaviorIntegration
       action: CallTargetModification
   - target:
@@ -1322,7 +1322,7 @@
       minimum_version: 4.0.0
       maximum_version: 4.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.14.1.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.15.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteScalarWithBehaviorIntegration
       action: CallTargetModification
   - target:
@@ -1335,7 +1335,7 @@
       minimum_version: 1.0.0
       maximum_version: 2.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.14.1.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.15.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteScalarWithBehaviorIntegration
       action: CallTargetModification
 - name: SqliteCommand
@@ -1350,7 +1350,7 @@
       minimum_version: 2.0.0
       maximum_version: 5.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.14.1.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.15.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteNonQueryAsyncIntegration
       action: CallTargetModification
   - target:
@@ -1363,7 +1363,7 @@
       minimum_version: 1.0.0
       maximum_version: 2.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.14.1.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.15.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteNonQueryAsyncIntegration
       action: CallTargetModification
   - target:
@@ -1375,7 +1375,7 @@
       minimum_version: 2.0.0
       maximum_version: 5.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.14.1.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.15.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteNonQueryIntegration
       action: CallTargetModification
   - target:
@@ -1387,7 +1387,7 @@
       minimum_version: 1.0.0
       maximum_version: 2.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.14.1.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.15.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteNonQueryIntegration
       action: CallTargetModification
   - target:
@@ -1400,7 +1400,7 @@
       minimum_version: 2.0.0
       maximum_version: 5.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.14.1.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.15.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteNonQueryWithBehaviorIntegration
       action: CallTargetModification
   - target:
@@ -1413,7 +1413,7 @@
       minimum_version: 1.0.0
       maximum_version: 2.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.14.1.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.15.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteNonQueryWithBehaviorIntegration
       action: CallTargetModification
   - target:
@@ -1426,7 +1426,7 @@
       minimum_version: 2.0.0
       maximum_version: 5.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.14.1.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.15.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteReaderAsyncIntegration
       action: CallTargetModification
   - target:
@@ -1439,7 +1439,7 @@
       minimum_version: 1.0.0
       maximum_version: 2.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.14.1.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.15.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteReaderAsyncIntegration
       action: CallTargetModification
   - target:
@@ -1451,7 +1451,7 @@
       minimum_version: 2.0.0
       maximum_version: 5.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.14.1.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.15.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteReaderIntegration
       action: CallTargetModification
   - target:
@@ -1463,7 +1463,7 @@
       minimum_version: 1.0.0
       maximum_version: 2.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.14.1.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.15.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteReaderIntegration
       action: CallTargetModification
   - target:
@@ -1477,7 +1477,7 @@
       minimum_version: 2.0.0
       maximum_version: 5.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.14.1.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.15.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteReaderWithBehaviorAsyncIntegration
       action: CallTargetModification
   - target:
@@ -1491,7 +1491,7 @@
       minimum_version: 1.0.0
       maximum_version: 2.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.14.1.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.15.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteReaderWithBehaviorAsyncIntegration
       action: CallTargetModification
   - target:
@@ -1505,7 +1505,7 @@
       minimum_version: 2.0.0
       maximum_version: 5.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.14.1.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.15.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteReaderWithBehaviorAsyncIntegration
       action: CallTargetModification
   - target:
@@ -1518,7 +1518,7 @@
       minimum_version: 2.0.0
       maximum_version: 5.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.14.1.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.15.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteReaderWithBehaviorIntegration
       action: CallTargetModification
   - target:
@@ -1531,7 +1531,7 @@
       minimum_version: 1.0.0
       maximum_version: 2.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.14.1.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.15.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteReaderWithBehaviorIntegration
       action: CallTargetModification
   - target:
@@ -1544,7 +1544,7 @@
       minimum_version: 2.0.0
       maximum_version: 5.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.14.1.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.15.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteReaderWithBehaviorIntegration
       action: CallTargetModification
   - target:
@@ -1557,7 +1557,7 @@
       minimum_version: 2.0.0
       maximum_version: 5.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.14.1.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.15.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteScalarAsyncIntegration
       action: CallTargetModification
   - target:
@@ -1570,7 +1570,7 @@
       minimum_version: 1.0.0
       maximum_version: 2.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.14.1.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.15.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteScalarAsyncIntegration
       action: CallTargetModification
   - target:
@@ -1582,7 +1582,7 @@
       minimum_version: 2.0.0
       maximum_version: 5.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.14.1.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.15.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteScalarIntegration
       action: CallTargetModification
   - target:
@@ -1594,7 +1594,7 @@
       minimum_version: 1.0.0
       maximum_version: 2.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.14.1.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.15.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteScalarIntegration
       action: CallTargetModification
   - target:
@@ -1607,7 +1607,7 @@
       minimum_version: 2.0.0
       maximum_version: 5.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.14.1.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.15.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteScalarWithBehaviorIntegration
       action: CallTargetModification
   - target:
@@ -1620,6 +1620,6 @@
       minimum_version: 1.0.0
       maximum_version: 2.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.14.1.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.15.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteScalarWithBehaviorIntegration
       action: CallTargetModification

--- a/test/Elastic.Apm.Profiler.Managed.Tests/AspNetCore/AspNetCoreTests.cs
+++ b/test/Elastic.Apm.Profiler.Managed.Tests/AspNetCore/AspNetCoreTests.cs
@@ -21,6 +21,12 @@ namespace Elastic.Apm.Profiler.Managed.Tests.AspNetCore
 
 		public AspNetCoreTests(ITestOutputHelper output) => _output = output;
 
+		/// <summary>
+		/// Runs SampleAspNetCoreApp by injecting the agent purely based on the profiler
+		/// It calls /home/index which generates: 1) a transaction 2) db spans 3) http span
+		/// Makes sure the expected transaction and spans are sent to APM Server
+		/// </summary>
+		/// <param name="framework"></param>
 		[Theory]
 		[InlineData("net5.0")]
 		public async void AspNetCoreTest(string framework)
@@ -74,6 +80,7 @@ namespace Elastic.Apm.Profiler.Managed.Tests.AspNetCore
 			apmServer.ReceivedData.Spans.Should().HaveCountGreaterOrEqualTo(1);
 
 			apmServer.ReceivedData.Spans.Any(span => span.Context.Db != null).Should().BeTrue();
+			apmServer.ReceivedData.Spans.Any(span => span.Context.Http != null).Should().BeTrue();
 
 		}
 	}

--- a/test/Elastic.Apm.Profiler.Managed.Tests/AspNetCore/AspNetCoreTests.cs
+++ b/test/Elastic.Apm.Profiler.Managed.Tests/AspNetCore/AspNetCoreTests.cs
@@ -64,7 +64,7 @@ namespace Elastic.Apm.Profiler.Managed.Tests.AspNetCore
 							waitForEventsSentToServer.Set();
 					},
 					exception => _output.WriteLine($"{exception}"),
-					true);
+					true, true);
 
 				waitForAppStart.WaitOne(TimeSpan.FromSeconds(30));
 

--- a/test/Elastic.Apm.Profiler.Managed.Tests/AspNetCore/AspNetCoreTests.cs
+++ b/test/Elastic.Apm.Profiler.Managed.Tests/AspNetCore/AspNetCoreTests.cs
@@ -1,0 +1,75 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Elastic.Apm.Profiler.Managed.Tests.AdoNet;
+using Elastic.Apm.Tests.MockApmServer;
+using Elastic.Apm.Tests.Utilities;
+using Elastic.Apm.Tests.Utilities.Docker;
+using FluentAssertions;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Elastic.Apm.Profiler.Managed.Tests.AspNetCore
+{
+	public class AspNetCoreTests : IClassFixture<MySqlFixture>
+	{
+		private readonly MySqlFixture _fixture;
+		private readonly ITestOutputHelper _output;
+
+		public AspNetCoreTests(MySqlFixture fixture, ITestOutputHelper output)
+		{
+			_fixture = fixture;
+			_output = output;
+		}
+
+		[DockerTheory]
+		[InlineData("net5.0")]
+		public async void AspNetCoreTest(string framework)
+		{
+			var apmLogger = new InMemoryBlockingLogger(Elastic.Apm.Logging.LogLevel.Error);
+			var apmServer = new MockApmServer(apmLogger, nameof(AspNetCoreTests));
+			var port = apmServer.FindAvailablePortToListen();
+			apmServer.RunInBackground(port);
+
+			var ignoreTopic = "ignore-topic";
+			using (var profiledApplication = new ProfiledApplication("SampleAspNetCoreApp"))
+			{
+				IDictionary<string, string> environmentVariables = new Dictionary<string, string>
+				{
+					["ELASTIC_APM_SERVER_URL"] = $"http://localhost:{port}",
+					["SKIP_AGENT_REGISTRATION"] = "true"
+				};
+
+				var waitForAppStart = new AutoResetEvent(false);
+
+
+				profiledApplication.Start(
+					framework,
+					TimeSpan.FromMinutes(2),
+					environmentVariables,
+					null,
+					line =>
+					{
+						_output.WriteLine(line.Line);
+						if(line.Line.ToLower().Contains("application started"))
+							waitForAppStart.Set();
+					},
+					exception => _output.WriteLine($"{exception}"),
+					true);
+
+				waitForAppStart.WaitOne(TimeSpan.FromSeconds(30));
+
+				var httpClient = new HttpClient();
+				var result = await httpClient.GetAsync("http://localhost:5000/home/index");
+				result.IsSuccessStatusCode.Should().BeTrue();
+				await result.Content.ReadAsStringAsync();
+			}
+
+			apmServer.ReceivedData.Transactions.Should().HaveCount(1);
+		}
+	}
+}

--- a/test/Elastic.Apm.Profiler.Managed.Tests/ProfiledApplication.cs
+++ b/test/Elastic.Apm.Profiler.Managed.Tests/ProfiledApplication.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to Elasticsearch B.V under
+// Licensed to Elasticsearch B.V under
 // one or more agreements.
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
@@ -101,7 +101,8 @@ namespace Elastic.Apm.Profiler.Managed.Tests
 			IDictionary<string, string> environmentVariables = null,
 			IDictionary<string, string> msBuildProperties = null,
 			Action<LineOut> onNext = null,
-			Action<Exception> onException = null
+			Action<Exception> onException = null,
+			bool doNotWaitForCompletion = false
 		)
 		{
 			var properties = CreateMsBuildProperties(msBuildProperties);
@@ -141,7 +142,9 @@ namespace Elastic.Apm.Profiler.Managed.Tests
 
 			_process = new ObservableProcess(arguments);
 			_process.SubscribeLines(onNext ?? (_ => { }), onException ?? (_ => { }));
-			_process.WaitForCompletion(timeout);
+
+			if(!doNotWaitForCompletion)
+				_process.WaitForCompletion(timeout);
 		}
 
 		private static string GetPublishOutputDirectory(string targetFramework, string properties)

--- a/test/Elastic.Apm.Profiler.Managed.Tests/ProfiledApplication.cs
+++ b/test/Elastic.Apm.Profiler.Managed.Tests/ProfiledApplication.cs
@@ -102,7 +102,8 @@ namespace Elastic.Apm.Profiler.Managed.Tests
 			IDictionary<string, string> msBuildProperties = null,
 			Action<LineOut> onNext = null,
 			Action<Exception> onException = null,
-			bool doNotWaitForCompletion = false
+			bool doNotWaitForCompletion = false,
+			bool useLocalhostHttp5000 = false
 		)
 		{
 			var properties = CreateMsBuildProperties(msBuildProperties);
@@ -135,7 +136,7 @@ namespace Elastic.Apm.Profiler.Managed.Tests
 			// use the .exe for net461
 			var arguments = targetFramework == "net461"
 				? new StartArguments(Path.Combine(workingDirectory, $"{_projectName}.exe"))
-				: new StartArguments("dotnet", $"{_projectName}.dll");
+				: useLocalhostHttp5000 ? new StartArguments("dotnet", $"{_projectName}.dll", "--urls", "http://localhost:5000") : new StartArguments("dotnet", $"{_projectName}.dll");
 
 			arguments.Environment = environmentVariables;
 			arguments.WorkingDirectory = workingDirectory;

--- a/test/Elastic.Apm.Tests.MockApmServer/AssertValidExtensions.cs
+++ b/test/Elastic.Apm.Tests.MockApmServer/AssertValidExtensions.cs
@@ -117,7 +117,7 @@ namespace Elastic.Apm.Tests.MockApmServer
 		private static void HttpVersionAssertValid(this string thisObj)
 		{
 			thisObj.NonEmptyAssertValid();
-			thisObj.Should().BeOneOf("1.0", "1.1", "2.0");
+			thisObj.Should().BeOneOf("1.0", "1.1", "2.0", "2");
 		}
 
 		private static void HttpMethodAssertValid(this string thisObj)


### PR DESCRIPTION
With this the profiler based agent will also trace incoming ASP.NET Core calls.

Solves https://github.com/elastic/apm-agent-dotnet/issues/1610