### PR TITLE
Fix failing docker tests

### DIFF
--- a/test/Elastic.Apm.Elasticsearch.Tests/Elastic.Apm.Elasticsearch.Tests.csproj
+++ b/test/Elastic.Apm.Elasticsearch.Tests/Elastic.Apm.Elasticsearch.Tests.csproj
@@ -17,7 +17,7 @@
     </PackageReference>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="2.1.0" />
     <PackageReference Include="Elasticsearch.Net.VirtualizedCluster" Version="7.6.1" />
-    <PackageReference Include="DotNet.Testcontainers" Version="1.0.0" />
+    <PackageReference Include="Testcontainers" Version="2.1.0" />
     <!-- Strong name any assemblies that aren't i.e. DotNet.Testcontainers -->
     <PackageReference Include="StrongNamer" Version="0.2.5" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />

--- a/test/Elastic.Apm.Elasticsearch.Tests/ElasticsearchFixture.cs
+++ b/test/Elastic.Apm.Elasticsearch.Tests/ElasticsearchFixture.cs
@@ -33,7 +33,14 @@ namespace Elastic.Apm.Elasticsearch.Tests
 		public async Task DisposeAsync()
 		{
 			await _container.StopAsync();
-			await _container.DisposeAsync();
+			try
+			{
+				await _container.DisposeAsync();
+			}
+			catch
+			{
+				//ignore
+			}
 		}
 
 		ValueTask IAsyncDisposable.DisposeAsync()
@@ -41,7 +48,7 @@ namespace Elastic.Apm.Elasticsearch.Tests
 			if (_container != null)
 				return _container.DisposeAsync();
 
-			return new ValueTask();
+			return default;
 		}
 	}
 }

--- a/test/Elastic.Apm.Elasticsearch.Tests/ElasticsearchFixture.cs
+++ b/test/Elastic.Apm.Elasticsearch.Tests/ElasticsearchFixture.cs
@@ -12,7 +12,6 @@ namespace Elastic.Apm.Elasticsearch.Tests
 {
 	public class ElasticsearchFixture : IAsyncDisposable, IAsyncLifetime
 	{
-
 		private readonly ElasticsearchTestContainer _container;
 
 		public ElasticsearchFixture()
@@ -37,6 +36,13 @@ namespace Elastic.Apm.Elasticsearch.Tests
 			await _container.DisposeAsync();
 		}
 
-		ValueTask IAsyncDisposable.DisposeAsync() => _container.DisposeAsync();
+		private readonly ValueTask _completedValueTask = default;
+		ValueTask IAsyncDisposable.DisposeAsync()
+		{
+			if (_container != null)
+				return _container.DisposeAsync();
+
+			return _completedValueTask;
+		}
 	}
 }

--- a/test/Elastic.Apm.Elasticsearch.Tests/ElasticsearchFixture.cs
+++ b/test/Elastic.Apm.Elasticsearch.Tests/ElasticsearchFixture.cs
@@ -5,13 +5,14 @@
 
 using System;
 using System.Threading.Tasks;
-using DotNet.Testcontainers.Containers.Builders;
+using DotNet.Testcontainers.Builders;
 using Xunit;
 
 namespace Elastic.Apm.Elasticsearch.Tests
 {
-	public class ElasticsearchFixture : IDisposable, IAsyncLifetime
+	public class ElasticsearchFixture : IAsyncDisposable, IAsyncLifetime
 	{
+
 		private readonly ElasticsearchTestContainer _container;
 
 		public ElasticsearchFixture()
@@ -33,9 +34,9 @@ namespace Elastic.Apm.Elasticsearch.Tests
 		public async Task DisposeAsync()
 		{
 			await _container.StopAsync();
-			_container.Dispose();
+			await _container.DisposeAsync();
 		}
 
-		public void Dispose() => _container?.Dispose();
+		ValueTask IAsyncDisposable.DisposeAsync() => _container.DisposeAsync();
 	}
 }

--- a/test/Elastic.Apm.Elasticsearch.Tests/ElasticsearchFixture.cs
+++ b/test/Elastic.Apm.Elasticsearch.Tests/ElasticsearchFixture.cs
@@ -36,13 +36,12 @@ namespace Elastic.Apm.Elasticsearch.Tests
 			await _container.DisposeAsync();
 		}
 
