### PR TITLE
Enable DOTNET_STARTUP_HOOKS for .NET 7

### DIFF
--- a/build/scripts/scripts.fsproj
+++ b/build/scripts/scripts.fsproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <OutputType>Exe</OutputType>
     <NoWarn>$(NoWarn);NU1701</NoWarn>
     <IsPackable>false</IsPackable>

--- a/sample/Elastic.Apm.StartupHook.Sample/Elastic.Apm.StartupHook.Sample.csproj
+++ b/sample/Elastic.Apm.StartupHook.Sample/Elastic.Apm.StartupHook.Sample.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0;net7.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   

--- a/sample/Elastic.Apm.StartupHook.Sample/README.md
+++ b/sample/Elastic.Apm.StartupHook.Sample/README.md
@@ -6,7 +6,9 @@ configured to run with
 - `netcoreapp3.0`
 - `netcoreapp3.1`
 - `net5.0` 
-  
+- `net6.0`
+- `net7.0`
+
 target frameworks that can be used to try out the [Elastic APM
 startup hooks implementation](../../src/ElasticApmAgentStartupHook).
 
@@ -18,7 +20,11 @@ startup hooks implementation](../../src/ElasticApmAgentStartupHook).
     ```
     set DOTNET_STARTUP_HOOKS=[pathToAgent]\ElasticApmAgentStartupHook.dll
     ```
-3. Set any other APM agent configuration using environment variables. For example,
+3. (optional) Enable logging.
+   ```
+   set ELASTIC_APM_STARTUP_HOOKS_LOGGING=1
+   ```
+4. Set any other APM agent configuration using environment variables. For example,
 
     ```
     set ELASTIC_APM_SERVER_URL=http://localhost:8200
@@ -27,6 +33,6 @@ startup hooks implementation](../../src/ElasticApmAgentStartupHook).
 4. Start the sample application with the specified target framework. From the `sample/Elastic.Apm.StartupHook.Sample` directory
 
     ```
