### PR TITLE
Enable CloudMetadataProvider on Azure Functions

### DIFF
--- a/src/Elastic.Apm/Cloud/AzureAppServiceMetadataProvider.cs
+++ b/src/Elastic.Apm/Cloud/AzureAppServiceMetadataProvider.cs
@@ -13,11 +13,12 @@ namespace Elastic.Apm.Cloud
 	/// <summary>
 	/// Provides cloud metadata for Microsoft Azure App Services
 	/// </summary>
-	internal class AzureAppServiceMetadataProvider : EnvironmentBasedAzureMetadataProvider
+	public class AzureAppServiceMetadataProvider : EnvironmentBasedAzureMetadataProvider
 	{
 		internal const string Name = "azure-app-service";
 
-		public AzureAppServiceMetadataProvider(IApmLogger logger, IDictionary environmentVariables) : base(Name, logger,
+		internal AzureAppServiceMetadataProvider(IApmLogger logger, IDictionary environmentVariables) : base(Name,
+			logger,
 			environmentVariables)
 		{
 		}
@@ -41,11 +42,11 @@ namespace Elastic.Apm.Cloud
 
 			return Task.FromResult(new Api.Cloud
 			{
-				Account = new CloudAccount { Id = tokens.Value.subscriptionId },
+				Account = new CloudAccount { Id = tokens.Value.SubscriptionId },
 				Instance = new CloudInstance { Id = websiteInstanceId, Name = websiteSiteName },
 				Project = new CloudProject { Name = websiteResourceGroup },
 				Provider = "azure",
-				Region = tokens.Value.region
+				Region = tokens.Value.Region
 			});
 		}
 	}

--- a/src/Elastic.Apm/Cloud/AzureAppServiceMetadataProvider.cs
+++ b/src/Elastic.Apm/Cloud/AzureAppServiceMetadataProvider.cs
@@ -3,7 +3,6 @@
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
 
-using System;
 using System.Collections;
 using System.Threading.Tasks;
 using Elastic.Apm.Api;
@@ -14,62 +13,21 @@ namespace Elastic.Apm.Cloud
 	/// <summary>
 	/// Provides cloud metadata for Microsoft Azure App Services
 	/// </summary>
