### PR TITLE
Add config option "span_stack_trace_min_duration"

### DIFF
--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -1178,8 +1178,8 @@ Setting this to `0` disables stack trace collection. Any positive integer value 
 NOTE: If you would like to disable stack trace capturing only for spans, but still capture stack traces for errors, set the <<config-span-frames-min-duration>> config to `0`.
 
 [float]
-[[config-span-frames-min-duration]]
-==== `SpanFramesMinDuration` (performance)
+[[config-span-stack-trace-min-duration]]
+==== `SpanStackTraceMinDuration` (performance)
 
 <<dynamic-configuration, image:./images/dynamic-config.svg[] >>
 
@@ -1187,12 +1187,13 @@ In its default settings,
 the APM agent collects a stack trace for every recorded span with duration longer than `5ms`.
 While this is very helpful to find the exact place in your code that causes the span,
 collecting this stack trace does have some overhead.
-When setting this option to a negative value, like `-1ms`, stack traces are collected for all spans.
+When setting this option to zero (regardless of the time unit), like `0ms`, stack traces are collected for all spans.
 Setting it to a positive value, e.g. `5ms`,
 limits stack trace collection to spans with durations equal to or longer than the given value,
 e.g. 5 milliseconds.
 
-To disable stack trace collection for spans completely, set the value to `0ms`.
+To disable stack trace collection for spans completely, set this option to a negative value,
+like `-1ms`.
 
 Supports the duration suffixes `ms`, `s` and `m`.
 Example: `5ms`.
@@ -1207,8 +1208,10 @@ The default unit for this option is `ms`
 [options="header"]
 |============
 | Environment variable name     | IConfiguration or Web.config key
-| `ELASTIC_APM_SPAN_FRAMES_MIN_DURATION` | `ElasticApm:SpanFramesMinDuration`
+| `ELASTIC_APM_SPAN_STACK_TRACE_MIN_DURATION` | `ElasticApm:SpanStackTraceMinDuration`
 |============
+
+IMPORTANT: Use of `SpanFramesMinDuration` is deprecated. Use `SpanStackTraceMinDuration`.
 
 
 [[config-supportability]]
