### PR TITLE
Group MetricSets in BreakdownMetricsProvider

### DIFF
--- a/src/Elastic.Apm/Api/MetricSample.cs
+++ b/src/Elastic.Apm/Api/MetricSample.cs
@@ -16,7 +16,7 @@ namespace Elastic.Apm.Api
 		public MetricSample(string key, double value)
 			=> KeyValue = new KeyValuePair<string, double>(key, value);
 
-		internal KeyValuePair<string, double> KeyValue { get; }
+		internal KeyValuePair<string, double> KeyValue { get; set; }
 
 		public override string ToString() => new ToStringBuilder(nameof(MetricSample)) { { KeyValue.Key, KeyValue.Value } }.ToString();
 	}

--- a/src/Elastic.Apm/Metrics/MetricSet.cs
+++ b/src/Elastic.Apm/Metrics/MetricSet.cs
@@ -2,6 +2,7 @@
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
 
+using System;
 using System.Collections.Generic;
 using Elastic.Apm.Api;
 using Elastic.Apm.Api.Constraints;
@@ -27,19 +28,77 @@ namespace Elastic.Apm.Metrics
 		public SpanInfo Span { get; set; }
 	}
 
-	public class TransactionInfo
+	public class TransactionInfo: IEquatable<TransactionInfo>
 	{
 		[MaxLength]
 		public string Name { get; set; }
 		[MaxLength]
 		public string Type { get; set; }
+
+		public bool Equals(TransactionInfo other)
+		{
+			if (ReferenceEquals(null, other)) return false;
+			if (ReferenceEquals(this, other)) return true;
+
+			return Name == other.Name && Type == other.Type;
+		}
+
+		public override bool Equals(object obj)
+		{
+			if (ReferenceEquals(null, obj)) return false;
+			if (ReferenceEquals(this, obj)) return true;
+			if (obj.GetType() != GetType()) return false;
+
+			return Equals((TransactionInfo)obj);
+		}
+
+		public override int GetHashCode()
+		{
+			unchecked
+			{
+				return ((Name != null ? Name.GetHashCode() : 0) * 397) ^ (Type != null ? Type.GetHashCode() : 0);
+			}
+		}
+
+		public static bool operator ==(TransactionInfo left, TransactionInfo right) => Equals(left, right);
+
+		public static bool operator !=(TransactionInfo left, TransactionInfo right) => !Equals(left, right);
 	}
 
-	public class SpanInfo
+	public class SpanInfo: IEquatable<SpanInfo>
 	{
 		[MaxLength]
 		public string Type { get; set; }
 		[MaxLength]
 		public string SubType { get; set; }
+
+		public bool Equals(SpanInfo other)
+		{
+			if (ReferenceEquals(null, other)) return false;
+			if (ReferenceEquals(this, other)) return true;
+
+			return Type == other.Type && SubType == other.SubType;
+		}
+
+		public override bool Equals(object obj)
+		{
+			if (ReferenceEquals(null, obj)) return false;
+			if (ReferenceEquals(this, obj)) return true;
+			if (obj.GetType() != GetType()) return false;
+
+			return Equals((SpanInfo)obj);
+		}
+
+		public override int GetHashCode()
+		{
+			unchecked
+			{
+				return ((Type != null ? Type.GetHashCode() : 0) * 397) ^ (SubType != null ? SubType.GetHashCode() : 0);
+			}
+		}
+
+		public static bool operator ==(SpanInfo left, SpanInfo right) => Equals(left, right);
+
+		public static bool operator !=(SpanInfo left, SpanInfo right) => !Equals(left, right);
 	}
 }

--- a/src/Elastic.Apm/Metrics/MetricSet.cs
+++ b/src/Elastic.Apm/Metrics/MetricSet.cs
@@ -16,6 +16,8 @@ namespace Elastic.Apm.Metrics
 	{
 		public MetricSet(long timestamp, IEnumerable<MetricSample> samples)
 			=> (Timestamp, Samples) = (timestamp, samples);
+		public MetricSet(IEnumerable<MetricSample> samples)
+			=> Samples = samples;
 
 		/// <inheritdoc />
 		public IEnumerable<MetricSample> Samples { get; set; }
@@ -28,7 +30,7 @@ namespace Elastic.Apm.Metrics
 		public SpanInfo Span { get; set; }
 	}
 
