### PR TITLE
Make sure PayloadSender uses up-to-date TLS

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <LangVersion>latest</LangVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <NoWarn>NU1503,NU1608,CS8002,</NoWarn>
+    <NoWarn>NU1701,NU1503,NU1608,CS8002,</NoWarn>
     <!-- suppress NETSDK1138 warnings for EOL frameworks -->
     <CheckEolTargetFramework>false</CheckEolTargetFramework>
     <SolutionRoot>$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), build.bat))</SolutionRoot>

--- a/src/Elastic.Apm/BackendComm/BackendCommUtils.cs
+++ b/src/Elastic.Apm/BackendComm/BackendCommUtils.cs
@@ -185,6 +185,8 @@ namespace Elastic.Apm.BackendComm
 				UseDefaultCredentials = useWindowsCredentials
 			};
 #if NETFRAMEWORK
+			ServicePointManager.SecurityProtocol |= SecurityProtocolType.Tls12;
+#else
 			httpClientHandler.SslProtocols |= SslProtocols.Tls12;
 #endif
 			return httpClientHandler;

--- a/src/Elastic.Apm/BackendComm/BackendCommUtils.cs
+++ b/src/Elastic.Apm/BackendComm/BackendCommUtils.cs
@@ -8,6 +8,7 @@ using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Net.Security;
 using System.Reflection;
+using System.Security.Authentication;
 using System.Security.Cryptography.X509Certificates;
 using System.Text;
 using System.Text.RegularExpressions;
@@ -178,7 +179,15 @@ namespace Elastic.Apm.BackendComm
 				};
 			}
 
-			return new HttpClientHandler { ServerCertificateCustomValidationCallback = serverCertificateCustomValidationCallback, UseDefaultCredentials = useWindowsCredentials };
+			var httpClientHandler = new HttpClientHandler
+			{
+				ServerCertificateCustomValidationCallback = serverCertificateCustomValidationCallback,
+				UseDefaultCredentials = useWindowsCredentials
+			};
+#if NETFRAMEWORK
+			httpClientHandler.SslProtocols |= SslProtocols.Tls12;
+#endif
+			return httpClientHandler;
 		}
 
 		internal static HttpClient BuildHttpClient(IApmLogger loggerArg, IConfiguration configuration, Service service, string dbgCallerDesc


### PR DESCRIPTION
Try to enable TLS 1.2 in all scenarios.
This small fix resulted from a customer issue where the application logic presumably affected the agent's SSL/TLS settings.