### PR TITLE
Remove warnings in Elastic.Apm(.Tests)

### DIFF
--- a/src/Elastic.Apm/BackendComm/BackendCommUtils.cs
+++ b/src/Elastic.Apm/BackendComm/BackendCommUtils.cs
@@ -3,8 +3,6 @@
 // See the LICENSE file in the project root for more information
 
 using System;
-using System.IO;
-using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
@@ -20,7 +18,7 @@ using Elastic.Apm.Logging;
 
 namespace Elastic.Apm.BackendComm
 {
-	internal class BackendCommUtils
+	internal static class BackendCommUtils
 	{
 		private const string ThisClassName = nameof(BackendCommUtils);
 
@@ -95,8 +93,10 @@ namespace Elastic.Apm.BackendComm
 		private static void ConfigServicePoint(Uri serverUrlBase, IApmLogger logger) =>
 			ConfigServicePointOnceHelper.IfNotInited?.Init(() =>
 			{
+// ServicePointManager is obsolete
+#pragma warning disable SYSLIB0014
 				var servicePoint = ServicePointManager.FindServicePoint(serverUrlBase);
-
+#pragma warning restore SYSLIB0014
 				try
 				{
 					servicePoint.ConnectionLeaseTimeout = (int)DnsTimeout.TotalMilliseconds;

--- a/src/Elastic.Apm/BackendComm/CentralConfig/CentralConfigurationFetcher.cs
+++ b/src/Elastic.Apm/BackendComm/CentralConfig/CentralConfigurationFetcher.cs
@@ -318,6 +318,7 @@ namespace Elastic.Apm.BackendComm.CentralConfig
 				_centralConfiguration.SpanFramesMinDurationInMilliseconds ?? _wrapped.SpanFramesMinDurationInMilliseconds;
 
 			public int StackTraceLimit => _centralConfiguration.StackTraceLimit ?? _wrapped.StackTraceLimit;
+			[Obsolete("Use TraceContinuationStrategy")]
 			public bool TraceContextIgnoreSampledFalse => _wrapped.TraceContextIgnoreSampledFalse;
 
 			public string TraceContinuationStrategy => _centralConfiguration.TraceContinuationStrategy ?? _wrapped.TraceContinuationStrategy;

--- a/src/Elastic.Apm/BackendComm/CentralConfig/CentralConfigurationReader.cs
+++ b/src/Elastic.Apm/BackendComm/CentralConfig/CentralConfigurationReader.cs
@@ -81,9 +81,13 @@ namespace Elastic.Apm.BackendComm.CentralConfig
 			SpanStackTraceMinDurationInMilliseconds =
 				GetSimpleConfigurationValue(CentralConfigurationResponseParser.CentralConfigPayload.SpanStackTraceMinDurationKey,
 					ParseSpanStackTraceMinDurationInMilliseconds);
+// Disable obsolete-warning
+#pragma warning disable CS0618
 			SpanFramesMinDurationInMilliseconds =
 				GetSimpleConfigurationValue(CentralConfigurationResponseParser.CentralConfigPayload.SpanFramesMinDurationKey,
 					ParseSpanFramesMinDurationInMilliseconds);
+// Disable obsolete-warning
+#pragma warning restore CS0618
 			StackTraceLimit = GetSimpleConfigurationValue(CentralConfigurationResponseParser.CentralConfigPayload.StackTraceLimitKey,
 				ParseStackTraceLimit);
 			Recording = GetSimpleConfigurationValue(CentralConfigurationResponseParser.CentralConfigPayload.Recording, ParseRecording);

--- a/src/Elastic.Apm/BackendComm/CentralConfig/CentralConfigurationResponseParser.cs
+++ b/src/Elastic.Apm/BackendComm/CentralConfig/CentralConfigurationResponseParser.cs
@@ -166,7 +166,10 @@ namespace Elastic.Apm.BackendComm.CentralConfig
 				Recording,
 				SanitizeFieldNames,
 				SpanStackTraceMinDurationKey,
+// Disable obsolete-warning
+#pragma warning disable CS0618
 				SpanFramesMinDurationKey,
+#pragma warning restore CS0618
 				StackTraceLimitKey,
 				TransactionIgnoreUrls,
 				TransactionMaxSpansKey,

--- a/src/Elastic.Apm/Cloud/CloudMetadataProviderCollection.cs
+++ b/src/Elastic.Apm/Cloud/CloudMetadataProviderCollection.cs
@@ -72,8 +72,6 @@ namespace Elastic.Apm.Cloud
 			return null;
 		}
 
-		public bool TryGetValue(string key, out ICloudMetadataProvider provider) => Dictionary.TryGetValue(key, out provider);
-
 		public override string ToString() => string.Join(",", Dictionary.Keys);
 	}
 }

--- a/src/Elastic.Apm/Config/ConfigurationSnapshotFromReader.cs
+++ b/src/Elastic.Apm/Config/ConfigurationSnapshotFromReader.cs
@@ -63,6 +63,7 @@ namespace Elastic.Apm.Config
 		public double SpanFramesMinDurationInMilliseconds => _content.SpanFramesMinDurationInMilliseconds;
 		public int StackTraceLimit => _content.StackTraceLimit;
 
+		[Obsolete("Use TraceContinuationStrategy")]
 		public bool TraceContextIgnoreSampledFalse => _content.TraceContextIgnoreSampledFalse;
 		public string TraceContinuationStrategy => _content.TraceContinuationStrategy;
 		public IReadOnlyList<WildcardMatcher> TransactionIgnoreUrls => _content.TransactionIgnoreUrls;

--- a/src/Elastic.Apm/Libraries/.editorconfig
+++ b/src/Elastic.Apm/Libraries/.editorconfig
@@ -1,0 +1,20 @@
+[*.cs]
+dotnet_diagnostic.CS8767.severity = none
+dotnet_diagnostic.CS8769.severity = none
+dotnet_diagnostic.CS0436.severity = none
+dotnet_diagnostic.CS8765.severity = none
+dotnet_diagnostic.CS8714.severity = none
+dotnet_diagnostic.CS8766.severity = none
+dotnet_diagnostic.CS0108.severity = none
+dotnet_diagnostic.CS8612.severity = none
+dotnet_diagnostic.CS8768.severity = none
+dotnet_diagnostic.CS8603.severity = none
+dotnet_diagnostic.CS8604.severity = none
+dotnet_diagnostic.CS8602.severity = none
+dotnet_diagnostic.CS8600.severity = none
+dotnet_diagnostic.CS8601.severity = none
+dotnet_diagnostic.CS8621.severity = none
+dotnet_diagnostic.CS8625.severity = none
+dotnet_diagnostic.CS8618.severity = none
+dotnet_diagnostic.CS8620.severity = none
+dotnet_diagnostic.CS8762.severity = none

--- a/test/Elastic.Apm.SqlClient.Tests/Elastic.Apm.SqlClient.Tests.csproj
+++ b/test/Elastic.Apm.SqlClient.Tests/Elastic.Apm.SqlClient.Tests.csproj
@@ -16,7 +16,6 @@
     <PackageReference Include="FluentAssertions" Version="5.6.0" />
     <PackageReference Include="Microsoft.Data.SqlClient" Version="1.1.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
-    <PackageReference Include="StrongNamer" Version="0.2.5" />
     <PackageReference Include="System.Data.SqlClient" Version="4.7.0" />
     <PackageReference Include="DotNet.Testcontainers" Version="1.0.0" />
     <!-- Strong name any assemblies that aren't i.e. DotNet.Testcontainers -->

--- a/test/Elastic.Apm.Tests/BackendCommTests/CentralConfig/CentralConfigResponseParserTests.cs
+++ b/test/Elastic.Apm.Tests/BackendCommTests/CentralConfig/CentralConfigResponseParserTests.cs
@@ -15,6 +15,9 @@ using Elastic.Apm.Tests.Utilities;
 using FluentAssertions;
 using Xunit;
 
+// Disable obsolete-warning due to Configuration.SpanFramesMinDurationInMilliseconds access.
+#pragma warning disable CS0618
+
 namespace Elastic.Apm.Tests.BackendCommTests.CentralConfig
 {
 	public class CentralConfigResponseParserTests

--- a/test/Elastic.Apm.Tests/Cloud/CloudMetadataProviderCollectionTests.cs
+++ b/test/Elastic.Apm.Tests/Cloud/CloudMetadataProviderCollectionTests.cs
@@ -20,10 +20,10 @@ namespace Elastic.Apm.Tests.Cloud
 			var providers = new CloudMetadataProviderCollection(DefaultValues.CloudProvider, new NoopLogger());
 
 			providers.Count.Should().Be(4);
-			providers.TryGetValue(AwsCloudMetadataProvider.Name, out _).Should().BeTrue();
-			providers.TryGetValue(GcpCloudMetadataProvider.Name, out _).Should().BeTrue();
-			providers.TryGetValue(AzureCloudMetadataProvider.Name, out _).Should().BeTrue();
-			providers.TryGetValue(AzureAppServiceMetadataProvider.Name, out _).Should().BeTrue();
+			providers.Contains(AwsCloudMetadataProvider.Name).Should().BeTrue();
+			providers.Contains(GcpCloudMetadataProvider.Name).Should().BeTrue();
+			providers.Contains(AzureCloudMetadataProvider.Name).Should().BeTrue();
+			providers.Contains(AzureAppServiceMetadataProvider.Name).Should().BeTrue();
 			providers.Select(p => p.Provider).Should().Equal("aws", "gcp", "azure", "azure-app-service");
 		}
 
@@ -39,7 +39,7 @@ namespace Elastic.Apm.Tests.Cloud
 		{
 			var providers = new CloudMetadataProviderCollection(SupportedValues.CloudProviderAws, new NoopLogger());
 			providers.Count.Should().Be(1);
-			providers.TryGetValue(SupportedValues.CloudProviderAws, out var provider).Should().BeTrue();
+			var provider = providers[SupportedValues.CloudProviderAws];
 			provider.Should().BeOfType<AwsCloudMetadataProvider>();
 		}
 
@@ -48,7 +48,7 @@ namespace Elastic.Apm.Tests.Cloud
 		{
 			var providers = new CloudMetadataProviderCollection(SupportedValues.CloudProviderGcp, new NoopLogger());
 			providers.Count.Should().Be(1);
-			providers.TryGetValue(SupportedValues.CloudProviderGcp, out var provider).Should().BeTrue();
+			var provider = providers[SupportedValues.CloudProviderGcp];
 			provider.Should().BeOfType<GcpCloudMetadataProvider>();
 		}
 
@@ -57,10 +57,10 @@ namespace Elastic.Apm.Tests.Cloud
 		{
 			var providers = new CloudMetadataProviderCollection(SupportedValues.CloudProviderAzure, new NoopLogger());
 			providers.Count.Should().Be(2);
-			providers.TryGetValue(SupportedValues.CloudProviderAzure, out var provider).Should().BeTrue();
+			var provider = providers[SupportedValues.CloudProviderAzure];
 			provider.Should().BeOfType<AzureCloudMetadataProvider>();
 
-			providers.TryGetValue(AzureAppServiceMetadataProvider.Name, out provider).Should().BeTrue();
+			provider = providers[AzureAppServiceMetadataProvider.Name];
 			provider.Should().BeOfType<AzureAppServiceMetadataProvider>();
 		}
 	}

--- a/test/Elastic.Apm.Tests/ConfigTests.cs
+++ b/test/Elastic.Apm.Tests/ConfigTests.cs
@@ -16,7 +16,7 @@ using FluentAssertions;
 using Xunit;
 using static Elastic.Apm.Config.ConfigConsts;
 
-// Disable obsolete-warning due to Configuration.SpanFramesMinDurationInMilliseconds access.
+// Disable warnings due to obsolete settings keys
 #pragma warning disable CS0618
 
 namespace Elastic.Apm.Tests
@@ -51,7 +51,6 @@ namespace Elastic.Apm.Tests
 			{ "key1=value1,=,key3=value3", new Dictionary<string, string> { { "key1", "value1" }, { "", "" }, { "key3", "value3" } } }
 		};
 