@@ -1277,7 +1280,7 @@ you must instead set the `LogLevel` for the internal APM logger under the `Loggi
 | <<config-span-compression-enabled,`SpanCompressionEnabled`>> | Yes | Core, Performance
 | <<config-span-compression-exact-match-max-duration,`SpanCompressionExactMatchMaxDuration`>> | Yes | Core, Performance
 | <<config-span-compression-same-kind-max-duration,`SpanCompressionSameKindMaxDuration`>> | Yes | Core, Performance
-| <<config-span-frames-min-duration,`SpanFramesMinDuration`>> | No | Stacktrace, Performance
+| <<config-span-stack-trace-min-duration,`SpanStackTraceMinDuration`>> | No | Stacktrace, Performance
 | <<config-stack-trace-limit,`StackTraceLimit`>> | No | Stacktrace, Performance
 | <<config-trace-context-ignore-sampled-false,`TraceContextIgnoreSampledFalse`>> | No | Core
 | <<config-transaction-ignore-urls,`TransactionIgnoreUrls`>>  | Yes | HTTP, Performance

--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -1175,7 +1175,7 @@ Setting this to `0` disables stack trace collection. Any positive integer value 
 | `ELASTIC_APM_STACK_TRACE_LIMIT` | `ElasticApm:StackTraceLimit`
 |============
 
-NOTE: If you would like to disable stack trace capturing only for spans, but still capture stack traces for errors, set the <<config-span-frames-min-duration>> config to `0`.
+NOTE: If you would like to disable stack trace capturing only for spans, but still capture stack traces for errors, set the <<config-span-stack-trace-min-duration>> config to `-1`.
 
 [float]
 [[config-span-stack-trace-min-duration]]

--- a/docs/performance-tuning.asciidoc
+++ b/docs/performance-tuning.asciidoc
@@ -55,7 +55,7 @@ set <<config-stack-trace-limit,`StackTraceLimit`>> to `0`.
 In its default settings,
 the APM agent collects a stack trace for every recorded span with duration longer than 5ms.
 To increase the duration threshold,
-set <<config-span-frames-min-duration,`SpanFramesMinDuration`>>.
+set <<config-span-stack-trace-min-duration,`SpanStackTraceMinDuration`>>.
 
 [float]
 [[performance-tuning-stack-frame-limit]]

--- a/docs/troubleshooting.asciidoc
+++ b/docs/troubleshooting.asciidoc
@@ -198,5 +198,5 @@ A good place to start is <<config-all-options-summary>>. There are multiple sett
 The most expensive operation in the agent is typically stack trace capturing. The agent, by default, only captures stack traces for spans with a duration of 5ms or more, and with a limit of 50 stack frames.
 If this is too much in your environment, consider disabling stack trace capturing either partially or entirely:
 
-- To disable stack trace capturing for spans, but continue to capture stack traces for errors, set the <<config-span-frames-min-duration>> to `0` and leave the <<config-stack-trace-limit>> on its default.
+- To disable stack trace capturing for spans, but continue to capture stack traces for errors, set the <<config-span-stack-trace-min-duration>> to `-1` and leave the <<config-stack-trace-limit>> on its default.
 - To disable stack trace capturing entirely –which in most applications reduces the agent overhead dramatically– set <<config-stack-trace-limit>> to `0`.

--- a/src/Elastic.Apm/BackendComm/CentralConfig/CentralConfigurationFetcher.cs
+++ b/src/Elastic.Apm/BackendComm/CentralConfig/CentralConfigurationFetcher.cs
@@ -310,6 +310,10 @@ namespace Elastic.Apm.BackendComm.CentralConfig
 			public double SpanCompressionSameKindMaxDuration =>
 				_centralConfiguration.SpanCompressionSameKindMaxDuration ?? _wrapped.SpanCompressionSameKindMaxDuration;
 
+			public double SpanStackTraceMinDurationInMilliseconds =>
+				_centralConfiguration.SpanStackTraceMinDurationInMilliseconds ?? _wrapped.SpanStackTraceMinDurationInMilliseconds;
+
+			[Obsolete("Use SpanStackTraceMinDurationInMilliseconds")]
 			public double SpanFramesMinDurationInMilliseconds =>
 				_centralConfiguration.SpanFramesMinDurationInMilliseconds ?? _wrapped.SpanFramesMinDurationInMilliseconds;
 

--- a/src/Elastic.Apm/BackendComm/CentralConfig/CentralConfigurationReader.cs
+++ b/src/Elastic.Apm/BackendComm/CentralConfig/CentralConfigurationReader.cs
@@ -52,6 +52,8 @@ namespace Elastic.Apm.BackendComm.CentralConfig
 
 		internal double? SpanCompressionSameKindMaxDuration { get; private set; }
 
+		internal double? SpanStackTraceMinDurationInMilliseconds { get; private set; }
+
 		internal double? SpanFramesMinDurationInMilliseconds { get; private set; }
 
 		internal int? StackTraceLimit { get; private set; }
@@ -76,6 +78,9 @@ namespace Elastic.Apm.BackendComm.CentralConfig
 			CaptureHeaders =
 				GetSimpleConfigurationValue(CentralConfigurationResponseParser.CentralConfigPayload.CaptureHeadersKey, ParseCaptureHeaders);
 			LogLevel = GetSimpleConfigurationValue(CentralConfigurationResponseParser.CentralConfigPayload.LogLevelKey, ParseLogLevel);
+			SpanStackTraceMinDurationInMilliseconds =
+				GetSimpleConfigurationValue(CentralConfigurationResponseParser.CentralConfigPayload.SpanStackTraceMinDurationKey,
+					ParseSpanStackTraceMinDurationInMilliseconds);
 			SpanFramesMinDurationInMilliseconds =
 				GetSimpleConfigurationValue(CentralConfigurationResponseParser.CentralConfigPayload.SpanFramesMinDurationKey,
 					ParseSpanFramesMinDurationInMilliseconds);

--- a/src/Elastic.Apm/BackendComm/CentralConfig/CentralConfigurationResponseParser.cs
+++ b/src/Elastic.Apm/BackendComm/CentralConfig/CentralConfigurationResponseParser.cs
@@ -147,6 +147,8 @@ namespace Elastic.Apm.BackendComm.CentralConfig
 			internal const string SpanCompressionEnabled = "span_compression_enabled";
 			internal const string SpanCompressionExactMatchMaxDuration = "span_compression_exact_match_max_duration";
 			internal const string SpanCompressionSameKindMaxDuration = "span_compression_same_kind_max_duration";
+			internal const string SpanStackTraceMinDurationKey = "span_stack_trace_min_duration";
+			[Obsolete("Use SpanStackTraceMinDurationKey")]
 			internal const string SpanFramesMinDurationKey = "span_frames_min_duration";
 			internal const string StackTraceLimitKey = "stack_trace_limit";
 			internal const string TraceContinuationStrategy = "trace_continuation_strategy";
@@ -163,6 +165,7 @@ namespace Elastic.Apm.BackendComm.CentralConfig
 				LogLevelKey,
 				Recording,
 				SanitizeFieldNames,
+				SpanStackTraceMinDurationKey,
 				SpanFramesMinDurationKey,
 				StackTraceLimitKey,
 				TransactionIgnoreUrls,

--- a/src/Elastic.Apm/Config/AbstractConfigurationReader.cs
+++ b/src/Elastic.Apm/Config/AbstractConfigurationReader.cs
@@ -561,6 +561,39 @@ namespace Elastic.Apm.Config
 			return valueInMilliseconds;
 		}
 
+		protected double ParseSpanStackTraceMinDurationInMilliseconds(ConfigurationKeyValue kv)
+		{
+			string value;
+			if (string.IsNullOrWhiteSpace(kv?.Value))
+				value = DefaultValues.SpanStackTraceMinDuration;
+			else
+				value = kv.Value;
+
+			double valueInMilliseconds;
+
+			try
+			{
+				if (!TryParseTimeInterval(value, out valueInMilliseconds, TimeSuffix.Ms))
+				{
+					_logger?.Error()
+						?.Log("Failed to parse provided span stack trace minimum duration `{ProvidedSpanStackTraceMinDuration}' - " +
+									"using default: {DefaultSpanStackTraceMinDuration}",
+							value,
+							DefaultValues.SpanStackTraceMinDuration);
+					return DefaultValues.SpanStackTraceMinDurationInMilliseconds;
+				}
+			}
+			catch (ArgumentException e)
+			{
+				_logger?.Critical()
+					?.LogException(e, nameof(ArgumentException) + " thrown from TryParseTimeInterval which means a programming bug - " +
+														"using default: {DefaultSpanStackTraceMinDuration}",
+						DefaultValues.SpanStackTraceMinDuration);
+				return DefaultValues.SpanStackTraceMinDurationInMilliseconds;
+			}
+
+			return valueInMilliseconds;
+		}
 
 		protected double ParseSpanFramesMinDurationInMilliseconds(ConfigurationKeyValue kv)
 		{

--- a/src/Elastic.Apm/Config/AbstractConfigurationWithEnvFallbackReader.cs
+++ b/src/Elastic.Apm/Config/AbstractConfigurationWithEnvFallbackReader.cs
@@ -16,6 +16,7 @@ namespace Elastic.Apm.Config
 		private readonly string _defaultEnvironmentName;
 
 		private readonly Lazy<double> _spanFramesMinDurationInMilliseconds;
+		private readonly Lazy<double> _spanStackTraceMinDurationInMilliseconds;
 
 		private readonly Lazy<int> _stackTraceLimit;
 
@@ -30,6 +31,11 @@ namespace Elastic.Apm.Config
 			_spanFramesMinDurationInMilliseconds = new Lazy<double>(() =>
 				ParseSpanFramesMinDurationInMilliseconds(Read(KeyNames.SpanFramesMinDuration,
 					EnvVarNames.SpanFramesMinDuration)));
+
+			_spanStackTraceMinDurationInMilliseconds = new Lazy<double>(() =>
+				ParseSpanStackTraceMinDurationInMilliseconds(Read(KeyNames.SpanStackTraceMinDuration,
+					EnvVarNames.SpanStackTraceMinDuration)));
+
 		}
 
 		protected abstract ConfigurationKeyValue Read(string key, string fallBackEnvVarName);
