### PR TITLE
Scanner Performance: Using direct string index accessor instead of ElementAt(index)

### DIFF
--- a/src/Elastic.Apm/Model/Scanner.cs
+++ b/src/Elastic.Apm/Model/Scanner.cs
@@ -379,7 +379,7 @@ namespace Elastic.Apm.Model
 			return Token.Eof;
 		}
 
-		private char Peek() => _input.ElementAt(_pos);
+		private char Peek() => _input[_pos];
 
 		public char Next()
 		{


### PR DESCRIPTION
Results in a much better performance.

For more information check: 
fixes #1763 
