### PR TITLE
Use json-specs/w3c_distributed_tracing.json test input

### DIFF
--- a/src/Elastic.Apm/DistributedTracing/TraceContext.cs
+++ b/src/Elastic.Apm/DistributedTracing/TraceContext.cs
@@ -4,8 +4,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using Elastic.Apm.Api;
 
 namespace Elastic.Apm.DistributedTracing
@@ -44,6 +42,8 @@ namespace Elastic.Apm.DistributedTracing
 			var bestAttempt = false;
 
 			if (string.IsNullOrWhiteSpace(traceParentValue)) return null;
+
+			traceParentValue = traceParentValue.Trim();
 
 			if (traceParentValue.Length < VersionPrefixIdLength || traceParentValue[VersionPrefixIdLength - 1] != '-') return null;
 

--- a/src/Elastic.Apm/DistributedTracing/TraceState.cs
+++ b/src/Elastic.Apm/DistributedTracing/TraceState.cs
@@ -222,6 +222,9 @@ namespace Elastic.Apm.DistributedTracing
 			{
 				// TODO: Span-ify
 				var item = listMember.Split('=');
+				if (item.Length > 2)
+					return null;
+
 				if (item.Length != 2)
 					continue;
 

--- a/test/Elastic.Apm.Tests.Utilities/JsonFileDataAttribute.cs
+++ b/test/Elastic.Apm.Tests.Utilities/JsonFileDataAttribute.cs
@@ -16,10 +16,10 @@ public class JsonFileDataAttribute : DataAttribute
 	private readonly string _fileName;
 	private readonly Type _inputDataType;
 
-	public JsonFileDataAttribute(string fileName, Type inputDataType)
+	public JsonFileDataAttribute(string fileName, Type inputDataType = null)
 	{
 		_fileName = fileName;
-		_inputDataType = inputDataType;
+		_inputDataType = inputDataType ?? typeof(JToken);
 	}
 
 	public override IEnumerable<object[]> GetData(MethodInfo testMethod)
@@ -27,7 +27,10 @@ public class JsonFileDataAttribute : DataAttribute
 		if (!File.Exists(_fileName))
 			throw new ArgumentException($"JSON input file {_fileName} does not exist");
 
-		var jToken = JToken.Parse(File.ReadAllText(_fileName));
+		var jToken = JToken.Parse(File.ReadAllText(_fileName), new JsonLoadSettings
+		{
+			CommentHandling = CommentHandling.Ignore
+		});
 		switch (jToken.Type)
 		{
 			case JTokenType.Array:
@@ -39,7 +42,7 @@ public class JsonFileDataAttribute : DataAttribute
 					yield return new [] { kvp.Key, kvp.Value.ToObject(_inputDataType) };
 				break;
 			default:
-				throw new Exception($"Unexpected JSON input: '{jToken}");
+				throw new Exception($"Unexpected JSON input: '{jToken}'");
 		}
 	}
 }

--- a/test/Elastic.Apm.Tests/DistributedTracing/DistributedTracingTests.cs
+++ b/test/Elastic.Apm.Tests/DistributedTracing/DistributedTracingTests.cs
@@ -31,7 +31,7 @@ namespace Elastic.Apm.Tests.DistributedTracing
 				.Select(h => h[1]);
 			var traceStates = data.Headers
 				.Where(h => h[0].Equals("tracestate", StringComparison.InvariantCultureIgnoreCase))
-				.Select(h => h?[1]);
+				.Select(h => h[1]);
 			// Multiple occurrences of the trace headers are automatically invalid.
 			if (traceParents.Count() < 2 && traceStates.Count() < 2)
 			{

--- a/test/Elastic.Apm.Tests/DistributedTracing/DistributedTracingTests.cs
+++ b/test/Elastic.Apm.Tests/DistributedTracing/DistributedTracingTests.cs
@@ -2,7 +2,12 @@
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
 
+using System;
+using System.Collections.Generic;
+using System.Linq;
 using Elastic.Apm.DistributedTracing;
+using Elastic.Apm.Libraries.Newtonsoft.Json;
+using Elastic.Apm.Tests.Utilities;
 using FluentAssertions;
 using Xunit;
 
@@ -10,6 +15,43 @@ namespace Elastic.Apm.Tests.DistributedTracing
 {
 	public class DistributedTracingTests
 	{
+		public class TraceStateTestData
+		{
+			public List<string[]> Headers { get; set; }
+			[JsonProperty("is_traceparent_valid")] public bool IsTraceParentValid { get; set; }
+			[JsonProperty("is_tracestate_valid")] public bool? IsTraceStateValid { get; set; }
+		}
+
+		[Theory]
+		[JsonFileData("./TestResources/json-specs/w3c_distributed_tracing.json", typeof(TraceStateTestData))]
+		public void TestCasesFromJsonSpec(TraceStateTestData data)
+		{
+			var traceParents = data.Headers
+				.Where(h => h[0].Equals("traceparent", StringComparison.InvariantCultureIgnoreCase))
+				.Select(h => h?[1]);
+			var traceStates = data.Headers
+				.Where(h => h[0].Equals("tracestate", StringComparison.InvariantCultureIgnoreCase))
+				.Select(h => h?[1]);
+			// Multiple occurrences of the trace headers are automatically invalid.
+			if (traceParents.Count() < 2 && traceStates.Count() < 2)
+			{
+				var traceParent = traceParents.FirstOrDefault();
+				var traceState = traceStates.FirstOrDefault();
+
+				var res = TraceContext.TryExtractTracingData(traceParent, traceState);
+				if (data.IsTraceParentValid)
+					res.Should().NotBeNull();
+				else
+					res.Should().BeNull(traceParent);
+
+				if (data.IsTraceStateValid.HasValue)
+				{
+					res.Should().NotBeNull();
+					res.HasTraceState.Should().Be(data.IsTraceStateValid.Value);
+				}
+			}
+		}
+
 		[Fact]
 		public void Valid_TraceParent_Recorded_Should_Be_Parsed()
 		{

--- a/test/Elastic.Apm.Tests/DistributedTracing/DistributedTracingTests.cs
+++ b/test/Elastic.Apm.Tests/DistributedTracing/DistributedTracingTests.cs
@@ -28,7 +28,7 @@ namespace Elastic.Apm.Tests.DistributedTracing
 		{
 			var traceParents = data.Headers
 				.Where(h => h[0].Equals("traceparent", StringComparison.InvariantCultureIgnoreCase))
-				.Select(h => h?[1]);
+				.Select(h => h[1]);
 			var traceStates = data.Headers
 				.Where(h => h[0].Equals("tracestate", StringComparison.InvariantCultureIgnoreCase))
 				.Select(h => h?[1]);


### PR DESCRIPTION
* Extend `DistributedTracingTests` to leverage the test cases from `json-specs`.
* Small fixes to `TraceContext` and `TraceState.cs` that were uncovered by those test cases.
* Make the `inputDataType` parameter optional in `JsonFileDataAttribute` and fall back to generic `JToken`.
  * Note that this is not necessarily required by the test in this PR (`DistributedTracingTests.cs`) but it will be handy in future tests.