-    dotnet run -f net5.0
+    dotnet run -f net7.0
     ```
 5. Observe APM data collected.

--- a/src/ElasticApmAgentStartupHook/StartupHook.cs
+++ b/src/ElasticApmAgentStartupHook/StartupHook.cs
@@ -94,8 +94,9 @@ internal class StartupHook
 
 			var diagnosticSourceVersion = diagnosticSourceAssemblyName.Version;
 			_logger.WriteLine($"{SystemDiagnosticsDiagnosticsource} {diagnosticSourceVersion} loaded");
-
-			loaderDirectory = Path.Combine(startupHookDirectory, $"{diagnosticSourceVersion.Major}.0.0");
+			// .NET 7 still uses LoaderDll version 6.
+			var majorVersion = Math.Min(6, diagnosticSourceVersion.Major);
+			loaderDirectory = Path.Combine(startupHookDirectory, $"{majorVersion}.0.0");
 			if (Directory.Exists(loaderDirectory))
 			{
 				loaderAssembly = AssemblyLoadContext.Default

--- a/test/Elastic.Apm.StartupHook.Tests/StartupHookTests.cs
+++ b/test/Elastic.Apm.StartupHook.Tests/StartupHookTests.cs
@@ -13,6 +13,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Elastic.Apm.Tests.MockApmServer;
 using Elastic.Apm.Tests.Utilities;
+using Elastic.Apm.Tests.Utilities.XUnit;
 using FluentAssertions;
 using Xunit;
 using static Elastic.Apm.Config.ConfigConsts;
@@ -22,6 +23,32 @@ namespace Elastic.Apm.StartupHook.Tests
 {
 	public class StartupHookTests
 	{
+		private static IEnumerable<(string TargetFramework, string RuntimeName, string Version, string ShortVersion)> GetDotNetFrameworkVersionInfos()
+		{
+			yield return ("netcoreapp3.1", ".NET Core", "3.1.0.0","31");
+			yield return ("net5.0", ".NET 5", "5.0.0.0", "50");
+			yield return ("net6.0", ".NET 6", "6.0.0.0", "60");
+			yield return ("net7.0", ".NET 7", "7.0.0.0", "70");
+		}
+
+		public static IEnumerable<object[]> DotNetFrameworkVersionInfos()
+			=> GetDotNetFrameworkVersionInfos().Select(i => new[] { i.TargetFramework, i.RuntimeName, i.Version });
+
+		public static IEnumerable<object[]> DotNetFrameworks()
+			=> DotNetFrameworkVersionInfos().Select(o => o[0 .. 1]);
+
+		public static IEnumerable<object[]> WebAppInfos()
+		{
+			var testData = new List<object[]>();
+			foreach (var i in GetDotNetFrameworkVersionInfos())
+			{
+				testData.Add(new []{ "webapi", $"WebApi{i.ShortVersion}", i.TargetFramework, "weatherforecast"});
+				testData.Add(new []{ "webapp", $"WebApp{i.ShortVersion}", i.TargetFramework, ""});
+				testData.Add(new []{ "mvc", $"Mvc{i.ShortVersion}", i.TargetFramework, ""});
+			}
+			return testData;
+		}
+
 		/// <summary>
 		/// Asserts that startup hooks successfully hook up the APM agent and
 		/// send data to mock APM server for the supported framework versions
@@ -29,10 +56,7 @@ namespace Elastic.Apm.StartupHook.Tests
 		/// <param name="targetFramework"></param>
 		/// <returns></returns>
 		[Theory]
-		[InlineData("netcoreapp3.1")]
-		[InlineData("net5.0")]
-		[InlineData("net6.0")]
-		[InlineData("net7.0")]
+		[MemberData(nameof(DotNetFrameworks))]
 		public async Task Auto_Instrument_With_StartupHook_Should_Capture_Transaction(string targetFramework)
 		{
 			var apmLogger = new InMemoryBlockingLogger(LogLevel.Error);
@@ -72,10 +96,7 @@ namespace Elastic.Apm.StartupHook.Tests
 		}
 
 		[Theory]
-		[InlineData("netcoreapp3.1")]
-		[InlineData("net5.0")]
-		[InlineData("net6.0")]
-		[InlineData("net7.0")]
+		[MemberData(nameof(DotNetFrameworks))]
 		public async Task Auto_Instrument_With_StartupHook_Should_Capture_Error(string targetFramework)
 		{
 			var apmLogger = new InMemoryBlockingLogger(LogLevel.Error);
@@ -125,10 +146,7 @@ namespace Elastic.Apm.StartupHook.Tests
 		}
 
 		[Theory]
-		[InlineData("netcoreapp3.1", ".NET Core", "3.1.0.0")]
-		[InlineData("net5.0", ".NET 5", "5.0.0.0")]
-		[InlineData("net6.0", ".NET 6", "6.0.0.0")]
-		[InlineData("net7.0", ".NET 7", "7.0.0.0")]
+		[MemberData(nameof(DotNetFrameworkVersionInfos))]
 		public async Task Auto_Instrument_With_StartupHook_Should_Capture_Metadata(
 			string targetFramework,
 			string expectedRuntimeName,
@@ -173,18 +191,7 @@ namespace Elastic.Apm.StartupHook.Tests
 		}
 
 		[Theory]
-		[InlineData("webapi", "WebApi31", "netcoreapp3.1", "weatherforecast")]
-		[InlineData("webapi", "WebApi50", "net5.0", "weatherforecast")]
-		[InlineData("webapi", "WebApi60", "net6.0", "weatherforecast")]
-		[InlineData("webapi", "WebApi70", "net7.0", "weatherforecast")]
-		[InlineData("webapp", "WebApp31", "netcoreapp3.1", "")]
-		[InlineData("webapp", "WebApp50", "net5.0", "")]
-		[InlineData("webapp", "WebApp60", "net6.0", "")]
-		[InlineData("webapp", "WebApp70", "net7.0", "")]
-		[InlineData("mvc", "Mvc31", "netcoreapp3.1", "")]
-		[InlineData("mvc", "Mvc50", "net5.0", "")]
-		[InlineData("mvc", "Mvc60", "net6.0", "")]
-		[InlineData("mvc", "Mvc70", "net7.0", "")]
+		[MemberData(nameof(WebAppInfos))]
 		public async Task Auto_Instrument_With_StartupHook(string template, string name, string targetFramework, string path)
 		{
 			var apmLogger = new InMemoryBlockingLogger(LogLevel.Trace);

--- a/test/Elastic.Apm.StartupHook.Tests/StartupHookTests.cs
+++ b/test/Elastic.Apm.StartupHook.Tests/StartupHookTests.cs
@@ -32,6 +32,7 @@ namespace Elastic.Apm.StartupHook.Tests
 		[InlineData("netcoreapp3.1")]
 		[InlineData("net5.0")]
 		[InlineData("net6.0")]
+		[InlineData("net7.0")]
 		public async Task Auto_Instrument_With_StartupHook_Should_Capture_Transaction(string targetFramework)
 		{
 			var apmLogger = new InMemoryBlockingLogger(LogLevel.Error);
@@ -74,6 +75,7 @@ namespace Elastic.Apm.StartupHook.Tests
 		[InlineData("netcoreapp3.1")]
 		[InlineData("net5.0")]
 		[InlineData("net6.0")]
+		[InlineData("net7.0")]
 		public async Task Auto_Instrument_With_StartupHook_Should_Capture_Error(string targetFramework)
 		{
 			var apmLogger = new InMemoryBlockingLogger(LogLevel.Error);
@@ -126,6 +128,7 @@ namespace Elastic.Apm.StartupHook.Tests
 		[InlineData("netcoreapp3.1", ".NET Core", "3.1.0.0")]
 		[InlineData("net5.0", ".NET 5", "5.0.0.0")]
 		[InlineData("net6.0", ".NET 6", "6.0.0.0")]
+		[InlineData("net7.0", ".NET 7", "7.0.0.0")]
 		public async Task Auto_Instrument_With_StartupHook_Should_Capture_Metadata(
 			string targetFramework,
 			string expectedRuntimeName,
@@ -172,12 +175,16 @@ namespace Elastic.Apm.StartupHook.Tests
 		[Theory]
 		[InlineData("webapi", "WebApi31", "netcoreapp3.1", "weatherforecast")]
 		[InlineData("webapi", "WebApi50", "net5.0", "weatherforecast")]
+		[InlineData("webapi", "WebApi60", "net6.0", "weatherforecast")]
+		[InlineData("webapi", "WebApi70", "net7.0", "weatherforecast")]
 		[InlineData("webapp", "WebApp31", "netcoreapp3.1", "")]
 		[InlineData("webapp", "WebApp50", "net5.0", "")]
 		[InlineData("webapp", "WebApp60", "net6.0", "")]
+		[InlineData("webapp", "WebApp70", "net7.0", "")]
 		[InlineData("mvc", "Mvc31", "netcoreapp3.1", "")]
 		[InlineData("mvc", "Mvc50", "net5.0", "")]
 		[InlineData("mvc", "Mvc60", "net6.0", "")]
+		[InlineData("mvc", "Mvc70", "net7.0", "")]
 		public async Task Auto_Instrument_With_StartupHook(string template, string name, string targetFramework, string path)
 		{
 			var apmLogger = new InMemoryBlockingLogger(LogLevel.Trace);


### PR DESCRIPTION
Enable the `DOTNET_STARTUP_HOOKS` functionality for .NET 7.

The important change is this [line](https://github.com/elastic/apm-agent-dotnet/pull/1933/files#diff-9e2a2dda2e5c74dfba09c0a6ea8be7e1f84bc637a10d44795b5887a95c27e271R98) - with that startup hooks functionality will be upwards compatible by default. That way we don't need to create an additional (redundant) folder for .NET 7.

The [test input mechanism](https://github.com/elastic/apm-agent-dotnet/pull/1933/files#diff-c07906b942fb1af3cb70e6198e8591a21fc0b6bfc391d99321e02272d2bfc362) was also refactored to allow for simple test extension (e.g. NET 8.0) in the future.