### PR TITLE
Include PathBase in the transaction name and details (#1771)

### DIFF
--- a/src/Elastic.Apm.AspNetCore/ApmMiddleware.cs
+++ b/src/Elastic.Apm.AspNetCore/ApmMiddleware.cs
@@ -38,7 +38,7 @@ namespace Elastic.Apm.AspNetCore
 				transaction = t;
 
 			if (transaction != null)
-				WebRequestTransactionCreator.FillSampledTransactionContextRequest(transaction, context, _logger);
+				WebRequestTransactionCreator.FillSampledTransactionContextRequest(transaction, context, _logger, _agent.ConfigurationStore.CurrentSnapshot);
 
 			try
 			{
@@ -55,7 +55,7 @@ namespace Elastic.Apm.AspNetCore
 					transaction.CollectRequestBody(true, context.Request, _logger);
 
 				if(transaction != null)
-					WebRequestTransactionCreator.StopTransaction(transaction, context, _logger);
+					WebRequestTransactionCreator.StopTransaction(transaction, context, _logger, _agent.ConfigurationStore.CurrentSnapshot);
 				else
 					createdTransaction?.End();
 			}

--- a/src/Elastic.Apm/BackendComm/CentralConfig/CentralConfigurationFetcher.cs
+++ b/src/Elastic.Apm/BackendComm/CentralConfig/CentralConfigurationFetcher.cs
@@ -326,6 +326,7 @@ namespace Elastic.Apm.BackendComm.CentralConfig
 			public double TransactionSampleRate => _centralConfiguration.TransactionSampleRate ?? _wrapped.TransactionSampleRate;
 
 			public bool UseElasticTraceparentHeader => _wrapped.UseElasticTraceparentHeader;
+			public bool UseFullPathRequestMatching => _wrapped.UseFullPathRequestMatching;
 
 			public bool VerifyServerCert => _wrapped.VerifyServerCert;
 		}

--- a/src/Elastic.Apm/Config/AbstractConfigurationReader.cs
+++ b/src/Elastic.Apm/Config/AbstractConfigurationReader.cs
@@ -55,6 +55,9 @@ namespace Elastic.Apm.Config
 		protected bool ParseUseElasticTraceparentHeader(ConfigurationKeyValue kv) =>
 			ParseBoolOption(kv, DefaultValues.UseElasticTraceparentHeader, "UseElasticTraceparentHeader");
 
+		protected bool ParseUseFullPathRequestMatching(ConfigurationKeyValue kv) =>
+			ParseBoolOption(kv, DefaultValues.UseFullPathRequestMatching, "UseFullPathRequestMatching");
+
 		protected internal static bool TryParseLogLevel(string value, out LogLevel level)
 		{
 			level = default;

--- a/src/Elastic.Apm/Config/AbstractConfigurationWithEnvFallbackReader.cs
+++ b/src/Elastic.Apm/Config/AbstractConfigurationWithEnvFallbackReader.cs
@@ -161,6 +161,9 @@ namespace Elastic.Apm.Config
 		public bool UseElasticTraceparentHeader => ParseUseElasticTraceparentHeader(Read(KeyNames.UseElasticTraceparentHeader,
 			EnvVarNames.UseElasticTraceparentHeader));
 
+		public bool UseFullPathRequestMatching => ParseUseElasticTraceparentHeader(Read(KeyNames.UseFullPathRequestMatching,
+			EnvVarNames.UseFullPathRequestMatching));
+
 		public virtual bool VerifyServerCert =>
 			ParseVerifyServerCert(Read(KeyNames.VerifyServerCert, EnvVarNames.VerifyServerCert));
 

--- a/src/Elastic.Apm/Config/ConfigConsts.cs
+++ b/src/Elastic.Apm/Config/ConfigConsts.cs
@@ -48,6 +48,7 @@ namespace Elastic.Apm.Config
 			public const double TransactionSampleRate = 1.0;
 			public const string UnknownServiceName = "unknown-" + Consts.AgentName + "-service";
 			public const bool UseElasticTraceparentHeader = true;
+			public const bool UseFullPathRequestMatching = false;
 			public const bool VerifyServerCert = true;
 			public const string TraceContinuationStrategy = "continue";
 
@@ -164,6 +165,7 @@ namespace Elastic.Apm.Config
 			public const string TransactionMaxSpans = Prefix + "TRANSACTION_MAX_SPANS";
 			public const string TransactionSampleRate = Prefix + "TRANSACTION_SAMPLE_RATE";
 			public const string UseElasticTraceparentHeader = Prefix + "USE_ELASTIC_TRACEPARENT_HEADER";
+			public const string UseFullPathRequestMatching = Prefix + "USE_FULL_PATH_REQUEST_MATCHING";
 			public const string VerifyServerCert = Prefix + "VERIFY_SERVER_CERT";
 		}
 
