### PR TITLE
Change logs around central config

### DIFF
--- a/src/Elastic.Apm.AspNetCore/WebRequestTransactionCreator.cs
+++ b/src/Elastic.Apm.AspNetCore/WebRequestTransactionCreator.cs
@@ -193,7 +193,7 @@ namespace Elastic.Apm.AspNetCore
 					//fixup Transaction.Name - e.g. /user/profile/1 -> /user/profile/{id}
 					var routeData = context.GetRouteData()?.Values;
 
-					if (routeData.Count > 0)
+					if (routeData != null && routeData.Count > 0)
 					{
 						logger?.Trace()?.Log("Calculating transaction name based on route data");
 						var name = Transaction.GetNameFromRouteContext(routeData);

--- a/src/Elastic.Apm/BackendComm/BackendCommComponentBase.cs
+++ b/src/Elastic.Apm/BackendComm/BackendCommComponentBase.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information
 
 using System;
+using System.Linq;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
@@ -89,8 +90,17 @@ namespace Elastic.Apm.BackendComm
 				}
 				catch (Exception ex)
 				{
-					_logger.Error()
-						?.LogException(ex, nameof(WorkLoop) + " Current thread: {ThreadDesc}", DbgUtils.CurrentThreadDesc);
+					if (ex is AggregateException aggregateException && aggregateException.InnerExceptions.Any(e => e is TaskCanceledException))
+					{
+						_logger.Debug()
+							?.LogException(ex, nameof(WorkLoop) + "TaskCanceledException -  Current thread: {ThreadDesc}", DbgUtils.CurrentThreadDesc);
+					}
+					else
+					{
+						_logger.Error()
+							?.LogException(ex, nameof(WorkLoop) + " Current thread: {ThreadDesc}", DbgUtils.CurrentThreadDesc);
+					}
+
 				}
 			}
 

--- a/src/Elastic.Apm/BackendComm/CentralConfig/CentralConfigurationFetcher.cs
+++ b/src/Elastic.Apm/BackendComm/CentralConfig/CentralConfigurationFetcher.cs
@@ -126,6 +126,11 @@ namespace Elastic.Apm.BackendComm.CentralConfig
 					waitInfo = fetchConfigException.WaitInfo;
 					level = fetchConfigException.Severity;
 				}
+				else if (ex is HttpRequestException)
+				{
+					level = LogLevel.Debug;
+					waitInfo = new WaitInfoS(TimeSpan.FromHours(1), "HttpRequestException during fetching, Central Config is likely disabled");
+				}
 				else
 				{
 					waitInfo = new WaitInfoS(WaitTimeIfAnyError, "Default wait time is used because exception was thrown"

--- a/test/Elastic.Apm.Tests/LoggerTests.cs
+++ b/test/Elastic.Apm.Tests/LoggerTests.cs
@@ -403,7 +403,7 @@ namespace Elastic.Apm.Tests
 			var userName = "abc";
 			var pw = "def";
 
-			var inMemoryLogger = new InMemoryBlockingLogger(LogLevel.Error);
+			var inMemoryLogger = new InMemoryBlockingLogger(LogLevel.Debug);
 			var configReader = new MockConfiguration(serverUrls: $"http://{userName}:{pw}@localhost:8123", maxBatchEventCount: "0",
 				flushInterval: "0");
 
@@ -411,7 +411,7 @@ namespace Elastic.Apm.Tests
 			using var centralConfigFetcher =
 				new CentralConfigurationFetcher(inMemoryLogger, configStore, Service.GetDefaultService(configReader, inMemoryLogger));
 
-			inMemoryLogger.Lines.Should().HaveCount(1);
+			inMemoryLogger.Lines.Should().HaveCountGreaterOrEqualTo(1);
 			inMemoryLogger.Lines.Should().NotContain(n => n.Contains($"{userName}:{pw}"));
 			inMemoryLogger.Lines.Should().Contain(n => n.Contains("http://[REDACTED]:[REDACTED]@localhost:8123"));
 		}


### PR DESCRIPTION
Solves https://github.com/elastic/apm-agent-dotnet/issues/1626

- In case of `HttpRequestException` only print debug log and no error - this mostly happens when central config is not enabled.
- In  `BackendCommComponentBase` handle `AggregateException` with `TaskCanceledException` and only print debug logs and no errors. This is in the working loop and printing errors would spam a lot and not give much useful info.