### PR TITLE
CentralConfig: handle MaxAge header with less than 5 sec according to spec

### DIFF
--- a/src/Elastic.Apm/BackendComm/CentralConfig/CentralConfigurationResponseParser.cs
+++ b/src/Elastic.Apm/BackendComm/CentralConfig/CentralConfigurationResponseParser.cs
@@ -83,7 +83,7 @@ namespace Elastic.Apm.BackendComm.CentralConfig
 				if (httpResponse.Headers.CacheControl.MaxAge > TimeSpan.FromSeconds(0) && httpResponse.Headers.CacheControl.MaxAge < TimeSpan.FromSeconds(5))
 				{
 					return new CentralConfigurationFetcher.WaitInfoS(TimeSpan.FromSeconds(5),
-						"The max-age directive in Cache-Control header in APM Server's response is less than 5 second, "
+						"The max-age directive in Cache-Control header in APM Server's response is less than 5 seconds, "
 						+ "which is less than expected by the spec - falling back to use 5 seconds wait time.");
 				}
 

--- a/src/Elastic.Apm/BackendComm/CentralConfig/CentralConfigurationResponseParser.cs
+++ b/src/Elastic.Apm/BackendComm/CentralConfig/CentralConfigurationResponseParser.cs
@@ -74,6 +74,19 @@ namespace Elastic.Apm.BackendComm.CentralConfig
 		{
 			if (httpResponse.Headers?.CacheControl?.MaxAge != null)
 			{
+				if (httpResponse.Headers.CacheControl.MaxAge <= TimeSpan.FromSeconds(0))
+				{
+					return new CentralConfigurationFetcher.WaitInfoS(WaitTimeIfNoCacheControlMaxAge,
+						"The max-age directive in Cache-Control header in APM Server's response is zero or negative, "
+						+ $"which is invalid - falling back to use default ({WaitTimeIfNoCacheControlMaxAge.Minutes} minutes) wait time.");
+				}
+				if (httpResponse.Headers.CacheControl.MaxAge > TimeSpan.FromSeconds(0) && httpResponse.Headers.CacheControl.MaxAge < TimeSpan.FromSeconds(5))
+				{
+					return new CentralConfigurationFetcher.WaitInfoS(TimeSpan.FromSeconds(5),
+						"The max-age directive in Cache-Control header in APM Server's response is less than 5 second, "
+						+ "which is less than expected by the spec - falling back to use 5 seconds wait time.");
+				}
+
 				return new CentralConfigurationFetcher.WaitInfoS(httpResponse.Headers.CacheControl.MaxAge.Value,
 					"Wait time is taken from max-age directive in Cache-Control header in APM Server's response");
 			}

--- a/test/Elastic.Apm.Tests/BackendCommTests/CentralConfig/CentralConfigResponseParserTests.cs
+++ b/test/Elastic.Apm.Tests/BackendCommTests/CentralConfig/CentralConfigResponseParserTests.cs
@@ -52,6 +52,61 @@ namespace Elastic.Apm.Tests.BackendCommTests.CentralConfig
 			waitInfoS.Interval.Should().Be(TimeSpan.FromMinutes(5));
 		}
 
