### PR TITLE
chore: Update Testcontainers for .NET to version 2.3.0

### DIFF
--- a/sample/StackExchangeRedisSample/Program.cs
+++ b/sample/StackExchangeRedisSample/Program.cs
@@ -1,8 +1,7 @@
-﻿using System;
-using System.Threading.Tasks;
-using DotNet.Testcontainers.Containers.Builders;
-using DotNet.Testcontainers.Containers.Configurations.Databases;
-using DotNet.Testcontainers.Containers.Modules.Databases;
+﻿using System.Threading.Tasks;
+using DotNet.Testcontainers.Builders;
+using DotNet.Testcontainers.Configurations;
+using DotNet.Testcontainers.Containers;
 using Elastic.Apm;
 using Elastic.Apm.Api;
 using Elastic.Apm.StackExchange.Redis;

--- a/sample/StackExchangeRedisSample/StackExchangeRedisSample.csproj
+++ b/sample/StackExchangeRedisSample/StackExchangeRedisSample.csproj
@@ -9,7 +9,7 @@
       <PackageReference Include="StackExchange.Redis" Version="2.0.495" />
       <!-- Strong name any assemblies that aren't i.e. DotNet.Testcontainers -->
       <PackageReference Include="StrongNamer" Version="0.2.5" />
-      <PackageReference Include="DotNet.Testcontainers" Version="1.4.0" />
+      <PackageReference Include="Testcontainers" Version="2.3.0" />
     </ItemGroup>
   
     <ItemGroup>

--- a/test/Elastic.Apm.Azure.CosmosDb.Tests/Elastic.Apm.Azure.CosmosDb.Tests.csproj
+++ b/test/Elastic.Apm.Azure.CosmosDb.Tests/Elastic.Apm.Azure.CosmosDb.Tests.csproj
@@ -10,7 +10,7 @@
       <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.0.0" />
       <PackageReference Include="Microsoft.Azure.DocumentDB.Core" Version="2.14.0" />
       <PackageReference Include="Proc" Version="0.6.2" />
-      <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
+      <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
       <PackageReference Include="FluentAssertions" Version="5.6.0" />
       <PackageReference Include="FluentAssertions.Analyzers" Version="0.11.4" />
       <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />

--- a/test/Elastic.Apm.Elasticsearch.Tests/Elastic.Apm.Elasticsearch.Tests.csproj
+++ b/test/Elastic.Apm.Elasticsearch.Tests/Elastic.Apm.Elasticsearch.Tests.csproj
@@ -17,7 +17,7 @@
     </PackageReference>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="2.1.0" />
     <PackageReference Include="Elasticsearch.Net.VirtualizedCluster" Version="7.6.1" />
-    <PackageReference Include="Testcontainers" Version="2.1.0" />
+    <PackageReference Include="Testcontainers" Version="2.3.0" />
     <!-- Strong name any assemblies that aren't i.e. DotNet.Testcontainers -->
     <PackageReference Include="StrongNamer" Version="0.2.5" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />

