### PR TITLE
Improve SOAP action parsing

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <LangVersion>latest</LangVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <NoWarn>NU1503,NU1608,CS8002,</NoWarn>
+    <NoWarn>NU1701,NU1503,NU1608,CS8002,</NoWarn>
     <!-- suppress NETSDK1138 warnings for EOL frameworks -->
     <CheckEolTargetFramework>false</CheckEolTargetFramework>
     <SolutionRoot>$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), build.bat))</SolutionRoot>

--- a/src/Elastic.Apm.AspNetFullFramework/ElasticApmModule.cs
+++ b/src/Elastic.Apm.AspNetFullFramework/ElasticApmModule.cs
@@ -146,8 +146,6 @@ namespace Elastic.Apm.AspNetFullFramework
 			}
 
 			var transactionName = $"{request.HttpMethod} {request.Unvalidated.Path}";
-			if (SoapRequest.TryExtractSoapAction(_logger, request, out var soapAction))
-				transactionName += $" {soapAction}";
 
 			var distributedTracingData = ExtractIncomingDistributedTracingData(request);
 			ITransaction transaction;
@@ -292,6 +290,9 @@ namespace Elastic.Apm.AspNetFullFramework
 			var application = (HttpApplication)sender;
 			var context = application.Context;
 			var response = context.Response;
+
+			if (SoapRequest.TryExtractSoapAction(_logger, context.Request, out var soapAction))
+				transaction.Name += $" {soapAction}";
 
 			// update the transaction name based on route values, if applicable
 			if (transaction is Transaction t && !t.HasCustomName)

--- a/src/Elastic.Apm.AspNetFullFramework/Extensions/SoapRequest.cs
+++ b/src/Elastic.Apm.AspNetFullFramework/Extensions/SoapRequest.cs
@@ -3,8 +3,10 @@
 // See the LICENSE file in the project root for more information
 
 using System;
+using System.Buffers;
 using System.Collections.Specialized;
 using System.IO;
+using System.Text;
 using System.Web;
 using System.Xml;
 using Elastic.Apm.Logging;
@@ -29,35 +31,25 @@ namespace Elastic.Apm.AspNetFullFramework.Extensions
 		/// <returns><c>true</c> if a soap action can be extracted, <c>false</c> otherwise.</returns>
 		public static bool TryExtractSoapAction(IApmLogger logger, HttpRequest request, out string soapAction)
 		{
+			soapAction = null;
 			try
 			{
 				var headers = request.Unvalidated.Headers;
 				soapAction = GetSoap11Action(headers);
-				if (soapAction != null) return true;
-
-				// if the input stream has already been read bufferless, we can't inspect it
-				if (request.ReadEntityBodyMode == ReadEntityBodyMode.Bufferless)
-				{
-					soapAction = null;
-					return false;
-				}
+				if (soapAction != null)
+					return true;
 
 				if (IsSoap12Action(headers))
 				{
-					// use request.GetBufferedInputStream() which causes the framework to buffer what is read
-					// so that subsequent reads can read from the beginning.
-					// ASMX SOAP services by default deserialize the SOAP message in the input stream into
-					// the parameters for the method.
-					soapAction = GetSoap12ActionFromInputStream(request.GetBufferedInputStream());
-					if (soapAction != null) return true;
+					soapAction = GetSoap12ActionFromHttpRequest(logger, request);
+					if (soapAction != null)
+						return true;
 				}
 			}
 			catch (Exception e)
 			{
 				logger.Error()?.LogException(e, "Error extracting soap action");
 			}
-
-			soapAction = null;
 			return false;
 		}
 
@@ -82,19 +74,50 @@ namespace Elastic.Apm.AspNetFullFramework.Extensions
 			return contentType != null && contentType.Contains(SoapAction12ContentType);
 		}
 
-		internal static string GetSoap12ActionFromInputStream(Stream stream)
+		internal static string GetSoap12ActionFromHttpRequest(IApmLogger logger, HttpRequest request)
 		{
-			StreamReader streamReader = null;
+			//
+			// If the input stream has already been read bufferless, we can't inspect it
+			//
+			if (request.ReadEntityBodyMode == ReadEntityBodyMode.Bufferless)
+			{
+				logger.Debug()?.Log("Request.ReadEntityBodyMode is 'Bufferless'");
+				return null;
+			}
+			//
+			// SOAP 1.2 action must be read from body data.
+			// Using the buffered input stream can have side effects with application code that
+			// runs before or after this.
+			// To be safe, we only access the stream directly if we have random access to it.
+			//
+			var stream = request.InputStream;
+			if (!stream.CanSeek)
+			{
+				logger.Debug()?.Log("Request.InputStream is not seekable");
+				return null;
+			}
+
+			return GetSoap12ActionFromInputStream(stream);
+		}
+
+		internal static string GetSoap12ActionFromInputStream(Stream stream)
+		{ 
+			var shared = ArrayPool<byte>.Shared;
+			var bytes = shared.Rent((int)stream.Length);
 			try
 			{
-				streamReader = new StreamReader(stream);
+				stream.Read(bytes, 0, bytes.Length);
+				stream.Position = 0;
+				var content = Encoding.ASCII.GetString(bytes);
+					content.ToString();
+
 				var settings = new XmlReaderSettings
 				{
 					IgnoreProcessingInstructions = true,
 					IgnoreComments = true,
 					IgnoreWhitespace = true
 				};
-
+				using var streamReader = new StreamReader(new MemoryStream(bytes));
 				using var reader = XmlReader.Create(streamReader, settings);
 				reader.MoveToContent();
 				if (reader.LocalName != "Envelope")
@@ -108,20 +131,18 @@ namespace Elastic.Apm.AspNetFullFramework.Extensions
 					if (reader.Read())
 						return reader.LocalName;
 				}
-
-				return null;
 			}
 			catch (XmlException)
 			{
-				//previous code will skip some errors, but some others can raise an exception
-				//for instance undeclared namespaces, typographical quotes, etc...
-				//If that's the case we don't need to care about them here. They will flow somewhere else.
-				return null;
+				// The previous code will skip some errors, but some others can raise an exception
+				// for instance undeclared namespaces, typographical quotes, etc...
+				// If that's the case we don't need to care about them here. They will flow somewhere else.
 			}
 			finally
 			{
-				streamReader?.ReadToEnd();
+				shared.Return(bytes);
 			}
