### PR TITLE
EOL table has been moved to central EOL Policy page

### DIFF
--- a/docs/upgrading.asciidoc
+++ b/docs/upgrading.asciidoc
@@ -16,4 +16,3 @@ We love all our products, but sometimes we must say goodbye to a release so that
 forward on future development and innovation.
 Our https://www.elastic.co/support/eol[End of life policy] defines how long a given release is considered supported,
 as well as how long a release is considered still in active development or maintenance.
-The table below is a simplified description of this policy.

--- a/docs/upgrading.asciidoc
+++ b/docs/upgrading.asciidoc
@@ -17,21 +17,3 @@ forward on future development and innovation.
 Our https://www.elastic.co/support/eol[End of life policy] defines how long a given release is considered supported,
 as well as how long a release is considered still in active development or maintenance.
 The table below is a simplified description of this policy.
-
-[options="header"]
-|====
-|Agent version |EOL Date |Maintained until
-|1.12.x |2023-05-11 |1.13.0
-|1.11.x |2022-12-29 |1.12.0
-|1.10.x |2022-11-28 |1.11.0
-|1.9.x  |2022-10-07 |1.10.0
-|1.8.x  |2022-08-17 |1.9.0
-|1.7.x  |2022-05-12 |1.8.0
-|1.6.x  |2022-01-10 |1.7.0
-|1.5.x  |2021-11-09 |1.6.0
-|1.4.x  |2021-09-20 |1.5.0
-|1.3.x  |2021-08-12 |1.4.0
-|1.2.x  |2021-05-22 |1.3.0
-|1.1.x  |2021-04-01 |1.2.0
-|1.0.x  |2021-01-31 |1.1.0
-|====


### PR DESCRIPTION
APM Agents are listed now in the central EOL policy table: https://www.elastic.co/support/eol