--- a/test/Elastic.Apm.Elasticsearch.Tests/ElasticsearchFixture.cs
+++ b/test/Elastic.Apm.Elasticsearch.Tests/ElasticsearchFixture.cs
@@ -33,7 +33,7 @@ namespace Elastic.Apm.Elasticsearch.Tests
 
 		public async Task DisposeAsync()
 		{
-			if (_container.State == TestcontainersState.Running)
+			if (_container.State == TestcontainersStates.Running)
 			{
 				await _container.StopAsync();
 				await _container.DisposeAsync();

--- a/test/Elastic.Apm.MongoDb.Tests/Elastic.Apm.MongoDb.Tests.csproj
+++ b/test/Elastic.Apm.MongoDb.Tests/Elastic.Apm.MongoDb.Tests.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
     <PackageReference Include="FluentAssertions" Version="5.6.0" />
     <PackageReference Include="FluentAssertions.Analyzers" Version="0.11.4" />
-    <PackageReference Include="DotNet.Testcontainers" Version="1.4.0" />
+    <PackageReference Include="Testcontainers" Version="2.3.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Elastic.Apm.MongoDb.Tests/Fixture/MongoDbTestcontainer.cs
+++ b/test/Elastic.Apm.MongoDb.Tests/Fixture/MongoDbTestcontainer.cs
@@ -3,15 +3,16 @@
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
 
-using DotNet.Testcontainers.Containers.Configurations;
-using DotNet.Testcontainers.Containers.Modules.Abstractions;
+using DotNet.Testcontainers.Configurations;
+using DotNet.Testcontainers.Containers;
+using Microsoft.Extensions.Logging;
 
 namespace Elastic.Apm.MongoDb.Tests.Fixture
 {
 	public sealed class MongoDbTestcontainer : TestcontainerDatabase
 	{
-		internal MongoDbTestcontainer(ITestcontainersConfiguration configuration)
-			: base(configuration)
+		internal MongoDbTestcontainer(ITestcontainersConfiguration configuration, ILogger logger)
+			: base(configuration, logger)
 		{
 		}
 

--- a/test/Elastic.Apm.MongoDb.Tests/Fixture/MongoDbTestcontainerConfiguration.cs
+++ b/test/Elastic.Apm.MongoDb.Tests/Fixture/MongoDbTestcontainerConfiguration.cs
@@ -4,9 +4,8 @@
 // See the LICENSE file in the project root for more information
 
 using System.IO;
-using DotNet.Testcontainers.Containers.Configurations.Abstractions;
-using DotNet.Testcontainers.Containers.OutputConsumers;
-using DotNet.Testcontainers.Containers.WaitStrategies;
+using DotNet.Testcontainers.Builders;
+using DotNet.Testcontainers.Configurations;
 
 namespace Elastic.Apm.MongoDb.Tests.Fixture
 {

--- a/test/Elastic.Apm.MongoDb.Tests/Fixture/MongoFixture.cs
+++ b/test/Elastic.Apm.MongoDb.Tests/Fixture/MongoFixture.cs
@@ -5,7 +5,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Threading.Tasks;
-using DotNet.Testcontainers.Containers.Builders;
+using DotNet.Testcontainers.Builders;
 using MongoDB.Driver;
 using Xunit;
 

--- a/test/Elastic.Apm.Profiler.Managed.Tests/AdoNet/AdoNetTestData.cs
+++ b/test/Elastic.Apm.Profiler.Managed.Tests/AdoNet/AdoNetTestData.cs
@@ -16,8 +16,6 @@ namespace Elastic.Apm.Profiler.Managed.Tests.AdoNet
 		public const int DbRunnerExpectedRunAllAsyncSpans = 111;
 		public const int DbRunnerExpectedRunBaseTypesAsyncSpans = 68;
 
-		// frequent commands are executed to retrieve session parameters. we should ignore these
-		public const int OracleProviderExpectedSpans = 63;
 		public const string OracleProviderSpanNameStart = "DECLARE";
 
 		public IEnumerator<object[]> GetEnumerator()

--- a/test/Elastic.Apm.Profiler.Managed.Tests/AdoNet/OracleManagedDataAccessCommandTests.cs
+++ b/test/Elastic.Apm.Profiler.Managed.Tests/AdoNet/OracleManagedDataAccessCommandTests.cs
@@ -65,7 +65,7 @@ namespace Elastic.Apm.Profiler.Managed.Tests.AdoNet
 			}
 
 			apmServer.ReceivedData.Transactions.Should().HaveCount(2);
-			apmServer.ReceivedData.Spans.Should().HaveCount(AdoNetTestData.DbRunnerExpectedTotalSpans + AdoNetTestData.OracleProviderExpectedSpans);
+			apmServer.ReceivedData.Spans.Should().HaveCount(AdoNetTestData.DbRunnerExpectedTotalSpans);
 
 			var testSpans = apmServer.ReceivedData.Spans
 				.Where(s => !s.Name.StartsWith(AdoNetTestData.OracleProviderSpanNameStart))

--- a/test/Elastic.Apm.Profiler.Managed.Tests/AdoNet/OracleManagedDataAccessCoreCommandTests.cs
+++ b/test/Elastic.Apm.Profiler.Managed.Tests/AdoNet/OracleManagedDataAccessCoreCommandTests.cs
@@ -63,7 +63,7 @@ namespace Elastic.Apm.Profiler.Managed.Tests.AdoNet
 
 			apmServer.ReceivedData.Transactions.Should().HaveCount(2);
 
-			apmServer.ReceivedData.Spans.Should().HaveCount(AdoNetTestData.DbRunnerExpectedTotalSpans + AdoNetTestData.OracleProviderExpectedSpans);
+			apmServer.ReceivedData.Spans.Should().HaveCount(AdoNetTestData.DbRunnerExpectedTotalSpans);
 
 			var testSpans = apmServer.ReceivedData.Spans
 				.Where(s => !s.Name.StartsWith(AdoNetTestData.OracleProviderSpanNameStart))

--- a/test/Elastic.Apm.Profiler.Managed.Tests/AdoNet/OracleSqlFixture.cs
+++ b/test/Elastic.Apm.Profiler.Managed.Tests/AdoNet/OracleSqlFixture.cs
@@ -23,7 +23,7 @@ namespace Elastic.Apm.Profiler.Managed.Tests.AdoNet
 		public OracleSqlFixture()
 		{
 			var builder = new TestcontainersBuilder<OracleTestcontainer>()
-				.WithDatabase(new OracleTestcontainerConfiguration());
+				.WithDatabase(new OracleTestcontainerConfiguration { Password = "oracle" });
 
 			_container = builder.Build();
 		}

--- a/test/Elastic.Apm.Profiler.Managed.Tests/Elastic.Apm.Profiler.Managed.Tests.csproj
+++ b/test/Elastic.Apm.Profiler.Managed.Tests/Elastic.Apm.Profiler.Managed.Tests.csproj
@@ -13,7 +13,7 @@
     <ItemGroup>
       <PackageReference Include="Oracle.ManagedDataAccess.Core" Version="2.19.120" />
       <PackageReference Include="Proc" Version="0.6.2" />
-      <PackageReference Include="DotNet.Testcontainers" Version="1.6.0-beta.2020" />
+      <PackageReference Include="Testcontainers" Version="2.3.0" />
       <PackageReference Include="StrongNamer" Version="0.2.5" />
       <PackageReference Include="System.Data.SqlClient" Version="4.8.5" />
       <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />

--- a/test/Elastic.Apm.SqlClient.Tests/Elastic.Apm.SqlClient.Tests.csproj
+++ b/test/Elastic.Apm.SqlClient.Tests/Elastic.Apm.SqlClient.Tests.csproj
@@ -17,7 +17,7 @@
     <PackageReference Include="Microsoft.Data.SqlClient" Version="1.1.4" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
     <PackageReference Include="System.Data.SqlClient" Version="4.8.5" />
-    <PackageReference Include="Testcontainers" Version="2.1.0" />
+    <PackageReference Include="Testcontainers" Version="2.3.0" />
     <!-- Strong name any assemblies that aren't i.e. DotNet.Testcontainers -->
     <PackageReference Include="StrongNamer" Version="0.2.5" />
     <PackageReference Include="xunit" Version="2.4.1" />

--- a/test/Elastic.Apm.StackExchange.Redis.Tests/Elastic.Apm.StackExchange.Redis.Tests.csproj
+++ b/test/Elastic.Apm.StackExchange.Redis.Tests/Elastic.Apm.StackExchange.Redis.Tests.csproj
@@ -17,7 +17,7 @@
     </PackageReference>
     <PackageReference Include="StackExchange.Redis" Version="2.0.495" />
     <PackageReference Include="Proc" Version="0.6.2" />
-    <PackageReference Include="DotNet.Testcontainers" Version="1.4.0" />
+    <PackageReference Include="Testcontainers" Version="2.3.0" />
     <!-- Strong name any assemblies that aren't i.e. DotNet.Testcontainers -->
     <PackageReference Include="StrongNamer" Version="0.2.5" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />

--- a/test/Elastic.Apm.StackExchange.Redis.Tests/ProfilingSessionTests.cs
+++ b/test/Elastic.Apm.StackExchange.Redis.Tests/ProfilingSessionTests.cs
@@ -6,9 +6,9 @@
 using System;
 using System.Linq;
 using System.Threading.Tasks;
-using DotNet.Testcontainers.Containers.Builders;
-using DotNet.Testcontainers.Containers.Configurations.Databases;
-using DotNet.Testcontainers.Containers.Modules.Databases;
+using DotNet.Testcontainers.Builders;
+using DotNet.Testcontainers.Configurations;
+using DotNet.Testcontainers.Containers;
 using Elastic.Apm.Api;
 using Elastic.Apm.Tests.Utilities;
 using Elastic.Apm.Tests.Utilities.Docker;

--- a/test/Elastic.Clients.Elasticsearch.Tests/Elastic.Clients.Elasticsearch.Tests.csproj
+++ b/test/Elastic.Clients.Elasticsearch.Tests/Elastic.Clients.Elasticsearch.Tests.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
     <PackageReference Include="Elastic.Clients.Elasticsearch" Version="8.0.1" />
-    <PackageReference Include="Testcontainers" Version="2.2.0" />
+    <PackageReference Include="Testcontainers" Version="2.3.0" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
   </ItemGroup>

--- a/test/Elastic.Clients.Elasticsearch.Tests/ElasticsearchTestFixture.cs
+++ b/test/Elastic.Clients.Elasticsearch.Tests/ElasticsearchTestFixture.cs
@@ -21,7 +21,6 @@ public class ElasticsearchTestFixture : IAsyncDisposable, IAsyncLifetime
 	public ElasticsearchTestFixture() =>
 		Container = new TestcontainersBuilder<ElasticsearchTestcontainer>()
 			.WithDatabase(_configuration)
-			.WithImage("docker.elastic.co/elasticsearch/elasticsearch:8.5")
 			.Build();
 
 	public async Task InitializeAsync()

--- a/test/Elastic.Clients.Elasticsearch.Tests/ElasticsearchTestFixture.cs
+++ b/test/Elastic.Clients.Elasticsearch.Tests/ElasticsearchTestFixture.cs
@@ -20,8 +20,8 @@ public class ElasticsearchTestFixture : IAsyncDisposable, IAsyncLifetime
 
 	public ElasticsearchTestFixture() =>
 		Container = new TestcontainersBuilder<ElasticsearchTestcontainer>()
-			.WithImage("docker.elastic.co/elasticsearch/elasticsearch:8.5")
 			.WithDatabase(_configuration)
+			.WithImage("docker.elastic.co/elasticsearch/elasticsearch:8.5")
 			.Build();
 
 	public async Task InitializeAsync()

--- a/test/Elastic.Clients.Elasticsearch.Tests/ElasticsearchTests.cs
+++ b/test/Elastic.Clients.Elasticsearch.Tests/ElasticsearchTests.cs
@@ -42,7 +42,7 @@ public class ElasticsearchTests : IClassFixture<ElasticsearchTestFixture>
 		payloadSender.FirstSpan.Otel.Attributes.Should().Contain(new KeyValuePair<string, string>("db.system", "elasticsearch"));
 		payloadSender.FirstSpan.Otel.Attributes.Should()
 			.Contain(new KeyValuePair<string, string>("http.url",
-				$"https://localhost:{_esClientListenerFixture.Container.Port}/my-tweet-index/_doc/1"));
+				$"{_esClientListenerFixture.Container.ConnectionString}/my-tweet-index/_doc/1"));
 		payloadSender.FirstSpan.Otel.Attributes.Should().Contain(new KeyValuePair<string, string>("net.peer.name", "localhost"));
 	}
 
@@ -70,7 +70,7 @@ public class ElasticsearchTests : IClassFixture<ElasticsearchTestFixture>
 		payloadSender.FirstSpan.Otel.Attributes.Should().Contain(new KeyValuePair<string, string>("db.system", "elasticsearch"));
 		payloadSender.FirstSpan.Otel.Attributes.Should()
 			.Contain(new KeyValuePair<string, string>("http.url",
-				$"https://localhost:{_esClientListenerFixture.Container.Port}/my-tweet-index/_doc/1"));
+				$"{_esClientListenerFixture.Container.ConnectionString}/my-tweet-index/_doc/1"));
 		payloadSender.FirstSpan.Otel.Attributes.Should().Contain(new KeyValuePair<string, string>("net.peer.name", "localhost"));
 	}
 