@@ -139,6 +145,9 @@ namespace Elastic.Apm.Config
 
 		public double SpanCompressionSameKindMaxDuration => ParseSpanCompressionSameKindMaxDuration(Read(KeyNames.SpanCompressionSameKindMaxDuration, EnvVarNames.SpanCompressionSameKindMaxDuration));
 
+		public virtual double SpanStackTraceMinDurationInMilliseconds => _spanStackTraceMinDurationInMilliseconds.Value;
+
+		[Obsolete("Use SpanStackTraceMinDurationInMilliseconds")]
 		public virtual double SpanFramesMinDurationInMilliseconds => _spanFramesMinDurationInMilliseconds.Value;
 
 		public virtual int StackTraceLimit => _stackTraceLimit.Value;

--- a/src/Elastic.Apm/Config/ConfigConsts.cs
+++ b/src/Elastic.Apm/Config/ConfigConsts.cs
@@ -42,6 +42,8 @@ namespace Elastic.Apm.Config
 			public const double SpanCompressionSameKindMaxDurationInMilliseconds = 0;
 			public const string SpanFramesMinDuration = "5ms";
 			public const double SpanFramesMinDurationInMilliseconds = 5;
+			public const string SpanStackTraceMinDuration = "5ms";
+			public const double SpanStackTraceMinDurationInMilliseconds = 5;
 			public const int StackTraceLimit = 50;
 			public const bool TraceContextIgnoreSampledFalse = false;
 			public const int TransactionMaxSpans = 500;
@@ -156,6 +158,7 @@ namespace Elastic.Apm.Config
 			public const string SpanCompressionEnabled = Prefix + "SPAN_COMPRESSION_ENABLED";
 			public const string SpanCompressionExactMatchMaxDuration = Prefix + "SPAN_COMPRESSION_EXACT_MATCH_MAX_DURATION";
 			public const string SpanCompressionSameKindMaxDuration = Prefix + "SPAN_COMPRESSION_SAME_KIND_MAX_DURATION";
+			public const string SpanStackTraceMinDuration = Prefix + "SPAN_STACK_TRACE_MIN_DURATION";
 			public const string SpanFramesMinDuration = Prefix + "SPAN_FRAMES_MIN_DURATION";
 			public const string StackTraceLimit = Prefix + "STACK_TRACE_LIMIT";
 			public const string TraceContextIgnoreSampledFalse = Prefix + "TRACE_CONTEXT_IGNORE_SAMPLED_FALSE";
@@ -206,6 +209,7 @@ namespace Elastic.Apm.Config
 			public const string SpanCompressionEnabled = Prefix + nameof(SpanCompressionEnabled);
 			public const string SpanCompressionExactMatchMaxDuration = Prefix + nameof(SpanCompressionExactMatchMaxDuration);
 			public const string SpanCompressionSameKindMaxDuration = Prefix + nameof(SpanCompressionSameKindMaxDuration);
