### PR TITLE
Mark current dev version as alpha

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -23,6 +23,25 @@ endif::[]
 [[release-notes-1.x]]
 === .NET Agent version 1.x
 
+[[release-notes-1.19.0]]
+==== 1.19.0
+
+===== Features
+- {pull}1867[#1867] Improve handling of multiple agent initialization.
+- {pull}1877[#1877] Enable CloudMetadataProvider on Azure Functions.
+- {pull}1892[#1892] CentralConfig: handle MaxAge header with less than 5 sec according to spec (issue: {issue}1831[#1831]).
+- {pull}1897[#1897] Add basic agent logging preamble.
+- {pull}1907[#1907] Publish docker image with agent (issue: {issue}1665[#1665]).
+- {pull}1917[#1917] Add .NET 7 support (issue: {issue}1860[#1860]).
+- {pull}1930[#1930] Improve SOAP action parsing.
+
+===== Bug fixes
+- {pull}1882[#1882] Fix transaction trace id not aligned when transaction is created from OTel bridge without parent (issue: {issue}1881[#1881]).
+- {pull}1905[#1905] Avoid NRE during startup hook init (issue: {issue}1904[#1904]).
+- {pull}1927[#1927] Avoid panic in file-logging setup (issue: {issue}1918[#1918]).
+- {pull}1922[#1922] Use Span timing instead of cumulative SqlCommand statistics (issue: {issue}1869[#1869]).
+- {pull}1933[#1933] Enable DOTNET_STARTUP_HOOKS for .NET 7 (issue: {issue}1900[#1900]).
+
 [[release-notes-1.18.0]]
 ==== 1.18.0
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -86,6 +86,30 @@ In this PR we need to update:
 - [`conf.yaml`](https://github.com/elastic/docs/blob/master/conf.yaml): Set the `current` part to the new `<major>.x` and add that to the `branches` and `live` parts. In addition, remove the previous major entry from the `live` key.
 - [`shared/versions/stack/*.asciidoc`](https://github.com/elastic/docs/tree/master/shared/versions/stack): This directory defines how links from stack-versioned documentation relate to links from non stack-versioned documentation. For example, in the `8.5` file, the variable `:apm-dotnet-branch:` is set to `1.x`. This means any links in the `8.5` stack docs (like the APM Guide) that point to the APM .NET Agent reference, will point to the `1.x` version of those docs. The number of files you update in this directory depends on version compatibility between stack docs and your APM agent. In general, we update as far back as the new version of the agent is compatible with the stack; this pushes new documentation to the user.
 
+### Prepare the next (pre-release) version
+
+In order to better differentiate between pre-release builds and artifacts from the just-released ones,
+bump the agent version again by adding the `-alpha` suffix in these files:
+
+- `/src/Directory.Build.props`:
+
+  ```xml
+  ...
+  <InformationalVersion>1.20.0-alpha</InformationalVersion>
+  <VersionPrefix>1.20.0-alpha</VersionPrefix>
+  ...
+  ```
+
+  **Note** that `AssemblyVersion` and `FileVersion` do not add the `-alpha` prefix.
+
+- `/src/elastic_apm_profiler/Cargo.toml`:
+
+  ```toml
+  ...
+  version = "1.20.0-alpha"
+  ...
+  ```
+
 ## Executing the release script locally
 
 If required then it's possible to run the release script locally, for such, the credentials are needed to push to the NuGet repo.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -88,8 +88,8 @@ In this PR we need to update:
 
 ### Prepare the next (pre-release) version
 
-In order to better differentiate between pre-release builds and artifacts from the just-released ones,
-bump the agent version again by adding the `-alpha` suffix in these files:
+To clearly distinguish pre-release builds and artifacts from the newly released ones,
+bump the agent version again by adding the `-alpha` suffix to the following files:
 
 - `/src/Directory.Build.props`:
 

--- a/build/scripts/Build.fs
+++ b/build/scripts/Build.fs
@@ -212,11 +212,12 @@ module Build =
     /// Creates versioned ElasticApmAgent.zip file    
     let AgentZip (canary:bool) =        
         let name = "ElasticApmAgent"      
+        let currentAssemblyVersion = Versioning.CurrentVersion.VersionPrefix
         let versionedName =
             if canary then
-                sprintf "%s_%s-%s" name (Versioning.CurrentVersion.AssemblyVersion.ToString()) versionSuffix
+                sprintf "%s_%s-%s" name (currentAssemblyVersion.ToString()) versionSuffix
             else
-                sprintf "%s_%s" name (Versioning.CurrentVersion.AssemblyVersion.ToString())
+                sprintf "%s_%s" name (currentAssemblyVersion.ToString())
                 
         let agentDir = Paths.BuildOutput name |> DirectoryInfo                    
         agentDir.Create()
@@ -271,7 +272,7 @@ module Build =
     /// Creates versioned elastic_apm_profiler.zip file containing all components needed for profiler auto-instrumentation  
     let ProfilerZip (canary:bool) =
         let name = "elastic_apm_profiler"
-        let currentAssemblyVersion = Versioning.CurrentVersion.AssemblyVersion
+        let currentAssemblyVersion = Versioning.CurrentVersion.VersionPrefix
         let versionedName =
             let os =
                 if RuntimeInformation.IsOSPlatform(OSPlatform.Windows) then "win-x64"

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -2,10 +2,10 @@
   <!-- Src Directory Build Properties -->
   <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
   <PropertyGroup>
-    <AssemblyVersion>1.19.0</AssemblyVersion>
-    <InformationalVersion>1.19.0</InformationalVersion>
-    <FileVersion>1.19.0</FileVersion>
-    <VersionPrefix>1.19.0</VersionPrefix>
+    <AssemblyVersion>1.20.0</AssemblyVersion>
+    <InformationalVersion>1.20.0-alpha</InformationalVersion>
+    <FileVersion>1.20.0</FileVersion>
+    <VersionPrefix>1.20.0-alpha</VersionPrefix>
     <Authors>Elastic and contributors</Authors>
     <Copyright>2022 Elasticsearch BV</Copyright>
     <PackageProjectUrl>https://github.com/elastic/apm-agent-dotnet</PackageProjectUrl>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -2,10 +2,10 @@
   <!-- Src Directory Build Properties -->
   <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
   <PropertyGroup>
-    <AssemblyVersion>1.18.0</AssemblyVersion>
-    <InformationalVersion>1.18.0</InformationalVersion>
-    <FileVersion>1.18.0</FileVersion>
-    <VersionPrefix>1.18.0</VersionPrefix>
+    <AssemblyVersion>1.19.0</AssemblyVersion>
+    <InformationalVersion>1.19.0</InformationalVersion>
+    <FileVersion>1.19.0</FileVersion>
+    <VersionPrefix>1.19.0</VersionPrefix>
     <Authors>Elastic and contributors</Authors>
     <Copyright>2022 Elasticsearch BV</Copyright>
     <PackageProjectUrl>https://github.com/elastic/apm-agent-dotnet</PackageProjectUrl>

--- a/src/Elastic.Apm.Profiler.IntegrationsGenerator/Elastic.Apm.Profiler.IntegrationsGenerator.csproj
+++ b/src/Elastic.Apm.Profiler.IntegrationsGenerator/Elastic.Apm.Profiler.IntegrationsGenerator.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/src/elastic_apm_profiler/Cargo.toml
+++ b/src/elastic_apm_profiler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "elastic_apm_profiler"
-version = "1.18.0"
+version = "1.19.0"
 edition = "2018"
 authors = ["Elastic and Contributors"]
 description = "Elastic APM .NET agent CLR profiler"

--- a/src/elastic_apm_profiler/Cargo.toml
+++ b/src/elastic_apm_profiler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "elastic_apm_profiler"
-version = "1.19.0"
+version = "1.20.0-alpha"
 edition = "2018"
 authors = ["Elastic and Contributors"]
 description = "Elastic APM .NET agent CLR profiler"


### PR DESCRIPTION
Bumping the development version to `1.20.0` and adding the `-alpha` prefix to `InformationalVersion` and `VersionPrefix` (`AssemblyVersion` and `FileVersion` have number-constraints on the version).

PTAL @gregkalapos - if we are OK with this approach, I'll add a note about this in `RELEASING.md` as well before I merge.

- [x] Update `RELEASING.md`