### PR TITLE
Implement logging premable spec

### DIFF
--- a/sample/ApiSamples/ApiSamples.csproj
+++ b/sample/ApiSamples/ApiSamples.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp3.0;net5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.0;net5.0;net7.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>

--- a/sample/ApiSamples/Program.cs
+++ b/sample/ApiSamples/Program.cs
@@ -19,6 +19,8 @@ namespace ApiSamples
 	{
 		private static void Main(string[] args)
 		{
+			Environment.SetEnvironmentVariable("ELASTIC_APM_LOG_LEVEL", "Trace");
+
 			CompressionSample();
 
 			Console.ReadKey();

--- a/sample/SampleAspNetCoreApp/appsettings.json
+++ b/sample/SampleAspNetCoreApp/appsettings.json
@@ -2,12 +2,12 @@
   "Logging": {
     "LogLevel": {
       "Default": "Warning",
-      "Elastic.Apm": "Error"
+      "Elastic.Apm": "Trace"
     }
   },
   "AllowedHosts": "*",
   "ElasticApm": {
-    "ServerUrls": "http://localhost:8200",
+    "ServerUrl": "http://localhost:8200",
     "TransactionSampleRate": 1.0,
     "CaptureBody": "all",
     "CaptureBodyContentTypes": "application/x-www-form-urlencoded*, text/*, application/json*, application/xml*",

--- a/src/Elastic.Apm/AgentComponents.cs
+++ b/src/Elastic.Apm/AgentComponents.cs
@@ -197,14 +197,15 @@ namespace Elastic.Apm
 					var info = logger.Info().Value;
 					info.Log("********************************************************************************");
 					info.Log(
-						$"Elastic APM .NET Agent, version: {Assembly.GetExecutingAssembly().GetName().Version}, file creation time: {File.GetCreationTime(Assembly.GetExecutingAssembly().Location).ToUniversalTime()} UTC");
+						$"Elastic APM .NET Agent, version: {Assembly.GetExecutingAssembly().GetCustomAttribute<AssemblyInformationalVersionAttribute>().InformationalVersion}");
 					info.Log($"Process ID: {Process.GetCurrentProcess().Id}");
 					info.Log($"Process Name: {Process.GetCurrentProcess().ProcessName}");
+					info.Log($"Command line arguments: '{string.Join(", ", Environment.GetCommandLineArgs())}'");
 					info.Log($"Operating System: {RuntimeInformation.OSDescription}");
 					info.Log($"CPU architecture: {RuntimeInformation.OSArchitecture}");
 					info.Log($"Host: {Environment.MachineName}");
-					info.Log($"Runtime: {RuntimeInformation.FrameworkDescription}");
 					info.Log($"Time zone: {TimeZoneInfo.Local}");
+					info.Log($"Runtime: {RuntimeInformation.FrameworkDescription}");
 					info.Log("********************************************************************************");
 				}
 				catch (Exception e)

--- a/src/Elastic.Apm/Config/AbstractConfigurationWithEnvFallbackReader.cs
+++ b/src/Elastic.Apm/Config/AbstractConfigurationWithEnvFallbackReader.cs
@@ -11,13 +11,12 @@ using static Elastic.Apm.Config.ConfigConsts;
 
 namespace Elastic.Apm.Config
 {
-	internal abstract class AbstractConfigurationWithEnvFallbackReader : AbstractConfigurationReader, IConfigurationReader
+	internal abstract class AbstractConfigurationWithEnvFallbackReader : AbstractConfigurationReader,
+		IConfigurationReader, IConfigurationMetaDataProvider
 	{
 		private readonly string _defaultEnvironmentName;
-
 		private readonly Lazy<double> _spanFramesMinDurationInMilliseconds;
 		private readonly Lazy<double> _spanStackTraceMinDurationInMilliseconds;
-
 		private readonly Lazy<int> _stackTraceLimit;
 
 		internal AbstractConfigurationWithEnvFallbackReader(IApmLogger logger, string defaultEnvironmentName, string dbgDerivedClassName)
@@ -177,5 +176,8 @@ namespace Elastic.Apm.Config
 
 		public bool EnableOpenTelemetryBridge =>
 			ParseEnableOpenTelemetryBridge(Read(KeyNames.EnableOpenTelemetryBridge, EnvVarNames.EnableOpenTelemetryBridge));
+
+		public ConfigurationKeyValue Get(ConfigurationItem item) =>
+			Read(item.ConfigurationKeyName, item.ConfigurationKeyName);
 	}
 }

--- a/src/Elastic.Apm/Config/ConfigConsts.cs
+++ b/src/Elastic.Apm/Config/ConfigConsts.cs
@@ -146,14 +146,14 @@ namespace Elastic.Apm.Config
 			public const string MaxBatchEventCount = Prefix + "MAX_BATCH_EVENT_COUNT";
 			public const string MaxQueueEventCount = Prefix + "MAX_QUEUE_EVENT_COUNT";
 			public const string MetricsInterval = Prefix + "METRICS_INTERVAL";
-			private const string Prefix = "ELASTIC_APM_";
+			internal const string Prefix = "ELASTIC_APM_";
 			public const string Recording = Prefix + "RECORDING";
 			public const string SanitizeFieldNames = Prefix + "SANITIZE_FIELD_NAMES";
 			public const string SecretToken = Prefix + "SECRET_TOKEN";
 			public const string ServerCert = Prefix + "SERVER_CERT";
 			public const string ServerUrl = Prefix + "SERVER_URL";
 			public const string ServerUrls = Prefix + "SERVER_URLS";
-			public const string UseWindowsCredentials = Prefix + "USE_WINDOWS_CREDENTIALS";			
+			public const string UseWindowsCredentials = Prefix + "USE_WINDOWS_CREDENTIALS";
 			public const string ServiceName = Prefix + "SERVICE_NAME";
 			public const string ServiceNodeName = Prefix + "SERVICE_NODE_NAME";
 			public const string ServiceVersion = Prefix + "SERVICE_VERSION";
@@ -198,7 +198,7 @@ namespace Elastic.Apm.Config
 			public const string MaxBatchEventCount = Prefix + nameof(MaxBatchEventCount);
 			public const string MaxQueueEventCount = Prefix + nameof(MaxQueueEventCount);
 			public const string MetricsInterval = Prefix + nameof(MetricsInterval);
-			private const string Prefix = "ElasticApm:";
+			internal const string Prefix = "ElasticApm:";
 			public const string Recording = Prefix + nameof(Recording);
 			public const string SanitizeFieldNames = Prefix + nameof(SanitizeFieldNames);
 			public const string SecretToken = Prefix + nameof(SecretToken);

--- a/src/Elastic.Apm/Config/ConfigurationKeyValue.cs
+++ b/src/Elastic.Apm/Config/ConfigurationKeyValue.cs
@@ -12,5 +12,7 @@ namespace Elastic.Apm.Config
 		public string Key { get; }
 		public string ReadFrom { get; }
 		public string Value { get; }
+
+		public override string ToString() => $"{Key} : {Value} ({ReadFrom})";
 	}
 }

