### PR TITLE
CentralConfigResponseParser - test with empty json

### DIFF
--- a/test/Elastic.Apm.Tests/BackendCommTests/CentralConfig/CentralConfigResponseParserTests.cs
+++ b/test/Elastic.Apm.Tests/BackendCommTests/CentralConfig/CentralConfigResponseParserTests.cs
@@ -225,6 +225,15 @@ namespace Elastic.Apm.Tests.BackendCommTests.CentralConfig
 					})
 				};
 
+				yield return new object[]
+				{
+					// making sure empty json does not cause any error.
+					"{}", new Action<CentralConfigurationReader>(cfg =>
+					{
+						cfg.Should().NotBeNull();
+					})
+				};
+
 				foreach (var value in Enum.GetValues(typeof(LogLevel)))
 				{
 					yield return new object[]


### PR DESCRIPTION
Add `{}` to test input.

This came up in another discussion. Empty json response from central config should not cause any issue to the agent.

This is already the case, but it wasn't tested - therefore adding `{}` to test inputs to cover this case. 