### PR TITLE
Use Span timing instead of cumulative SqlCommand statistics

### DIFF
--- a/src/Elastic.Apm.SqlClient/SqlClientDiagnosticListener.cs
+++ b/src/Elastic.Apm.SqlClient/SqlClientDiagnosticListener.cs
@@ -85,13 +85,7 @@ namespace Elastic.Apm.SqlClient
 				{
 					if (!_spans.TryRemove(operationId, out var span)) return;
 
-					TimeSpan? duration = null;
-
-					if (propertyFetcherSet.Statistics.Fetch(payloadData) is IDictionary<object, object> statistics &&
-						statistics.ContainsKey("ExecutionTime") && statistics["ExecutionTime"] is long durationInMs && durationInMs > 0)
-						duration = TimeSpan.FromMilliseconds(durationInMs);
-
-					_agent?.TracerInternal.DbSpanCommon.EndSpan(span, dbCommand, Outcome.Success, duration);
+					_agent?.TracerInternal.DbSpanCommon.EndSpan(span, dbCommand, Outcome.Success);
 				}
 			}
 			catch (Exception ex)


### PR DESCRIPTION
Closes #1869 

* Removed usage of SqlCommand statistics (`ExecutionTime`) for span duration, as that statistic is cumulative (see: https://learn.microsoft.com/en-us/dotnet/framework/data/adonet/sql/provider-statistics-for-sql-server).
* Removal of `duration` parameter on `EndSpan()`, results in the Span timing being used instead.
* Added test to check if span duration with multiple operations is not cumulative.