+			return null;
 		}
 	}
 }

--- a/src/Elastic.Apm.AspNetFullFramework/Extensions/SoapRequest.cs
+++ b/src/Elastic.Apm.AspNetFullFramework/Extensions/SoapRequest.cs
@@ -109,7 +109,6 @@ namespace Elastic.Apm.AspNetFullFramework.Extensions
 				stream.Position = 0;
 				stream.Read(bytes, 0, bytes.Length);
 				stream.Position = 0;
-				var content = Encoding.ASCII.GetString(bytes);
 
 				var settings = new XmlReaderSettings
 				{
@@ -137,7 +136,7 @@ namespace Elastic.Apm.AspNetFullFramework.Extensions
 				// The previous code will skip some errors, but some others can raise an exception
 				// for instance undeclared namespaces, typographical quotes, etc...
 				// If that's the case we don't need to care about them here. They will flow somewhere else.
-				logger?.Trace()?.LogException(e, "Error while trying to read SOAP 1.2 action");
+				logger.Trace()?.LogException(e, "Error while trying to read SOAP 1.2 action");
 			}
 			finally
 			{

--- a/test/Elastic.Apm.AspNetFullFramework.Tests/Soap/SoapParsingTests.cs
+++ b/test/Elastic.Apm.AspNetFullFramework.Tests/Soap/SoapParsingTests.cs
@@ -1,6 +1,7 @@
 using System.IO;
 using System.Text;
 using Elastic.Apm.AspNetFullFramework.Extensions;
+using Elastic.Apm.Tests.Utilities;
 using FluentAssertions;
 using Xunit;
 
@@ -184,7 +185,7 @@ namespace Elastic.Apm.AspNetFullFramework.Tests.Soap
 		public void Soap12Parser_ParsesHeaderAndBody(string soap, string expectedAction)
 		{
 			var requestStream = new MemoryStream(Encoding.UTF8.GetBytes(soap));
-			var action = SoapRequest.GetSoap12ActionFromInputStream(null, requestStream);
+			var action = SoapRequest.GetSoap12ActionFromInputStream(new NoopLogger(), requestStream);
 
 			action.Should().Be(expectedAction);
 		}

--- a/test/Elastic.Apm.AspNetFullFramework.Tests/Soap/SoapParsingTests.cs
+++ b/test/Elastic.Apm.AspNetFullFramework.Tests/Soap/SoapParsingTests.cs
@@ -1,4 +1,4 @@
-﻿using System.IO;
+using System.IO;
 using System.Text;
 using Elastic.Apm.AspNetFullFramework.Extensions;
 using FluentAssertions;
@@ -184,7 +184,7 @@ namespace Elastic.Apm.AspNetFullFramework.Tests.Soap
 		public void Soap12Parser_ParsesHeaderAndBody(string soap, string expectedAction)
 		{
 			var requestStream = new MemoryStream(Encoding.UTF8.GetBytes(soap));
-			var action = SoapRequest.GetSoap12ActionFromInputStream(requestStream);
+			var action = SoapRequest.GetSoap12ActionFromInputStream(null, requestStream);
 
 			action.Should().Be(expectedAction);
 		}


### PR DESCRIPTION
This PR aims to make the SOAP action parsing logic less error-prone. 

The reason is that we recently noticed side effects with other application/extension-logic trying to parse SOAP body data as well.

Notable changes:
* `GetSoap12ActionFromInputStream` now works directly on `request.InputStream`, copies it to a `MemoryStream` and resets `Stream.Position` to `0`.
  * This seems to be the recommended approach (see e.g. [here](https://stackoverflow.com/questions/1678846/how-to-log-request-inputstream-with-httpmodule-then-reset-inputstream-position)).
  * Before that, we used `request.GetBufferedInputStream()` which could result in failing subsequent reads as the underlying `Stream` was not seekable any more.
* The code has an additional check that the `Stream` is actually seekable.
* More logging was added in error cases.
* `TryExtractSoapAction` was moved to `ProcessEndRequest` to further reduce any side-effect potential with application logic reading the body data.