### PR TITLE
Remove `Opbeans` stage from pipeline

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -548,36 +548,6 @@ pipeline {
         }
       }
     }
-    stage('AfterRelease') {
-      options {
-        skipDefaultCheckout()
-      }
-      when {
-        anyOf {
-          tag pattern: 'v\\d+\\.\\d+\\.\\d+', comparator: 'REGEXP'
-        }
-      }
-      stages {
-        stage('Opbeans') {
-          environment {
-            REPO_NAME = "${OPBEANS_REPO}"
-          }
-          steps {
-            deleteDir()
-            dir("${OPBEANS_REPO}"){
-              git(credentialsId: 'f6c7695a-671e-4f4f-a331-acdce44ff9ba',
-                  url: "git@github.com:elastic/${OPBEANS_REPO}.git",
-                  branch: 'main')
-              sh script: ".ci/bump-version.sh ${env.BRANCH_NAME.replaceAll('^v', '')}", label: 'Bump version'
-              // The opbeans pipeline will trigger a release for the main branch
-              gitPush()
-              // The opbeans pipeline will trigger a release for the release tag with the format v<major>.<minor>.<patch>
-              gitCreateTag(tag: "${env.BRANCH_NAME}")
-            }
-          }
-        }
-      }
-    }
   }
   post {
     cleanup {


### PR DESCRIPTION
This is a stage which consistently fails when we release. An example can be seen [here](https://apm-ci.elastic.co/blue/organizations/jenkins/apm-agent-dotnet%2Fapm-agent-dotnet-mbp/detail/v1.18.0/1/pipeline/):

```
[2022-10-13T20:28:11.078Z] error: Unable to find package Elastic.Apm.NetCoreAll with version (>= 1.18.0)
[2022-10-13T20:28:11.078Z] error:   - Found 30 version(s) in nuget.org [ Nearest version: 1.17.0 ]
```
We pushed out `1.18.0`, but it's not yet available.

Same story on all releases.

### What's this stage
We run this when we release (only on releases based on tag name). The intention with it is to update [opbeans-dotnet](https://github.com/elastic/opbeans-dotnet) to the agent version we release in the same pipeline. So e.g. we release `v1.18.0` which we publish to nuget.org, and then we want opbeans-dotnet to use this version.

### Why I suggest to remove
Unfortunately this consistently fails, because we try to update the agent packages in opbeans-dotnet to a version which we just pushed a few seconds earlier in an earlier step. This never works, because NuGet needs some time to index the new versions. Therefore we need another way to automatically bump up the agent version in opbeans-dotnet.

Since this makes release pipeline red, I think the best is to just remove it (failing releases due to this is in my opinion really not ok), and then at the same time I opened an issue so we can think about a better way to automate this later: https://github.com/elastic/apm-agent-dotnet/issues/1876