--- a/src/Elastic.Apm/Config/ConfigurationMetaData.cs
+++ b/src/Elastic.Apm/Config/ConfigurationMetaData.cs
@@ -1,0 +1,205 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System.Collections.Generic;
+
+namespace Elastic.Apm.Config
+{
+	internal enum ConfigurationItemId
+	{
+		ApiKey,
+		ApplicationNamespaces,
+		CaptureBody,
+		CaptureBodyContentTypes,
+		CaptureHeaders,
+		CentralConfig,
+		CloudProvider,
+		DisableMetrics,
+		Enabled,
+		EnableOpenTelemetryBridge,
+		Environment,
+		ExcludedNamespaces,
+		ExitSpanMinDuration,
+		FlushInterval,
+		GlobalLabels,
+		HostName,
+		IgnoreMessageQueues,
+		LogLevel,
+		MaxBatchEventCount,
+		MaxQueueEventCount,
+		MetricsInterval,
+		Recording,
+		SanitizeFieldNames,
+		SecretToken,
+		ServerCert,
+		ServerUrl,
+		UseWindowsCredentials,
+		ServiceName,
+		ServiceNodeName,
+		ServiceVersion,
+		SpanCompressionEnabled,
+		SpanCompressionExactMatchMaxDuration,
+		SpanCompressionSameKindMaxDuration,
+		SpanStackTraceMinDuration,
+		StackTraceLimit,
+		TraceContinuationStrategy,
+		TransactionIgnoreUrls,
+		TransactionMaxSpans,
+		TransactionSampleRate,
+		UseElasticTraceparentHeader,
+		VerifyServerCert,
+		ServerUrls,
+		SpanFramesMinDuration,
+		TraceContextIgnoreSampledFalse,
+	}
+
+	internal class ConfigurationItem
+	{
+		internal ConfigurationItem(ConfigurationItemId id, string environmentVariableName, string configurationKeyName)
+		{
+			Id = id;
+			EnvironmentVariableName = environmentVariableName;
+			ConfigurationKeyName = configurationKeyName;
+			NormalizedName = EnvironmentVariableName.Substring(ConfigConsts.EnvVarNames.Prefix.Length).ToLower();
+			NeedsMasking = Id switch
+			{
+				ConfigurationItemId.ApiKey => true,
+				ConfigurationItemId.SecretToken => true,
+				_ => false
+			};
+			LogAlways = Id switch
+			{
+				ConfigurationItemId.ServerUrl => true,
+				ConfigurationItemId.ServiceName => true,
+				ConfigurationItemId.ServiceVersion => true,
+				ConfigurationItemId.LogLevel => true,
+				_ => false
+			};
+		}
+
+		public override string ToString() => $"{Id}";
+
+		internal ConfigurationItemId Id { get; }
+		internal string ConfigurationKeyName { get; }
+		internal string EnvironmentVariableName { get; }
+		internal string NormalizedName { get; }
+		internal bool NeedsMasking { get; }
+		internal bool LogAlways { get; }
+
+		public bool IsEssentialForLogging =>
+			LogAlways || Id is ConfigurationItemId.SecretToken or ConfigurationItemId.ApiKey;
+	}
+
+	internal interface IConfigurationMetaDataProvider
+	{
+		ConfigurationKeyValue Get(ConfigurationItem item);
+	}
+
+	internal static class ConfigurationMetaData
+	{
+		internal static string GetDefaultValueForLogging(ConfigurationItemId configurationItemId,
+			IConfigurationReader configurationReader) =>
+			configurationItemId switch
+			{
+				ConfigurationItemId.ServerUrl => configurationReader.ServerUrl.AbsoluteUri,
+				ConfigurationItemId.ServiceName => configurationReader.ServiceName,
+				ConfigurationItemId.ServiceVersion => configurationReader.ServiceVersion,
+				ConfigurationItemId.LogLevel => configurationReader.LogLevel.ToString(),
+				ConfigurationItemId.SecretToken => configurationReader.SecretToken,
+				ConfigurationItemId.ApiKey => configurationReader.ApiKey,
+				_ => null,
+			};
+
+		internal static IEnumerable<ConfigurationItem> ConfigurationItems { get; } = new ConfigurationItem[]
+		{
+			new(ConfigurationItemId.ApiKey, ConfigConsts.EnvVarNames.ApiKey, ConfigConsts.KeyNames.ApiKey), new(
+				ConfigurationItemId.ApplicationNamespaces, ConfigConsts.EnvVarNames.ApplicationNamespaces,
+				ConfigConsts.KeyNames.ApplicationNamespaces),
+			new(ConfigurationItemId.CaptureBody, ConfigConsts.EnvVarNames.CaptureBody,
+				ConfigConsts.KeyNames.CaptureBody),
+			new(ConfigurationItemId.CaptureBodyContentTypes, ConfigConsts.EnvVarNames.CaptureBodyContentTypes,
+				ConfigConsts.KeyNames.CaptureBodyContentTypes),
+			new(ConfigurationItemId.CaptureHeaders, ConfigConsts.EnvVarNames.CaptureHeaders,
+				ConfigConsts.KeyNames.CaptureHeaders),
+			new(ConfigurationItemId.CentralConfig, ConfigConsts.EnvVarNames.CentralConfig,
+				ConfigConsts.KeyNames.CentralConfig),
+			new(ConfigurationItemId.CloudProvider, ConfigConsts.EnvVarNames.CloudProvider,
+				ConfigConsts.KeyNames.CloudProvider),
+			new(ConfigurationItemId.DisableMetrics, ConfigConsts.EnvVarNames.DisableMetrics,
+				ConfigConsts.KeyNames.DisableMetrics),
+			new(ConfigurationItemId.Enabled, ConfigConsts.EnvVarNames.Enabled, ConfigConsts.KeyNames.Enabled), new(
+				ConfigurationItemId.EnableOpenTelemetryBridge, ConfigConsts.EnvVarNames.EnableOpenTelemetryBridge,
+				ConfigConsts.KeyNames.EnableOpenTelemetryBridge),
+			new(ConfigurationItemId.Environment, ConfigConsts.EnvVarNames.Environment,
+				ConfigConsts.KeyNames.Environment),
+			new(ConfigurationItemId.ExcludedNamespaces, ConfigConsts.EnvVarNames.ExcludedNamespaces,
+				ConfigConsts.KeyNames.ExcludedNamespaces),
+			new(ConfigurationItemId.ExitSpanMinDuration, ConfigConsts.EnvVarNames.ExitSpanMinDuration,
+				ConfigConsts.KeyNames.ExitSpanMinDuration),
+			new(ConfigurationItemId.FlushInterval, ConfigConsts.EnvVarNames.FlushInterval,
+				ConfigConsts.KeyNames.FlushInterval),
+			new(ConfigurationItemId.GlobalLabels, ConfigConsts.EnvVarNames.GlobalLabels,
+				ConfigConsts.KeyNames.GlobalLabels),
+			new(ConfigurationItemId.HostName, ConfigConsts.EnvVarNames.HostName, ConfigConsts.KeyNames.HostName), new(
+				ConfigurationItemId.IgnoreMessageQueues, ConfigConsts.EnvVarNames.IgnoreMessageQueues,
+				ConfigConsts.KeyNames.IgnoreMessageQueues),
+			new(ConfigurationItemId.LogLevel, ConfigConsts.EnvVarNames.LogLevel, ConfigConsts.KeyNames.LogLevel), new(
+				ConfigurationItemId.MaxBatchEventCount, ConfigConsts.EnvVarNames.MaxBatchEventCount,
+				ConfigConsts.KeyNames.MaxBatchEventCount),
+			new(ConfigurationItemId.MaxQueueEventCount, ConfigConsts.EnvVarNames.MaxQueueEventCount,
+				ConfigConsts.KeyNames.MaxQueueEventCount),
+			new(ConfigurationItemId.MetricsInterval, ConfigConsts.EnvVarNames.MetricsInterval,
+				ConfigConsts.KeyNames.MetricsInterval),
+			new(ConfigurationItemId.Recording, ConfigConsts.EnvVarNames.Recording, ConfigConsts.KeyNames.Recording),
+			new(ConfigurationItemId.SanitizeFieldNames, ConfigConsts.EnvVarNames.SanitizeFieldNames,
+				ConfigConsts.KeyNames.SanitizeFieldNames),
+			new(ConfigurationItemId.SecretToken, ConfigConsts.EnvVarNames.SecretToken,
+				ConfigConsts.KeyNames.SecretToken),
+			new(ConfigurationItemId.ServerCert, ConfigConsts.EnvVarNames.ServerCert,
+				ConfigConsts.KeyNames.ServerCert),
+			new(ConfigurationItemId.ServerUrl, ConfigConsts.EnvVarNames.ServerUrl, ConfigConsts.KeyNames.ServerUrl),
+			new(ConfigurationItemId.UseWindowsCredentials, ConfigConsts.EnvVarNames.UseWindowsCredentials,
+				ConfigConsts.KeyNames.UseWindowsCredentials),
+			new(ConfigurationItemId.ServiceName, ConfigConsts.EnvVarNames.ServiceName,
+				ConfigConsts.KeyNames.ServiceName),
+			new(ConfigurationItemId.ServiceNodeName, ConfigConsts.EnvVarNames.ServiceNodeName,
+				ConfigConsts.KeyNames.ServiceNodeName),
+			new(ConfigurationItemId.ServiceVersion, ConfigConsts.EnvVarNames.ServiceVersion,
+				ConfigConsts.KeyNames.ServiceVersion),
+			new(ConfigurationItemId.SpanCompressionEnabled, ConfigConsts.EnvVarNames.SpanCompressionEnabled,
+				ConfigConsts.KeyNames.SpanCompressionEnabled),
+			new(ConfigurationItemId.SpanCompressionExactMatchMaxDuration,
+				ConfigConsts.EnvVarNames.SpanCompressionExactMatchMaxDuration,
+				ConfigConsts.KeyNames.SpanCompressionExactMatchMaxDuration),
+			new(ConfigurationItemId.SpanCompressionSameKindMaxDuration,
+				ConfigConsts.EnvVarNames.SpanCompressionSameKindMaxDuration,
+				ConfigConsts.KeyNames.SpanCompressionSameKindMaxDuration),
+			new(ConfigurationItemId.SpanStackTraceMinDuration,
+				ConfigConsts.EnvVarNames.SpanStackTraceMinDuration,
+				ConfigConsts.KeyNames.SpanStackTraceMinDuration),
+			new(ConfigurationItemId.StackTraceLimit, ConfigConsts.EnvVarNames.StackTraceLimit,
+				ConfigConsts.KeyNames.StackTraceLimit),
+			new(ConfigurationItemId.TraceContinuationStrategy, ConfigConsts.EnvVarNames.TraceContinuationStrategy,
+				ConfigConsts.KeyNames.TraceContinuationStrategy),
+			new(ConfigurationItemId.TransactionIgnoreUrls, ConfigConsts.EnvVarNames.TransactionIgnoreUrls,
+				ConfigConsts.KeyNames.TransactionIgnoreUrls),
+			new(ConfigurationItemId.TransactionMaxSpans, ConfigConsts.EnvVarNames.TransactionMaxSpans,
+				ConfigConsts.KeyNames.TransactionMaxSpans),
+			new(ConfigurationItemId.TransactionSampleRate, ConfigConsts.EnvVarNames.TransactionSampleRate,
+				ConfigConsts.KeyNames.TransactionSampleRate),
+			new(ConfigurationItemId.UseElasticTraceparentHeader,
+				ConfigConsts.EnvVarNames.UseElasticTraceparentHeader,
+				ConfigConsts.KeyNames.UseElasticTraceparentHeader),
+			new(ConfigurationItemId.VerifyServerCert, ConfigConsts.EnvVarNames.VerifyServerCert,
+				ConfigConsts.KeyNames.VerifyServerCert),
+			new(ConfigurationItemId.ServerUrls, ConfigConsts.EnvVarNames.ServerUrls,
+				ConfigConsts.KeyNames.ServerUrls),
+			new(ConfigurationItemId.SpanFramesMinDuration,
+				ConfigConsts.EnvVarNames.SpanFramesMinDuration, ConfigConsts.KeyNames.SpanFramesMinDuration),
+			new(ConfigurationItemId.TraceContextIgnoreSampledFalse,
+				ConfigConsts.EnvVarNames.TraceContextIgnoreSampledFalse,
+				ConfigConsts.KeyNames.TraceContextIgnoreSampledFalse),
+		};
+	}
+}