-		private readonly ValueTask _completedValueTask = default;
 		ValueTask IAsyncDisposable.DisposeAsync()
 		{
 			if (_container != null)
 				return _container.DisposeAsync();
 
-			return _completedValueTask;
+			return new ValueTask();
 		}
 	}
 }

--- a/test/Elastic.Apm.Elasticsearch.Tests/ElasticsearchTestContainer.cs
+++ b/test/Elastic.Apm.Elasticsearch.Tests/ElasticsearchTestContainer.cs
@@ -3,14 +3,18 @@
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
 
-using DotNet.Testcontainers.Containers.Configurations;
-using DotNet.Testcontainers.Containers.Modules.Abstractions;
+
+using System.Linq;
+using DotNet.Testcontainers.Configurations;
+using DotNet.Testcontainers.Containers;
+using Microsoft.Extensions.Logging;
 
 namespace Elastic.Apm.Elasticsearch.Tests
 {
-	public class ElasticsearchTestContainer : HostedServiceContainer
+	public sealed class ElasticsearchTestContainer : TestcontainerDatabase
 	{
-		internal ElasticsearchTestContainer(TestcontainersConfiguration configuration) : base(configuration) => Hostname = "localhost";
+		internal ElasticsearchTestContainer(ITestcontainersConfiguration configuration, ILogger logger)
+			: base(configuration, logger) => ContainerPort = int.Parse(configuration.ExposedPorts.First().Value);
 
 		public override string ConnectionString => $"http://{Hostname}:{Port}";
 	}

--- a/test/Elastic.Apm.Elasticsearch.Tests/ElasticsearchTests.cs
+++ b/test/Elastic.Apm.Elasticsearch.Tests/ElasticsearchTests.cs
@@ -10,7 +10,6 @@ using Elastic.Apm.DiagnosticSource;
 using Elastic.Apm.Tests.Utilities;
 using Elastic.Apm.Tests.Utilities.Docker;
 using Elasticsearch.Net;
-using Elasticsearch.Net.VirtualizedCluster;
 using FluentAssertions;
 using Xunit;
 

--- a/test/Elastic.Apm.SqlClient.Tests/Elastic.Apm.SqlClient.Tests.csproj
+++ b/test/Elastic.Apm.SqlClient.Tests/Elastic.Apm.SqlClient.Tests.csproj
@@ -18,7 +18,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
     <PackageReference Include="StrongNamer" Version="0.2.5" />
     <PackageReference Include="System.Data.SqlClient" Version="4.7.0" />
-    <PackageReference Include="DotNet.Testcontainers" Version="1.0.0" />
+    <PackageReference Include="Testcontainers" Version="2.1.0" />
     <!-- Strong name any assemblies that aren't i.e. DotNet.Testcontainers -->
     <PackageReference Include="StrongNamer" Version="0.2.5" />
     <PackageReference Include="xunit" Version="2.4.1" />

--- a/test/Elastic.Apm.SqlClient.Tests/SqlServerFixture.cs
+++ b/test/Elastic.Apm.SqlClient.Tests/SqlServerFixture.cs
@@ -49,7 +49,7 @@ namespace Elastic.Apm.SqlClient.Tests
 #if NET5_0_OR_GREATER
 			return ValueTask.CompletedTask;
 #else
-			return new ValueTask();
+			return default;
 #endif
 		}
 	}

--- a/test/Elastic.Apm.SqlClient.Tests/SqlServerFixture.cs
+++ b/test/Elastic.Apm.SqlClient.Tests/SqlServerFixture.cs
@@ -42,9 +42,6 @@ namespace Elastic.Apm.SqlClient.Tests
 			await _container.DisposeAsync();
 		}
 
-#if !NET5_0_OR_GREATER
-		private readonly ValueTask _completedValueTask = default;
-#endif
 		ValueTask IAsyncDisposable.DisposeAsync()
 		{
 			if (_container != null)
@@ -52,7 +49,7 @@ namespace Elastic.Apm.SqlClient.Tests
 #if NET5_0_OR_GREATER
 			return ValueTask.CompletedTask;
 #else
-			return _completedValueTask;
+			return new ValueTask();
 #endif
 		}
 	}

