### PR TITLE
Add test which asserts the traceId is the same on a root activity and the corresponding transaction

### DIFF
--- a/test/Elastic.Apm.Tests/OpenTelemetryTests.cs
+++ b/test/Elastic.Apm.Tests/OpenTelemetryTests.cs
@@ -173,6 +173,21 @@ namespace Elastic.Apm.Tests
 
 			payloadSender.FirstTransaction.TraceId.Should().Be(payloadSender.Transactions[1].TraceId, because: "The transactions should be under the same trace.");
 		}
+
+		/// <summary>
+		/// Make sure that the traceId on a root activity is the same as the traceId on the transaction which the bridge creates from the root activity.
+		/// </summary>
+		[Fact]
+		public void ActivityAndTransactionTraceIdSynced()
+		{
+			var payloadSender = new MockPayloadSender();
+			using var agent = new ApmAgent(new TestAgentComponents(payloadSender: payloadSender, apmServerInfo: MockApmServerInfo.Version716,
+				configuration: new MockConfiguration(enableOpenTelemetryBridge: "true")));
+			var src = new ActivitySource("Test");
+			string traceId;
+			using (var activity = src.StartActivity("foo", ActivityKind.Server)) traceId = activity.TraceId.ToString();
+			payloadSender.FirstTransaction.TraceId.Should().Be(traceId);
+		}
 	}
 }
 


### PR DESCRIPTION
Follow up from https://github.com/elastic/apm-agent-dotnet/pull/1882#pullrequestreview-1152603638. 

Add small test to make sure the traceId is synced across a root activity and the transaction created based on that root activity.

 cc @kuanpak
