### PR TITLE
Fix incorrect transaction name in ASP.NET Web Api

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -107,7 +107,7 @@ pipeline {
                           whenTrue(isPR()) {
                             // build nuget packages and profiler
                             sh(label: 'Package', script: '.ci/linux/release.sh true')
-                            sh label: 'Rustup', script: 'rustup default 1.57.0'
+                            sh label: 'Rustup', script: 'rustup default 1.59.0'
                             sh label: 'Cargo make', script: 'cargo install --force cargo-make'
                             sh(label: 'Build profiler', script: './build.sh profiler-zip')
                           }
@@ -186,7 +186,7 @@ pipeline {
                       unstash 'source'
                       dir("${BASE_DIR}"){
                         dotnet(){
-                          sh label: 'Rustup', script: 'rustup default 1.57.0'
+                          sh label: 'Rustup', script: 'rustup default 1.59.0'
                           sh label: 'Cargo make', script: 'cargo install --force cargo-make'
                           sh label: 'Build', script: './build.sh profiler-zip'
                           sh label: 'Test & coverage', script: '.ci/linux/test-profiler.sh'

--- a/sample/AspNetFullFrameworkSampleApp/Controllers/AttributeRoutingWebApiController.cs
+++ b/sample/AspNetFullFrameworkSampleApp/Controllers/AttributeRoutingWebApiController.cs
@@ -12,10 +12,16 @@ namespace AspNetFullFrameworkSampleApp.Controllers
 	{
 		public const string RoutePrefix = "api/AttributeRoutingWebApi";
 		public const string Route = "{id}";
+		public const string RouteAmbiguous = "ambiguous";
 
 		[HttpGet]
 		[Route(Route)]
 		public IHttpActionResult Get(string id) =>
 			Ok($"attributed routed web api controller {id}");
+
+		[HttpGet]
+		[Route(RouteAmbiguous)]
+		public IHttpActionResult Get2() =>
+			Ok($"attributed routed web api controller with ambiguous route");
 	}
 }

--- a/src/Elastic.Apm.AspNetFullFramework/ElasticApmModule.cs
+++ b/src/Elastic.Apm.AspNetFullFramework/ElasticApmModule.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to Elasticsearch B.V under one or more agreements.
+// Licensed to Elasticsearch B.V under one or more agreements.
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
 
@@ -35,8 +35,9 @@ namespace Elastic.Apm.AspNetFullFramework
 		private readonly string _dbgInstanceName;
 		private HttpApplication _application;
 		private IApmLogger _logger;
-		private Type _httpRouteDataInterfaceType;
+		private readonly Lazy<Type> _httpRouteDataInterfaceType = new Lazy<Type>(() => Type.GetType("System.Web.Http.Routing.IHttpRouteData,System.Web.Http"));
 		private Func<object, string> _routeDataTemplateGetter;
+		private Func<object, decimal> _routePrecedenceGetter;
 
 		public ElasticApmModule() =>
 			// ReSharper disable once ImpureMethodCallOnReadonlyValueField
@@ -85,6 +86,7 @@ namespace Elastic.Apm.AspNetFullFramework
 			}
 
 			_routeDataTemplateGetter = CreateWebApiAttributeRouteTemplateGetter();
+			_routePrecedenceGetter = CreateRoutePrecedenceGetter();
 			_application = application;
 			_application.BeginRequest += OnBeginRequest;
 			_application.EndRequest += OnEndRequest;
@@ -325,18 +327,24 @@ namespace Elastic.Apm.AspNetFullFramework
 						string name = null;
 
 						// if we're dealing with Web API attribute routing, get transaction name from the route template
-						if (routeData.TryGetValue("MS_SubRoutes", out var template) && _httpRouteDataInterfaceType != null)
+						if (routeData.TryGetValue("MS_SubRoutes", out var template) && _httpRouteDataInterfaceType.Value != null)
 						{
 							if (template is IEnumerable enumerable)
 							{
+								var minPrecedence = decimal.MaxValue;
 								var enumerator = enumerable.GetEnumerator();
-								if (enumerator.MoveNext())
+								while (enumerator.MoveNext())
 								{
 									var subRoute = enumerator.Current;
-									if (subRoute != null && _httpRouteDataInterfaceType.IsInstanceOfType(subRoute))
+									if (subRoute != null && _httpRouteDataInterfaceType.Value.IsInstanceOfType(subRoute))
 									{
-										_logger?.Trace()?.Log("Calculating transaction name from web api attribute routing");
-										name = _routeDataTemplateGetter(subRoute);
+										var precedence = _routePrecedenceGetter(subRoute);
+										if (precedence < minPrecedence)
+										{
+											_logger?.Trace()?.Log($"Calculating transaction name from web api attribute routing (route precedence: {precedence})");
+											minPrecedence = precedence;
+											name = _routeDataTemplateGetter(subRoute);
+										}
 									}
 								}
 							}
@@ -463,22 +471,58 @@ namespace Elastic.Apm.AspNetFullFramework
 		}
 
 		/// <summary>
+		/// Compiles a delegate from a lambda expression to get a route's DataTokens property,
+		/// which holds the precedence value.
+		/// </summary>
+		private Func<object, decimal> CreateRoutePrecedenceGetter()
+		{
+			if (_httpRouteDataInterfaceType.Value != null)
+			{
+				var routePropertyInfo = _httpRouteDataInterfaceType.Value.GetProperty("Route");
+				if (routePropertyInfo != null)
+				{
+					var routeType = routePropertyInfo.PropertyType;
+					var dataTokensPropertyInfo = routeType.GetProperty("DataTokens");
+					if (dataTokensPropertyInfo != null)
+					{
+						var routePropertyGetter = ExpressionBuilder.BuildPropertyGetter(_httpRouteDataInterfaceType.Value, routePropertyInfo);
+						var dataTokensPropertyGetter = ExpressionBuilder.BuildPropertyGetter(routeType, dataTokensPropertyInfo);
+						return subRoute =>
+						{
+							var precedence = decimal.MaxValue;
+							var route = routePropertyGetter(subRoute);
+							if (route != null)
+							{
+								var dataTokens = dataTokensPropertyGetter(route) as IDictionary<string, object>;
+								object v = null;
+								if (dataTokens?.TryGetValue("precedence", out v) ?? true)
+									precedence = (decimal)v;
+							}
+							return precedence;
+						};
+					}
+				}
+			}
+
+			return null;
+		}
+
+		/// <summary>
 		/// Compiles a delegate from a lambda expression to get the route template from HttpRouteData when
 		/// System.Web.Http is referenced.
 		/// </summary>
 		private Func<object, string> CreateWebApiAttributeRouteTemplateGetter()
 		{
-			_httpRouteDataInterfaceType = Type.GetType("System.Web.Http.Routing.IHttpRouteData,System.Web.Http");
-			if (_httpRouteDataInterfaceType != null)
+			if (_httpRouteDataInterfaceType.Value != null)
 			{
-				var routePropertyInfo = _httpRouteDataInterfaceType.GetProperty("Route");
+				var routePropertyInfo = _httpRouteDataInterfaceType.Value.GetProperty("Route");
 				if (routePropertyInfo != null)
 				{
 					var routeType = routePropertyInfo.PropertyType;
 					var routeTemplatePropertyInfo = routeType.GetProperty("RouteTemplate");
 					if (routeTemplatePropertyInfo != null)
 					{
-						var routePropertyGetter = ExpressionBuilder.BuildPropertyGetter(_httpRouteDataInterfaceType, routePropertyInfo);
+						var routePropertyGetter = ExpressionBuilder.BuildPropertyGetter(_httpRouteDataInterfaceType.Value, routePropertyInfo);
 						var routeTemplatePropertyGetter = ExpressionBuilder.BuildPropertyGetter(routeType, routeTemplatePropertyInfo);
 						return routeData =>
 						{

--- a/test/Elastic.Apm.AspNetFullFramework.Tests/TransactionNameTests.cs
+++ b/test/Elastic.Apm.AspNetFullFramework.Tests/TransactionNameTests.cs
@@ -134,6 +134,19 @@ namespace Elastic.Apm.AspNetFullFramework.Tests
 		}
 
 		[AspNetFullFrameworkFact]
+		public async Task Name_Should_Be_Correct_RouteTemplate_When_Multiple_WebApi_Attribute_Routing()
+		{
+			var pathData = SampleAppUrlPaths.AttributeRoutingWebApiPage("ambiguous");
+			await SendGetRequestToSampleAppAndVerifyResponse(pathData.Uri, pathData.StatusCode);
+
+			await WaitAndCustomVerifyReceivedData(receivedData =>
+			{
+				receivedData.Transactions.Count.Should().Be(1);
+				var transaction = receivedData.Transactions.Single();
+				transaction.Name.Should().Be($"GET {AttributeRoutingWebApiController.RoutePrefix}/{AttributeRoutingWebApiController.RouteAmbiguous}");
+			});
+		}
+		[AspNetFullFrameworkFact]
 		public async Task Name_Should_Be_Path_When_Webforms_Page()
 		{
 			var pathData = SampleAppUrlPaths.WebformsPage;


### PR DESCRIPTION
Fixes #1645

When selecting the matching route template and multiple candidates exist, the *precedence* value of the route must be considered.

Previously, we always selected the first route (see [here](https://github.com/elastic/apm-agent-dotnet/blob/20fea7888fd3a044e13fb34c3e657d26502a6911/src/Elastic.Apm.AspNetFullFramework/ElasticApmModule.cs#L330)) which could lead to the undesired behavior when multiple potential route matches are present.