+		/// <summary>
+		/// According to spec, the agent should retry fetching central config with not less than 5 sec interval.
+		/// Makes sure that MaxAge headers with less than 5 sec fall back to use a 5 sec wait time.
+		/// </summary>
+		/// <param name="seconds">The MaxAge header returned to the agent.</param>
+		[Theory]
+		[InlineData(1)]
+		[InlineData(4)]
+		[InlineData(5)]
+		public void ParseHttpResponse_ShouldUse5SecWaitTime_WhenMaxAgeIsLessThan5Sec(int seconds)
+		{
+			var response = new HttpResponseMessage
+			{
+				StatusCode = HttpStatusCode.NotModified,
+				Headers = { CacheControl = new CacheControlHeaderValue { MaxAge = TimeSpan.FromSeconds(seconds) } }
+			};
+
+			var (_, waitInfoS) = _parser.ParseHttpResponse(response, string.Empty);
+
+			waitInfoS.Interval.Should().Be(TimeSpan.FromSeconds(5));
+
+			if(seconds < 5)
+			{
+				waitInfoS.Reason.Should().Be("The max-age directive in Cache-Control header in APM Server's response is less than 5 second, "
+					+ "which is less than expected by the spec - falling back to use 5 seconds wait time.");
+			}
+			else
+			{
+				waitInfoS.Reason.Should().NotBe("The max-age directive in Cache-Control header in APM Server's response is less than 5 second, "
+					+ "which is less than expected by the spec - falling back to use 5 seconds wait time.");
+			}
+		}
+
+		/// <summary>
+		/// Makes sure the agent handles 0 or negative MaxAge headers by falling back to the default wait time (5 minutes).
+		/// </summary>
+		/// <param name="seconds">The MaxAge header returned to the agent.</param>
+		[Theory]
+		[InlineData(0)]
+		[InlineData(-1)]
+		[InlineData(-10)]
+		[InlineData(int.MinValue)]
+		public void  ParseHttpResponse_ShouldUseDefaultWaitTime_WhenMaxAgeIsZeroOrNegative(int seconds)
+		{
+			var response = new HttpResponseMessage
+			{
+				StatusCode = HttpStatusCode.NotModified,
+				Headers = { CacheControl = new CacheControlHeaderValue { MaxAge = TimeSpan.FromSeconds(seconds) } }
+			};
+
+			var (_, waitInfoS) = _parser.ParseHttpResponse(response, string.Empty);
+
+			waitInfoS.Interval.Should().Be(TimeSpan.FromMinutes(5));
+		}
+
 		[Fact]
 		public void ParseHttpResponse_ShouldReturnNullConfigDelta_WhenResponseStatusCodeIs304()
 		{

--- a/test/Elastic.Apm.Tests/BackendCommTests/CentralConfig/CentralConfigResponseParserTests.cs
+++ b/test/Elastic.Apm.Tests/BackendCommTests/CentralConfig/CentralConfigResponseParserTests.cs
@@ -75,12 +75,12 @@ namespace Elastic.Apm.Tests.BackendCommTests.CentralConfig
 
 			if(seconds < 5)
 			{
-				waitInfoS.Reason.Should().Be("The max-age directive in Cache-Control header in APM Server's response is less than 5 second, "
+				waitInfoS.Reason.Should().Be("The max-age directive in Cache-Control header in APM Server's response is less than 5 seconds, "
 					+ "which is less than expected by the spec - falling back to use 5 seconds wait time.");
 			}
 			else
 			{
-				waitInfoS.Reason.Should().NotBe("The max-age directive in Cache-Control header in APM Server's response is less than 5 second, "
+				waitInfoS.Reason.Should().NotBe("The max-age directive in Cache-Control header in APM Server's response is less than 5 seconds, "
 					+ "which is less than expected by the spec - falling back to use 5 seconds wait time.");
 			}
 		}

--- a/test/Elastic.Apm.Tests/BackendCommTests/CentralConfig/CentralConfigResponseParserTests.cs
+++ b/test/Elastic.Apm.Tests/BackendCommTests/CentralConfig/CentralConfigResponseParserTests.cs
@@ -105,6 +105,8 @@ namespace Elastic.Apm.Tests.BackendCommTests.CentralConfig
 			var (_, waitInfoS) = _parser.ParseHttpResponse(response, string.Empty);
 
 			waitInfoS.Interval.Should().Be(TimeSpan.FromMinutes(5));
+			waitInfoS.Reason.Should().Be("The max-age directive in Cache-Control header in APM Server's response is zero or negative, "
+				+ $"which is invalid - falling back to use default ({CentralConfigurationResponseParser.WaitTimeIfNoCacheControlMaxAge.Minutes} minutes) wait time.");
 		}
 
 		[Fact]


### PR DESCRIPTION
Solves https://github.com/elastic/apm-agent-dotnet/issues/1831.

The recent spec change referenced in https://github.com/elastic/apm-agent-dotnet/issues/1831 defines how to treat:
- `MaxAge` headers with zero or negative values (use default)
- `MaxAge` headers with positive, but less than 5 second values (use 5 sec)

This PR adapts the agent to the spec and adds tests.