--- a/src/Elastic.Apm/Config/EnvironmentConfigurationReader.cs
+++ b/src/Elastic.Apm/Config/EnvironmentConfigurationReader.cs
@@ -10,14 +10,13 @@ using Elastic.Apm.Logging;
 
 namespace Elastic.Apm.Config
 {
-	internal class EnvironmentConfigurationReader : AbstractConfigurationReader, IConfiguration, IConfigurationSnapshotDescription
+	internal class EnvironmentConfigurationReader : AbstractConfigurationReader, IConfiguration,
+		IConfigurationSnapshotDescription, IConfigurationMetaDataProvider
 	{
 		internal const string Origin = "environment variables";
 		private const string ThisClassName = nameof(EnvironmentConfigurationReader);
-
 		private readonly Lazy<double> _spanFramesMinDurationInMilliseconds;
 		private readonly Lazy<double> _spanStackTraceMinDurationInMilliseconds;
-
 		private readonly Lazy<int> _stackTraceLimit;
 
 		public EnvironmentConfigurationReader(IApmLogger logger = null) : base(logger, ThisClassName)
@@ -148,7 +147,8 @@ namespace Elastic.Apm.Config
 
 		public bool VerifyServerCert => ParseVerifyServerCert(Read(ConfigConsts.EnvVarNames.VerifyServerCert));
 
-		private ConfigurationKeyValue Read(string key) =>
-			new ConfigurationKeyValue(key, ReadEnvVarValue(key), Origin);
+		private ConfigurationKeyValue Read(string key) => new(key, ReadEnvVarValue(key), Origin);
+
+		public ConfigurationKeyValue Get(ConfigurationItem item) => Read(item.EnvironmentVariableName);
 	}
 }