-	public class AzureAppServiceMetadataProvider : ICloudMetadataProvider
+	internal class AzureAppServiceMetadataProvider : EnvironmentBasedAzureMetadataProvider
 	{
 		internal const string Name = "azure-app-service";
 
-		private readonly IApmLogger _logger;
-		private readonly IDictionary _environmentVariables;
-
-		/// <summary>
-		/// Value of the form {subscription id}+{app service plan resource group}-{region}webspace
-		/// </summary>
-		/// <example>
-		/// f5940f10-2e30-3e4d-a259-63451ba6dae4+elastic-apm-AustraliaEastwebspace
-		/// </example>
-		internal static readonly string WebsiteOwnerName = "WEBSITE_OWNER_NAME";
-
-		internal static readonly string WebsiteResourceGroup = "WEBSITE_RESOURCE_GROUP";
-
-		internal static readonly string WebsiteSiteName = "WEBSITE_SITE_NAME";
-
-		internal static readonly string WebsiteInstanceId = "WEBSITE_INSTANCE_ID";
-
-		private static readonly string Webspace = "webspace";
-
-		public AzureAppServiceMetadataProvider(IApmLogger logger, IDictionary environmentVariables)
+		public AzureAppServiceMetadataProvider(IApmLogger logger, IDictionary environmentVariables) : base(Name, logger,
+			environmentVariables)
 		{
-			_logger = logger;
-			_environmentVariables = environmentVariables;
 		}
 
-		public string Provider { get; } = Name;
-
-		public Task<Api.Cloud> GetMetadataAsync()
+		public override Task<Api.Cloud> GetMetadataAsync()
 		{
-			if (_environmentVariables is null)
-			{
-				_logger.Trace()?.Log("Unable to get {Provider} cloud metadata as no environment variables available", Provider);
-				return Task.FromResult<Api.Cloud>(null);
-			}
-
 			var websiteOwnerName = GetEnvironmentVariable(WebsiteOwnerName);
 			var websiteResourceGroup = GetEnvironmentVariable(WebsiteResourceGroup);
 			var websiteSiteName = GetEnvironmentVariable(WebsiteSiteName);
 			var websiteInstanceId = GetEnvironmentVariable(WebsiteInstanceId);
-
-			bool NullOrEmptyVariable(string key, string value)
-			{
-				if (!string.IsNullOrEmpty(value)) return false;
-
-				_logger.Trace()?.Log(
-					"Unable to get {Provider} cloud metadata as no {EnvironmentVariable} environment variable exists. The application is likely not running in {Provider}",
-					Provider,
-					key,
-					Provider);
-
-				return true;
-			}
 
 			if (NullOrEmptyVariable(WebsiteOwnerName, websiteOwnerName) ||
 				NullOrEmptyVariable(WebsiteResourceGroup, websiteResourceGroup) ||
@@ -77,47 +35,18 @@ namespace Elastic.Apm.Cloud
 				NullOrEmptyVariable(WebsiteInstanceId, websiteInstanceId))
 				return Task.FromResult<Api.Cloud>(null);
 
-			var websiteOwnerNameParts = websiteOwnerName.Split('+');
-			if (websiteOwnerNameParts.Length != 2)
-			{
-				_logger.Trace()?.Log(
-					"Unable to get {Provider} cloud metadata as {EnvironmentVariable} does not contain expected format",
-					Provider,
-					WebsiteOwnerName);
+			var tokens = TokenizeWebSiteOwnerName(websiteOwnerName);
+			if (!tokens.HasValue)
 				return Task.FromResult<Api.Cloud>(null);
-			}
-
-			var subscriptionId = websiteOwnerNameParts[0];
-
-			var webspaceIndex = websiteOwnerNameParts[1].LastIndexOf(Webspace, StringComparison.Ordinal);
-			if (webspaceIndex != -1)
-				websiteOwnerNameParts[1] = websiteOwnerNameParts[1].Substring(0, webspaceIndex);
-
-			var lastHyphenIndex = websiteOwnerNameParts[1].LastIndexOf('-');
-			if (lastHyphenIndex == -1)
-			{
-				_logger.Trace()?.Log(
-					"Unable to get {Provider} cloud metadata as {EnvironmentVariable} does not contain expected format",
-					Provider,
-					WebsiteOwnerName);
-				return Task.FromResult<Api.Cloud>(null);
-			}
-
-			var region = websiteOwnerNameParts[1].Substring(lastHyphenIndex + 1);
 
 			return Task.FromResult(new Api.Cloud
 			{
-				Account = new CloudAccount { Id = subscriptionId },
+				Account = new CloudAccount { Id = tokens.Value.subscriptionId },
 				Instance = new CloudInstance { Id = websiteInstanceId, Name = websiteSiteName },
 				Project = new CloudProject { Name = websiteResourceGroup },
 				Provider = "azure",
-				Region = region
+				Region = tokens.Value.region
 			});
 		}
-
-		private string GetEnvironmentVariable(string key) =>
-			_environmentVariables.Contains(key)
-				? _environmentVariables[key]?.ToString()
-				: null;
 	}
 }

--- a/src/Elastic.Apm/Cloud/AzureFunctionsMetadataProvider.cs
+++ b/src/Elastic.Apm/Cloud/AzureFunctionsMetadataProvider.cs
@@ -39,15 +39,15 @@ namespace Elastic.Apm.Cloud
 			if (!tokens.HasValue) return Task.FromResult<Api.Cloud>(null);
 
 			if (string.IsNullOrEmpty(regionName))
-				regionName = tokens.Value.region;
+				regionName = tokens.Value.Region;
 
 			if (string.IsNullOrEmpty(websiteResourceGroup))
