### PR TITLE
Avoid NRE during startup hook init

### DIFF
--- a/src/ElasticApmAgentStartupHook/StartupHook.cs
+++ b/src/ElasticApmAgentStartupHook/StartupHook.cs
@@ -110,8 +110,8 @@ internal class StartupHook
 
 		if (loaderAssembly is null)
 		{
-			_logger.WriteLine(
-				$"No {LoaderDll} assembly loaded. Agent not loaded");
+			_logger.WriteLine($"No {LoaderDll} assembly loaded. Agent not loaded");
+			return;
 		}
 
 		LoadAssembliesFromLoaderDirectory(loaderDirectory);


### PR DESCRIPTION
If `Elastic.Apm.StartupHook.Loader.dll` cannot be found/loaded, a `NullReferenceException` is caused which brings the application down.

Note: This does not solve an underlying issue of a malfunctioning startup hook, but it avoids crashing the to-be-monitored application.