--- a/test/Elastic.Apm.Tests/Config/ConfigTests.cs
+++ b/test/Elastic.Apm.Tests/Config/ConfigTests.cs
@@ -120,9 +120,8 @@ namespace Elastic.Apm.Tests.Config
 
 			logger.Lines.Should().NotBeEmpty();
 			// ReSharper disable once UseIndexFromEndExpression
-			logger.Lines[logger.Lines.Count - 1]
-				.Should()
-				.Contain($"{EnvVarNames.ServerUrls} is deprecated. Use {EnvVarNames.ServerUrl}");
+			logger.Lines.Should()
+				.Contain(l => l.Contains($"{EnvVarNames.ServerUrls} is deprecated. Use {EnvVarNames.ServerUrl}"));
 		}
 
 		[Fact]
@@ -1171,6 +1170,7 @@ namespace Elastic.Apm.Tests.Config
 		{
 			Environment.SetEnvironmentVariable(EnvVarNames.ServerUrls, null);
 			Environment.SetEnvironmentVariable(EnvVarNames.MetricsInterval, null);
+			Environment.SetEnvironmentVariable(EnvVarNames.CloudProvider, null);
 		}
 
 		/// <summary>

--- a/test/Elastic.Apm.Tests/Config/ConfigTests.cs
+++ b/test/Elastic.Apm.Tests/Config/ConfigTests.cs
@@ -19,7 +19,7 @@ using static Elastic.Apm.Config.ConfigConsts;
 // Disable warnings due to obsolete settings keys
 #pragma warning disable CS0618
 