@@ -97,7 +97,7 @@ public class ElasticsearchTests : IClassFixture<ElasticsearchTestFixture>
 		payloadSender.FirstSpan.Otel.Attributes.Should().Contain(new KeyValuePair<string, string>("db.system", "elasticsearch"));
 		payloadSender.FirstSpan.Otel.Attributes.Should()
 			.Contain(new KeyValuePair<string, string>("http.url",
-				$"https://localhost:{_esClientListenerFixture.Container.Port}/my-tweet-index/_search"));
+				$"{_esClientListenerFixture.Container.ConnectionString}/my-tweet-index/_search"));
 		payloadSender.FirstSpan.Otel.Attributes.Should().Contain(new KeyValuePair<string, string>("net.peer.name", "localhost"));
 	}
 
@@ -132,7 +132,7 @@ public class ElasticsearchTests : IClassFixture<ElasticsearchTestFixture>
 		updateSpan.Otel.Attributes.Should().Contain(new KeyValuePair<string, string>("db.system", "elasticsearch"));
 		updateSpan.Otel.Attributes.Should()
 			.Contain(new KeyValuePair<string, string>("http.url",
-				$"https://localhost:{_esClientListenerFixture.Container.Port}/my-tweet-index/_update/1"));
+				$"{_esClientListenerFixture.Container.ConnectionString}/my-tweet-index/_update/1"));
 		updateSpan.Otel.Attributes.Should().Contain(new KeyValuePair<string, string>("net.peer.name", "localhost"));
 	}
 