--- a/test/Elastic.Apm.SqlClient.Tests/SqlServerFixture.cs
+++ b/test/Elastic.Apm.SqlClient.Tests/SqlServerFixture.cs
@@ -3,16 +3,16 @@
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
 
-using System;
 using System.Threading.Tasks;
-using DotNet.Testcontainers.Containers.Builders;
-using DotNet.Testcontainers.Containers.Configurations.Databases;
-using DotNet.Testcontainers.Containers.Modules.Databases;
+using DotNet.Testcontainers.Builders;
+using DotNet.Testcontainers.Configurations;
+using DotNet.Testcontainers.Containers;
 using Xunit;
 
 namespace Elastic.Apm.SqlClient.Tests
 {
-	public class SqlServerFixture : IDisposable, IAsyncLifetime
+	// ReSharper disable once ClassNeverInstantiated.Global - it's used as a generic parameter
+	public class SqlServerFixture : IAsyncLifetime
 	{
 		private readonly MsSqlTestcontainer _container;
 
@@ -35,12 +35,6 @@ namespace Elastic.Apm.SqlClient.Tests
 			ConnectionString = _container.ConnectionString;
 		}
 
-		public async Task DisposeAsync()
-		{
-			await _container.StopAsync();
-			_container.Dispose();
-		}
-
-		public void Dispose() => _container?.Dispose();
+		public async Task DisposeAsync() => await _container.StopAsync();
 	}
 }

--- a/test/Elastic.Apm.SqlClient.Tests/SqlServerFixture.cs
+++ b/test/Elastic.Apm.SqlClient.Tests/SqlServerFixture.cs
@@ -3,6 +3,7 @@
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
 
+using System;
 using System.Threading.Tasks;
 using DotNet.Testcontainers.Builders;
 using DotNet.Testcontainers.Configurations;
@@ -12,7 +13,7 @@ using Xunit;
 namespace Elastic.Apm.SqlClient.Tests
 {
 	// ReSharper disable once ClassNeverInstantiated.Global - it's used as a generic parameter
-	public class SqlServerFixture : IAsyncLifetime
+	public class SqlServerFixture : IAsyncDisposable, IAsyncLifetime
 	{
 		private readonly MsSqlTestcontainer _container;
 
@@ -35,6 +36,12 @@ namespace Elastic.Apm.SqlClient.Tests
 			ConnectionString = _container.ConnectionString;
 		}
 
-		public async Task DisposeAsync() => await _container.StopAsync();
+		public async Task DisposeAsync()
+		{
+			await _container.StopAsync();
+			await _container.DisposeAsync();
+		}
+
+		ValueTask IAsyncDisposable.DisposeAsync() => _container.DisposeAsync();
 	}
 }

--- a/test/Elastic.Apm.SqlClient.Tests/SqlServerFixture.cs
+++ b/test/Elastic.Apm.SqlClient.Tests/SqlServerFixture.cs
@@ -42,6 +42,18 @@ namespace Elastic.Apm.SqlClient.Tests
 			await _container.DisposeAsync();
 		}
 
-		ValueTask IAsyncDisposable.DisposeAsync() => _container.DisposeAsync();
+#if !NET5_0_OR_GREATER
+		private readonly ValueTask _completedValueTask = default;
+#endif
+		ValueTask IAsyncDisposable.DisposeAsync()
+		{
+			if (_container != null)
+				return _container.DisposeAsync();
+#if NET5_0_OR_GREATER
+			return ValueTask.CompletedTask;
+#else
+			return _completedValueTask;
+#endif
+		}
 	}
 }


### PR DESCRIPTION
Fixes https://github.com/elastic/apm-agent-dotnet/issues/1819 

Prior to this PR we used `DotNet.TestContainer` `Version="1.0.0"`. That [package is already deprecated](https://www.nuget.org/packages/DotNet.Testcontainers/1.7.0-beta.2269) in favor of [Testcontainers](https://www.nuget.org/packages/Testcontainers/2.1.0).

This PR updates to the latest stable release of `Testcontainers` and adapts user code to breaking changes.

Reason for updating the package:
- Most importantly, it fixes the failing tests - unlike the current `main`, this PR with `Testcontainers` can set up the docker environments and tests are green.
- I also noticed it gives better error messages (details on  https://github.com/elastic/apm-agent-dotnet/issues/1819)