### PR TITLE
Include test in .NET versions >= 5

### DIFF
--- a/test/Elastic.Apm.Tests/Elastic.Apm.Tests.csproj
+++ b/test/Elastic.Apm.Tests/Elastic.Apm.Tests.csproj
@@ -47,10 +47,7 @@
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net5.0' OR '$(TargetFramework)' == 'net6.0' ">
     <ProjectReference Include="..\..\sample\OpenTelemetrySample\OpenTelemetrySample.csproj" />
-  </ItemGroup>
-  
-  <ItemGroup Condition="'$(TargetFramework)' == 'net5.0'">
-    <ProjectReference Include="..\Elastic.Apm.Tests.MockApmServer\Elastic.Apm.Tests.MockApmServer.csproj" />
+    <ProjectReference Include="..\Elastic.Apm.Tests.MockApmServer\Elastic.Apm.Tests.MockApmServer.csproj"/>
   </ItemGroup>
   
   <ItemGroup>

--- a/test/Elastic.Apm.Tests/ServerCertificateTests.cs
+++ b/test/Elastic.Apm.Tests/ServerCertificateTests.cs
@@ -4,7 +4,8 @@
 // See the LICENSE file in the project root for more information
 
 // depends on Mock APM server project TargetFramework
-#if NET5_0
+
+#if NET5_0_OR_GREATER
 
 using System;
 using System.IO;
@@ -13,10 +14,10 @@ using System.Security.Cryptography.X509Certificates;
 using System.Threading;
 using System.Threading.Tasks;
 using Elastic.Apm.Logging;
-using Elastic.Apm.Tests.Utilities;
-using Xunit;
 using Elastic.Apm.Tests.MockApmServer;
+using Elastic.Apm.Tests.Utilities;
 using FluentAssertions;
+using Xunit;
 
 namespace Elastic.Apm.Tests
 {


### PR DESCRIPTION
I stumbled over this test today.
I assume it's meant to run on .NET versions >= 5 not just on 5.