@@ -160,7 +160,7 @@ public class ElasticsearchTests : IClassFixture<ElasticsearchTestFixture>
 		payloadSender.FirstSpan.Otel.Attributes.Should().Contain(new KeyValuePair<string, string>("db.system", "elasticsearch"));
 		payloadSender.FirstSpan.Otel.Attributes.Should()
 			.Contain(new KeyValuePair<string, string>("http.url",
-				$"https://localhost:{_esClientListenerFixture.Container.Port}/my-tweet-index/_doc/1"));
+				$"{_esClientListenerFixture.Container.ConnectionString}/my-tweet-index/_doc/1"));
 		payloadSender.FirstSpan.Otel.Attributes.Should().Contain(new KeyValuePair<string, string>("net.peer.name", "localhost"));
 	}
 

--- a/test/Elastic.Clients.Elasticsearch.Tests/ElasticsearchTests.cs
+++ b/test/Elastic.Clients.Elasticsearch.Tests/ElasticsearchTests.cs
@@ -43,7 +43,7 @@ public class ElasticsearchTests : IClassFixture<ElasticsearchTestFixture>
 		payloadSender.FirstSpan.Otel.Attributes.Should()
 			.Contain(new KeyValuePair<string, string>("http.url",
 				$"{_esClientListenerFixture.Container.ConnectionString}/my-tweet-index/_doc/1"));
