### PR TITLE
Change conditionals to NET5_0_OR_GREATER

### DIFF
--- a/sample/Elastic.Apm.StartupHook.Sample/Startup.cs
+++ b/sample/Elastic.Apm.StartupHook.Sample/Startup.cs
@@ -21,7 +21,7 @@ namespace Elastic.Apm.StartupHook.Sample
 		// This method gets called by the runtime. Use this method to add services to the container.
 		public void ConfigureServices(IServiceCollection services)
 		{
-#if NET5_0 || NET6_0
+#if NET5_0_OR_GREATER
 			services.AddControllersWithViews();
 #else
 			services.AddMvc();

--- a/sample/SampleAspNetCoreApp/Startup.cs
+++ b/sample/SampleAspNetCoreApp/Startup.cs
@@ -3,21 +3,18 @@
 // See the LICENSE file in the project root for more information
 
 using System;
-using Elastic.Apm;
-using Elastic.Apm.EntityFrameworkCore;
 using Elastic.Apm.NetCoreAll;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Identity;
-using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using SampleAspNetCoreApp.Data;
 #if NET5_0
 using OpenTelemetry;
 using OpenTelemetry.Trace;
 #endif
-using SampleAspNetCoreApp.Data;
 
 namespace SampleAspNetCoreApp
 {
@@ -57,7 +54,7 @@ namespace SampleAspNetCoreApp
 		}
 
 		// This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
-#if NETCOREAPP3_0 || NETCOREAPP3_1 || NET5_0 || NET6_0
+#if NETCOREAPP3_0 || NETCOREAPP3_1 || NET5_0_OR_GREATER
 		public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
 #else
 		public void Configure(IApplicationBuilder app, IHostingEnvironment env)
@@ -81,7 +78,7 @@ namespace SampleAspNetCoreApp
 
 		public static void ConfigureRoutingAndMvc(IApplicationBuilder app)
 		{
-#if NETCOREAPP3_0 || NETCOREAPP3_1 || NET5_0 || NET6_0
+#if NETCOREAPP3_0 || NETCOREAPP3_1 || NET5_0_OR_GREATER
 			app.UseRouting();
 
 			app.UseAuthentication();

--- a/sample/WebApiSample/Startup.cs
+++ b/sample/WebApiSample/Startup.cs
@@ -5,7 +5,6 @@
 using Elastic.Apm.NetCoreAll;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
-using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -23,7 +22,7 @@ namespace WebApiSample
 
 
 		// This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
-#if NETCOREAPP3_0 || NETCOREAPP3_1 || NET5_0 || NET6_0
+#if NETCOREAPP3_0 || NETCOREAPP3_1 || NET5_0_OR_GREATER
 		public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
 #else
 		public void Configure(IApplicationBuilder app, IHostingEnvironment env)
@@ -39,7 +38,7 @@ namespace WebApiSample
 
 			app.UseHttpsRedirection();
 
-#if NETCOREAPP3_0 || NETCOREAPP3_1 || NET5_0 || NET6_0
+#if NETCOREAPP3_0 || NETCOREAPP3_1 || NET5_0_OR_GREATER
 			app.UseRouting();
 
 			app.UseEndpoints(endpoints => { endpoints.MapControllers(); });

--- a/src/Elastic.Apm/AgentComponents.cs
+++ b/src/Elastic.Apm/AgentComponents.cs
@@ -18,7 +18,7 @@ using Elastic.Apm.Metrics;
 using Elastic.Apm.Metrics.MetricsProvider;
 using Elastic.Apm.Report;
 using Elastic.Apm.ServerInfo;
-#if NET5_0 || NET6_0
+#if NET5_0_OR_GREATER
 using Elastic.Apm.OpenTelemetry;
 #endif
 
@@ -61,7 +61,7 @@ namespace Elastic.Apm
 				// Called by PayloadSenderV2 after the ServerInfo is fetched
 				Action<bool, IApmServerInfo> serverInfoCallback = null;
 
-#if NET5_0 || NET6_0
+#if NET5_0_OR_GREATER
 				ElasticActivityListener activityListener = null;
 				if (ConfigurationReader.EnableOpenTelemetryBridge)
 				{
@@ -110,7 +110,7 @@ namespace Elastic.Apm
 				TracerInternal = new Tracer(Logger, Service, PayloadSender, ConfigurationStore,
 					currentExecutionSegmentsContainer ?? new CurrentExecutionSegmentsContainer(), ApmServerInfo, breakdownMetricsProvider);
 
-#if NET5_0 || NET6_0
+#if NET5_0_OR_GREATER
 				if (ConfigurationReader.EnableOpenTelemetryBridge)
 				{
 					// If the server version is not known yet, we enable the listener - and then the callback will do the version check once we have the version

--- a/src/Elastic.Apm/Libraries/Newtonsoft.Json/Serialization/DefaultContractResolver.cs
+++ b/src/Elastic.Apm/Libraries/Newtonsoft.Json/Serialization/DefaultContractResolver.cs
@@ -1260,7 +1260,7 @@ namespace Elastic.Apm.Libraries.Newtonsoft.Json.Serialization
 			// warning - this method use to cause errors with Intellitrace. Retest in VS Ultimate after changes
 			IValueProvider valueProvider;
 
-#if !(PORTABLE40 || PORTABLE || DOTNET || NETSTANDARD2_0 || NET5_0 || NET6_0)
+#if !(PORTABLE40 || PORTABLE || DOTNET || NETSTANDARD2_0 || NET5_0_OR_GREATER)
             if (DynamicCodeGeneration)
             {
                 valueProvider = new DynamicValueProvider(member);

--- a/src/Elastic.Apm/Libraries/Newtonsoft.Json/Serialization/JsonTypeReflector.cs
+++ b/src/Elastic.Apm/Libraries/Newtonsoft.Json/Serialization/JsonTypeReflector.cs
@@ -468,7 +468,7 @@ namespace Elastic.Apm.Libraries.Newtonsoft.Json.Serialization
 		{
 			get
 			{
-#if !(PORTABLE40 || PORTABLE || DOTNET || NETSTANDARD2_0 || NET5_0 || NET6_0)
+#if !(PORTABLE40 || PORTABLE || DOTNET || NETSTANDARD2_0 || NET5_0_OR_GREATER)
                 if (DynamicCodeGeneration)
                 {
                     return DynamicReflectionDelegateFactory.Instance;

--- a/src/Elastic.Apm/OpenTelemetry/ElasticActivityListener.cs
+++ b/src/Elastic.Apm/OpenTelemetry/ElasticActivityListener.cs
@@ -3,7 +3,7 @@
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
 
-#if NET5_0 || NET6_0
+#if NET5_0_OR_GREATER
 
 using System;
 using System.Collections.Concurrent;

--- a/test/Elastic.Apm.AspNetCore.Tests/AspNetCoreBasicTests.cs
+++ b/test/Elastic.Apm.AspNetCore.Tests/AspNetCoreBasicTests.cs
@@ -125,7 +125,7 @@ namespace Elastic.Apm.AspNetCore.Tests
 			}
 
 			//test transaction.context.request
-#if NET5_0 || NET6_0
+#if NET5_0_OR_GREATER
 			transaction.Context.Request.HttpVersion.Should().Be("1.1");
 #elif NETCOREAPP3_0 || NETCOREAPP3_1
 			transaction.Context.Request.HttpVersion.Should().Be("2");
@@ -281,7 +281,7 @@ namespace Elastic.Apm.AspNetCore.Tests
 			}
 
 			//test transaction.context.request
-#if NET5_0 || NET6_0
+#if NET5_0_OR_GREATER
 			transaction.Context.Request.HttpVersion.Should().Be("1.1");
 #elif NETCOREAPP3_0 || NETCOREAPP3_1
 			transaction.Context.Request.HttpVersion.Should().Be("2");

--- a/test/Elastic.Apm.AspNetCore.Tests/DistributedTracingAspNetCoreTests.cs
+++ b/test/Elastic.Apm.AspNetCore.Tests/DistributedTracingAspNetCoreTests.cs
@@ -511,7 +511,7 @@ namespace Elastic.Apm.AspNetCore.Tests
 		/// <returns></returns>
 		private async Task ExecuteAndCheckDistributedCall(bool startActivityBeforeHttpCall = true)
 		{
-#if NET5_0 || NET6_0
+#if NET5_0_OR_GREATER
 			// .NET 5 has built-in W3C TraceContext support and Activity uses the W3C id format by default (pre .NET 5 it was opt-in)
 			// This means if there is no active activity, the outgoing HTTP request on HttpClient will add the traceparent header with
 			// a flag recorded=false. The agent would pick this up on the incoming call and start an unsampled transaction.

--- a/test/Elastic.Apm.Tests/ConfigTests.cs
+++ b/test/Elastic.Apm.Tests/ConfigTests.cs
@@ -324,7 +324,7 @@ namespace Elastic.Apm.Tests
 			using (var agent = new ApmAgent(
 					   new TestAgentComponents(payloadSender: payloadSender, configuration: new EnvironmentConfigurationReader())))
 			{
-#if !NETCOREAPP3_0 && !NETCOREAPP3_1 && !NET5_0 && !NET6_0
+#if !NETCOREAPP3_0 && !NETCOREAPP3_1 && !NET5_0_OR_GREATER
 				agent.ConfigurationReader.ServerUrls.First().Should().NotBe(serverUrlsWithSpace);
 				agent.ConfigurationReader.ServerUrl.Should().NotBe(serverUrlsWithSpace);
 #endif
@@ -1156,7 +1156,7 @@ namespace Elastic.Apm.Tests
 			var appNamespaces = config.ApplicationNamespaces;
 			appNamespaces.Should().BeNullOrEmpty();
 			var excludedNamespaces = config.ExcludedNamespaces;
-			excludedNamespaces.Should().BeEquivalentTo(ConfigConsts.DefaultValues.DefaultExcludedNamespaces);
+			excludedNamespaces.Should().BeEquivalentTo(DefaultValues.DefaultExcludedNamespaces);
 		}
 
 		private static double MetricsIntervalTestCommon(string configValue)

--- a/test/Elastic.Apm.Tests/OpenTelemetryTests.cs
+++ b/test/Elastic.Apm.Tests/OpenTelemetryTests.cs
@@ -3,7 +3,7 @@
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
 
-#if NET5_0 || NET6_0
+#if NET5_0_OR_GREATER
 using System;
 using System.Diagnostics;
 using System.Linq;


### PR DESCRIPTION
In preparation for the release of .NET 7, change occurrences of `#if NET5_0 || NET6_0` to `#if NET5_0_OR_GREATER`.