+			public const string SpanStackTraceMinDuration = Prefix + nameof(SpanStackTraceMinDuration);
 			public const string SpanFramesMinDuration = Prefix + nameof(SpanFramesMinDuration);
 			public const string StackTraceLimit = Prefix + nameof(StackTraceLimit);
 			public const string TraceContextIgnoreSampledFalse = Prefix + nameof(TraceContextIgnoreSampledFalse);

--- a/src/Elastic.Apm/Config/ConfigurationSnapshotFromReader.cs
+++ b/src/Elastic.Apm/Config/ConfigurationSnapshotFromReader.cs
@@ -58,6 +58,8 @@ namespace Elastic.Apm.Config
 		public bool SpanCompressionEnabled => _content.SpanCompressionEnabled;
 		public double SpanCompressionExactMatchMaxDuration => _content.SpanCompressionExactMatchMaxDuration;
 		public double SpanCompressionSameKindMaxDuration => _content.SpanCompressionSameKindMaxDuration;
+		public double SpanStackTraceMinDurationInMilliseconds => _content.SpanStackTraceMinDurationInMilliseconds;
+		[Obsolete("Use SpanStackTraceMinDurationInMilliseconds")]
 		public double SpanFramesMinDurationInMilliseconds => _content.SpanFramesMinDurationInMilliseconds;
 		public int StackTraceLimit => _content.StackTraceLimit;
 

--- a/src/Elastic.Apm/Config/EnvironmentConfigurationReader.cs
+++ b/src/Elastic.Apm/Config/EnvironmentConfigurationReader.cs
@@ -16,6 +16,7 @@ namespace Elastic.Apm.Config
 		private const string ThisClassName = nameof(EnvironmentConfigurationReader);
 
 		private readonly Lazy<double> _spanFramesMinDurationInMilliseconds;
+		private readonly Lazy<double> _spanStackTraceMinDurationInMilliseconds;
 
 		private readonly Lazy<int> _stackTraceLimit;
 
@@ -24,6 +25,10 @@ namespace Elastic.Apm.Config
 			_spanFramesMinDurationInMilliseconds
 				= new Lazy<double>(() =>
 					ParseSpanFramesMinDurationInMilliseconds(Read(ConfigConsts.EnvVarNames.SpanFramesMinDuration)));
+
+			_spanStackTraceMinDurationInMilliseconds
+				= new Lazy<double>(() =>
+					ParseSpanStackTraceMinDurationInMilliseconds(Read(ConfigConsts.EnvVarNames.SpanStackTraceMinDuration)));
 
 			_stackTraceLimit = new Lazy<int>(() => ParseStackTraceLimit(Read(ConfigConsts.EnvVarNames.StackTraceLimit)));
 		}
@@ -118,6 +123,9 @@ namespace Elastic.Apm.Config
 		public double SpanCompressionSameKindMaxDuration =>
 			ParseSpanCompressionSameKindMaxDuration(Read(ConfigConsts.EnvVarNames.SpanCompressionSameKindMaxDuration));
 
+		public double SpanStackTraceMinDurationInMilliseconds => _spanStackTraceMinDurationInMilliseconds.Value;
+
+		[Obsolete("Use SpanStackTraceMinDurationInMilliseconds")]
 		public double SpanFramesMinDurationInMilliseconds => _spanFramesMinDurationInMilliseconds.Value;
 
 		public int StackTraceLimit => _stackTraceLimit.Value;

--- a/src/Elastic.Apm/Config/IConfigurationReader.cs
+++ b/src/Elastic.Apm/Config/IConfigurationReader.cs
@@ -292,10 +292,19 @@ namespace Elastic.Apm.Config
 
 		/// <summary>
 		/// The agent limits stack trace collection to spans with durations equal or longer than the given value
+		/// negative value: Disables stack trace collection for spans completely
+		/// 0: stacktrace will be collected for all spans
+		/// positive value n: stacktrace will be captured for spans with a duration equal or longer than n ms.
+		/// </summary>
+		double SpanStackTraceMinDurationInMilliseconds { get; }
+
+		/// <summary>
+		/// The agent limits stack trace collection to spans with durations equal or longer than the given value
 		/// 0: Disables stack trace collection for spans completely
 		/// negative value: stacktrace will be collected for all spans
 		/// positive value n: stacktrace will be captured for spans with a duration equal or longer than n ms.
 		/// </summary>
+		[Obsolete("Use SpanStackTraceMinDurationInMilliseconds")]
 		double SpanFramesMinDurationInMilliseconds { get; }
 
 		/// <summary>

