### PR TITLE
Use ConcurrentQueue in InMemoryBlockingLogger

### DIFF
--- a/test/Elastic.Apm.Tests.Utilities/InMemoryBlockingLogger.cs
+++ b/test/Elastic.Apm.Tests.Utilities/InMemoryBlockingLogger.cs
@@ -1,9 +1,9 @@
 ﻿using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
-using System.Threading.Tasks;
 using Elastic.Apm.Logging;
-using Timer = System.Timers.Timer;
 
 namespace Elastic.Apm.Tests.Utilities
 {
@@ -12,7 +12,7 @@ namespace Elastic.Apm.Tests.Utilities
 	/// </summary>
 	public class InMemoryBlockingLogger : IApmLogger
 	{
-		private readonly List<string> _lines = new List<string>();
+		private readonly ConcurrentQueue<string> _lines = new ConcurrentQueue<string>();
 		private readonly LogLevel _logLevel;
 		private readonly ManualResetEvent _waitHandle;
 
@@ -31,7 +31,7 @@ namespace Elastic.Apm.Tests.Utilities
 			get
 			{
 				_waitHandle.WaitOne(TimeSpan.FromMinutes(1));
-				return _lines;
+				return _lines.ToList();
 			}
 		}
 
@@ -42,7 +42,7 @@ namespace Elastic.Apm.Tests.Utilities
 		{
 			if (!IsEnabled(level)) return;
 
-			_lines.Add(formatter(state, e));
+			_lines.Enqueue(formatter(state, e));
 			_waitHandle.Set();
 		}
 	}


### PR DESCRIPTION
After looking at #1832 I saw a failing test which is unrelated to #1832 itself.

[`Elastic.Apm.Tests.LoggerTests.CentralConfigNoUserNamePwPrinted` failed with:](https://apm-ci.elastic.co/job/apm-agent-dotnet/job/apm-agent-dotnet-mbp/job/PR-1832/11/testReport/Elastic.Apm.Tests/LoggerTests/Initializing___Parallel___Linux___Test___LoggerTests_Elastic_Apm_Tests_LoggerTests_CentralConfigNoUserNamePwPrinted/) 

```
System.InvalidOperationException : Collection was modified; enumeration operation may not execute.
Stack Trace:
   at System.Collections.Generic.List`1.Enumerator.MoveNextRare()
   at System.Linq.Enumerable.WhereListIterator`1.MoveNext()
   at System.Linq.Enumerable.Any[TSource](IEnumerable`1 source)
   at FluentAssertions.Collections.SelfReferencingCollectionAssertions`2.NotContain(Expression`1 predicate, String because, Object[] becauseArgs)
   at Elastic.Apm.Tests.LoggerTests.CentralConfigNoUserNamePwPrinted() in /var/lib/jenkins/workspace/net_apm-agent-dotnet-mbp_PR-1832/apm-agent-dotnet/test/Elastic.Apm.Tests/LoggerTests.cs:line 418
```

This PR makes `InMemoryBlockingLogger` more thread safe and addresses the scenarios showed by the failing test.