### PR TITLE
Fix potential NullReferenecException in TraceContinuationStrategy implementation

### DIFF
--- a/src/Elastic.Apm/Model/Transaction.cs
+++ b/src/Elastic.Apm/Model/Transaction.cs
@@ -134,7 +134,7 @@ namespace Elastic.Apm.Model
 
 			var shouldRestartTrace = configuration.TraceContinuationStrategy == ConfigConsts.SupportedValues.Restart ||
 				configuration.TraceContinuationStrategy == ConfigConsts.SupportedValues.RestartExternal
-				&& !distributedTracingData.TraceState.SampleRate.HasValue;
+				&& distributedTracingData is { TraceState: { SampleRate: null } };
 
 			// For each new transaction, start an Activity if we're not ignoring them.
 			// If Activity.Current is not null, the started activity will be a child activity,

--- a/test/Elastic.Apm.AspNetCore.Tests/DistributedTracingAspNetCoreTests.cs
+++ b/test/Elastic.Apm.AspNetCore.Tests/DistributedTracingAspNetCoreTests.cs
@@ -450,14 +450,16 @@ namespace Elastic.Apm.AspNetCore.Tests
 		}
 
 		[Fact]
-		public async Task TraceContinuationStrategyWithRestartExternalAndNoTraceParent()
+		public async Task TraceContinuationStrategyRestartExternalAndNoTraceParent()
 		{
 			_agent1.ConfigurationStore.CurrentSnapshot =
 				new MockConfiguration(new NoopLogger(), traceContinuationStrategy: "restart_external");
 
 			var client = new HttpClient();
 
-			client.DefaultRequestHeaders.Remove("traceparent");
+			// HttpClient always seem to add a `traceparent` header - calling `Remove("traceparent")` does not help.
+			// Therefore we add a fake value which fails validation and it'll be treated as a `null` traceparent` header.
+			client.DefaultRequestHeaders.Add("traceparent", "foo");
 			client.DefaultRequestHeaders.Remove("tracestate");
 
 			var res = await client.GetAsync("http://localhost:5901/Home/Index");

--- a/test/Elastic.Apm.AspNetCore.Tests/DistributedTracingAspNetCoreTests.cs
+++ b/test/Elastic.Apm.AspNetCore.Tests/DistributedTracingAspNetCoreTests.cs
@@ -449,6 +449,23 @@ namespace Elastic.Apm.AspNetCore.Tests
 			_payloadSender1.FirstTransaction.Links.ElementAt(0).TraceId.Should().Be("0af7651916cd43dd8448eb211c80319c");
 		}
 
+		[Fact]
+		public async Task TraceContinuationStrategyWithRestartExternalAndNoTraceParent()
+		{
+			_agent1.ConfigurationStore.CurrentSnapshot =
+				new MockConfiguration(new NoopLogger(), traceContinuationStrategy: "restart_external");
+
+			var client = new HttpClient();
+
+			client.DefaultRequestHeaders.Remove("traceparent");
+			client.DefaultRequestHeaders.Remove("tracestate");
+
+			var res = await client.GetAsync("http://localhost:5901/Home/Index");
+			res.IsSuccessStatusCode.Should().BeTrue();
+
+			_payloadSender1.Transactions.Should().NotBeNullOrEmpty();
+		}
+
 		public async Task DisposeAsync()
 		{
 			_cancellationTokenSource.Cancel();


### PR DESCRIPTION
Potential fix for https://github.com/elastic/apm-agent-dotnet/issues/1802  Not verified yet if it's the same bug, but this PR definitely fixes a real bug.

This feature was introduced in https://github.com/elastic/apm-agent-dotnet/pull/1739 (released in `1.17.0`). 

The added test shows the case which caused the `NullReferenceException`: It's when`TraceContinuationStrategy` was set to `restart_external` and an incoming request did not have a traceparent header.

Fix: adding a null-check.