### PR TITLE
Prepare Release 1.18.0

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -23,6 +23,22 @@ endif::[]
 [[release-notes-1.x]]
 === .NET Agent version 1.x
 
+[[release-notes-1.18.0]]
+==== 1.18.0
+
+===== Features
+- Profiler based agent is now GA
+- {pull}1806[#1806] Capture request body in ASP.NET Full Framework (issue: {issue}379[#379]).
+- {pull}1832[#1832] `UseWindowsCredentials`: new configuration to force the agent to use the credentials of the authenticated Windows user when events are sent to the APM Server (issue: {issue}1825[#1825]).
+
+===== Bug fixes
+- {pull}1800[#1800] Fix incorrect transaction name in ASP.NET Web Api (issue: {issue}1645[#1637]).
+- {pull}1803[#1803] and {pull}1804[#1804] Fix potential NullReferenceException in TraceContinuationStrategy implementation (issue: {issue}1802[#1802]).
+- {pull}1780[#1780] Fix container ID parsing in AWS ECS/Fargate environments (issue: {issue}1779[#1779]). 
+- {pull}1814[#1814] Use correct default value for ExitSpanMinDuration (issue: {issue}1789[#1789]).
+- {pull}1811[#1811] Fixed crashes on some SOAP 1.2 requests when using GetBufferedInputStream (issue: {issue}1759[#1759]). 
+- {pull}1816[#1816] Group MetricSets in BreakdownMetricsProvider (issue: {issue}1678[#1678]).
+
 [[release-notes-1.17.0]]
 ==== 1.17.0
 

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -2,10 +2,10 @@
   <!-- Src Directory Build Properties -->
   <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
   <PropertyGroup>
-    <AssemblyVersion>1.17.0</AssemblyVersion>
-    <InformationalVersion>1.17.0</InformationalVersion>
-    <FileVersion>1.17.0</FileVersion>
-    <VersionPrefix>1.17.0</VersionPrefix>
+    <AssemblyVersion>1.18.0</AssemblyVersion>
+    <InformationalVersion>1.18.0</InformationalVersion>
+    <FileVersion>1.18.0</FileVersion>
+    <VersionPrefix>1.18.0</VersionPrefix>
     <Authors>Elastic and contributors</Authors>
     <Copyright>2022 Elasticsearch BV</Copyright>
     <PackageProjectUrl>https://github.com/elastic/apm-agent-dotnet</PackageProjectUrl>

--- a/src/elastic_apm_profiler/Cargo.toml
+++ b/src/elastic_apm_profiler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "elastic_apm_profiler"
-version = "1.17.0"
+version = "1.18.0"
 edition = "2018"
 authors = ["Elastic and Contributors"]
 description = "Elastic APM .NET agent CLR profiler"


### PR DESCRIPTION
The usual PR for the release.

- Bump up managed agent version
- Bump up profiler version
- Add release notes for `1.18.0`