### PR TITLE
Add readme file to  test/Elastic.Apm.Feature.Tests

### DIFF
--- a/test/Elastic.Apm.Feature.Tests/README.md
+++ b/test/Elastic.Apm.Feature.Tests/README.md
@@ -1,7 +1,7 @@
 # Elastic.Apm.Feature.Tests
 
-This project contains gherkin specifications and their implementation in C# which test the agent.
+This project contains [gherkin](https://cucumber.io/docs/gherkin/) specifications and their implementation in C# which test the agent.
 
-The specification from the `/Features` folder is synced from the [`github.com/elastic/apm`](https://github.com/elastic/apm) repository from the [`tests/agents/gherkin-specs`](https://github.com/elastic/apm/tree/main/tests/agents/gherkin-specs) folder via automated PRs. Every APM Agent implements these spec files and therefore they are manged centrally in the `/elastic/apm` repository.
+The specification from the `/Features` folder is synced from the [`github.com/elastic/apm`](https://github.com/elastic/apm) repository from the [`tests/agents/gherkin-specs`](https://github.com/elastic/apm/tree/main/tests/agents/gherkin-specs) folder via automated PRs. Every APM Agent implements these spec files and therefore they are managed centrally in the `/elastic/apm` repository.
 
 Spec files (files with `.feature` extension) in this project should not be changed - in case we need to adapt the specification, a PR in the [`github.com/elastic/apm`](https://github.com/elastic/apm) needs to be opened. That way changes in the spec files are synced across all APM Agents.

--- a/test/Elastic.Apm.Feature.Tests/README.md
+++ b/test/Elastic.Apm.Feature.Tests/README.md
@@ -1,0 +1,7 @@
+# Elastic.Apm.Feature.Tests
+
+This project contains gherkin specifications and their implementation in C# which test the agent.
+
+The specification from the `/Features` folder is synced from the [`github.com/elastic/apm`](https://github.com/elastic/apm) repository from the [`tests/agents/gherkin-specs`](https://github.com/elastic/apm/tree/main/tests/agents/gherkin-specs) folder via automated PRs. Every APM Agent implements these spec files and therefore they are manged centrally in the `/elastic/apm` repository.
+
+Spec files (files with `.feature` extension) in this project should not be changed - in case we need to adapt the specification, a PR in the [`github.com/elastic/apm`](https://github.com/elastic/apm) needs to be opened. That way changes in the spec files are synced across all APM Agents.

--- a/test/Elastic.Apm.Feature.Tests/README.md
+++ b/test/Elastic.Apm.Feature.Tests/README.md
@@ -2,6 +2,8 @@
 
 This project contains [gherkin](https://cucumber.io/docs/gherkin/) specifications and their implementation in C# which test the agent.
 
-The specification from the `/Features` folder is synced from the [`github.com/elastic/apm`](https://github.com/elastic/apm) repository from the [`tests/agents/gherkin-specs`](https://github.com/elastic/apm/tree/main/tests/agents/gherkin-specs) folder via automated PRs. Every APM Agent implements these spec files and therefore they are managed centrally in the `/elastic/apm` repository.
+The specification from the `/Features` folder is synced from the [`github.com/elastic/apm`](https://github.com/elastic/apm) repository from the [`tests/agents/gherkin-specs`](https://github.com/elastic/apm/tree/main/tests/agents/gherkin-specs) folder via automated PRs.
+Every APM Agent implements these spec files and therefore they are managed centrally in the `/elastic/apm` repository.
 
-Spec files (files with `.feature` extension) in this project should not be changed - in case we need to adapt the specification, a PR in the [`github.com/elastic/apm`](https://github.com/elastic/apm) needs to be opened. That way changes in the spec files are synced across all APM Agents.
+Spec files (files with `.feature` extension) in this project should not be changed - in case we need to adapt the specification, a PR in the [`github.com/elastic/apm`](https://github.com/elastic/apm) needs to be opened.
+That way changes in the spec files are synced across all APM Agents.


### PR DESCRIPTION
After looking at https://github.com/elastic/apm-agent-dotnet/pull/1882 I realize we don't communicate very well how the `.feature` files are synced from the `apm` repo.

To fix this, this PR adds a short readme explaining how those files are synced. 