@@ -214,6 +216,7 @@ namespace Elastic.Apm.Config
 			public const string TransactionMaxSpans = Prefix + nameof(TransactionMaxSpans);
 			public const string TransactionSampleRate = Prefix + nameof(TransactionSampleRate);
 			public const string UseElasticTraceparentHeader = Prefix + nameof(UseElasticTraceparentHeader);
+			public const string UseFullPathRequestMatching = Prefix + nameof(UseFullPathRequestMatching);
 			public const string VerifyServerCert = Prefix + nameof(VerifyServerCert);
 		}
 

--- a/src/Elastic.Apm/Config/ConfigurationSnapshotFromReader.cs
+++ b/src/Elastic.Apm/Config/ConfigurationSnapshotFromReader.cs
@@ -67,6 +67,7 @@ namespace Elastic.Apm.Config
 		public int TransactionMaxSpans => _content.TransactionMaxSpans;
 		public double TransactionSampleRate => _content.TransactionSampleRate;
 		public bool UseElasticTraceparentHeader => _content.UseElasticTraceparentHeader;
+		public bool UseFullPathRequestMatching => _content.UseFullPathRequestMatching;
 		public bool VerifyServerCert => _content.VerifyServerCert;
 	}
 }

--- a/src/Elastic.Apm/Config/EnvironmentConfigurationReader.cs
+++ b/src/Elastic.Apm/Config/EnvironmentConfigurationReader.cs
@@ -136,6 +136,8 @@ namespace Elastic.Apm.Config
 
 		public bool UseElasticTraceparentHeader => ParseUseElasticTraceparentHeader(Read(ConfigConsts.EnvVarNames.UseElasticTraceparentHeader));
 
+		public bool UseFullPathRequestMatching => ParseUseFullPathRequestMatching(Read(ConfigConsts.EnvVarNames.UseFullPathRequestMatching));
+
 		public bool VerifyServerCert => ParseVerifyServerCert(Read(ConfigConsts.EnvVarNames.VerifyServerCert));
 
 		private ConfigurationKeyValue Read(string key) =>

--- a/src/Elastic.Apm/Config/IConfigurationReader.cs
+++ b/src/Elastic.Apm/Config/IConfigurationReader.cs
@@ -375,6 +375,12 @@ namespace Elastic.Apm.Config
 		bool UseElasticTraceparentHeader { get; }
 
 		/// <summary>
+		/// When set to <c>true</c> agent will use full HTTP request path when recording a transaction
+		/// (including <see href="https://docs.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.http.httprequest.pathbase">HttpRequest.PathBase</see>).
+		/// </summary>
+		bool UseFullPathRequestMatching { get; }
+
+		/// <summary>
 		/// The agent verifies the server's certificate if an HTTPS connection to the APM server is used.
 		/// Verification can be disabled by setting to <c>false</c>.
 		/// </summary>

