### PR TITLE
Fix locale-dependent test issue

### DIFF
--- a/test/Elastic.Apm.Tests/BackendCommTests/CentralConfig/CentralConfigResponseParserTests.cs
+++ b/test/Elastic.Apm.Tests/BackendCommTests/CentralConfig/CentralConfigResponseParserTests.cs
@@ -163,7 +163,7 @@ namespace Elastic.Apm.Tests.BackendCommTests.CentralConfig
 
 				yield return new object[]
 				{
-					$"{{\"{CentralConfigurationResponseParser.CentralConfigPayload.TransactionSampleRateKey}\": \"{0.75}\"}}",
+					$"{{\"{CentralConfigurationResponseParser.CentralConfigPayload.TransactionSampleRateKey}\": \"0.75\"}}",
 					new Action<CentralConfigurationReader>(cfg =>
 					{
 						cfg.TransactionSampleRate.Should()


### PR DESCRIPTION
This test has a subtle locale-dependent problem when a floating point number's `ToString()` gets invoked and the decimal point becomes a comma.