### PR TITLE
Fix if routeData is null to prevent throwing Exception

### DIFF
--- a/src/Elastic.Apm.AspNetCore/WebRequestTransactionCreator.cs
+++ b/src/Elastic.Apm.AspNetCore/WebRequestTransactionCreator.cs
@@ -193,7 +193,7 @@ namespace Elastic.Apm.AspNetCore
 					//fixup Transaction.Name - e.g. /user/profile/1 -> /user/profile/{id}
 					var routeData = context.GetRouteData()?.Values;
 
-					if (routeData.Count > 0)
+					if (routeData != null && routeData.Count > 0)
 					{
 						logger?.Trace()?.Log("Calculating transaction name based on route data");
 						var name = Transaction.GetNameFromRouteContext(routeData);


### PR DESCRIPTION
When updating from 1.15.0 to 1.16.0 some exceptions were being thrown when running in some legacy services running aspnet core 2.2 using net48.