### PR TITLE
Fix flaky tests

### DIFF
--- a/test/Elastic.Apm.Grpc.Tests/Elastic.Apm.Grpc.Tests.csproj
+++ b/test/Elastic.Apm.Grpc.Tests/Elastic.Apm.Grpc.Tests.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0;net7.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>
@@ -17,13 +17,13 @@
     </PackageReference>
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
 
-    <PackageReference Include="Google.Protobuf" Version="3.21.4" />
-    <PackageReference Include="Grpc.Net.ClientFactory" Version="2.27.0" />
-    <PackageReference Include="Grpc.Tools" Version="2.47.0">
+    <PackageReference Include="Google.Protobuf" Version="3.21.10" />
+    <PackageReference Include="Grpc.Net.ClientFactory" Version="2.49.0" />
+    <PackageReference Include="Grpc.Tools" Version="2.49.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Grpc.AspNetCore" Version="2.27.0" />
+    <PackageReference Include="Grpc.AspNetCore" Version="2.49.0" />
   </ItemGroup>
   <!--<ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1' ">
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="3.1.0" />

--- a/test/Elastic.Apm.Grpc.Tests/SampleAppHostBuilder.cs
+++ b/test/Elastic.Apm.Grpc.Tests/SampleAppHostBuilder.cs
@@ -38,8 +38,8 @@ namespace Elastic.Apm.Grpc.Tests
 
 	public class SampleAppHostBuilder
 	{
-		public static int SampleAppPort = 5866;
-		public static string SampleAppUrl = $"http://localhost:{SampleAppPort}";
+		public static readonly int SampleAppPort = 5866;
+		public static readonly string SampleAppUrl = $"http://localhost:{SampleAppPort}";
 
 		public IHost BuildHost()
 		{


### PR DESCRIPTION
This PR aims at making the GRPC tests less flaky by:
* Updating GRPC-related NuGet packages (e.g. `Grpc.Tools`) to their latest version.
* Add proper cleanup/shutdown to test cases (also in case of failures).

Also, run this test on more .NET versions.