-				websiteResourceGroup = tokens.Value.resourceGroup;
+				websiteResourceGroup = tokens.Value.ResourceGroup;
 
 			return Task.FromResult(new Api.Cloud
 			{
 				Provider = "azure",
-				Account = new CloudAccount { Id = tokens.Value.subscriptionId },
+				Account = new CloudAccount { Id = tokens.Value.SubscriptionId },
 				Instance = new CloudInstance { Name = websiteSiteName },
 				Project = new CloudProject { Name = websiteResourceGroup },
 				Region = regionName

--- a/src/Elastic.Apm/Cloud/AzureFunctionsMetadataProvider.cs
+++ b/src/Elastic.Apm/Cloud/AzureFunctionsMetadataProvider.cs
@@ -1,0 +1,57 @@
+// Licensed to Elasticsearch B.V under
+// one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System.Collections;
+using System.Threading.Tasks;
+using Elastic.Apm.Api;
+using Elastic.Apm.Logging;
+
+namespace Elastic.Apm.Cloud
+{
+	/// <summary>
+	/// Provides cloud metadata for Microsoft Azure Functions
+	/// </summary>
+	internal class AzureFunctionsMetadataProvider : EnvironmentBasedAzureMetadataProvider
+	{
+		internal const string Name = "azure-functions";
+
+		public AzureFunctionsMetadataProvider(IApmLogger logger, IDictionary environmentVariables) : base(Name, logger,
+			environmentVariables)
+		{
+		}
+
+		public override Task<Api.Cloud> GetMetadataAsync()
+		{
+			var functionsExtensionVersion = GetEnvironmentVariable(FunctionsExtensionVersion);
+			var websiteOwnerName = GetEnvironmentVariable(WebsiteOwnerName);
+			var websiteResourceGroup = GetEnvironmentVariable(WebsiteResourceGroup);
+			var websiteSiteName = GetEnvironmentVariable(WebsiteSiteName);
+			var regionName = GetEnvironmentVariable(RegionName);
+
+			if (NullOrEmptyVariable(FunctionsExtensionVersion, functionsExtensionVersion) ||
+			    NullOrEmptyVariable(WebsiteOwnerName, websiteOwnerName) ||
+			    NullOrEmptyVariable(WebsiteSiteName, websiteSiteName))
+				return Task.FromResult<Api.Cloud>(null);
+
+			var tokens = TokenizeWebSiteOwnerName(websiteOwnerName);
+			if (!tokens.HasValue) return Task.FromResult<Api.Cloud>(null);
+
+			if (string.IsNullOrEmpty(regionName))
+				regionName = tokens.Value.region;
+
+			if (string.IsNullOrEmpty(websiteResourceGroup))
+				websiteResourceGroup = tokens.Value.resourceGroup;
+
+			return Task.FromResult(new Api.Cloud
+			{
+				Provider = "azure",
+				Account = new CloudAccount { Id = tokens.Value.subscriptionId },
+				Instance = new CloudInstance { Name = websiteSiteName },
+				Project = new CloudProject { Name = websiteResourceGroup },
+				Region = regionName
+			});
+		}
+	}
+}

--- a/src/Elastic.Apm/Cloud/CloudMetadataProviderCollection.cs
+++ b/src/Elastic.Apm/Cloud/CloudMetadataProviderCollection.cs
@@ -37,20 +37,28 @@ namespace Elastic.Apm.Cloud
 					Add(new GcpCloudMetadataProvider(logger));
 					break;
 				case SupportedValues.CloudProviderAzure:
+				{
 					Add(new AzureCloudMetadataProvider(logger));
-					Add(new AzureAppServiceMetadataProvider(logger, environmentVariables.GetEnvironmentVariables()));
+					var environment = environmentVariables.GetEnvironmentVariables();
+					Add(new AzureAppServiceMetadataProvider(logger, environment));
+					Add(new AzureFunctionsMetadataProvider(logger, environment));
 					break;
+				}
 				case SupportedValues.CloudProviderNone:
 					break;
 				case SupportedValues.CloudProviderAuto:
 				case "":
 				case null:
+				{
 					// keyed collection is ordered
 					Add(new AwsCloudMetadataProvider(logger));
 					Add(new GcpCloudMetadataProvider(logger));
 					Add(new AzureCloudMetadataProvider(logger));
-					Add(new AzureAppServiceMetadataProvider(logger, environmentVariables.GetEnvironmentVariables()));
+					var environment = environmentVariables.GetEnvironmentVariables();
+					Add(new AzureAppServiceMetadataProvider(logger, environment));
+					Add(new AzureFunctionsMetadataProvider(logger, environment));
 					break;
+				}
 				default:
 					throw new ArgumentException($"Unknown cloud provider {cloudProvider}", nameof(cloudProvider));
 			}

--- a/src/Elastic.Apm/Cloud/EnvironmentBasedAzureMetadataProvider.cs
+++ b/src/Elastic.Apm/Cloud/EnvironmentBasedAzureMetadataProvider.cs
@@ -1,0 +1,110 @@
+// Licensed to Elasticsearch B.V under
+// one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System;
+using System.Collections;
+using System.Threading.Tasks;
+using Elastic.Apm.Logging;
+
+namespace Elastic.Apm.Cloud
+{
+	/// <summary>
+	/// Base blass for Azure metadata providers that operate on environment variables.
+	/// </summary>
+	internal abstract class EnvironmentBasedAzureMetadataProvider : ICloudMetadataProvider
+	{
+		protected readonly IApmLogger _logger;
+		protected readonly IDictionary _environmentVariables;
+
+		/// <summary>
+		/// Value of the form {subscription id}+{app service plan resource group}-{region}webspace
+		/// </summary>
+		/// <example>
+		/// f5940f10-2e30-3e4d-a259-63451ba6dae4+elastic-apm-AustraliaEastwebspace
+		/// </example>
+		internal const string WebsiteOwnerName = "WEBSITE_OWNER_NAME";
+		internal const string WebsiteResourceGroup = "WEBSITE_RESOURCE_GROUP";
+		internal const string WebsiteSiteName = "WEBSITE_SITE_NAME";
+		internal const string WebsiteInstanceId = "WEBSITE_INSTANCE_ID";
+		internal const string RegionName = "REGION_NAME";
+		internal const string FunctionsExtensionVersion = "FUNCTIONS_EXTENSION_VERSION";
+
+		public string Provider { get; }
+
+		public abstract Task<Api.Cloud> GetMetadataAsync();
+
+		protected EnvironmentBasedAzureMetadataProvider(string name, IApmLogger logger,
+			IDictionary environmentVariables)
+		{
+			Provider = name;
+			_logger = logger;
+			_environmentVariables = environmentVariables;
+
+			if (_environmentVariables is null)
+			{
+				_logger.Trace()?.Log("Unable to get {Provider} cloud metadata as no environment variables available",
+					Provider);
+			}
+		}
+
+		protected string GetEnvironmentVariable(string key) =>
+			_environmentVariables != null && _environmentVariables.Contains(key)
+				? _environmentVariables[key]?.ToString()
+				: null;
+
+		protected bool NullOrEmptyVariable(string key, string value)
+		{
+			if (!string.IsNullOrEmpty(value)) return false;
+
+			_logger.Trace()?.Log(
+				"Unable to get {Provider} cloud metadata as no {EnvironmentVariable} environment variable exists. The application is likely not running in {Provider}",
+				Provider,
+				key,
+				Provider);
+
+			return true;
+		}
+
+		protected (string subscriptionId, string resourceGroup, string region)? TokenizeWebSiteOwnerName(
+			string websiteOwnerName)
+		{
+			var websiteOwnerNameParts = websiteOwnerName.Split('+');
+			if (websiteOwnerNameParts.Length != 2)
+			{
+				_logger.Trace()?.Log(
+					"Unable to get {Provider} cloud metadata as {EnvironmentVariable} does not contain expected format",
+					Provider,
+					WebsiteOwnerName);
+				return null;
+			}
+
+			var subscriptionId = websiteOwnerNameParts[0];
+
+			var webSpaceIndex = websiteOwnerNameParts[1].LastIndexOf("webspace", StringComparison.Ordinal);
+			if (webSpaceIndex != -1)
+				websiteOwnerNameParts[1] = websiteOwnerNameParts[1].Substring(0, webSpaceIndex);
+
+			var lastHyphenIndex = websiteOwnerNameParts[1].LastIndexOf('-');
+			if (lastHyphenIndex == -1)
+			{
+				_logger.Trace()?.Log(
+					"Unable to get {Provider} cloud metadata as {EnvironmentVariable} does not contain expected format",
+					Provider,
+					WebsiteOwnerName);
+				return null;
+			}
+
+			var region = websiteOwnerNameParts[1].Substring(lastHyphenIndex + 1);
+			var resourceGroup = websiteOwnerNameParts[1].Substring(0, lastHyphenIndex);
+
+			return
+			(
+				subscriptionId,
+				resourceGroup,
+				region
+			);
+		}
+	}
+}

--- a/src/Elastic.Apm/Cloud/EnvironmentBasedAzureMetadataProvider.cs
+++ b/src/Elastic.Apm/Cloud/EnvironmentBasedAzureMetadataProvider.cs
@@ -13,7 +13,7 @@ namespace Elastic.Apm.Cloud
 	/// <summary>
 	/// Base blass for Azure metadata providers that operate on environment variables.
 	/// </summary>
-	internal abstract class EnvironmentBasedAzureMetadataProvider : ICloudMetadataProvider
+	public abstract class EnvironmentBasedAzureMetadataProvider : ICloudMetadataProvider
 	{
 		protected readonly IApmLogger _logger;
 		protected readonly IDictionary _environmentVariables;
@@ -67,8 +67,7 @@ namespace Elastic.Apm.Cloud
 			return true;
 		}
 
-		protected (string subscriptionId, string resourceGroup, string region)? TokenizeWebSiteOwnerName(
-			string websiteOwnerName)
+		internal WebSiteOwnerNameTokens? TokenizeWebSiteOwnerName(string websiteOwnerName)
 		{
 			var websiteOwnerNameParts = websiteOwnerName.Split('+');
 			if (websiteOwnerNameParts.Length != 2)
@@ -99,12 +98,23 @@ namespace Elastic.Apm.Cloud
 			var region = websiteOwnerNameParts[1].Substring(lastHyphenIndex + 1);
 			var resourceGroup = websiteOwnerNameParts[1].Substring(0, lastHyphenIndex);
 
-			return
-			(
-				subscriptionId,
-				resourceGroup,
-				region
-			);
+			return new WebSiteOwnerNameTokens(subscriptionId, resourceGroup, region);
 		}
+	}
+
+	internal struct WebSiteOwnerNameTokens
+	{
+		internal WebSiteOwnerNameTokens(string subscriptionId, string resourceGroup, string region)
+		{
+			SubscriptionId = subscriptionId;
+			ResourceGroup = resourceGroup;
+			Region = region;
+		}
+
+		internal string Region { get; }
+
+		internal string ResourceGroup { get; }
+
+		internal string SubscriptionId { get; }
 	}
 }