-namespace Elastic.Apm.Tests
+namespace Elastic.Apm.Tests.Config
 {
 	/// <summary>
 	/// Tests the configuration through environment variables
@@ -1183,7 +1183,7 @@ namespace Elastic.Apm.Tests
 				logger, "test", nameof(ConcreteEmptyConfigurationWithEnvFallbackReader)) { }
 
 			protected override ConfigurationKeyValue Read(string key, string fallBackEnvVarName) =>
-				new ConfigurationKeyValue(key, string.Empty, "InMemmory");
+				new ConfigurationKeyValue(key, string.Empty, "InMemory");
 		}
 	}
 }

--- a/test/Elastic.Apm.Tests/Config/ConfigurationMetaDataTests.cs
+++ b/test/Elastic.Apm.Tests/Config/ConfigurationMetaDataTests.cs
@@ -1,0 +1,69 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System.Linq;
+using System.Text.RegularExpressions;
+using Elastic.Apm.Config;
+using Elastic.Apm.Tests.Utilities;
+using FluentAssertions;
+using Xunit;
+
+namespace Elastic.Apm.Tests.Config;
+
+public class ConfigurationMetaDataTests
+{
+	[Fact]
+	public void ConfigurationItemId_MapsCorrectly_ToEnvironmentVariable_And_ConfigKey()
+	{
+		static string CamelCaseRegex(string input)
+		{
+			return string.Join("", Regex.Matches(input, "(^[A-Z]+(?![a-z])|[A-Z][a-z]+)")
+				.OfType<Match>()
+				.Select(m => m.Value.ToLower()));
+		}
+
+		foreach (var item in ConfigurationMetaData.ConfigurationItems)
+		{
+			// Lowercase and concat all tokens of Id, EnvironmentVariableName and ConfigKeyName. They must match then.
+
+			// Id
+			var flatId = CamelCaseRegex(item.Id.ToString());
+
+			// EnvironmentVariableName
+			var flatEnvVar = string.Join("",
+				item.EnvironmentVariableName.Substring(ConfigConsts.EnvVarNames.Prefix.Length).Split('_')
+					.Select(t => t.ToLower()));
+			flatId.Should().Be(flatEnvVar);
+
+			// ConfigurationKeyName
+			var flatConfigKey =
+				CamelCaseRegex(item.ConfigurationKeyName.Substring(ConfigConsts.KeyNames.Prefix.Length));
+			flatEnvVar.Should().Be(flatConfigKey);
+		}
+	}
+
+	[Fact]
+	public void ConfigurationItems_MustContainAll_IConfigurationReader_Properties()
+	{
+		foreach (var propertyName in typeof(IConfigurationReader).GetProperties().Select(p => p.Name))
+		{
+			// Extra treatment required?
+			var n = propertyName;
+			if (n.EndsWith("InMilliseconds")) n = propertyName.Replace("InMilliseconds", string.Empty);
+			ConfigurationMetaData.ConfigurationItems.Should().Contain(i => i.Id.ToString() == n);
+		}
+	}
+
+	[Fact]
+	public void ConfigurationItems_ThatAlwaysLog_MustProvideDefaultValue()
+	{
+		var configuration = new MockConfiguration(serviceVersion: "42");
+		foreach (var item in ConfigurationMetaData.ConfigurationItems.Where(i => i.LogAlways))
+		{
+			var value = ConfigurationMetaData.GetDefaultValueForLogging(item.Id, configuration);
+			value.Should().NotBeNullOrEmpty($"for {item}");
+			value.Should().NotBe("UnknownDefaultValue");
+		}
+	}
+}

