### PR TITLE
Use json-specs/sql_signature_examples.json as test input

### DIFF
--- a/src/Elastic.Apm/Model/SignatureParser.cs
+++ b/src/Elastic.Apm/Model/SignatureParser.cs
@@ -90,7 +90,7 @@ namespace Elastic.Apm.Model
 					return;
 				case Scanner.Token.Insert:
 				case Scanner.Token.Replace:
-					signature.Append(firstToken.ToString());
+					signature.Append(firstToken.ToString().ToUpperInvariant());
 					if (scanner.ScanUntil(Scanner.Token.Into) && scanner.ScanUntil(Scanner.Token.Ident))
 					{
 						signature.Append(" INTO");

--- a/test/Elastic.Apm.Tests/DbSpanNameTests.cs
+++ b/test/Elastic.Apm.Tests/DbSpanNameTests.cs
@@ -11,6 +11,7 @@ using System.Text;
 using Elastic.Apm.Libraries.Newtonsoft.Json;
 using Elastic.Apm.Libraries.Newtonsoft.Json.Linq;
 using Elastic.Apm.Model;
+using Elastic.Apm.Tests.Utilities;
 using FluentAssertions;
 using Xunit;
 
@@ -18,9 +19,26 @@ namespace Elastic.Apm.Tests;
 
 public class DbSpanNameTests
 {
+	public struct SqlSignatureTestData
+	{
+		public string Input;
+		public string Output;
+	}
+
+	[Theory]
+	[JsonFileData("./TestResources/json-specs/sql_signature_examples.json", typeof(SqlSignatureTestData))]
+	public void TestDbSignatures(SqlSignatureTestData data)
+	{
+		var signatureParser = new SignatureParser(new Scanner());
+		var name = new StringBuilder();
+		signatureParser.QuerySignature(data.Input, name, false);
+
+		name.ToString().Should().Be(data.Output);
+	}
+
 	[MemberData(nameof(SqlSignatureExamplesTestData))]
 	[Theory]
-	public void TestDbSignatures(string input, string output)
+	public void TestDbSignatures_Legacy(string input, string output)
 	{
 		var signatureParser = new SignatureParser(new Scanner());
 		var name = new StringBuilder();


### PR DESCRIPTION
Renamed the existing test method to `TestDbSignatures_Legacy`. This method will be removed as soon as the consolidation of the test case input data in https://github.com/elastic/apm/pull/699 has happened.

Fix small cosmetic inconsistency in `SignatureParser` where `INSERT `and `REPLACE` keywords were not uppercased while the rest was. This also gets rid of case-invariant assertions.