--- a/test/Elastic.Apm.Feature.Tests/TestConfiguration.cs
+++ b/test/Elastic.Apm.Feature.Tests/TestConfiguration.cs
@@ -60,6 +60,7 @@ namespace Elastic.Apm.Feature.Tests
 		public int TransactionMaxSpans { get; set; } = DefaultValues.TransactionMaxSpans;
 		public double TransactionSampleRate { get; set; } = DefaultValues.TransactionSampleRate;
 		public bool UseElasticTraceparentHeader { get; set; } = DefaultValues.UseElasticTraceparentHeader;
+		public bool UseFullPathRequestMatching { get; set; } = DefaultValues.UseFullPathRequestMatching;
 		public bool VerifyServerCert { get; set; } = DefaultValues.VerifyServerCert;
 		public bool EnableOpenTelemetryBridge { get; set; }
 	}

--- a/test/Elastic.Apm.Tests.Utilities/MockConfiguration.cs
+++ b/test/Elastic.Apm.Tests.Utilities/MockConfiguration.cs
@@ -58,6 +58,7 @@ namespace Elastic.Apm.Tests.Utilities
 		private readonly string _transactionMaxSpans;
 		private readonly string _transactionSampleRate;
 		private readonly string _useElasticTraceparentHeader;
+		private readonly string _useFullPathRequestMatching;
 		private readonly string _verifyServerCert;
 
 		public MockConfiguration(IApmLogger logger = null,
@@ -89,6 +90,7 @@ namespace Elastic.Apm.Tests.Utilities
 			string disableMetrics = null,
 			string verifyServerCert = null,
 			string useElasticTraceparentHeader = null,
+			string useFullPathRequestMatching = null,
 			string applicationNamespaces = null,
 			string excludedNamespaces = null,
 			string transactionIgnoreUrls = null,
@@ -134,6 +136,7 @@ namespace Elastic.Apm.Tests.Utilities
 			_disableMetrics = disableMetrics;
 			_verifyServerCert = verifyServerCert;
 			_useElasticTraceparentHeader = useElasticTraceparentHeader;
+			_useFullPathRequestMatching = useFullPathRequestMatching;
 			_applicationNamespaces = applicationNamespaces;
 			_excludedNamespaces = excludedNamespaces;
 			_transactionIgnoreUrls = transactionIgnoreUrls;
@@ -257,6 +260,9 @@ namespace Elastic.Apm.Tests.Utilities
 
 		public bool UseElasticTraceparentHeader =>
 			ParseUseElasticTraceparentHeader(Kv(EnvVarNames.UseElasticTraceparentHeader, _useElasticTraceparentHeader, Origin));
+
+		public bool UseFullPathRequestMatching =>
+			ParseUseElasticTraceparentHeader(Kv(EnvVarNames.UseFullPathRequestMatching, _useFullPathRequestMatching, Origin));
 
 		public bool VerifyServerCert =>
 			ParseVerifyServerCert(Kv(EnvVarNames.VerifyServerCert, _verifyServerCert, Origin));

--- a/test/Elastic.Apm.Tests/ConstructorTests.cs
+++ b/test/Elastic.Apm.Tests/ConstructorTests.cs
@@ -85,6 +85,7 @@ namespace Elastic.Apm.Tests
 			public IReadOnlyCollection<string> ApplicationNamespaces => ConfigConsts.DefaultValues.DefaultApplicationNamespaces;
 
 			public bool UseElasticTraceparentHeader => ConfigConsts.DefaultValues.UseElasticTraceparentHeader;
+			public bool UseFullPathRequestMatching => ConfigConsts.DefaultValues.UseFullPathRequestMatching;
 
 			public int TransactionMaxSpans => ConfigConsts.DefaultValues.TransactionMaxSpans;
 			// ReSharper restore UnassignedGetOnlyAutoProperty


### PR DESCRIPTION
This PR introduces automatic inclusion of PathBase in the transaction building process. The change is managed by a new configuration entry.

Closes #1771