--- a/test/Elastic.Apm.Tests/DroppedSpansStatsTests.cs
+++ b/test/Elastic.Apm.Tests/DroppedSpansStatsTests.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Elastic.Apm.Api;
+using Elastic.Apm.Config;
 using Elastic.Apm.Model;
 using Elastic.Apm.Tests.Utilities;
 using FluentAssertions;
@@ -22,7 +23,7 @@ namespace Elastic.Apm.Tests
 		[Fact]
 		public void DroppedSpanStats_MustReflect_ExitSpanMinDuration_Configuration()
 		{
-			Helper_CreateSpanWithDuration(Config.ConfigConsts.DefaultValues.ExitSpanMinDuration, 0).Should().BeNull();
+			Helper_CreateSpanWithDuration(ConfigConsts.DefaultValues.ExitSpanMinDuration, 0).Should().BeNull();
 			Helper_CreateSpanWithDuration("Oms", 0).Should().BeNull();
 			Helper_CreateSpanWithDuration("10ms", 0).Count().Should().Be(1);
 		}

--- a/test/Elastic.Apm.Tests/Elastic.Apm.Tests.csproj
+++ b/test/Elastic.Apm.Tests/Elastic.Apm.Tests.csproj
@@ -46,8 +46,8 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net5.0' OR '$(TargetFramework)' == 'net6.0' OR '$(TargetFramework)' == 'net7.0' ">
-    <ProjectReference Include="..\..\sample\OpenTelemetrySample\OpenTelemetrySample.csproj"/>
-    <ProjectReference Include="..\Elastic.Apm.Tests.MockApmServer\Elastic.Apm.Tests.MockApmServer.csproj"/>
+    <ProjectReference Include="..\..\sample\OpenTelemetrySample\OpenTelemetrySample.csproj" />
+    <ProjectReference Include="..\Elastic.Apm.Tests.MockApmServer\Elastic.Apm.Tests.MockApmServer.csproj" />
   </ItemGroup>
   
   <ItemGroup>


### PR DESCRIPTION
This PR implements the remaining part of the [Logging Preamble](https://github.com/elastic/apm/blob/main/specs/agents/logging.md#logging-preamble) spec.

Most importantly, this is about printing configuration values and their source (e.g. environment, configuration file).
For that, a new (`internal`) interface `IConfigurationMetaDataProvider` was introduced that is used to provide the metadata for individual configuration items.

For `IConfigurationReader` implementations that do not implement `IConfigurationMetaDataProvider`(e.g. custom implementations) we still print the **essential** configuration items (server URL, service name, ...).