### PR TITLE
Make build warning-free (treat as errors from now on)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,7 +2,8 @@
   <!-- Root Directory Build Properties -->
   <PropertyGroup>
     <LangVersion>latest</LangVersion>
-    <NoWarn>NU1503</NoWarn>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <NoWarn>NU1503,NU1608,CS8002,</NoWarn>
     <!-- suppress NETSDK1138 warnings for EOL frameworks -->
     <CheckEolTargetFramework>false</CheckEolTargetFramework>
     <SolutionRoot>$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), build.bat))</SolutionRoot>

--- a/build/scripts/scripts.fsproj
+++ b/build/scripts/scripts.fsproj
@@ -16,7 +16,6 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Buildalyzer" Version="3.2.0" />
-    <PackageReference Include="FSharp.Core" Version="4.7.2" />
     <PackageReference Include="Bullseye" Version="3.5.0" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta1.20427.1" />
     


### PR DESCRIPTION
This PR fixes https://github.com/elastic/apm-agent-dotnet/issues/1823.

`TreatWarningsAsErrors` is enabled from now on.

Ignore warnings related to:
* Assemblies w/o a strong name (`warning CS8002`): This is a compile-time "issue" only. At runtime, the strong-named assembly will be present anyway.
* "Versions outside of dependency constraint" (`warning NU1608`): Not an actual issue. At compile-time, we need to target certain minimal versions of supported assemblies.