### PR TITLE
Publish artifacts in CI on non-PRs

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -102,13 +102,11 @@ pipeline {
                       dir("${BASE_DIR}"){
                         dotnet(){
                           sh '.ci/linux/build.sh'
-                          whenTrue() {
-                            // build nuget packages and profiler
-                            sh(label: 'Package', script: '.ci/linux/release.sh true')
-                            sh label: 'Rustup', script: 'rustup default 1.59.0'
-                            sh label: 'Cargo make', script: 'cargo install --force cargo-make'
-                            sh(label: 'Build profiler', script: './build.sh profiler-zip')
-                          }
+                          // build nuget packages and profiler
+                          sh(label: 'Package', script: '.ci/linux/release.sh true')
+                          sh label: 'Rustup', script: 'rustup default 1.59.0'
+                          sh label: 'Cargo make', script: 'cargo install --force cargo-make'
+                          sh(label: 'Build profiler', script: './build.sh profiler-zip')
                         }
                       }
                     }
@@ -119,9 +117,7 @@ pipeline {
                         artifacts: "${MSBUILDDEBUGPATH}/**/MSBuild_*.failure.txt")
                     }
                     success {
-                      whenTrue() {
-                        archiveArtifacts(allowEmptyArchive: true, artifacts: "${BASE_DIR}/build/output/_packages/*.nupkg,${BASE_DIR}/build/output/*.zip")
-                      }
+                      archiveArtifacts(allowEmptyArchive: true, artifacts: "${BASE_DIR}/build/output/_packages/*.nupkg,${BASE_DIR}/build/output/*.zip")
                     }
                   }
                 }
@@ -332,19 +328,15 @@ pipeline {
                         unstash 'source'
                         dir("${BASE_DIR}"){
                           bat label: 'Build', script: '.ci/windows/dotnet.bat'
-                          whenTrue() {
-                            bat(label: 'Build agent', script: './build.bat agent-zip')
-                            bat(label: 'Build profiler', script: './build.bat profiler-zip')
-                          }
+                          bat(label: 'Build agent', script: './build.bat agent-zip')
+                          bat(label: 'Build profiler', script: './build.bat profiler-zip')
                         }
                       }
                     }
                   }
                   post {
                     success {
-                      whenTrue() {
-                        archiveArtifacts(allowEmptyArchive: true, artifacts: "${BASE_DIR}/build/output/*.zip")
-                      }
+                      archiveArtifacts(allowEmptyArchive: true, artifacts: "${BASE_DIR}/build/output/*.zip")
                     }
                     unsuccessful {
                       archiveArtifacts(allowEmptyArchive: true,

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -102,7 +102,7 @@ pipeline {
                       dir("${BASE_DIR}"){
                         dotnet(){
                           sh '.ci/linux/build.sh'
-                          whenTrue(isPR()) {
+                          whenTrue() {
                             // build nuget packages and profiler
                             sh(label: 'Package', script: '.ci/linux/release.sh true')
                             sh label: 'Rustup', script: 'rustup default 1.59.0'
@@ -119,7 +119,7 @@ pipeline {
                         artifacts: "${MSBUILDDEBUGPATH}/**/MSBuild_*.failure.txt")
                     }
                     success {
-                      whenTrue(isPR()) {
+                      whenTrue() {
                         archiveArtifacts(allowEmptyArchive: true, artifacts: "${BASE_DIR}/build/output/_packages/*.nupkg,${BASE_DIR}/build/output/*.zip")
                       }
                     }
@@ -332,7 +332,7 @@ pipeline {
                         unstash 'source'
                         dir("${BASE_DIR}"){
                           bat label: 'Build', script: '.ci/windows/dotnet.bat'
-                          whenTrue(isPR()) {
+                          whenTrue() {
                             bat(label: 'Build agent', script: './build.bat agent-zip')
                             bat(label: 'Build profiler', script: './build.bat profiler-zip')
                           }
@@ -342,7 +342,7 @@ pipeline {
                   }
                   post {
                     success {
-                      whenTrue(isPR()) {
+                      whenTrue() {
                         archiveArtifacts(allowEmptyArchive: true, artifacts: "${BASE_DIR}/build/output/*.zip")
                       }
                     }


### PR DESCRIPTION
We have these `isPR()` checks in our `Jenkinsfile`. 

The problem with this is that we don't publish fairly important artifacts on:
- tags for releases
- when we merge PRs to `main`
- _(there are probably other non-PRs where this happens, but the two above is my focus here)_

This PR removes these checks and the goal is that we always publish those artifacts.

Why we need this?

I'm looking at https://github.com/elastic/apm-agent-dotnet/issues/1665 - we plan to offer a docker image with the agent in it. We run `./build.bat profiler-zip` in `Jenkinsfile` (you can see below), but we only published the artifacts (in this case the zip file containing the profiler we build) on PRs, we don't publish them when merging to `main` and when we release. These profiler zip files could be used in https://github.com/elastic/apm-agent-dotnet/issues/1665, but for that, we need to always publish them.

Additionally, during release, these artifacts were always missing from the build that pushed the agent to nuget.org (that build in never from a PR, it's a build for a tag). So we needed to find (or build locally) the profiler and the startup hook zip files. which are part of the release. Once we remove these checks, we'll have those files simply under artifacts.