--- a/test/Elastic.Apm.Tests/Cloud/AzureFunctionsMetadataProviderTests.cs
+++ b/test/Elastic.Apm.Tests/Cloud/AzureFunctionsMetadataProviderTests.cs
@@ -1,0 +1,90 @@
+// Licensed to Elasticsearch B.V under
+// one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System.Collections;
+using System.Threading.Tasks;
+using Elastic.Apm.Cloud;
+using Elastic.Apm.Tests.Utilities;
+using FluentAssertions;
+using Xunit;
+
+namespace Elastic.Apm.Tests.Cloud;
+
+public class AzureFunctionsMetadataProviderTests
+{
+	[Theory]
+	[InlineData("~4", "d2cd53b3-acdc-4964-9563-3f5201556a81+wolfgangfaas_group-CentralUSwebspace-Linux", "wolfgangfaas",
+		"wolfgangfaas_group", "CentralUS")]
+	[InlineData("~4", "d2cd53b3-acdc-4964-9563-3f5201556a81+wolfgangfaas_group-CentralUSwebspace-Linux", "wolfgangfaas",
+		"wolfgangfaas_group", null)]
+	[InlineData("~4", "d2cd53b3-acdc-4964-9563-3f5201556a81+wolfgangfaas_group-CentralUSwebspace-Linux", "wolfgangfaas",
+		null, null)]
+	public async Task GetMetadataAsync_Returns_Expected_Cloud_Metadata(string functionsExtensionVersion,
+		string websiteOwnerName, string websiteName,
+		string resourceGroup, string regionName)
+	{
+		var environmentVariables = new Hashtable
+		{
+			{ EnvironmentBasedAzureMetadataProvider.FunctionsExtensionVersion, functionsExtensionVersion },
+			{ EnvironmentBasedAzureMetadataProvider.WebsiteOwnerName, websiteOwnerName },
+			{ EnvironmentBasedAzureMetadataProvider.WebsiteSiteName, websiteName },
+			{ EnvironmentBasedAzureMetadataProvider.WebsiteResourceGroup, resourceGroup },
+			{ EnvironmentBasedAzureMetadataProvider.RegionName, regionName }
+		};
+
+		var provider = new AzureFunctionsMetadataProvider(new NoopLogger(), environmentVariables);
+		var metadata = await provider.GetMetadataAsync();
+
+		metadata.Should().NotBeNull();
+		metadata.Account.Should().NotBeNull();
+		metadata.Account.Id.Should().Be("d2cd53b3-acdc-4964-9563-3f5201556a81");
+		metadata.Provider.Should().Be("azure");
+		metadata.Instance.Name.Should().Be("wolfgangfaas");
+		metadata.Project.Should().NotBeNull();
+		metadata.Project.Name.Should().Be("wolfgangfaas_group");
+		metadata.Region.Should().Be("CentralUS");
+	}
+
+
+	[Theory]
+	[InlineData(null, "d2cd53b3-acdc-4964-9563-3f5201556a81+wolfgangfaas_group-CentralUSwebspace-Linux", "wolfgangfaas",
+		null, null)]
+	[InlineData("~4", "d2cd53b3-acdc-4964-9563-3f5201556a81+wolfgangfaas_group-CentralUSwebspace-Linux", null, null,
+		null)]
+	[InlineData("~4", null, "wolfgangfaas", null, null)]
+	[InlineData("~4", "foo", "wolfgangfaas", null,
+		null)]
+	[InlineData("~4", "d2cd53b3-acdc-4964-9563-3f5201556a81*wolfgangfaas_group-CentralUSwebspace-Linux", "wolfgangfaas",
+		null,
+		null)]
+	public async Task GetMetadataAsync_Returns_Null_When_Expected_EnvironmentVariable_Is_Missing_Or_Corrupt(
+		string functionsExtensionVersion,
+		string websiteOwnerName, string websiteName,
+		string resourceGroup, string regionName)
+	{
+		var environmentVariables = new Hashtable
+		{
+			{ EnvironmentBasedAzureMetadataProvider.FunctionsExtensionVersion, functionsExtensionVersion },
+			{ EnvironmentBasedAzureMetadataProvider.WebsiteOwnerName, websiteOwnerName },
+			{ EnvironmentBasedAzureMetadataProvider.WebsiteSiteName, websiteName },
+			{ EnvironmentBasedAzureMetadataProvider.WebsiteResourceGroup, resourceGroup },
+			{ EnvironmentBasedAzureMetadataProvider.RegionName, regionName }
+		};
+
+		var provider = new AzureFunctionsMetadataProvider(new NoopLogger(), environmentVariables);
+		var metadata = await provider.GetMetadataAsync();
+
+		metadata.Should().BeNull();
+	}
+
+	[Fact]
+	public async Task GetMetadataAsync_Returns_Null_When_EnvironmentVariables_Is_Null()
+	{
+		var provider = new AzureFunctionsMetadataProvider(new NoopLogger(), null);
+		var metadata = await provider.GetMetadataAsync();
+
+		metadata.Should().BeNull();
+	}
+}

