### PR TITLE
Debug Agent: Loosen the constraints on calling Agent.Setup()

### DIFF
--- a/src/Elastic.Apm/Agent.cs
+++ b/src/Elastic.Apm/Agent.cs
@@ -170,25 +170,15 @@ namespace Elastic.Apm
 		{
 			lock (InitializationLock)
 			{
-				if (LazyApmAgent.IsValueCreated)
-				{
-					Components?.Logger?.Error()
-						?.Log("The singleton APM agent has" +
-							" already been instantiated and can no longer be configured. Reusing existing instance. "
-							+ "Callstack: {callstack}", new StackTrace().ToString());
-
-					// Above line logs on the already configured `Components`
-					// In order to let the caller know, we also log on the logger of the rejected `agentComponents`
-					agentComponents?.Logger?.Error()
-						?.Log("The singleton APM agent has" +
-							" already been instantiated and can no longer be configured. Reusing existing instance. "
-							+ "Callstack: {callstack}", new StackTrace().ToString());
-
-					return;
-				}
-
 				agentComponents?.Logger?.Trace()
 					?.Log("Initialization - Agent.Setup called");
+
+				if (LazyApmAgent.IsValueCreated)
+				{
+					agentComponents?.Logger?.Warning()
+						?.Log("Agent.Setup called - An already initialized agent is getting re-initialized - new AgentComponents will be used"
+							+ "Callstack: {callstack}", new StackTrace().ToString());
+				}
 
 				Components = agentComponents;
 				// Force initialization

--- a/test/Elastic.Apm.StaticExplicitInitialization.Tests/StaticImplicitInitializationTests.cs
+++ b/test/Elastic.Apm.StaticExplicitInitialization.Tests/StaticImplicitInitializationTests.cs
@@ -16,19 +16,21 @@ namespace Elastic.Apm.StaticExplicitInitialization.Tests
 		{
 			Agent.IsConfigured.Should().BeFalse();
 
-			var logger = new InMemoryBlockingLogger(LogLevel.Error);
-			using var agentComponents = new TestAgentComponents(logger: logger);
+			using var agentComponents = new TestAgentComponents();
 			Agent.Setup(agentComponents);
 			Agent.IsConfigured.Should().BeTrue();
 
 			// 2. initialization with a new dummy-AgentComponents - this will be rejected
-			Agent.Setup(new AgentComponents());
+			var logger = new InMemoryBlockingLogger(LogLevel.Warning);
+			using var secondAgentComponents = new TestAgentComponents(logger: logger);
+			Agent.Setup(secondAgentComponents);
 
-			Agent.Components.Should().Be(agentComponents);
+			Agent.Components.Should().NotBe(agentComponents);
+			Agent.Components.Should().Be(secondAgentComponents);
 
 			logger.Lines.Should()
 				.Contain(n => n.Contains(
-					"The singleton APM agent has already been instantiated and can no longer be configured. Reusing existing instance"));
+					"re-initialized"));
 		}
 	}
 }


### PR DESCRIPTION
The main purpose of this PR is to create an agent for debugging.

We see issues with `Agent.Setup()` being called multiple times in specific environments. In order to debug this more, this PR flips the behaviour in `Agent.Setup()`: Instead of rejecting the new AgentComponents instance, the agent will accept and use the new instance and abandon the old one.

Essentially with this, the agent can be initialized multiple times and always the last setup wins.

With this we may have new insights on the specific issues we see - depending on the outcome we may investigate if this behaviour is better than the old one.

Although, that'd open up a bunch of other issues, e.g.: Multiple payloadsenders can be initialized with multiple server urls, if multiple tracers are present, they may capture things multiple times, multiple MetricsCollector will also likely run in parallel. None of these are addressed here and if we keep the behaviour in this PR we'll need to investigate and address all those potential issues.