### PR TITLE
Avoid panic in file-logging setup

### DIFF
--- a/src/elastic_apm_profiler/src/profiler/mod.rs
+++ b/src/elastic_apm_profiler/src/profiler/mod.rs
@@ -627,7 +627,7 @@ impl Profiler {
         // Store the profiler and runtime info for later use
         self.profiler_info.replace(Some(profiler_info));
         self.runtime_info.replace(Some(runtime_info));
-        self.logger.replace(Some(logger));
+        self.logger.replace(logger);
 
         IS_ATTACHED.store(true, Ordering::SeqCst);
         IS_DESKTOP_CLR.store(is_desktop_clr, Ordering::SeqCst);


### PR DESCRIPTION
* Removed `unwrap()` calls in the file logging setup to avoid panics due to permissions, etc.
* Log file names include a timestamp component now so that name clashes become much less likely.