--- a/test/Elastic.Apm.Tests/Cloud/CloudMetadataProviderCollectionTests.cs
+++ b/test/Elastic.Apm.Tests/Cloud/CloudMetadataProviderCollectionTests.cs
@@ -19,12 +19,13 @@ namespace Elastic.Apm.Tests.Cloud
 		{
 			var providers = new CloudMetadataProviderCollection(DefaultValues.CloudProvider, new NoopLogger());
 
-			providers.Count.Should().Be(4);
+			providers.Count.Should().Be(5);
 			providers.Contains(AwsCloudMetadataProvider.Name).Should().BeTrue();
 			providers.Contains(GcpCloudMetadataProvider.Name).Should().BeTrue();
 			providers.Contains(AzureCloudMetadataProvider.Name).Should().BeTrue();
 			providers.Contains(AzureAppServiceMetadataProvider.Name).Should().BeTrue();
-			providers.Select(p => p.Provider).Should().Equal("aws", "gcp", "azure", "azure-app-service");
+			providers.Select(p => p.Provider).Should()
+				.Equal("aws", "gcp", "azure", "azure-app-service", "azure-functions");
 		}
 
 		[Fact]
@@ -56,12 +57,15 @@ namespace Elastic.Apm.Tests.Cloud
 		public void CloudProvider_Azure_Should_Register_Azure_Providers()
 		{
 			var providers = new CloudMetadataProviderCollection(SupportedValues.CloudProviderAzure, new NoopLogger());
-			providers.Count.Should().Be(2);
+			providers.Count.Should().Be(3);
 			var provider = providers[SupportedValues.CloudProviderAzure];
 			provider.Should().BeOfType<AzureCloudMetadataProvider>();
 
 			provider = providers[AzureAppServiceMetadataProvider.Name];
 			provider.Should().BeOfType<AzureAppServiceMetadataProvider>();
+
+			provider = providers[AzureFunctionsMetadataProvider.Name];
+			provider.Should().BeOfType<AzureFunctionsMetadataProvider>();
 		}
 	}
 }


### PR DESCRIPTION
This is the first PR for the Azure Functions support feature (#1642).

I'm adding this as a separate PR because it adds value already when using the `Tracer` API in an Azure Functions environment as the agent picks up cloud metadata correctly now.

* Make sure that setting cloud metadata also works in Azure Functions. There are subtle differences to the existing `AzureAppServiceMetadataProvider`, which is why a dedicated provider class was implemented for that.
* Existing code could be reused and was refactored into the newly introduced base class `EnvironmentBasedAzureMetadataProvider`.