-#pragma warning disable 618
 		[Fact]
 		public void ServerUrlsSimpleTest()
 		{
@@ -167,7 +166,6 @@ namespace Elastic.Apm.Tests
 					serverUrl
 				);
 		}
-#pragma warning restore 618
 
 		/// <summary>
 		/// Makes sure that empty string means sanitization is turned off
@@ -254,7 +252,6 @@ namespace Elastic.Apm.Tests
 			agent.ConfigurationReader.Enabled.Should().BeTrue();
 		}
 
-#pragma warning disable 618
 		/// <summary>
 		/// Sets 2 servers and makes sure that they are all parsed
 		/// </summary>
@@ -335,7 +332,6 @@ namespace Elastic.Apm.Tests
 				agent.ConfigurationReader.ServerUrl.Should().Be("http://myServer:1234");
 			}
 		}
-#pragma warning restore 618
 
 		[Fact]
 		public void SecretTokenSimpleTest()
@@ -716,9 +712,7 @@ namespace Elastic.Apm.Tests
 			Environment.SetEnvironmentVariable(EnvVarNames.ServerUrls, "localhost"); //invalid, it should be "http://localhost"
 			var testLogger = new TestLogger();
 			var config = new EnvironmentConfigurationReader(testLogger);
-#pragma warning disable 618
 			var serverUrl = config.ServerUrls.FirstOrDefault();
-#pragma warning restore 618
 			serverUrl.Should().NotBeNull();
 			testLogger.Lines.Should().NotBeEmpty();
 		}

--- a/test/Elastic.Apm.Tests/FilterTests.cs
+++ b/test/Elastic.Apm.Tests/FilterTests.cs
@@ -219,7 +219,7 @@ public class FilterTests
 			// hold the test run until the event is processed within PayloadSender's thread - also makes sure that PayloadSender is not disposed
 			await taskCompletionSource.Task;
 		}
-		catch (Exception e)
+		catch (Exception)
 		{
 			//ignore
 		}


### PR DESCRIPTION
This removes the remaining warnings in `Elastic.Apm` and `Elastic.Apm.Tests`.

* `CloudMetadataProviderCollection` produced a warning due to hiding the method `TryGetValue` from its base class. However, this method was only used in tests and was not really required. Hence, I just removed it and updated the tests accordingly.
* I added a `pragma` to suppress the obsolete warning of `ServicePointManager`.