### PR TITLE
Test ElasticsearchDiagnosticsSubscriber with the new client

### DIFF
--- a/test/Elastic.Clients.Elasticsearch.Tests/Elastic.Clients.Elasticsearch.Tests.csproj
+++ b/test/Elastic.Clients.Elasticsearch.Tests/Elastic.Clients.Elasticsearch.Tests.csproj
@@ -17,6 +17,9 @@
   </ItemGroup>
 
   <ItemGroup>
+    <!--Only adding this for testing: make sure `ElasticsearchDiagnosticsSubscriber` does not cause any issue with the new client  -->
+    <ProjectReference Include="..\..\src\Elastic.Apm.Elasticsearch\Elastic.Apm.Elasticsearch.csproj" />
+
     <ProjectReference Include="..\..\src\Elastic.Apm\Elastic.Apm.csproj" />
     <ProjectReference Include="..\Elastic.Apm.Tests.Utilities\Elastic.Apm.Tests.Utilities.csproj" />
   </ItemGroup>

--- a/test/Elastic.Clients.Elasticsearch.Tests/ElasticsearchTests.cs
+++ b/test/Elastic.Clients.Elasticsearch.Tests/ElasticsearchTests.cs
@@ -3,6 +3,7 @@ using Xunit;
 using Elastic.Apm;
 using Elastic.Apm.Api;
 using Elastic.Apm.DiagnosticSource;
+using Elastic.Apm.Elasticsearch;
 using Elastic.Apm.Tests.Utilities.Docker;
 using FluentAssertions;
 using Xunit.Abstractions;
@@ -110,7 +111,7 @@ public class ElasticsearchTests : IClassFixture<ElasticsearchTestFixture>
 
 		var tweet = response.Source;
 		tweet.Should().NotBeNull();
-		if(tweet ==null)return;
+		if (tweet == null) return;
 
 		var (payloadSender, apmAgent) = SetUpAgent();
 
@@ -174,6 +175,10 @@ public class ElasticsearchTests : IClassFixture<ElasticsearchTestFixture>
 
 		// Enable outgoing HTTP capturing and later assert that no HTTP span is captured for the es calls as defined in our spec.
 		agent.Subscribe(new HttpDiagnosticsSubscriber());
+
+		// `ElasticsearchDiagnosticsSubscriber` is for the old Elasticsearch client, in these tests with the new client it does not create any spans.
+		// Let's turn it on and make sure it doesn't cause any trouble with the new client.
+		agent.Subscribe(new ElasticsearchDiagnosticsSubscriber());
 
 		return (payloadSender, agent);
 	}


### PR DESCRIPTION
Inspired by https://discuss.elastic.co/t/application-startup-exception/321640. 

`ElasticsearchDiagnosticsSubscriber` is for the old es client - this PR turns it on in the tests for the new client just to make sure it does not cause any trouble.

This will not fix the issue reported on discuss, but I think this is a test case which we should cover.