### PR TITLE
Add .NET 7 support

### DIFF
--- a/.ci/windows/tools.ps1
+++ b/.ci/windows/tools.ps1
@@ -12,6 +12,7 @@ Write-Host "Install .Net SDKs"
 choco install dotnetcore-sdk -m -y --no-progress -r --version 3.1.416
 choco install dotnet-sdk -m -y --no-progress -r --version 5.0.100
 choco install dotnet-sdk -m -y --no-progress -r --version 6.0.101
+choco install dotnet-sdk -m -y --no-progress -r --version 7.0.100
 
 # Install NuGet Tool
 choco install nuget.commandline -y --no-progress -r --version 6.0.0

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -627,6 +627,7 @@ def dotnet(Closure body){
     ./dotnet-install.sh --install-dir "\${DOTNET_ROOT}" -version '3.1.100'
     ./dotnet-install.sh --install-dir "\${DOTNET_ROOT}" -version '5.0.100'
     ./dotnet-install.sh --install-dir "\${DOTNET_ROOT}" -version '6.0.100'
+    ./dotnet-install.sh --install-dir "\${DOTNET_ROOT}" -version '7.0.100'
     """)
     withAzureCredentials(path: "${homePath}", credentialsFile: '.credentials.json') {
       withTerraformEnv(version: '0.15.3'){

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "6.0.100",
+    "version": "7.0.100",
     "rollForward": "latestFeature",
     "allowPrerelease": false
   }

--- a/sample/SampleAspNetCoreApp/SampleAspNetCoreApp.csproj
+++ b/sample/SampleAspNetCoreApp/SampleAspNetCoreApp.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0;net7.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <PlatformTarget>AnyCPU</PlatformTarget>
   </PropertyGroup>
@@ -25,26 +25,34 @@
     <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="5.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="5.0.0" />
     <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.0.0-rc6" />
-    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.0.0-rc6" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.0.0-rc6"/>
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="6.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="6.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="6.0.0" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.0.0-rc6" />
-    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.0.0-rc6" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="6.0.0"/>
+    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="6.0.0"/>
+    <PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="6.0.0"/>
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.0.0-rc6"/>
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.0.0-rc6"/>
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0"/>
+  </ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net7.0' ">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="7.0.0"/>
+    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="7.0.0"/>
+    <PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="7.0.0"/>
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.0.0-rc6"/>
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.0.0-rc6"/>
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="7.0.0"/>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1"/>
   </ItemGroup>
   <ItemGroup>
-    <Folder Include="Data\" />
-    <Folder Include="Data\HistoricalData" />
-    <Folder Include="Migrations" />
+    <Folder Include="Data\"/>
+    <Folder Include="Data\HistoricalData"/>
+    <Folder Include="Migrations"/>
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\src\Elastic.Apm.NetCoreAll\Elastic.Apm.NetCoreAll.csproj" />
+    <ProjectReference Include="..\..\src\Elastic.Apm.NetCoreAll\Elastic.Apm.NetCoreAll.csproj"/>
   </ItemGroup>
   <ItemGroup>
     <Content Update="Views\Home\Index.cshtml">

--- a/sample/WebApiSample/WebApiSample.csproj
+++ b/sample/WebApiSample/WebApiSample.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0;net7.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/src/Elastic.Apm/Elastic.Apm.csproj
+++ b/src/Elastic.Apm/Elastic.Apm.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net5.0;net6.0;net7.0;net461</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net5.0;net6.0;net461</TargetFrameworks>
     <IsPackable>true</IsPackable>
   </PropertyGroup>
   <PropertyGroup>
@@ -71,7 +71,7 @@
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="System.Diagnostics.PerformanceCounter" Version="4.5.0"/>
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'net5.0' or '$(TargetFramework)' == 'net6.0' or '$(TargetFramework)' == 'net7.0'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net5.0' or '$(TargetFramework)' == 'net6.0'">
     <PackageReference Include="System.Diagnostics.PerformanceCounter" Version="4.5.0"/>
   </ItemGroup>
   <ItemGroup>

--- a/src/Elastic.Apm/Elastic.Apm.csproj
+++ b/src/Elastic.Apm/Elastic.Apm.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net5.0;net6.0;net461</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net5.0;net6.0;net7.0;net461</TargetFrameworks>
     <IsPackable>true</IsPackable>
   </PropertyGroup>
   <PropertyGroup>
@@ -57,12 +57,7 @@
     <InternalsVisibleTo Include="Elastic.Apm.Profiler.Managed.Tests" Key="$(ExposedPublicKey)" />
     <InternalsVisibleTo Include="Elastic.Apm.StaticExplicitInitialization.Tests" Key="$(ExposedPublicKey)" />
   </ItemGroup>
-<!--  <ItemGroup Condition="'$(DiagnosticSourceVersion)' == '' and '$(TargetFramework)' == 'net6.0'">-->
-<!--    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="6.0.0" />-->
-<!--  </ItemGroup>-->
 
-<!--  <ItemGroup Condition="'$(DiagnosticSourceVersion)' == '' and '$(TargetFramework)' != 'net6.0'">-->
-    
   <ItemGroup Condition="'$(DiagnosticSourceVersion)' == ''">
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="5.0.0" />
   </ItemGroup>
@@ -71,22 +66,22 @@
        compile multiple versions of the agent.
    -->
   <ItemGroup Condition="'$(DiagnosticSourceVersion)' != ''">
-    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="$(DiagnosticSourceVersion)" />
+    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="$(DiagnosticSourceVersion)"/>
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-    <PackageReference Include="System.Diagnostics.PerformanceCounter" Version="4.5.0" />
+    <PackageReference Include="System.Diagnostics.PerformanceCounter" Version="4.5.0"/>
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'net5.0' or '$(TargetFramework)' == 'net6.0'">
-    <PackageReference Include="System.Diagnostics.PerformanceCounter" Version="4.5.0" />
+  <ItemGroup Condition="'$(TargetFramework)' == 'net5.0' or '$(TargetFramework)' == 'net6.0' or '$(TargetFramework)' == 'net7.0'">
+    <PackageReference Include="System.Diagnostics.PerformanceCounter" Version="4.5.0"/>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="2.0.2" />
-    <PackageReference Include="System.Threading.Tasks.Dataflow" Version="4.9.0" />
+    <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="2.0.2"/>
+    <PackageReference Include="System.Threading.Tasks.Dataflow" Version="4.9.0"/>
     <!-- Used by Ben.Demystifier -->
-    <PackageReference Include="System.Reflection.Metadata" Version="5.0.0" />
-    <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
+    <PackageReference Include="System.Reflection.Metadata" Version="5.0.0"/>
+    <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4"/>
   </ItemGroup>
-  
+
   <!-- Newtonsoft.Json constants -->
   <PropertyGroup Condition="'$(TargetFramework)'=='net461'">
     <DefineConstants>$(DefineConstants);HAVE_ADO_NET;HAVE_APP_DOMAIN;HAVE_ASYNC;HAVE_BIG_INTEGER;HAVE_BINARY_FORMATTER;HAVE_BINARY_SERIALIZATION;HAVE_BINARY_EXCEPTION_SERIALIZATION;HAVE_CAS;HAVE_CHAR_TO_LOWER_WITH_CULTURE;HAVE_CHAR_TO_STRING_WITH_CULTURE;HAVE_COM_ATTRIBUTES;HAVE_COMPONENT_MODEL;HAVE_CONCURRENT_COLLECTIONS;HAVE_CONCURRENT_DICTIONARY;HAVE_COVARIANT_GENERICS;HAVE_DATE_TIME_OFFSET;HAVE_DATA_CONTRACTS;HAVE_DB_NULL_TYPE_CODE;HAVE_DYNAMIC;HAVE_EMPTY_TYPES;HAVE_ENTITY_FRAMEWORK;HAVE_EXPRESSIONS;HAVE_FAST_REVERSE;HAVE_FSHARP_TYPES;HAVE_FULL_REFLECTION;HAVE_GUID_TRY_PARSE;HAVE_HASH_SET;HAVE_ICLONEABLE;HAVE_ICONVERTIBLE;HAVE_INOTIFY_COLLECTION_CHANGED;HAVE_INOTIFY_PROPERTY_CHANGING;HAVE_ISET;HAVE_LINQ;HAVE_MEMORY_BARRIER;HAVE_METHOD_IMPL_ATTRIBUTE;HAVE_NON_SERIALIZED_ATTRIBUTE;HAVE_READ_ONLY_COLLECTIONS;HAVE_REFLECTION_EMIT;HAVE_SECURITY_SAFE_CRITICAL_ATTRIBUTE;HAVE_SERIALIZATION_BINDER_BIND_TO_NAME;HAVE_STREAM_READER_WRITER_CLOSE;HAVE_STRING_JOIN_WITH_ENUMERABLE;HAVE_TIME_SPAN_PARSE_WITH_CULTURE;HAVE_TIME_SPAN_TO_STRING_WITH_CULTURE;HAVE_TIME_ZONE_INFO;HAVE_TRACE_WRITER;HAVE_TYPE_DESCRIPTOR;HAVE_UNICODE_SURROGATE_DETECTION;HAVE_VARIANT_TYPE_PARAMETERS;HAVE_VERSION_TRY_PARSE;HAVE_XML_DOCUMENT;HAVE_XML_DOCUMENT_TYPE</DefineConstants>

--- a/test/Elastic.Apm.AspNetCore.Static.Tests/ConfigTests.cs
+++ b/test/Elastic.Apm.AspNetCore.Static.Tests/ConfigTests.cs
@@ -11,6 +11,7 @@ using Elastic.Apm.AspNetCore.Tests;
 using Elastic.Apm.Config;
 using Elastic.Apm.Extensions.Hosting.Config;
 using Elastic.Apm.Tests.Utilities;
+using Elastic.Apm.Tests.Utilities.XUnit;
 using FluentAssertions;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.Extensions.Configuration;
@@ -34,9 +35,8 @@ namespace Elastic.Apm.AspNetCore.Static.Tests
 		/// Tests for: https://github.com/elastic/apm-agent-dotnet/issues/1077
 		/// </summary>
 		/// <param name="withDiagnosticSourceOnly"></param>
-		[InlineData(true)]
-		[InlineData(false)]
 		[Theory]
+		[MemberData(nameof(MemberData.TestWithDiagnosticSourceOnly), MemberType = typeof(MemberData))]
 		public async Task AgentDisabledInAppConfig(bool withDiagnosticSourceOnly)
 		{
 			var defaultServerUrlConnectionMade = false;

--- a/test/Elastic.Apm.AspNetCore.Static.Tests/Elastic.Apm.AspNetCore.Static.Tests.csproj
+++ b/test/Elastic.Apm.AspNetCore.Static.Tests/Elastic.Apm.AspNetCore.Static.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
     <PropertyGroup>
-      <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
+      <TargetFrameworks>netcoreapp3.1;net5.0;net6.0;net7.0</TargetFrameworks>
     </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="5.6.0" />
@@ -22,22 +22,26 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="3.0.0" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1' ">
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="3.1.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="3.1.0"/>
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net5.0' ">
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="5.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="5.0.0"/>
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
-    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Configuration" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="6.0.0"/>
+    <PackageReference Include="Microsoft.Extensions.Logging.Configuration" Version="6.0.0"/>
+  </ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net7.0' ">
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="7.0.0"/>
+    <PackageReference Include="Microsoft.Extensions.Logging.Configuration" Version="7.0.0"/>
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\src\Elastic.Apm.AspNetCore\Elastic.Apm.AspNetCore.csproj" />
-    <ProjectReference Include="..\..\src\Elastic.Apm\Elastic.Apm.csproj" />
-    <ProjectReference Include="..\..\sample\WebApiSample\WebApiSample.csproj" />
-    <ProjectReference Include="..\..\sample\SampleAspNetCoreApp\SampleAspNetCoreApp.csproj" />
-    <ProjectReference Include="..\Elastic.Apm.AspNetCore.Tests\Elastic.Apm.AspNetCore.Tests.csproj" />
-    <ProjectReference Include="..\Elastic.Apm.Tests.Utilities\Elastic.Apm.Tests.Utilities.csproj" />
+    <ProjectReference Include="..\..\src\Elastic.Apm.AspNetCore\Elastic.Apm.AspNetCore.csproj"/>
+    <ProjectReference Include="..\..\src\Elastic.Apm\Elastic.Apm.csproj"/>
+    <ProjectReference Include="..\..\sample\WebApiSample\WebApiSample.csproj"/>
+    <ProjectReference Include="..\..\sample\SampleAspNetCoreApp\SampleAspNetCoreApp.csproj"/>
+    <ProjectReference Include="..\Elastic.Apm.AspNetCore.Tests\Elastic.Apm.AspNetCore.Tests.csproj"/>
+    <ProjectReference Include="..\Elastic.Apm.Tests.Utilities\Elastic.Apm.Tests.Utilities.csproj"/>
   </ItemGroup>
   <ItemGroup>
     <Content Update="TestConfigs\appsettings_agentdisabled.json">

--- a/test/Elastic.Apm.AspNetCore.Static.Tests/Elastic.Apm.AspNetCore.Static.Tests.csproj
+++ b/test/Elastic.Apm.AspNetCore.Static.Tests/Elastic.Apm.AspNetCore.Static.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
     <PropertyGroup>
-      <TargetFrameworks>netcoreapp3.1;net5.0;net6.0;net7.0</TargetFrameworks>
+      <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
     </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="5.6.0" />

--- a/test/Elastic.Apm.AspNetCore.Static.Tests/Elastic.Apm.AspNetCore.Static.Tests.csproj
+++ b/test/Elastic.Apm.AspNetCore.Static.Tests/Elastic.Apm.AspNetCore.Static.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
     <PropertyGroup>
-      <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
+      <TargetFrameworks>netcoreapp3.1;net5.0;net6.0;net7.0</TargetFrameworks>
     </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="5.6.0" />

--- a/test/Elastic.Apm.AspNetCore.Tests/AspNetCoreBasicTests.cs
+++ b/test/Elastic.Apm.AspNetCore.Tests/AspNetCoreBasicTests.cs
@@ -18,6 +18,7 @@ using Elastic.Apm.Extensions.Hosting;
 using Elastic.Apm.Logging;
 using Elastic.Apm.Model;
 using Elastic.Apm.Tests.Utilities;
+using Elastic.Apm.Tests.Utilities.XUnit;
 using FluentAssertions;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
@@ -63,22 +64,11 @@ namespace Elastic.Apm.AspNetCore.Tests
 
 		private HttpClient _client;
 
-		public static IEnumerable<object[]> TestWithDiagnosticSourceOnly()
-		{
-			yield return new object[] { false };
-			//
-			// Skip "DiagnosticSourceOnly" tests on .NET 7
-			// until https://github.com/dotnet/aspnetcore/issues/45233 is resolved.
-			//
-			if (Environment.Version.Major < 7)
-				yield return new object[] { true };
-		}
-
 		/// <summary>
 		/// Simulates an HTTP GET call to /home/simplePage and asserts on what the agent should send to the server
 		/// </summary>
 		[Theory]
-		[MemberData(nameof(TestWithDiagnosticSourceOnly))]
+		[MemberData(nameof(MemberData.TestWithDiagnosticSourceOnly), MemberType = typeof(MemberData))]
 		public async Task HomeSimplePageTransactionTest(bool withDiagnosticSourceOnly)
 		{
 			_client = Helper.ConfigureHttpClient(true, withDiagnosticSourceOnly, _agent, _factory);
@@ -167,7 +157,7 @@ namespace Elastic.Apm.AspNetCore.Tests
 		/// <param name="withDiagnosticSourceOnly"></param>
 		/// <returns></returns>
 		[Theory]
-		[MemberData(nameof(TestWithDiagnosticSourceOnly))]
+		[MemberData(nameof(MemberData.TestWithDiagnosticSourceOnly), MemberType = typeof(MemberData))]
 		public async Task HomeIndexTransactionWithEnabledFalse(bool withDiagnosticSourceOnly)
 		{
 			_agent = new ApmAgent(new TestAgentComponents(
@@ -187,7 +177,7 @@ namespace Elastic.Apm.AspNetCore.Tests
 		}
 
 		[Theory]
-		[MemberData(nameof(TestWithDiagnosticSourceOnly))]
+		[MemberData(nameof(MemberData.TestWithDiagnosticSourceOnly), MemberType = typeof(MemberData))]
 		public async Task HomeIndexTransactionWithToggleRecording(bool withDiagnosticSourceOnly)
 		{
 			_agent = new ApmAgent(new TestAgentComponents(
@@ -226,7 +216,7 @@ namespace Elastic.Apm.AspNetCore.Tests
 		/// to test the 'CaptureBody' configuration option
 		/// </summary>
 		[Theory]
-		[MemberData(nameof(TestWithDiagnosticSourceOnly))]
+		[MemberData(nameof(MemberData.TestWithDiagnosticSourceOnly), MemberType = typeof(MemberData))]
 		public async Task HomeSimplePagePostTransactionTest(bool withDiagnosticSourceOnly)
 		{
 			_client = Helper.ConfigureHttpClient(true, withDiagnosticSourceOnly, _agent, _factory);
@@ -321,7 +311,7 @@ namespace Elastic.Apm.AspNetCore.Tests
 		/// Prerequisite: The /home/index has to generate spans (which should be the case).
 		/// </summary>
 		[Theory]
-		[MemberData(nameof(TestWithDiagnosticSourceOnly))]
+		[MemberData(nameof(MemberData.TestWithDiagnosticSourceOnly), MemberType = typeof(MemberData))]
 		public async Task HomeIndexSpanTest(bool withDiagnosticSourceOnly)
 		{
 			_client = Helper.ConfigureHttpClient(true, withDiagnosticSourceOnly, _agent, _factory);
@@ -340,7 +330,7 @@ namespace Elastic.Apm.AspNetCore.Tests
 		/// It also assumes that /home/index makes a requrst to github.com
 		/// </summary>
 		[Theory]
-		[MemberData(nameof(TestWithDiagnosticSourceOnly))]
+		[MemberData(nameof(MemberData.TestWithDiagnosticSourceOnly), MemberType = typeof(MemberData))]
 		public async Task HomeIndexDestinationTest(bool withDiagnosticSourceOnly)
 		{
 			_client = Helper.ConfigureHttpClient(true, withDiagnosticSourceOnly, _agent, _factory);
@@ -364,7 +354,7 @@ namespace Elastic.Apm.AspNetCore.Tests
 		/// and asserts that all automatically captured spans are children of the span for controller's action.
 		/// </summary>
 		[Theory]
-		[MemberData(nameof(TestWithDiagnosticSourceOnly))]
+		[MemberData(nameof(MemberData.TestWithDiagnosticSourceOnly), MemberType = typeof(MemberData))]
 		public async Task HomeIndexAutoCapturedSpansAreChildrenOfControllerActionAsSpan(bool withDiagnosticSourceOnly)
 		{
 			_client = Helper.ConfigureHttpClient(true, withDiagnosticSourceOnly, _agent, _factory);
@@ -402,7 +392,7 @@ namespace Elastic.Apm.AspNetCore.Tests
 		/// Makes sure that we still capture the failed request.
 		/// </summary>
 		[Theory]
-		[MemberData(nameof(TestWithDiagnosticSourceOnly))]
+		[MemberData(nameof(MemberData.TestWithDiagnosticSourceOnly), MemberType = typeof(MemberData))]
 		public async Task FailingRequestWithoutConfiguredExceptionPage(bool withDiagnosticSourceOnly)
 		{
 			_client = Helper.ConfigureHttpClient(false, withDiagnosticSourceOnly, _agent, _factory);
@@ -438,7 +428,7 @@ namespace Elastic.Apm.AspNetCore.Tests
 		/// Makes sure that we still capture the failed request along with the request body
 		/// </summary>
 		[Theory]
-		[MemberData(nameof(TestWithDiagnosticSourceOnly))]
+		[MemberData(nameof(MemberData.TestWithDiagnosticSourceOnly), MemberType = typeof(MemberData))]
 		public async Task FailingPostRequestWithoutConfiguredExceptionPage(bool withDiagnosticSourceOnly)
 		{
 			_client = Helper.ConfigureHttpClient(false, withDiagnosticSourceOnly, _agent, _factory);
@@ -492,7 +482,7 @@ namespace Elastic.Apm.AspNetCore.Tests
 		/// Makes sure auto instrumentation does not overwrite the outcome.
 		/// </summary>
 		[Theory]
-		[MemberData(nameof(TestWithDiagnosticSourceOnly))]
+		[MemberData(nameof(MemberData.TestWithDiagnosticSourceOnly), MemberType = typeof(MemberData))]
 		public async Task ManualTransactionOutcomeTest(bool withDiagnosticSourceOnly)
 		{
 			_client = Helper.ConfigureHttpClient(true, withDiagnosticSourceOnly, _agent, _factory);

--- a/test/Elastic.Apm.AspNetCore.Tests/AspNetCoreBasicTests.cs
+++ b/test/Elastic.Apm.AspNetCore.Tests/AspNetCoreBasicTests.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information
 
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Net.Http;
@@ -62,13 +63,22 @@ namespace Elastic.Apm.AspNetCore.Tests
 
 		private HttpClient _client;
 
+		public static IEnumerable<object[]> TestWithDiagnosticSourceOnly()
+		{
+			yield return new object[] { false };
+			//
+			// Skip "DiagnosticSourceOnly" tests on .NET 7
+			// until https://github.com/dotnet/aspnetcore/issues/45233 is resolved.
+			//
+			if (Environment.Version.Major < 7)
+				yield return new object[] { true };
+		}
 
 		/// <summary>
 		/// Simulates an HTTP GET call to /home/simplePage and asserts on what the agent should send to the server
 		/// </summary>
-		[InlineData(true)]
-		[InlineData(false)]
 		[Theory]
+		[MemberData(nameof(TestWithDiagnosticSourceOnly))]
 		public async Task HomeSimplePageTransactionTest(bool withDiagnosticSourceOnly)
 		{
 			_client = Helper.ConfigureHttpClient(true, withDiagnosticSourceOnly, _agent, _factory);
@@ -98,6 +108,8 @@ namespace Elastic.Apm.AspNetCore.Tests
 			_agent.Service.Runtime.Name.Should().Be(Runtime.DotNetName + " 5");
 #elif NET6_0
 			_agent.Service.Runtime.Name.Should().Be(Runtime.DotNetName + " 6");
+#elif NET7_0
+			_agent.Service.Runtime.Name.Should().Be(Runtime.DotNetName + " 7");
 #else
 			_agent.Service.Runtime.Name.Should().Be(Runtime.DotNetCoreName);
 #endif
@@ -154,9 +166,8 @@ namespace Elastic.Apm.AspNetCore.Tests
 		/// </summary>
 		/// <param name="withDiagnosticSourceOnly"></param>
 		/// <returns></returns>
-		[InlineData(true)]
-		[InlineData(false)]
 		[Theory]
+		[MemberData(nameof(TestWithDiagnosticSourceOnly))]
 		public async Task HomeIndexTransactionWithEnabledFalse(bool withDiagnosticSourceOnly)
 		{
 			_agent = new ApmAgent(new TestAgentComponents(
@@ -175,9 +186,8 @@ namespace Elastic.Apm.AspNetCore.Tests
 			_capturedPayload.Errors.Should().BeNullOrEmpty();
 		}
 
-		[InlineData(true)]
-		[InlineData(false)]
 		[Theory]
+		[MemberData(nameof(TestWithDiagnosticSourceOnly))]
 		public async Task HomeIndexTransactionWithToggleRecording(bool withDiagnosticSourceOnly)
 		{
 			_agent = new ApmAgent(new TestAgentComponents(
@@ -215,9 +225,8 @@ namespace Elastic.Apm.AspNetCore.Tests
 		/// Simulates an HTTP POST call to /home/simplePage and asserts on what the agent should send to the server
 		/// to test the 'CaptureBody' configuration option
 		/// </summary>
-		[InlineData(true)]
-		[InlineData(false)]
 		[Theory]
+		[MemberData(nameof(TestWithDiagnosticSourceOnly))]
 		public async Task HomeSimplePagePostTransactionTest(bool withDiagnosticSourceOnly)
 		{
 			_client = Helper.ConfigureHttpClient(true, withDiagnosticSourceOnly, _agent, _factory);
@@ -249,6 +258,8 @@ namespace Elastic.Apm.AspNetCore.Tests
 			_agent.Service.Runtime.Name.Should().Be(Runtime.DotNetName + " 5");
 #elif NET6_0
 			_agent.Service.Runtime.Name.Should().Be(Runtime.DotNetName + " 6");
+#elif NET7_0
+			_agent.Service.Runtime.Name.Should().Be(Runtime.DotNetName + " 7");
 #else
 			_agent.Service.Runtime.Name.Should().Be(Runtime.DotNetCoreName);
 #endif
@@ -309,9 +320,8 @@ namespace Elastic.Apm.AspNetCore.Tests
 		/// Simulates an HTTP GET call to /home/index and asserts that the agent captures spans.
 		/// Prerequisite: The /home/index has to generate spans (which should be the case).
 		/// </summary>
-		[InlineData(true)]
-		[InlineData(false)]
 		[Theory]
+		[MemberData(nameof(TestWithDiagnosticSourceOnly))]
 		public async Task HomeIndexSpanTest(bool withDiagnosticSourceOnly)
 		{
 			_client = Helper.ConfigureHttpClient(true, withDiagnosticSourceOnly, _agent, _factory);
@@ -329,9 +339,8 @@ namespace Elastic.Apm.AspNetCore.Tests
 		/// Prerequisite: The /home/index has to generate spans (which should be the case).
 		/// It also assumes that /home/index makes a requrst to github.com
 		/// </summary>
-		[InlineData(true)]
-		[InlineData(false)]
 		[Theory]
+		[MemberData(nameof(TestWithDiagnosticSourceOnly))]
 		public async Task HomeIndexDestinationTest(bool withDiagnosticSourceOnly)
 		{
 			_client = Helper.ConfigureHttpClient(true, withDiagnosticSourceOnly, _agent, _factory);
@@ -354,9 +363,8 @@ namespace Elastic.Apm.AspNetCore.Tests
 		/// Simulates an HTTP GET call to /Home/Index?captureControllerActionAsSpan=true
 		/// and asserts that all automatically captured spans are children of the span for controller's action.
 		/// </summary>
-		[InlineData(true)]
-		[InlineData(false)]
 		[Theory]
+		[MemberData(nameof(TestWithDiagnosticSourceOnly))]
 		public async Task HomeIndexAutoCapturedSpansAreChildrenOfControllerActionAsSpan(bool withDiagnosticSourceOnly)
 		{
 			_client = Helper.ConfigureHttpClient(true, withDiagnosticSourceOnly, _agent, _factory);
@@ -393,9 +401,8 @@ namespace Elastic.Apm.AspNetCore.Tests
 		/// With other words: there is no error page with an exception handler configured in the ASP.NET Core pipeline.
 		/// Makes sure that we still capture the failed request.
 		/// </summary>
-		[InlineData(true)]
-		[InlineData(false)]
 		[Theory]
+		[MemberData(nameof(TestWithDiagnosticSourceOnly))]
 		public async Task FailingRequestWithoutConfiguredExceptionPage(bool withDiagnosticSourceOnly)
 		{
 			_client = Helper.ConfigureHttpClient(false, withDiagnosticSourceOnly, _agent, _factory);
@@ -430,9 +437,8 @@ namespace Elastic.Apm.AspNetCore.Tests
 		/// With other words: there is no error page with an exception handler configured in the ASP.NET Core pipeline.
 		/// Makes sure that we still capture the failed request along with the request body
 		/// </summary>
-		[InlineData(true)]
-		[InlineData(false)]
 		[Theory]
+		[MemberData(nameof(TestWithDiagnosticSourceOnly))]
 		public async Task FailingPostRequestWithoutConfiguredExceptionPage(bool withDiagnosticSourceOnly)
 		{
 			_client = Helper.ConfigureHttpClient(false, withDiagnosticSourceOnly, _agent, _factory);
@@ -485,9 +491,8 @@ namespace Elastic.Apm.AspNetCore.Tests
 		/// An HTTP call to an action method which manually sets <see cref="IExecutionSegment.Outcome"/>.
 		/// Makes sure auto instrumentation does not overwrite the outcome.
 		/// </summary>
-		[InlineData(true)]
-		[InlineData(false)]
 		[Theory]
+		[MemberData(nameof(TestWithDiagnosticSourceOnly))]
 		public async Task ManualTransactionOutcomeTest(bool withDiagnosticSourceOnly)
 		{
 			_client = Helper.ConfigureHttpClient(true, withDiagnosticSourceOnly, _agent, _factory);

--- a/test/Elastic.Apm.AspNetCore.Tests/AspNetCoreDiagnosticListenerTest.cs
+++ b/test/Elastic.Apm.AspNetCore.Tests/AspNetCoreDiagnosticListenerTest.cs
@@ -12,6 +12,7 @@ using Elastic.Apm.Config;
 using Elastic.Apm.DiagnosticSource;
 using Elastic.Apm.Model;
 using Elastic.Apm.Tests.Utilities;
+using Elastic.Apm.Tests.Utilities.XUnit;
 using FluentAssertions;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
@@ -37,9 +38,8 @@ namespace Elastic.Apm.AspNetCore.Tests
 		/// and makes sure that the error is captured.
 		/// </summary>
 		/// <returns>The error in ASP net core.</returns>
-		[InlineData(true)]
-		[InlineData(false)]
 		[Theory]
+		[MemberData(nameof(MemberData.TestWithDiagnosticSourceOnly), MemberType = typeof(MemberData))]
 		public async Task TestErrorInAspNetCore(bool useOnlyDiagnosticSource)
 		{
 			var capturedPayload = new MockPayloadSender();
@@ -81,9 +81,8 @@ namespace Elastic.Apm.AspNetCore.Tests
 		/// retrieved from the HttpRequest
 		/// </summary>
 		/// <returns>The error in ASP net core.</returns>
-		[InlineData(true)]
-		[InlineData(false)]
 		[Theory]
+		[MemberData(nameof(MemberData.TestWithDiagnosticSourceOnly), MemberType = typeof(MemberData))]
 		public async Task TestJsonBodyRetrievalOnRequestFailureInAspNetCore(bool useOnlyDiagnosticSource)
 		{
 			var capturedPayload = new MockPayloadSender();

--- a/test/Elastic.Apm.AspNetCore.Tests/Elastic.Apm.AspNetCore.Tests.csproj
+++ b/test/Elastic.Apm.AspNetCore.Tests/Elastic.Apm.AspNetCore.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0;net7.0</TargetFrameworks>
     <AssemblyName>Elastic.Apm.AspNetCore.Tests</AssemblyName>
     <RootNamespace>Elastic.Apm.AspNetCore.Tests</RootNamespace>
   </PropertyGroup>
@@ -31,22 +31,27 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="3.0.0" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1' ">
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="3.1.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="3.1.0"/>
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net5.0' ">
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="5.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="5.0.0"/>
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Configuration" Version="6.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.0"/>
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="6.0.0"/>
+    <PackageReference Include="Microsoft.Extensions.Logging.Configuration" Version="6.0.0"/>
+  </ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net7.0' ">
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="7.0.0"/>
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="7.0.0"/>
+    <PackageReference Include="Microsoft.Extensions.Logging.Configuration" Version="7.0.0"/>
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\src\Elastic.Apm.AspNetCore\Elastic.Apm.AspNetCore.csproj" />
-    <ProjectReference Include="..\..\src\Elastic.Apm\Elastic.Apm.csproj" />
-    <ProjectReference Include="..\..\sample\WebApiSample\WebApiSample.csproj" />
-    <ProjectReference Include="..\..\sample\SampleAspNetCoreApp\SampleAspNetCoreApp.csproj" />
-    <ProjectReference Include="..\Elastic.Apm.Tests.Utilities\Elastic.Apm.Tests.Utilities.csproj" />
+    <ProjectReference Include="..\..\src\Elastic.Apm.AspNetCore\Elastic.Apm.AspNetCore.csproj"/>
+    <ProjectReference Include="..\..\src\Elastic.Apm\Elastic.Apm.csproj"/>
+    <ProjectReference Include="..\..\sample\WebApiSample\WebApiSample.csproj"/>
+    <ProjectReference Include="..\..\sample\SampleAspNetCoreApp\SampleAspNetCoreApp.csproj"/>
+    <ProjectReference Include="..\Elastic.Apm.Tests.Utilities\Elastic.Apm.Tests.Utilities.csproj"/>
   </ItemGroup>
   <ItemGroup>
     <Content Update="TestConfigs\appsettings_valid.json">

--- a/test/Elastic.Apm.AspNetCore.Tests/SanitizeFieldNamesTests.cs
+++ b/test/Elastic.Apm.AspNetCore.Tests/SanitizeFieldNamesTests.cs
@@ -9,6 +9,7 @@ using System.Net.Http;
 using System.Threading.Tasks;
 using Elastic.Apm.Logging;
 using Elastic.Apm.Tests.Utilities;
+using Elastic.Apm.Tests.Utilities.XUnit;
 using FluentAssertions;
 using Microsoft.AspNetCore.Mvc.Testing;
 using SampleAspNetCoreApp;
@@ -206,9 +207,8 @@ namespace Elastic.Apm.AspNetCore.Tests
 		/// </summary>
 		/// <param name="useDiagnosticSourceOnly"></param>
 		/// <returns></returns>
-		[InlineData(true)]
-		[InlineData(false)]
 		[Theory]
+		[MemberData(nameof(MemberData.TestWithDiagnosticSourceOnly), MemberType = typeof(MemberData))]
 		public async Task ChangeSanitizeFieldNamesAfterStart(bool useDiagnosticSourceOnly)
 		{
 			var startConfigSnapshot = new MockConfiguration(new NoopLogger());

--- a/test/Elastic.Apm.AspNetCore.Tests/SanitizeFieldNamesTests.cs
+++ b/test/Elastic.Apm.AspNetCore.Tests/SanitizeFieldNamesTests.cs
@@ -138,17 +138,25 @@ namespace Elastic.Apm.AspNetCore.Tests
 			// Add true and false to the end of each test data, so we test it both with middleware and with diagnosticsource
 			foreach (var testDataItem in testData)
 			{
-				var newItem = new List<object>();
-				foreach (var item in testDataItem) newItem.Add(item);
-				newItem.Add(true);
+				//
+				// Skip "DiagnosticSourceOnly" tests on .NET 7
+				// until https://github.com/dotnet/aspnetcore/issues/45233 is resolved.
+				//
+				if (Environment.Version.Major < 7)
+				{
+					var newItem = new List<object>();
+					foreach (var item in testDataItem) newItem.Add(item);
+					newItem.Add(true);
 
-				retVal.Add(newItem.ToArray());
+					retVal.Add(newItem.ToArray());
+				}
+				{
+					var newItem = new List<object>();
+					foreach (var item in testDataItem) newItem.Add(item);
+					newItem.Add(false);
 
-				newItem = new List<object>();
-				foreach (var item in testDataItem) newItem.Add(item);
-				newItem.Add(false);
-
-				retVal.Add(newItem.ToArray());
+					retVal.Add(newItem.ToArray());
+				}
 			}
 
 			return retVal;

--- a/test/Elastic.Apm.AspNetCore.Tests/TransactionIgnoreUrlsTest.cs
+++ b/test/Elastic.Apm.AspNetCore.Tests/TransactionIgnoreUrlsTest.cs
@@ -9,6 +9,7 @@ using System.Threading.Tasks;
 using Elastic.Apm.Extensions.Hosting;
 using Elastic.Apm.Logging;
 using Elastic.Apm.Tests.Utilities;
+using Elastic.Apm.Tests.Utilities.XUnit;
 using FluentAssertions;
 using Microsoft.AspNetCore.Mvc.Testing;
 using SampleAspNetCoreApp;
@@ -61,9 +62,8 @@ namespace Elastic.Apm.AspNetCore.Tests
 		/// </summary>
 		/// <param name="useDiagnosticSourceOnly"></param>
 		/// <returns></returns>
-		[InlineData(true)]
-		[InlineData(false)]
 		[Theory]
+		[MemberData(nameof(MemberData.TestWithDiagnosticSourceOnly), MemberType = typeof(MemberData))]
 		public async Task ChangeTransactionIgnoreUrlsAfterStart(bool useDiagnosticSourceOnly)
 		{
 			// Start with default config
@@ -118,9 +118,8 @@ namespace Elastic.Apm.AspNetCore.Tests
 		/// In the ctor we add `*SimplePage` to the ignoreUrl list. This test makes sure that /home/SimplePage is indeed ignored.
 		/// </summary>
 		/// <returns></returns>
-		[InlineData(true)]
-		[InlineData(false)]
 		[Theory]
+		[MemberData(nameof(MemberData.TestWithDiagnosticSourceOnly), MemberType = typeof(MemberData))]
 		public async Task IgnoreSimplePage(bool useOnlyDiagnosticSource)
 		{
 			Setup(useOnlyDiagnosticSource);

--- a/test/Elastic.Apm.AspNetCore.Tests/TransactionNameTests.cs
+++ b/test/Elastic.Apm.AspNetCore.Tests/TransactionNameTests.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using Elastic.Apm.Extensions.Hosting;
 using Elastic.Apm.Logging;
 using Elastic.Apm.Tests.Utilities;
+using Elastic.Apm.Tests.Utilities.XUnit;
 using FluentAssertions;
 using Microsoft.AspNetCore.Mvc.Testing;
 using SampleAspNetCoreApp;
@@ -48,9 +49,8 @@ namespace Elastic.Apm.AspNetCore.Tests
 		/// Calls a URL that maps to a route with optional parameter (id).
 		/// Makes sure the Transaction.Name contains "{id}" instead of the value.
 		/// </summary>
-		[InlineData(true)]
-		[InlineData(false)]
 		[Theory]
+		[MemberData(nameof(MemberData.TestWithDiagnosticSourceOnly), MemberType = typeof(MemberData))]
 		public async Task OptionalRouteParameter(bool diagnosticSourceOnly)
 		{
 			var httpClient = Helper.GetClient(_agent, _factory, diagnosticSourceOnly);
@@ -64,9 +64,8 @@ namespace Elastic.Apm.AspNetCore.Tests
 		/// Calls a URL and sets custom transaction name.
 		/// Makes sure the Transaction.Name can be set to custom name.
 		/// </summary>
-		[InlineData(true)]
-		[InlineData(false)]
 		[Theory]
+		[MemberData(nameof(MemberData.TestWithDiagnosticSourceOnly), MemberType = typeof(MemberData))]
 		public async Task CustomTransactionName(bool diagnosticSourceOnly)
 		{
 			var httpClient = Helper.GetClient(_agent, _factory, diagnosticSourceOnly);
@@ -82,9 +81,8 @@ namespace Elastic.Apm.AspNetCore.Tests
 		/// change that.
 		/// See: https://github.com/elastic/apm-agent-dotnet/pull/258#discussion_r291025014
 		/// </summary>
-		[InlineData(true)]
-		[InlineData(false)]
 		[Theory]
+		[MemberData(nameof(MemberData.TestWithDiagnosticSourceOnly), MemberType = typeof(MemberData))]
 		public async Task CustomTransactionNameWithNameUsingRequestInfo(bool diagnosticSourceOnly)
 		{
 			var httpClient = Helper.GetClient(_agent, _factory, diagnosticSourceOnly);
@@ -101,9 +99,8 @@ namespace Elastic.Apm.AspNetCore.Tests
 		/// Calls a URL that would map to a route with optional parameter (id), but does not pass the id value.
 		/// Makes sure no template value is captured in Transaction.Name.
 		/// </summary>
-		[InlineData(true)]
-		[InlineData(false)]
 		[Theory]
+		[MemberData(nameof(MemberData.TestWithDiagnosticSourceOnly), MemberType = typeof(MemberData))]
 		public async Task OptionalRouteParameterWithNull(bool diagnosticSourceOnly)
 		{
 			var httpClient = Helper.GetClient(_agent, _factory, diagnosticSourceOnly);
@@ -117,9 +114,8 @@ namespace Elastic.Apm.AspNetCore.Tests
 		/// Tests a URL that maps to a route with default values. Calls "/", which maps to "home/index".
 		/// Makes sure "Home/Index" is in the Transaction.Name.
 		/// </summary>
-		[InlineData(true)]
-		[InlineData(false)]
 		[Theory]
+		[MemberData(nameof(MemberData.TestWithDiagnosticSourceOnly), MemberType = typeof(MemberData))]
 		public async Task DefaultRouteParameterValues(bool diagnosticSourceOnly)
 		{
 			var httpClient = Helper.GetClient(_agent, _factory, diagnosticSourceOnly);
@@ -134,9 +130,8 @@ namespace Elastic.Apm.AspNetCore.Tests
 		/// Tests a URL that maps to an area route with an area route value and default values. Calls "/MyArea", which maps to "MyArea/Home/Index".
 		/// Makes sure "GET MyArea/Home/Index" is the Transaction.Name.
 		/// </summary>
-		[InlineData(true)]
-		[InlineData(false)]
 		[Theory]
+		[MemberData(nameof(MemberData.TestWithDiagnosticSourceOnly), MemberType = typeof(MemberData))]
 		public async Task Name_Should_Be_Area_Controller_Action_When_Mvc_Area_Controller_Action(bool diagnosticSourceOnly)
 		{
 			var httpClient = Helper.GetClient(_agent, _factory, diagnosticSourceOnly);
@@ -151,9 +146,8 @@ namespace Elastic.Apm.AspNetCore.Tests
 		/// Tests a URL that maps to an explicit area route with default values. Calls "/MyOtherArea", which maps to "MyOtherArea/Home/Index".
 		/// Makes sure "GET MyOtherArea/Home/Index" is the Transaction.Name.
 		/// </summary>
-		[InlineData(true)]
-		[InlineData(false)]
 		[Theory]
+		[MemberData(nameof(MemberData.TestWithDiagnosticSourceOnly), MemberType = typeof(MemberData))]
 		public async Task Name_Should_Be_Area_Controller_Action_When_Mvc_Area_Controller_Action_With_Area_Route(bool diagnosticSourceOnly)
 		{
 			var httpClient = Helper.GetClient(_agent, _factory, diagnosticSourceOnly);
@@ -187,9 +181,8 @@ namespace Elastic.Apm.AspNetCore.Tests
 		/// If a URL matches a route, but the controller method returns e.g. HTTP 404,
 		/// the method name should be the real route and not "unknown route".
 		/// </summary>
-		[InlineData(true)]
-		[InlineData(false)]
 		[Theory]
+		[MemberData(nameof(MemberData.TestWithDiagnosticSourceOnly), MemberType = typeof(MemberData))]
 		public async Task Http404WithValidRoute(bool diagnosticSourceOnly)
 		{
 			var httpClient = Helper.GetClient(_agent, _factory, diagnosticSourceOnly);

--- a/test/Elastic.Apm.Extensions.Hosting.Tests/Elastic.Apm.Extensions.Hosting.Tests.csproj
+++ b/test/Elastic.Apm.Extensions.Hosting.Tests/Elastic.Apm.Extensions.Hosting.Tests.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0;net7.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Elastic.Apm.Extensions.Logging.Tests/Elastic.Apm.Extensions.Logging.Tests.csproj
+++ b/test/Elastic.Apm.Extensions.Logging.Tests/Elastic.Apm.Extensions.Logging.Tests.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0;net7.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>
@@ -25,15 +25,19 @@
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net5.0'">
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="5.0.0"/>
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0'">
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.0"/>
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net7.0'">
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="7.0.0"/>
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1'">
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="3.1.5" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="3.1.5"/>
   </ItemGroup>
 
 </Project>

--- a/test/Elastic.Apm.Grpc.Tests/GrpcTests.cs
+++ b/test/Elastic.Apm.Grpc.Tests/GrpcTests.cs
@@ -29,9 +29,8 @@ namespace Elastic.Apm.Grpc.Tests
 		/// </summary>
 		/// <param name="withDiagnosticSource"></param>
 		/// <returns></returns>
-		[InlineData(true)]
-		[InlineData(false)]
 		[Theory]
+		[MemberData(nameof(MemberData.TestWithDiagnosticSourceOnly), MemberType = typeof(MemberData))]
 		public async Task BasicGrpcTest(bool withDiagnosticSource)
 		{
 			var payloadSender = new MockPayloadSender { IsStrictSpanCheckEnabled = true };
@@ -95,14 +94,10 @@ namespace Elastic.Apm.Grpc.Tests
 		/// </summary>
 		/// <param name="withDiagnosticSource"></param>
 		/// <returns></returns>
-		// [InlineData(true)]
-		// [InlineData(false)]
-		[DisabledTestFact("Flaky in CI")]
-		public async Task FailingGrpcCallTest()
+		[Theory]
+		[MemberData(nameof(MemberData.TestWithDiagnosticSourceOnly), MemberType = typeof(MemberData))]
+		public async Task FailingGrpcCallTest(bool withDiagnosticSource)
 		{
-			//TODO: once test re-enabled move this into a method parameter
-			var withDiagnosticSource = false;
-
 			var payloadSender = new MockPayloadSender();
 			using var apmAgent = new ApmAgent(new TestAgentComponents(payloadSender: payloadSender));
 			var grpcClientDiagnosticSubscriber = new GrpcClientDiagnosticSubscriber();

--- a/test/Elastic.Apm.StaticExplicitInitialization.Tests/Elastic.Apm.StaticExplicitInitialization.Tests.csproj
+++ b/test/Elastic.Apm.StaticExplicitInitialization.Tests/Elastic.Apm.StaticExplicitInitialization.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0;net7.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Elastic.Apm.StaticImplicitInitialization.Tests/Elastic.Apm.StaticImplicitInitialization.Tests.csproj
+++ b/test/Elastic.Apm.StaticImplicitInitialization.Tests/Elastic.Apm.StaticImplicitInitialization.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0;net7.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Elastic.Apm.Tests.Utilities/Elastic.Apm.Tests.Utilities.csproj
+++ b/test/Elastic.Apm.Tests.Utilities/Elastic.Apm.Tests.Utilities.csproj
@@ -31,14 +31,14 @@
   
     <ItemGroup>
       <PackageReference Include="Proc" Version="0.6.2" />
-      <PackageReference Include="FluentAssertions" Version="5.6.0"/>
-      <PackageReference Include="Moq" Version="4.12.0"/>
-      <PackageReference Include="RichardSzalay.MockHttp" Version="6.0.0"/>
-      <PackageReference Include="xunit" Version="2.4.1"/>
+      <PackageReference Include="FluentAssertions" Version="5.6.0" />
+      <PackageReference Include="Moq" Version="4.12.0" />
+      <PackageReference Include="RichardSzalay.MockHttp" Version="6.0.0" />
+      <PackageReference Include="xunit" Version="2.4.1" />
     </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\Elastic.Apm\Elastic.Apm.csproj"/>
+    <ProjectReference Include="..\..\src\Elastic.Apm\Elastic.Apm.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Elastic.Apm.Tests.Utilities/XUnit/MemberData.cs
+++ b/test/Elastic.Apm.Tests.Utilities/XUnit/MemberData.cs
@@ -1,0 +1,22 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+using System;
+using System.Collections.Generic;
+
+namespace Elastic.Apm.Tests.Utilities.XUnit;
+
+public static class MemberData
+{
+	public static IEnumerable<object[]> TestWithDiagnosticSourceOnly()
+	{
+		yield return new object[] { false };
+		//
+		// Skip "DiagnosticSourceOnly" tests on .NET 7
+		// until https://github.com/dotnet/aspnetcore/issues/45233 is resolved.
+		//
+		if (Environment.Version.Major < 7)
+			yield return new object[] { true };
+	}
+
+}

--- a/test/Elastic.Apm.Tests/Elastic.Apm.Tests.csproj
+++ b/test/Elastic.Apm.Tests/Elastic.Apm.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net461;net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net461;net5.0;net6.0;net7.0</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -45,8 +45,8 @@
     <ProjectReference Include="..\Elastic.Apm.Tests.Utilities\Elastic.Apm.Tests.Utilities.csproj" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net5.0' OR '$(TargetFramework)' == 'net6.0' ">
-    <ProjectReference Include="..\..\sample\OpenTelemetrySample\OpenTelemetrySample.csproj" />
+  <ItemGroup Condition="'$(TargetFramework)' == 'net5.0' OR '$(TargetFramework)' == 'net6.0' OR '$(TargetFramework)' == 'net7.0' ">
+    <ProjectReference Include="..\..\sample\OpenTelemetrySample\OpenTelemetrySample.csproj"/>
     <ProjectReference Include="..\Elastic.Apm.Tests.MockApmServer\Elastic.Apm.Tests.MockApmServer.csproj"/>
   </ItemGroup>
   

--- a/test/Elastic.Apm.Tests/HelpersTests/AgentTimerTests.cs
+++ b/test/Elastic.Apm.Tests/HelpersTests/AgentTimerTests.cs
@@ -23,7 +23,7 @@ namespace Elastic.Apm.Tests.HelpersTests
 
 		private static readonly TimeSpan ShortTimeAfterTaskStarted = 10.Milliseconds();
 		private static readonly TimeSpan VeryLongTimeout = 1.Days();
-		private static readonly TimeSpan ShortTimeout = 100.Milliseconds();
+		private static readonly TimeSpan ShortTimeout = 200.Milliseconds();
 		private readonly IApmLogger _logger;
 
 		public AgentTimerTests(ITestOutputHelper xUnitOutputHelper) : base(xUnitOutputHelper) => _logger = LoggerBase.Scoped(ThisClassName);

--- a/test/Elastic.Apm.Tests/HelpersTests/AgentTimerTests.cs
+++ b/test/Elastic.Apm.Tests/HelpersTests/AgentTimerTests.cs
@@ -23,7 +23,7 @@ namespace Elastic.Apm.Tests.HelpersTests
 
 		private static readonly TimeSpan ShortTimeAfterTaskStarted = 10.Milliseconds();
 		private static readonly TimeSpan VeryLongTimeout = 1.Days();
-		private static readonly TimeSpan VeryShortTimeout = 20.Milliseconds();
+		private static readonly TimeSpan ShortTimeout = 100.Milliseconds();
 		private readonly IApmLogger _logger;
 
 		public AgentTimerTests(ITestOutputHelper xUnitOutputHelper) : base(xUnitOutputHelper) => _logger = LoggerBase.Scoped(ThisClassName);
@@ -145,7 +145,7 @@ namespace Elastic.Apm.Tests.HelpersTests
 			tryAwaitOrTimeoutTask.IsCompleted.Should().BeFalse();
 
 			cts.Cancel();
-			sutEnv.AgentTimer.WaitForTimeToPass(VeryShortTimeout);
+			sutEnv.AgentTimer.WaitForTimeToPass(ShortTimeout);
 
 			sutEnv.VerifyDelayCancelled(tryAwaitOrTimeoutTask, delayTask);
 		}
@@ -211,7 +211,7 @@ namespace Elastic.Apm.Tests.HelpersTests
 			awaitOrTimeoutTask.IsCompleted.Should().BeFalse();
 
 			cts.Cancel();
-			sutEnv.AgentTimer.WaitForTimeToPass(VeryShortTimeout);
+			sutEnv.AgentTimer.WaitForTimeToPass(ShortTimeout);
 
 			sutEnv.VerifyDelayCancelled(awaitOrTimeoutTask, delayTask);
 		}

--- a/test/Elastic.Apm.Tests/HelpersTests/AgentTimerTests.cs
+++ b/test/Elastic.Apm.Tests/HelpersTests/AgentTimerTests.cs
@@ -23,7 +23,6 @@ namespace Elastic.Apm.Tests.HelpersTests
 
 		private static readonly TimeSpan ShortTimeAfterTaskStarted = 10.Milliseconds();
 		private static readonly TimeSpan VeryLongTimeout = 1.Days();
-
 		private static readonly TimeSpan VeryShortTimeout = 20.Milliseconds();
 		private readonly IApmLogger _logger;
 
@@ -146,6 +145,7 @@ namespace Elastic.Apm.Tests.HelpersTests
 			tryAwaitOrTimeoutTask.IsCompleted.Should().BeFalse();
 
 			cts.Cancel();
+			sutEnv.AgentTimer.WaitForTimeToPass(VeryShortTimeout);
 
 			sutEnv.VerifyDelayCancelled(tryAwaitOrTimeoutTask, delayTask);
 		}
@@ -211,6 +211,7 @@ namespace Elastic.Apm.Tests.HelpersTests
 			awaitOrTimeoutTask.IsCompleted.Should().BeFalse();
 
 			cts.Cancel();
+			sutEnv.AgentTimer.WaitForTimeToPass(VeryShortTimeout);
 
 			sutEnv.VerifyDelayCancelled(awaitOrTimeoutTask, delayTask);
 		}


### PR DESCRIPTION
This PR enables .NET 7 builds and tests in our CI.

Noteworthy changes:
* Due to the issue (see https://github.com/dotnet/aspnetcore/issues/45233) regarding `DiagnosticListener` and **request body capturing**, a few tests had to be disabled specifically for .NET 7 (see [here](https://github.com/elastic/apm-agent-dotnet/pull/1917/files#diff-eb6612129df49ea767714f3e0db1e1731461ff72510455a11626edcfab8049d2)).
* `AgentTimerTests` showed increasing flakiness which could by resolved by introducing the test helper method `WaitForTaskCancelled` (see [here](https://github.com/elastic/apm-agent-dotnet/pull/1917/files#diff-60ff9289177d8ac72d0266955030ce32b50e5f8aebd0da70e441c1808d50892b)).

**Note** that this PR will not resolve https://github.com/elastic/apm-agent-dotnet/issues/1860 yet as a couple of manual and automated tests (e.g. `DOTNET_STARTUP_HOOKS`, request body capturing, ...) need yet to be done.
