### PR TITLE
Fix in handling TraceContinuationStrategy=restart_external

### DIFF
--- a/src/Elastic.Apm/Model/Transaction.cs
+++ b/src/Elastic.Apm/Model/Transaction.cs
@@ -142,7 +142,6 @@ namespace Elastic.Apm.Model
 					&& (distributedTracingData?.TraceState == null || distributedTracingData is { TraceState: { SampleRate: null } }));
 
 			// For each new transaction, start an Activity if we're not ignoring them.
-			// For each new transaction, start an Activity if we're not ignoring them.
 			// If Activity.Current is not null, the started activity will be a child activity,
 			// so the traceid and tracestate of the parent will flow to it.
 			if (!ignoreActivity)


### PR DESCRIPTION
Follow up to https://github.com/elastic/apm-agent-dotnet/pull/1803 after https://github.com/elastic/apm-agent-dotnet/issues/1802#issuecomment-1229194614. After thinking about it and looking at it again, I realized we needed to tweak the `shouldRestartTrace` check in `Transaction.cs`. 

Prior to this PR with https://github.com/elastic/apm-agent-dotnet/pull/1803 we already handled the missing `traceparent` and/or `tracestate` header, but the following case wasn't handled correctly:

- TraceContinuationStrategy=restart_external
- TraceParent is present and it's valid
- TraceState is not present

Prior to this PR those traces were never restarted (despite `restart_external`), which is fixed here.

Also adding a test case to cover this.