### PR TITLE
Use correct default value for ExitSpanMinDuration

### DIFF
--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -589,7 +589,7 @@ Additionally, spans that lead to an error can't be discarded.
 [options="header"]
 |============
 | Default | Type
-| `1ms`  | TimeDuration
+| `0ms`  | TimeDuration
 |============
 
 

--- a/src/Elastic.Apm/Config/ConfigConsts.cs
+++ b/src/Elastic.Apm/Config/ConfigConsts.cs
@@ -27,8 +27,8 @@ namespace Elastic.Apm.Config
 			public const bool CentralConfig = true;
 			public const string CloudProvider = SupportedValues.CloudProviderAuto;
 			public const bool EnableOpenTelemetryBridge = false;
-			public const string ExitSpanMinDuration = "1ms";
-			public const int ExitSpanMinDurationInMilliseconds = 1000;
+			public const string ExitSpanMinDuration = "0ms";
+			public const int ExitSpanMinDurationInMilliseconds = 0;
 			public const int FlushIntervalInMilliseconds = 10_000; // 10 seconds
 			public const LogLevel LogLevel = Logging.LogLevel.Error;
 			public const int MaxBatchEventCount = 10;

--- a/test/Elastic.Apm.Tests.Utilities/MockApmServerInfo.cs
+++ b/test/Elastic.Apm.Tests.Utilities/MockApmServerInfo.cs
@@ -18,5 +18,7 @@ namespace Elastic.Apm.Tests.Utilities
 		public MockApmServerInfo(ElasticVersion version) => Version = version;
 
 		public ElasticVersion Version { get; set; }
+
+		public override string ToString() => $"{nameof(MockApmServerInfo)}: {Version}";
 	}
 }

--- a/test/Elastic.Apm.Tests/DroppedSpansStatsTests.cs
+++ b/test/Elastic.Apm.Tests/DroppedSpansStatsTests.cs
@@ -4,6 +4,7 @@
 // See the LICENSE file in the project root for more information
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using Elastic.Apm.Api;
 using Elastic.Apm.Model;
@@ -18,6 +19,32 @@ namespace Elastic.Apm.Tests
 	/// </summary>
 	public class DroppedSpansStatsTests
 	{
+		[Fact]
+		public void DroppedSpanStats_MustReflect_ExitSpanMinDuration_Configuration()
+		{
+			Helper_CreateSpanWithDuration(Config.ConfigConsts.DefaultValues.ExitSpanMinDuration, 0).Should().BeNull();
+			Helper_CreateSpanWithDuration("Oms", 0).Should().BeNull();
+			Helper_CreateSpanWithDuration("10ms", 0).Count().Should().Be(1);
+		}
+
+		private static IEnumerable<DroppedSpanStats> Helper_CreateSpanWithDuration(string exitSpanMinDuration, double actualSpanDuration)
+		{
+			var payloadSender = new MockPayloadSender();
+			using (var agent =
+			       new ApmAgent(new TestAgentComponents(configuration: new MockConfiguration(exitSpanMinDuration: exitSpanMinDuration),
+				       payloadSender: payloadSender)))
+			{
+				agent.Tracer.CaptureTransaction("transaction", "type", transaction =>
+				{
+					var span = transaction.StartSpan("exit_span", "type", isExitSpan: true);
+					span.Duration = actualSpanDuration;
+					span.End();
+				});
+			}
+
+			return payloadSender.FirstTransaction.DroppedSpanStats;
+		}
+
 		[Fact]
 		public void SingleDroppedSpanTest()
 		{


### PR DESCRIPTION
Fixes #1789

Both the [documentation](https://www.elastic.co/guide/en/apm/agent/dotnet/master/config-core.html#config-exit-span-min-duration) for `ExitSpanMinDuration` and the implementation of `DefaultValues.ExitSpanMinDurationInMilliseconds` (see [here](https://github.com/elastic/apm-agent-dotnet/blob/main/src/Elastic.Apm/Config/ConfigConsts.cs?rgh-link-date=2022-08-17T15%3A07%3A39Z#L30-L31)) are in violation of the [specification](https://github.com/elastic/apm-agent-java/blob/198cfac574fcbaae2d9a374702637bbcf44c46f8/apm-agent-core/src/main/java/co/elastic/apm/agent/configuration/SpanConfiguration.java#L68).