### PR TITLE
Fixed crashes on some SOAP 1.2 requests when using GetBufferedInputStream

### DIFF
--- a/src/Elastic.Apm.AspNetFullFramework/Extensions/SoapRequest.cs
+++ b/src/Elastic.Apm.AspNetFullFramework/Extensions/SoapRequest.cs
@@ -85,11 +85,9 @@ namespace Elastic.Apm.AspNetFullFramework.Extensions
 		internal static string GetSoap12ActionFromInputStream(Stream stream)
 		{
 			StreamReader streamReader = null;
-
 			try
 			{
 				streamReader = new StreamReader(stream);
-
 				var settings = new XmlReaderSettings
 				{
 					IgnoreProcessingInstructions = true,

--- a/src/Elastic.Apm.AspNetFullFramework/Extensions/SoapRequest.cs
+++ b/src/Elastic.Apm.AspNetFullFramework/Extensions/SoapRequest.cs
@@ -116,6 +116,14 @@ namespace Elastic.Apm.AspNetFullFramework.Extensions
 				//If that's the case we don't need to care about them here. They will flow somewhere else.
 				return null;
 			}
+			finally
+			{
+				var streamReader = new StreamReader(stream);
+				streamReader.ReadToEnd();
+				if (stream.CanSeek)
+					stream.Seek(0, SeekOrigin.Begin); //StreamReader doesn't have the Seek method, stream does.
+				streamReader.ReadToEnd(); // This now works
+			}
 		}
 	}
 }

--- a/src/Elastic.Apm.AspNetFullFramework/Extensions/SoapRequest.cs
+++ b/src/Elastic.Apm.AspNetFullFramework/Extensions/SoapRequest.cs
@@ -84,8 +84,12 @@ namespace Elastic.Apm.AspNetFullFramework.Extensions
 
 		internal static string GetSoap12ActionFromInputStream(Stream stream)
 		{
+			StreamReader streamReader = null;
+
 			try
 			{
+				streamReader = new StreamReader(stream);
+
 				var settings = new XmlReaderSettings
 				{
 					IgnoreProcessingInstructions = true,
@@ -93,7 +97,7 @@ namespace Elastic.Apm.AspNetFullFramework.Extensions
 					IgnoreWhitespace = true
 				};
 
-				using var reader = XmlReader.Create(stream, settings);
+				using var reader = XmlReader.Create(streamReader, settings);
 				reader.MoveToContent();
 				if (reader.LocalName != "Envelope")
 					return null;
@@ -118,11 +122,7 @@ namespace Elastic.Apm.AspNetFullFramework.Extensions
 			}
 			finally
 			{
-				var streamReader = new StreamReader(stream);
-				streamReader.ReadToEnd();
-				if (stream.CanSeek)
-					stream.Seek(0, SeekOrigin.Begin); //StreamReader doesn't have the Seek method, stream does.
-				streamReader.ReadToEnd(); // This now works
+				streamReader?.ReadToEnd();
 			}
 		}
 	}

--- a/test/Elastic.Apm.AspNetFullFramework.Tests/Soap/SoapRequestTests.cs
+++ b/test/Elastic.Apm.AspNetFullFramework.Tests/Soap/SoapRequestTests.cs
@@ -31,7 +31,8 @@ namespace Elastic.Apm.AspNetFullFramework.Tests.Soap
 			var pathData = SampleAppUrlPaths.CallSoapServiceProtocolV12;
 			var action = "Input";
 
-			var input = @"This is the input";
+			var input = string.Join("", Enumerable.Repeat(@"This is the input.", 300));
+
 			var request = new HttpRequestMessage(HttpMethod.Post, pathData.Uri)
 			{
 				Content = new StringContent($@"<?xml version=""1.0"" encoding=""utf-8""?>

--- a/test/Elastic.Apm.AspNetFullFramework.Tests/Soap/SoapRequestTests.cs
+++ b/test/Elastic.Apm.AspNetFullFramework.Tests/Soap/SoapRequestTests.cs
@@ -26,12 +26,14 @@ namespace Elastic.Apm.AspNetFullFramework.Tests.Soap
 		/// to parse the parameters for the web method.
 		/// </summary>
 		[AspNetFullFrameworkFact]
-		public async Task Name_Should_Should_Not_Throw_Exception_When_Asmx_Soap12_Request()
+		[InlineData(false)]
+		[InlineData(true)]
+		public async Task Name_Should_Should_Not_Throw_Exception_When_Asmx_Soap12_Request(bool useLargePayload)
 		{
 			var pathData = SampleAppUrlPaths.CallSoapServiceProtocolV12;
 			var action = "Input";
 
-			var input = string.Join("", Enumerable.Repeat(@"This is the input.", 300));
+			var input = useLargePayload ? string.Join("", Enumerable.Repeat("This is a large input. ", 500)) : "This is the input";
 
 			var request = new HttpRequestMessage(HttpMethod.Post, pathData.Uri)
 			{

--- a/test/Elastic.Apm.AspNetFullFramework.Tests/Soap/SoapRequestTests.cs
+++ b/test/Elastic.Apm.AspNetFullFramework.Tests/Soap/SoapRequestTests.cs
@@ -25,7 +25,7 @@ namespace Elastic.Apm.AspNetFullFramework.Tests.Soap
 		/// does not cause an exception to be thrown when the framework deserializes the input stream
 		/// to parse the parameters for the web method.
 		/// </summary>
-		[AspNetFullFrameworkFact]
+		[AspNetFullFrameworkTheory]
 		[InlineData(false)]
 		[InlineData(true)]
 		public async Task Name_Should_Should_Not_Throw_Exception_When_Asmx_Soap12_Request(bool useLargePayload)


### PR DESCRIPTION
This fixes issue [1759 ](https://github.com/elastic/apm-agent-dotnet/issues/1759) crashes on some SOAP 1.2 requests when using GetBufferedInputStream