### PR TITLE
Retrieve hosting environment name via reflection

### DIFF
--- a/src/Elastic.Apm.Extensions.Hosting/Elastic.Apm.Extensions.Hosting.csproj
+++ b/src/Elastic.Apm.Extensions.Hosting/Elastic.Apm.Extensions.Hosting.csproj
@@ -17,6 +17,7 @@
     <InternalsVisibleTo Include="Elastic.Apm.StartupHook.Loader" Key="$(ExposedPublicKey)" />
     <InternalsVisibleTo Include="Elastic.Apm.AspNetCore.Tests" Key="$(ExposedPublicKey)" />
     <InternalsVisibleTo Include="Elastic.Apm.AspNetCore.Static.Tests" Key="$(ExposedPublicKey)" />
+    <InternalsVisibleTo Include="Elastic.Apm.Extensions.Hosting.Tests" Key="$(ExposedPublicKey)" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">

--- a/src/Elastic.Apm.Extensions.Hosting/HostBuilderExtensions.cs
+++ b/src/Elastic.Apm.Extensions.Hosting/HostBuilderExtensions.cs
@@ -15,6 +15,21 @@ namespace Elastic.Apm.Extensions.Hosting
 {
 	public static class HostBuilderExtensions
 	{
+		private static string GetHostingEnvironmentName(HostBuilderContext ctx)
+		{
+			try
+			{
+				var propertyInfo = ctx.GetType().GetProperty("HostingEnvironment");
+				var hostingEnvironment = propertyInfo.GetValue(ctx, null);
+				propertyInfo = hostingEnvironment.GetType().GetProperty("EnvironmentName");
+				return propertyInfo.GetValue(hostingEnvironment, null) as string;
+			}
+			catch (Exception)
+			{
+			}
+			return null;
+		}
+
 		/// <summary>
 		///  Register Elastic APM .NET Agent with components in the container.
 		///  You can customize the agent by passing additional IDiagnosticsSubscriber components to this method.
@@ -34,7 +49,7 @@ namespace Elastic.Apm.Extensions.Hosting
 				{
 					services.AddSingleton<IApmLogger, NetCoreLogger>();
 					services.AddSingleton<IConfigurationReader>(sp =>
-						new MicrosoftExtensionsConfig(ctx.Configuration, sp.GetService<IApmLogger>(), ctx.HostingEnvironment.EnvironmentName));
+						new MicrosoftExtensionsConfig(ctx.Configuration, sp.GetService<IApmLogger>(), GetHostingEnvironmentName(ctx)));
 				}
 				else
 				{

--- a/src/Elastic.Apm.Extensions.Hosting/HostBuilderExtensions.cs
+++ b/src/Elastic.Apm.Extensions.Hosting/HostBuilderExtensions.cs
@@ -15,7 +15,7 @@ namespace Elastic.Apm.Extensions.Hosting
 {
 	public static class HostBuilderExtensions
 	{
-		private static string GetHostingEnvironmentName(HostBuilderContext ctx)
+		internal static string GetHostingEnvironmentName(HostBuilderContext ctx, IApmLogger logger)
 		{
 			try
 			{
@@ -24,8 +24,9 @@ namespace Elastic.Apm.Extensions.Hosting
 				propertyInfo = hostingEnvironment.GetType().GetProperty("EnvironmentName");
 				return propertyInfo.GetValue(hostingEnvironment, null) as string;
 			}
-			catch (Exception)
+			catch (Exception e)
 			{
+				logger?.Warning()?.LogException(e, "Failed to retrieve hosting environment name");
 			}
 			return null;
 		}
@@ -49,7 +50,7 @@ namespace Elastic.Apm.Extensions.Hosting
 				{
 					services.AddSingleton<IApmLogger, NetCoreLogger>();
 					services.AddSingleton<IConfigurationReader>(sp =>
-						new MicrosoftExtensionsConfig(ctx.Configuration, sp.GetService<IApmLogger>(), GetHostingEnvironmentName(ctx)));
+						new MicrosoftExtensionsConfig(ctx.Configuration, sp.GetService<IApmLogger>(), GetHostingEnvironmentName(ctx, sp.GetService<IApmLogger>())));
 				}
 				else
 				{

--- a/test/Elastic.Apm.Extensions.Hosting.Tests/HostBuilderExtensionTests.cs
+++ b/test/Elastic.Apm.Extensions.Hosting.Tests/HostBuilderExtensionTests.cs
@@ -56,6 +56,18 @@ namespace Elastic.Apm.Extensions.Hosting.Tests
 			fakeSubscriber.IsSubscribed.Should().BeTrue();
 		}
 
+		[Fact]
+		public void GetHostingEnvironmentName_WorksViaReflection()
+		{
+			var environmentName = default(string);
+			CreateHostBuilder().ConfigureServices((ctx, services) =>
+			{
+				environmentName = HostBuilderExtensions.GetHostingEnvironmentName(ctx, null);
+			}).Build();
+
+			environmentName.Should().Be("Production");
+		}
+
 		/// <summary>
 		/// Sets `enabled=false` and makes sure that <see cref="HostBuilderExtensions.UseElasticApm" /> does not turn on diagnostic
 		/// listeners.


### PR DESCRIPTION
This is a draft PR for the idea suggested in https://github.com/elastic/apm-agent-dotnet/issues/1579#issuecomment-1240729413.
As a minimally inversive fix (rather than updating many project dependencies), retrieve the `HostingEnvironment` and the respective `EnvironmentName` via reflection.

(Note that the code currently lacks error handling/logging/tests)