### PR TITLE
#1759 Fixed crashes on some SOAP 1.2 requests when using GetBufferedInputStream

### DIFF
--- a/src/Elastic.Apm.AspNetFullFramework/Extensions/SoapRequest.cs
+++ b/src/Elastic.Apm.AspNetFullFramework/Extensions/SoapRequest.cs
@@ -116,6 +116,14 @@ namespace Elastic.Apm.AspNetFullFramework.Extensions
 				//If that's the case we don't need to care about them here. They will flow somewhere else.
 				return null;
 			}
+			finally
+			{
+				var streamReader = new StreamReader(stream);
+				streamReader.ReadToEnd();
+				if (stream.CanSeek)
+					stream.Seek(0, SeekOrigin.Begin); //StreamReader doesn't have the Seek method, stream does.
+				streamReader.ReadToEnd(); // This now works
+			}
 		}
 	}
 }


### PR DESCRIPTION
This fixes issue [1759 ](https://github.com/elastic/apm-agent-dotnet/issues/1759) crashes on some SOAP 1.2 requests when using GetBufferedInputStream