### PR TITLE
ci: skip stdout by default

### DIFF
--- a/.ci/windows/test.bat
+++ b/.ci/windows/test.bat
@@ -23,9 +23,8 @@ dotnet sln remove test/Elastic.Apm.StaticExplicitInitialization.Tests/Elastic.Ap
 :: LogFilePath property
 ::
 dotnet test -c Release ^
- --verbosity normal ^
+ --verbosity quiet ^
  --results-directory target ^
- --diag target\diag.log ^
  --logger:"junit;LogFilePath=junit-{framework}-{assembly}.xml;MethodFormat=Class;FailureBodyFormat=Verbose" ^
  --collect:"XPlat Code Coverage" ^
  --settings coverlet.runsettings ^

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -680,7 +680,7 @@ def release(Map args = [:]){
 def reportTests() {
   dir("${BASE_DIR}"){
     archiveArtifacts(allowEmptyArchive: true, artifacts: 'target/diag-*.log,test/**/junit-*.xml,target/**/Sequence_*.xml,target/**/testhost*.dmp')
-    junit(allowEmptyResults: true, keepLongStdio: true, testResults: 'test/**/junit-*.xml')
+    junit(allowEmptyResults: true, keepLongStdio: false, testResults: 'test/**/junit-*.xml')
   }
 }
 

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -24,6 +24,6 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="JunitXml.TestLogger" Version="2.1.81" Condition="'$(IsTestProject)' == 'true'" />
+    <PackageReference Include="JunitXml.TestLogger" Version="3.0.114" Condition="'$(IsTestProject)' == 'true'" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
### What

As per the Jenkins docs

> keepLongStdio : boolean (optional)
If checked, any standard output or error from a test suite will be retained in the test results after the build completes. (This refers only to additional messages printed to console, not to a failure stack trace.) Such output is always kept if the test failed, but by default lengthy output from passing tests is truncated to save space. Check this option if you need to see every log message from even passing tests, but beware that Jenkins's memory consumption can substantially increase as a result, even if you never look at the test results!

### Why

There a dozens of lines in the `system-out`

<img width="1762" alt="image" src="https://user-images.githubusercontent.com/2871786/184838809-fc757868-a82b-4f17-9aa6-899e9fd4bdd4.png">


And produces memory heaps when digesting the test results

Discussed offline so this is not needed by default
