### PR TITLE
Repair agent build on Apple M1 HW

### DIFF
--- a/sample/GrpcClientSample/GrpcClientSample.csproj
+++ b/sample/GrpcClientSample/GrpcClientSample.csproj
@@ -6,9 +6,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Protobuf" Version="3.11.2" />
+    <PackageReference Include="Google.Protobuf" Version="3.21.4" />
     <PackageReference Include="Grpc.Net.ClientFactory" Version="2.27.0" />
-    <PackageReference Include="Grpc.Tools" Version="2.27.0">
+    <PackageReference Include="Grpc.Tools" Version="2.47.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/sample/GrpcServiceSample/GrpcServiceSample.csproj
+++ b/sample/GrpcServiceSample/GrpcServiceSample.csproj
@@ -9,7 +9,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Grpc.AspNetCore" Version="2.27.0" />
+    <PackageReference Include="Grpc.AspNetCore" Version="2.47.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Elastic.Apm.Grpc.Tests/Elastic.Apm.Grpc.Tests.csproj
+++ b/test/Elastic.Apm.Grpc.Tests/Elastic.Apm.Grpc.Tests.csproj
@@ -17,9 +17,9 @@
     </PackageReference>
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
 
-    <PackageReference Include="Google.Protobuf" Version="3.15.0" />
+    <PackageReference Include="Google.Protobuf" Version="3.21.4" />
     <PackageReference Include="Grpc.Net.ClientFactory" Version="2.27.0" />
-    <PackageReference Include="Grpc.Tools" Version="2.27.0">
+    <PackageReference Include="Grpc.Tools" Version="2.47.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
Fixes #1775 

Use the latest versions of these NuGet packages which are M1 aware:

* Google.Protobuf
* Grpc.Tools
* Grpc.AspNetCore