-	public class TransactionInfo: IEquatable<TransactionInfo>
+	public class TransactionInfo : IEquatable<TransactionInfo>
 	{
 		[MaxLength]
 		public string Name { get; set; }
@@ -65,7 +67,7 @@ namespace Elastic.Apm.Metrics
 		public static bool operator !=(TransactionInfo left, TransactionInfo right) => !Equals(left, right);
 	}
 
-	public class SpanInfo: IEquatable<SpanInfo>
+	public class SpanInfo : IEquatable<SpanInfo>
 	{
 		[MaxLength]
 		public string Type { get; set; }

--- a/src/Elastic.Apm/Metrics/MetricsProvider/BreakdownMetricsProvider.cs
+++ b/src/Elastic.Apm/Metrics/MetricsProvider/BreakdownMetricsProvider.cs
@@ -64,11 +64,9 @@ namespace Elastic.Apm.Metrics.MetricsProvider
 		{
 			lock (_lock)
 			{
-				var timestampNow = TimeUtils.TimestampNow();
-
 				foreach (var item in transaction.SpanTimings)
 				{
-					var groupKey = new GroupKey(new TransactionInfo { Name = transaction.Name, Type = transaction.Type },
+					var groupKey = new GroupKey(new TransactionInfo() { Name = transaction.Name, Type = transaction.Type },
 						new SpanInfo { Type = item.Key.Type, SubType = item.Key.SubType });
 
 					if (_itemsToSend.ContainsKey(groupKey))
@@ -94,11 +92,10 @@ namespace Elastic.Apm.Metrics.MetricsProvider
 					else if (_itemsToSend.Count < MetricLimit)
 					{
 						var metricSet =
-							new MetricSet(timestampNow,
-								new List<MetricSample>
-								{
-									new(SpanSelfTimeCount, item.Value.Count), new(SpanSelfTimeSumUs, item.Value.TotalDuration * 1000)
-								}) { Span = groupKey.Span, Transaction = groupKey.Transaction };
+							new MetricSet(new List<MetricSample>
+							{
+								new(SpanSelfTimeCount, item.Value.Count), new(SpanSelfTimeSumUs, item.Value.TotalDuration * 1000)
+							}) { Span = groupKey.Span, Transaction = groupKey.Transaction };
 						_itemsToSend.Add(groupKey, metricSet);
 					}
 					else
@@ -128,6 +125,9 @@ namespace Elastic.Apm.Metrics.MetricsProvider
 				_loggedWarning = false;
 			}
 
+			var timestampNow = TimeUtils.TimestampNow();
+			// According to the spec, timestampNow should be the time when we report the metrics.
+			foreach (var item in retVal) item.Timestamp = timestampNow;
 			return retVal;
 		}
 	}

--- a/test/Elastic.Apm.Tests/BreakdownTests.cs
+++ b/test/Elastic.Apm.Tests/BreakdownTests.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Linq;
 using System.Threading;
+using Elastic.Apm.Api;
 using Elastic.Apm.Logging;
 using Elastic.Apm.Metrics;
 using Elastic.Apm.Metrics.MetricsProvider;
@@ -574,6 +575,75 @@ namespace Elastic.Apm.Tests
 		}
 
 		/// <summary>
+		/// Creates 2k transactions with the same name.
+		/// Makes sure only a single MetricSet is created and metrics for transactions with the same name and type are aggregated
+		/// </summary>
+		[Fact]
+		public void SameTransactionTest()
+		{
+			var (agent, breakdownMetricsProvider) = SetUpAgent(metricsInterval: "30s");
+			using (agent)
+			{
+				for (var i = 0; i < 2000; i++)
+					agent.TracerInternal.CaptureTransaction("test", "request", () => { });
+			}
+
+			var samples = breakdownMetricsProvider.GetSamples().ToList();
+			samples.Count.Should().Be(1);
+
+			samples.First().Span.Type.Should().Be("app");
+			samples.First().Samples.First().KeyValue.Value.Should().Be(2000);
+			samples.First().Transaction.Name.Should().Be("test");
+			samples.First().Transaction.Type.Should().Be("request");
+		}
+
+		/// <summary>
+		/// Creates multiple transactions with the same name and type and multiple spans on it with the same type and subtype.
+		/// Makes sure that MetricSets are aggregated correctly.
+		/// </summary>
+		[Fact]
+		public void SameTransactionWithMultipleSameSpans()
+		{
+			var (agent, breakdownMetricsProvider) = SetUpAgent(metricsInterval: "30s");
+			using (agent)
+			{
+				for (var i = 0; i < 500; i++)
+				{
+					agent.TracerInternal.CaptureTransaction("test", "request", (t) =>
+					{
+						for (var j = 0; j < 10; j++) t.CaptureSpan("Span1", ApiConstants.TypeDb, () => { }, ApiConstants.SubtypeMssql);
+						for (var j = 0; j < 10; j++) t.CaptureSpan("Span2", ApiConstants.TypeExternal, () => { }, ApiConstants.SubtypeHttp);
+						for (var j = 0; j < 10; j++) t.CaptureSpan("Span2", ApiConstants.TypeDb, () => { }, ApiConstants.SubtypeMssql);
+					});
+				}
+			}
+
+			var samples = breakdownMetricsProvider.GetSamples().ToList();
+			samples.Count.Should().Be(3);
+
+			samples.Should()
+				.Contain(m => m.Span.Type == "app" &&
+					m.Samples.First().KeyValue.Value == 500 &&
+					m.Transaction.Name == "test" &&
+					m.Transaction.Type == "request");
+
+
+			samples.Should()
+				.Contain(m => m.Span.Type == ApiConstants.TypeDb &&
+					m.Span.SubType == ApiConstants.SubtypeMssql &&
+					m.Samples.First().KeyValue.Value == 10000 &&
+					m.Transaction.Name == "test" &&
+					m.Transaction.Type == "request");
+
+			samples.Should()
+				.Contain(m => m.Span.Type == ApiConstants.TypeExternal &&
+					m.Span.SubType == ApiConstants.SubtypeHttp &&
+					m.Samples.First().KeyValue.Value == 5000 &&
+					m.Transaction.Name == "test" &&
+					m.Transaction.Type == "request");
+		}
+
+		/// <summary>
 		/// Makes sure the 1K limit warning in <see cref="BreakdownMetricsProvider" /> is only printed once per metric collection
 		/// (and e.g. not per transaction).
 		/// See https://github.com/elastic/apm-agent-dotnet/issues/1361.
@@ -590,7 +660,6 @@ namespace Elastic.Apm.Tests
 				for (var transactionNumber = 0; transactionNumber < 50; transactionNumber++)
 				{
 					var t = agent.TracerInternal.StartTransactionInternal("test", "request");
-
 
 					for (var i = 0; i < 5000; i++) t.CaptureSpan("foo", $"bar-{rnd.Next().ToString()}", () => { });
 					t.End();
@@ -615,14 +684,14 @@ namespace Elastic.Apm.Tests
 
 		private static bool DoubleCompare(double value, double expectedValue) => Math.Abs(value - expectedValue) < 1000;
 
-		private (ApmAgent, BreakdownMetricsProvider) SetUpAgent(IApmLogger logger = null)
+		private (ApmAgent, BreakdownMetricsProvider) SetUpAgent(IApmLogger logger = null, string metricsInterval = null)
 		{
 			logger ??= new NoopLogger();
 			var breakdownMetricsProvider = new BreakdownMetricsProvider(logger);
 
 			var agentComponents = new AgentComponents(
 				logger,
-				new MockConfiguration(metricsInterval: "1s"),
+				new MockConfiguration(metricsInterval: metricsInterval ?? "1s"),
 				new NoopPayloadSender(),
 				new FakeMetricsCollector(), //metricsCollector will be set in AgentComponents.ctor
 				new CurrentExecutionSegmentsContainer(),


### PR DESCRIPTION
In `BreakdownMetricsProvider` we collected metrics in a `List<MetricSet>` - each span and transaction added a new item into this list without aggregating those. The result was technically correct, but the list was growing quickly and we also have a 1k limit which was very easy to reach.

This PR fixes it and groups MetricSets according to the spec. The new tests in `test/Elastic.Apm.Tests/BreakdownTests.cs` show test cases which were failing with the original code - in all those scenarios we quickly reached the 1k limit.

Additionally this PR also changes the timestamp of the reported `MetricSet`s - as discussed in the weekly meeting, the timestamp should be the timestamp when we report the metrics (and not when the transaction finishes; as it was before). 

Addresses https://github.com/elastic/apm-agent-dotnet/issues/1678 