### PR TITLE
Error in docs for gRPC setup

### DIFF
--- a/docs/packages.asciidoc
+++ b/docs/packages.asciidoc
@@ -200,11 +200,11 @@ app.UseElasticApm(Configuration, new GrpcClientDiagnosticListener()); <1>
 ----
 <1> Configuration is the `IConfiguration` instance passed to your `Startup` type
 
-or passing `GrpcClientDiagnosticListener` to the `Subscribe` method
+or passing `GrpcClientDiagnosticSubscriber` to the `Subscribe` method
 
 [source,csharp]
 ----
-Agent.Subscribe(new GrpcClientDiagnosticListener());
+Agent.Subscribe(new GrpcClientDiagnosticSubscriber());
 ----
 
 Diagnostic events from `Grpc.Net.Client` are captured as spans.


### PR DESCRIPTION
In asp.net `Agent.Subscribe` params are of `IDiagnosticsSubscriber` type, not the `GrpcClientDiagnosticListener`.