-		payloadSender.FirstSpan.Otel.Attributes.Should().Contain(new KeyValuePair<string, string>("net.peer.name", "localhost"));
+		payloadSender.FirstSpan.Otel.Attributes.Should().Contain(new KeyValuePair<string, string>("net.peer.name", _esClientListenerFixture.Container.Hostname));
 	}
 
 
@@ -71,7 +71,7 @@ public class ElasticsearchTests : IClassFixture<ElasticsearchTestFixture>
 		payloadSender.FirstSpan.Otel.Attributes.Should()
 			.Contain(new KeyValuePair<string, string>("http.url",
 				$"{_esClientListenerFixture.Container.ConnectionString}/my-tweet-index/_doc/1"));
-		payloadSender.FirstSpan.Otel.Attributes.Should().Contain(new KeyValuePair<string, string>("net.peer.name", "localhost"));
+		payloadSender.FirstSpan.Otel.Attributes.Should().Contain(new KeyValuePair<string, string>("net.peer.name", _esClientListenerFixture.Container.Hostname));
 	}
 
 	[DockerFact]
@@ -98,7 +98,7 @@ public class ElasticsearchTests : IClassFixture<ElasticsearchTestFixture>
 		payloadSender.FirstSpan.Otel.Attributes.Should()
 			.Contain(new KeyValuePair<string, string>("http.url",
 				$"{_esClientListenerFixture.Container.ConnectionString}/my-tweet-index/_search"));
-		payloadSender.FirstSpan.Otel.Attributes.Should().Contain(new KeyValuePair<string, string>("net.peer.name", "localhost"));
+		payloadSender.FirstSpan.Otel.Attributes.Should().Contain(new KeyValuePair<string, string>("net.peer.name", _esClientListenerFixture.Container.Hostname));
 	}
 
 	[DockerFact]
@@ -133,7 +133,7 @@ public class ElasticsearchTests : IClassFixture<ElasticsearchTestFixture>
 		updateSpan.Otel.Attributes.Should()
 			.Contain(new KeyValuePair<string, string>("http.url",
 				$"{_esClientListenerFixture.Container.ConnectionString}/my-tweet-index/_update/1"));
-		updateSpan.Otel.Attributes.Should().Contain(new KeyValuePair<string, string>("net.peer.name", "localhost"));
+		updateSpan.Otel.Attributes.Should().Contain(new KeyValuePair<string, string>("net.peer.name", _esClientListenerFixture.Container.Hostname));
 	}
 
 	[DockerFact]
@@ -161,7 +161,7 @@ public class ElasticsearchTests : IClassFixture<ElasticsearchTestFixture>
 		payloadSender.FirstSpan.Otel.Attributes.Should()
 			.Contain(new KeyValuePair<string, string>("http.url",
 				$"{_esClientListenerFixture.Container.ConnectionString}/my-tweet-index/_doc/1"));
-		payloadSender.FirstSpan.Otel.Attributes.Should().Contain(new KeyValuePair<string, string>("net.peer.name", "localhost"));
+		payloadSender.FirstSpan.Otel.Attributes.Should().Contain(new KeyValuePair<string, string>("net.peer.name", _esClientListenerFixture.Container.Hostname));
 	}
 
 	private (MockPayloadSender, ApmAgent) SetUpAgent()


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change.
-->

## What does this PR do?

Updates the Testcontainers for .NET NuGet dependency to its latest release 2.3.0.

## Why is it important?

I noticed you are using an outdated version. The old versions are not compatible with Docker Desktop anymore.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Relates to #1936

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->