--- a/src/Elastic.Apm/Model/Span.cs
+++ b/src/Elastic.Apm/Model/Span.cs
@@ -133,13 +133,10 @@ namespace Elastic.Apm.Model
 		{
 			if (Configuration.StackTraceLimit != 0)
 			{
-				if (Configuration.SpanStackTraceMinDurationInMilliseconds !=
-				    ConfigConsts.DefaultValues.SpanStackTraceMinDurationInMilliseconds)
-				{
-					return Configuration.SpanStackTraceMinDurationInMilliseconds >= 0;
-				}
-				// Legacy setting?
-				if (Configuration.SpanFramesMinDurationInMilliseconds != ConfigConsts.DefaultValues.SpanFramesMinDurationInMilliseconds)
+				// If the legacy setting (span_frames_min_duration) is present but the new
+				// setting (span_stack_trace_min_duration) is not (or has a default value), the legacy setting dominates.
+				if (Configuration.SpanFramesMinDurationInMilliseconds != ConfigConsts.DefaultValues.SpanFramesMinDurationInMilliseconds &&
+				    Configuration.SpanStackTraceMinDurationInMilliseconds == ConfigConsts.DefaultValues.SpanStackTraceMinDurationInMilliseconds)
 				{
 					return Configuration.SpanFramesMinDurationInMilliseconds != 0;
 				}
@@ -153,15 +150,10 @@ namespace Elastic.Apm.Model
 		{
 			if (Configuration.StackTraceLimit != 0 && RawStackTrace == null)
 			{
-				if (Configuration.SpanStackTraceMinDurationInMilliseconds !=
-				    ConfigConsts.DefaultValues.SpanStackTraceMinDurationInMilliseconds)
-				{
-					return Configuration.SpanStackTraceMinDurationInMilliseconds >= 0 &&
-					       Duration >= Configuration.SpanStackTraceMinDurationInMilliseconds;
-				}
-				// Legacy setting?
-				if (Configuration.SpanFramesMinDurationInMilliseconds !=
-				    ConfigConsts.DefaultValues.SpanFramesMinDurationInMilliseconds)
+				// If the legacy setting (span_frames_min_duration) is present but the new
+				// setting (span_stack_trace_min_duration) is not (or has a default value), the legacy setting dominates.
+				if (Configuration.SpanFramesMinDurationInMilliseconds != ConfigConsts.DefaultValues.SpanFramesMinDurationInMilliseconds &&
+				    Configuration.SpanStackTraceMinDurationInMilliseconds == ConfigConsts.DefaultValues.SpanStackTraceMinDurationInMilliseconds)
 				{
 					return Configuration.SpanFramesMinDurationInMilliseconds != 0 &&
 					       (Duration >= Configuration.SpanFramesMinDurationInMilliseconds ||

--- a/test/Elastic.Apm.Feature.Tests/TestConfiguration.cs
+++ b/test/Elastic.Apm.Feature.Tests/TestConfiguration.cs
@@ -52,6 +52,8 @@ namespace Elastic.Apm.Feature.Tests
 		public bool SpanCompressionEnabled => DefaultValues.SpanCompressionEnabled;
 		public double SpanCompressionExactMatchMaxDuration => DefaultValues.SpanCompressionExactMatchMaxDurationInMilliseconds;
 		public double SpanCompressionSameKindMaxDuration => DefaultValues.SpanCompressionSameKindMaxDurationInMilliseconds;
+		public double SpanStackTraceMinDurationInMilliseconds { get; set; } = DefaultValues.SpanStackTraceMinDurationInMilliseconds;
+		[Obsolete("Use SpanStackTraceMinDurationInMilliseconds")]
 		public double SpanFramesMinDurationInMilliseconds { get; set; } = DefaultValues.SpanFramesMinDurationInMilliseconds;
 		public int StackTraceLimit { get; set; } = DefaultValues.StackTraceLimit;
 		public bool TraceContextIgnoreSampledFalse { get; set; } = DefaultValues.TraceContextIgnoreSampledFalse;

--- a/test/Elastic.Apm.Tests.Utilities/MockConfiguration.cs
+++ b/test/Elastic.Apm.Tests.Utilities/MockConfiguration.cs
@@ -50,6 +50,7 @@ namespace Elastic.Apm.Tests.Utilities
 		private readonly string _spanCompressionEnabled;
 		private readonly string _spanCompressionExactMatchMaxDuration;
 		private readonly string _spanCompressionSameKindMaxDuration;
+		private readonly string _spanStackTraceMinDurationInMilliseconds;
 		private readonly string _spanFramesMinDurationInMilliseconds;
 		private readonly string _stackTraceLimit;
 		private readonly string _traceContextIgnoreSampledFalse;
@@ -79,6 +80,7 @@ namespace Elastic.Apm.Tests.Utilities
 			string metricsInterval = null,
 			string captureBody = SupportedValues.CaptureBodyOff,
 			string stackTraceLimit = null,
+			string spanStackTraceMinDurationInMilliseconds = null,
 			string spanFramesMinDurationInMilliseconds = null,
 			string captureBodyContentTypes = DefaultValues.CaptureBodyContentTypes,
 			string flushInterval = null,
@@ -124,6 +126,7 @@ namespace Elastic.Apm.Tests.Utilities
 			_metricsInterval = metricsInterval;
 			_captureBody = captureBody;
 			_stackTraceLimit = stackTraceLimit;
+			_spanStackTraceMinDurationInMilliseconds = spanStackTraceMinDurationInMilliseconds;
 			_spanFramesMinDurationInMilliseconds = spanFramesMinDurationInMilliseconds;
 			_captureBodyContentTypes = captureBodyContentTypes;
 			_flushInterval = flushInterval;
@@ -235,6 +238,11 @@ namespace Elastic.Apm.Tests.Utilities
 		public double SpanCompressionSameKindMaxDuration => ParseSpanCompressionSameKindMaxDuration(Kv(EnvVarNames.SpanCompressionSameKindMaxDuration,
 			_spanCompressionSameKindMaxDuration, Origin));
 
+		public double SpanStackTraceMinDurationInMilliseconds => ParseSpanStackTraceMinDurationInMilliseconds(Kv(
+			EnvVarNames.SpanStackTraceMinDuration,
+			_spanStackTraceMinDurationInMilliseconds, Origin));
+
+		[Obsolete("Use SpanStackTraceMinDurationInMilliseconds")]
 		public double SpanFramesMinDurationInMilliseconds => ParseSpanFramesMinDurationInMilliseconds(Kv(
 			EnvVarNames.SpanFramesMinDuration,
 			_spanFramesMinDurationInMilliseconds, Origin));

--- a/test/Elastic.Apm.Tests/ConfigTests.cs
+++ b/test/Elastic.Apm.Tests/ConfigTests.cs
@@ -16,6 +16,9 @@ using FluentAssertions;
 using Xunit;
 using static Elastic.Apm.Config.ConfigConsts;
 
+// Disable obsolete-warning due to Configuration.SpanFramesMinDurationInMilliseconds access.
+#pragma warning disable CS0618
+
 namespace Elastic.Apm.Tests
 {
 	/// <summary>

--- a/test/Elastic.Apm.Tests/ConstructorTests.cs
+++ b/test/Elastic.Apm.Tests/ConstructorTests.cs
@@ -71,6 +71,8 @@ namespace Elastic.Apm.Tests
 			public double SpanCompressionSameKindMaxDuration => ConfigConsts.DefaultValues.SpanCompressionSameKindMaxDurationInMilliseconds;
 			public IReadOnlyList<WildcardMatcher> DisableMetrics => ConfigConsts.DefaultValues.DisableMetrics;
 			public IReadOnlyList<WildcardMatcher> IgnoreMessageQueues => ConfigConsts.DefaultValues.IgnoreMessageQueues;
+			public double SpanStackTraceMinDurationInMilliseconds =>  ConfigConsts.DefaultValues.SpanStackTraceMinDurationInMilliseconds;
+			[Obsolete("Use SpanStackTraceMinDurationInMilliseconds")]
 			public double SpanFramesMinDurationInMilliseconds => ConfigConsts.DefaultValues.SpanFramesMinDurationInMilliseconds;
 			public int StackTraceLimit => ConfigConsts.DefaultValues.StackTraceLimit;
 			public double TransactionSampleRate => ConfigConsts.DefaultValues.TransactionSampleRate;

--- a/test/Elastic.Apm.Tests/SpanTests.cs
+++ b/test/Elastic.Apm.Tests/SpanTests.cs
@@ -3,7 +3,11 @@
 // See the LICENSE file in the project root for more information
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
+using Elastic.Apm.Api;
+using Elastic.Apm.Config;
+using Elastic.Apm.Helpers;
 using Elastic.Apm.Tests.Utilities;
 using FluentAssertions;
 using Xunit;
@@ -18,7 +22,8 @@ namespace Elastic.Apm.Tests
 			// Arrange
 			var payloadSender = new MockPayloadSender();
 			using (var agent =
-				new ApmAgent(new TestAgentComponents(configuration: new MockConfiguration(transactionMaxSpans: "0"), payloadSender: payloadSender)))
+			       new ApmAgent(new TestAgentComponents(configuration: new MockConfiguration(transactionMaxSpans: "0"),
+				       payloadSender: payloadSender)))
 			{
 				agent.Tracer.CaptureTransaction("transaction", "type", transaction =>
 				{
@@ -40,7 +45,8 @@ namespace Elastic.Apm.Tests
 			// Arrange
 			var payloadSender = new MockPayloadSender();
 			using (var agent =
-				new ApmAgent(new TestAgentComponents(configuration: new MockConfiguration(transactionMaxSpans: "0"), payloadSender: payloadSender)))
+			       new ApmAgent(new TestAgentComponents(configuration: new MockConfiguration(transactionMaxSpans: "0"),
+				       payloadSender: payloadSender)))
 			{
 				agent.Tracer.CaptureTransaction("transaction", "type", transaction =>
 				{
@@ -62,7 +68,8 @@ namespace Elastic.Apm.Tests
 			// Arrange
 			var payloadSender = new MockPayloadSender();
 			using (var agent =
-				new ApmAgent(new TestAgentComponents(configuration: new MockConfiguration(transactionSampleRate: "0"), payloadSender: payloadSender)))
+			       new ApmAgent(new TestAgentComponents(
+				       configuration: new MockConfiguration(transactionSampleRate: "0"), payloadSender: payloadSender)))
 			{
 				agent.Tracer.CaptureTransaction("transaction", "type", transaction =>
 				{
@@ -84,7 +91,8 @@ namespace Elastic.Apm.Tests
 			// Arrange
 			var payloadSender = new MockPayloadSender();
 			using (var agent =
-				new ApmAgent(new TestAgentComponents(configuration: new MockConfiguration(transactionSampleRate: "0"), payloadSender: payloadSender)))
+			       new ApmAgent(new TestAgentComponents(
+				       configuration: new MockConfiguration(transactionSampleRate: "0"), payloadSender: payloadSender)))
 			{
 				agent.Tracer.CaptureTransaction("transaction", "type", transaction =>
 				{
@@ -106,7 +114,8 @@ namespace Elastic.Apm.Tests
 			// Arrange
 			var payloadSender = new MockPayloadSender();
 			using (var agent =
-				new ApmAgent(new TestAgentComponents(configuration: new MockConfiguration(transactionSampleRate: "0"), payloadSender: payloadSender)))
+			       new ApmAgent(new TestAgentComponents(
+				       configuration: new MockConfiguration(transactionSampleRate: "0"), payloadSender: payloadSender)))
 			{
 				var transaction = agent.Tracer.StartTransaction("transaction", "type");
 
@@ -119,6 +128,125 @@ namespace Elastic.Apm.Tests
 				payloadSender.Spans.Count.Should().Be(0);
 				agent.Tracer.CurrentSpan.Should().Be(parentSpan);
 			}
+		}
+
+		[Fact]
+		public void IsCaptureStackTraceOnEndEnabled_test_with_new_and_legacy_settings()
+		{
+			// Enabled by default if duration is met
+			Create_Span_ForCaptureStackTraceTest(new MockConfiguration()).Let(span =>
+			{
+				span.Duration = ConfigConsts.DefaultValues.SpanStackTraceMinDurationInMilliseconds;
+				span.IsCaptureStackTraceOnEndEnabled().Should().BeTrue();
+			});
+
+			// Disabled if duration is too low.
+			Create_Span_ForCaptureStackTraceTest(new MockConfiguration()).Let(span =>
+			{
+				span.Duration = ConfigConsts.DefaultValues.SpanStackTraceMinDurationInMilliseconds - 1;
+				span.IsCaptureStackTraceOnEndEnabled().Should().BeFalse();
+			});
+
+			// Disabled via "StackTraceLimit".
+			Create_Span_ForCaptureStackTraceTest(new MockConfiguration(stackTraceLimit: "0")).Let(span =>
+			{
+				span.Duration = ConfigConsts.DefaultValues.SpanStackTraceMinDurationInMilliseconds;
+				span.IsCaptureStackTraceOnEndEnabled().Should().BeFalse();
+			});
+
+			// Disabled if a StackTrace is already present.
+			Create_Span_ForCaptureStackTraceTest(new MockConfiguration()).Let(span =>
+			{
+				span.Duration = ConfigConsts.DefaultValues.SpanStackTraceMinDurationInMilliseconds;
+				span.RawStackTrace = new StackTrace();
+				span.IsCaptureStackTraceOnEndEnabled().Should().BeFalse();
+			});
+
+			// Enabled if duration is greater or equal
+			Create_Span_ForCaptureStackTraceTest(new MockConfiguration()).Let(span =>
+			{
+				span.Duration = ConfigConsts.DefaultValues.SpanStackTraceMinDurationInMilliseconds;
+				span.IsCaptureStackTraceOnEndEnabled().Should().BeTrue();
+			});
+
+			// Disabled via "SpanStackTraceMinDurationInMilliseconds"
+			Create_Span_ForCaptureStackTraceTest(new MockConfiguration(spanStackTraceMinDurationInMilliseconds: "-1")).Let(span =>
+			{
+				span.Duration = ConfigConsts.DefaultValues.SpanStackTraceMinDurationInMilliseconds;
+				span.IsCaptureStackTraceOnEndEnabled().Should().BeFalse();
+			});
+
+			// Disabled via legacy setting "SpanFramesMinDurationInMilliseconds"
+			Create_Span_ForCaptureStackTraceTest(new MockConfiguration(spanFramesMinDurationInMilliseconds: "0")).Let(span =>
+			{
+				span.Duration = ConfigConsts.DefaultValues.SpanStackTraceMinDurationInMilliseconds;
+				span.IsCaptureStackTraceOnEndEnabled().Should().BeFalse();
+			});
+
+			// Disabled: "SpanStackTraceMinDurationInMilliseconds"	 dominates legacy setting "SpanFramesMinDurationInMilliseconds"
+			Create_Span_ForCaptureStackTraceTest(new MockConfiguration(spanStackTraceMinDurationInMilliseconds: "-1", spanFramesMinDurationInMilliseconds: "1000ms")).Let(span =>
+			{
+				span.Duration = ConfigConsts.DefaultValues.SpanStackTraceMinDurationInMilliseconds;
+				span.IsCaptureStackTraceOnEndEnabled().Should().BeFalse();
+			});
+
+			// Disabled: legacy setting "SpanFramesMinDurationInMilliseconds" still dominates over default value for "SpanStackTraceMinDurationInMilliseconds"
+			Create_Span_ForCaptureStackTraceTest(new MockConfiguration(spanStackTraceMinDurationInMilliseconds: ConfigConsts.DefaultValues.SpanStackTraceMinDuration, spanFramesMinDurationInMilliseconds: "1s")).Let(span =>
+			{
+				span.Duration = ConfigConsts.DefaultValues.SpanStackTraceMinDurationInMilliseconds;
+				span.IsCaptureStackTraceOnEndEnabled().Should().BeFalse();
+			});
+
+			// Enabled if duration exceeds set value
+			Create_Span_ForCaptureStackTraceTest(new MockConfiguration(spanStackTraceMinDurationInMilliseconds: "200ms")).Let(span =>
+			{
+				span.Duration = 300;
+				span.IsCaptureStackTraceOnEndEnabled().Should().BeTrue();
+			});
+
+			// Enabled if duration exceeds set legacy value
+			Create_Span_ForCaptureStackTraceTest(new MockConfiguration(spanFramesMinDurationInMilliseconds: "200ms")).Let(span =>
+			{
+				span.Duration = 300;
+				span.IsCaptureStackTraceOnEndEnabled().Should().BeTrue();
+			});
+		}
+
+		[Fact]
+		public void IsCaptureStackTraceOnStartEnabled_test_with_new_and_legacy_settings()
+		{
+			// Enabled by default
+			Create_Span_ForCaptureStackTraceTest(new MockConfiguration()).IsCaptureStackTraceOnStartEnabled().Should()
+				.BeTrue();
+
+			// Disabled via "StackTraceLimit"
+			Create_Span_ForCaptureStackTraceTest(new MockConfiguration(stackTraceLimit: "0"))
+				.IsCaptureStackTraceOnStartEnabled().Should().BeFalse();
+
+			// Disabled via "SpanStackTraceMinDurationInMilliseconds"
+			Create_Span_ForCaptureStackTraceTest(new MockConfiguration(spanStackTraceMinDurationInMilliseconds: "-1"))
+				.IsCaptureStackTraceOnStartEnabled().Should().BeFalse();
+
+			// Disabled via legacy setting "SpanFramesMinDurationInMilliseconds"
+			Create_Span_ForCaptureStackTraceTest(new MockConfiguration(spanFramesMinDurationInMilliseconds: "0"))
+				.IsCaptureStackTraceOnStartEnabled().Should().BeFalse();
+
+			// Disabled: "SpanStackTraceMinDurationInMilliseconds" dominates legacy setting "SpanFramesMinDurationInMilliseconds"
+			Create_Span_ForCaptureStackTraceTest(new MockConfiguration(spanStackTraceMinDurationInMilliseconds: "-1",
+				spanFramesMinDurationInMilliseconds: "23ms")).IsCaptureStackTraceOnStartEnabled().Should().BeFalse();
+
+			// Disabled: legacy setting "SpanFramesMinDurationInMilliseconds" still dominates over default value for "SpanStackTraceMinDurationInMilliseconds"
+			Create_Span_ForCaptureStackTraceTest(new MockConfiguration(
+				spanStackTraceMinDurationInMilliseconds: ConfigConsts.DefaultValues.SpanStackTraceMinDuration,
+				spanFramesMinDurationInMilliseconds: "23ms")).IsCaptureStackTraceOnStartEnabled().Should().BeTrue();
+		}
+
+		private static Model.Span Create_Span_ForCaptureStackTraceTest(IConfiguration configuration)
+		{
+			var agent = new ApmAgent(new TestAgentComponents(configuration: configuration,
+				payloadSender: new MockPayloadSender()));
+			var transaction = agent.Tracer.StartTransaction("transaction", "type");
+			return transaction.StartSpan("span", "type") as Model.Span;
 		}
 	}
 }

--- a/test/Elastic.Apm.Tests/SpanTests.cs
+++ b/test/Elastic.Apm.Tests/SpanTests.cs
@@ -3,9 +3,7 @@
 // See the LICENSE file in the project root for more information
 
 using System;
-using System.Collections.Generic;
 using System.Diagnostics;
-using Elastic.Apm.Api;
 using Elastic.Apm.Config;
 using Elastic.Apm.Helpers;
 using Elastic.Apm.Tests.Utilities;


### PR DESCRIPTION
Fixes #1529

Introduce the new configuration option `span_stack_trace_min_duration` that replaces the now deprecated option `span_frames_min_duration`.
*Note*:
* The deprecated option will still be evaluated iff the new option is not present or has a default value set.
* The semantics of negative and 0 values have changed compared to the legacy setting (`span_frames_min_duration`).
  * Negative value will result in never capturing the stack traces.
  * A value of `0` (regardless of the time unit suffix) will always capture the stack traces.

The `Span` class was extended with the methods 
* `IsCaptureStackTraceOnStartEnabled`
* `IsCaptureStackTraceOnEndEnabled`
which evaluate the conditions for both versions of these settings which must be met so that stack traces are captures.
`SpanTests` exercise these new methods.