### PR TITLE
Implement latest Azure Functions spec changes

### DIFF
--- a/sample/Elastic.AzureFunctionApp.Isolated/local.settings.json
+++ b/sample/Elastic.AzureFunctionApp.Isolated/local.settings.json
@@ -5,6 +5,7 @@
     "FUNCTIONS_WORKER_RUNTIME": "dotnet-isolated",
     "FUNCTIONS_EXTENSION_VERSION": "4",
     "WEBSITE_OWNER_NAME": "abcd1234-abcd-acdc-1234-112233445566+testfaas_group-CentralUSwebspace-Linux",
-    "WEBSITE_SITE_NAME": "testfaas"
+    "WEBSITE_SITE_NAME": "testfaas",
+    "WEBSITE_INSTANCE_ID": "20367ea8-70b9-41b4-a552-b2a826b3aa0b"
   }
 }

--- a/src/Elastic.Apm.Azure.Functions/ApmMiddleware.cs
+++ b/src/Elastic.Apm.Azure.Functions/ApmMiddleware.cs
@@ -5,6 +5,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Elastic.Apm.Api;
 using Elastic.Apm.Cloud;
+using Elastic.Apm.Config;
 using Elastic.Apm.Extensions;
 using Elastic.Apm.Logging;
 using Elastic.Apm.Model;
@@ -74,9 +75,16 @@ public class ApmMiddleware : IFunctionsWorkerMiddleware
 			return;
 		}
 
+		if (service.Name == AbstractConfigurationReader.GetDefaultNameServiceName())
+		{
+			// Only override the service name if it was set to default.
+			service.Name = MetaData.WebsiteSiteName;
+		}
 		service.Framework = new() { Name = "Azure Functions", Version = MetaData.FunctionsExtensionVersion };
 		var runtimeVersion = service.Runtime?.Version ?? "n/a";
 		service.Runtime = new() { Name = MetaData.FunctionsWorkerRuntime, Version = runtimeVersion };
+		service.Node ??= new Node();
+		service.Node.ConfiguredName = MetaData.WebsiteInstanceId;
 	}
 
 	private static bool IsColdStart() => Interlocked.Exchange(ref ColdStart, 0) == 1;

--- a/src/Elastic.Apm.Azure.Functions/ApmMiddleware.cs
+++ b/src/Elastic.Apm.Azure.Functions/ApmMiddleware.cs
@@ -84,6 +84,10 @@ public class ApmMiddleware : IFunctionsWorkerMiddleware
 		var runtimeVersion = service.Runtime?.Version ?? "n/a";
 		service.Runtime = new() { Name = MetaData.FunctionsWorkerRuntime, Version = runtimeVersion };
 		service.Node ??= new Node();
+		if (!string.IsNullOrEmpty(Agent.Config.ServiceNodeName))
+			Logger.Warning()
+				?.Log(
+					$"The configured {ConfigConsts.EnvVarNames.ServiceNodeName} value '{Agent.Config.ServiceNodeName}' will be overwritten with '{MetaData.WebsiteInstanceId}'");
 		service.Node.ConfiguredName = MetaData.WebsiteInstanceId;
 	}
 

--- a/src/Elastic.Apm.Azure.Functions/ApmMiddleware.cs
+++ b/src/Elastic.Apm.Azure.Functions/ApmMiddleware.cs
@@ -75,7 +75,7 @@ public class ApmMiddleware : IFunctionsWorkerMiddleware
 			return;
 		}
 
-		if (service.Name == AbstractConfigurationReader.GetDefaultNameServiceName())
+		if (service.Name == AbstractConfigurationReader.AdaptServiceName(AbstractConfigurationReader.DiscoverDefaultServiceName()))
 		{
 			// Only override the service name if it was set to default.
 			service.Name = MetaData.WebsiteSiteName;

--- a/src/Elastic.Apm/Api/Cloud.cs
+++ b/src/Elastic.Apm/Api/Cloud.cs
@@ -34,6 +34,24 @@ namespace Elastic.Apm.Api
 		[MaxLength]
 		public string Region { get; set; }
 		public CloudProject Project { get; set; }
+
+		/// <summary>
+		/// The service that is monitored on cloud.
+		/// </summary>
+		public CloudService Service { get; set; }
+	}
+
+	/// <summary>
+	/// The service that is monitored on cloud.
+	/// </summary>
+	public class CloudService
+	{
+		/// <summary>
+		/// Name of the cloud service, intended to distinguish services running on different
+		/// platforms within a provider, eg AWS EC2 vs Lambda, GCP GCE vs App Engine, Azure VM vs App Server.
+		/// </summary>
+		[MaxLength]
+		public string Name { get; set; }
 	}
 
 	public class CloudProject

--- a/src/Elastic.Apm/Cloud/AzureFunctionsMetadataProvider.cs
+++ b/src/Elastic.Apm/Cloud/AzureFunctionsMetadataProvider.cs
@@ -19,6 +19,7 @@ namespace Elastic.Apm.Cloud
 		internal string WebsiteResourceGroup { get; set; }
 		internal string SubscriptionId { get; set; }
 		internal string FunctionsWorkerRuntime { get; set; }
+		internal string WebsiteInstanceId { get; set; }
 	}
 
 	/// <summary>
@@ -52,6 +53,7 @@ namespace Elastic.Apm.Cloud
 			var regionName = helper.GetEnvironmentVariable(AzureEnvironmentVariables.RegionName);
 			var functionsWorkerRuntime =
 				helper.GetEnvironmentVariable(AzureEnvironmentVariables.FunctionsWorkerRuntime);
+			var websiteInstanceId = helper.GetEnvironmentVariable(AzureEnvironmentVariables.WebsiteInstanceId);
 
 			if (helper.NullOrEmptyVariable(AzureEnvironmentVariables.FunctionsExtensionVersion,
 				    functionsExtensionVersion) ||
@@ -76,7 +78,8 @@ namespace Elastic.Apm.Cloud
 				FunctionsWorkerRuntime = functionsWorkerRuntime,
 				WebsiteSiteName = websiteSiteName,
 				WebsiteResourceGroup = websiteResourceGroup,
-				SubscriptionId = tokens.Value.SubscriptionId
+				SubscriptionId = tokens.Value.SubscriptionId,
+				WebsiteInstanceId = websiteInstanceId,
 			};
 		}
 
@@ -87,10 +90,11 @@ namespace Elastic.Apm.Cloud
 				? new Api.Cloud
 				{
 					Provider = "azure",
+					Service = new CloudService { Name = "functions" },
 					Account = new CloudAccount { Id = data.SubscriptionId },
 					Instance = new CloudInstance { Name = data.WebsiteSiteName },
 					Project = new CloudProject { Name = data.WebsiteResourceGroup },
-					Region = data.RegionName
+					Region = data.RegionName,
 				}
 				: null;
 		}

--- a/src/Elastic.Apm/Config/AbstractConfigurationReader.cs
+++ b/src/Elastic.Apm/Config/AbstractConfigurationReader.cs
@@ -797,7 +797,7 @@ namespace Elastic.Apm.Config
 
 		protected virtual string DiscoverServiceName() => DiscoverDefaultServiceName();
 
-		private static string DiscoverDefaultServiceName()
+		internal static string DiscoverDefaultServiceName()
 		{
 			var entryAssemblyName = DiscoverEntryAssemblyName();
 			if (entryAssemblyName != null) return entryAssemblyName.Name;
@@ -819,8 +819,6 @@ namespace Elastic.Apm.Config
 				? Regex.Replace(originalName, "[^a-zA-Z0-9 _-]", "_")
 				: null;
 
-		internal static string GetDefaultNameServiceName() => AdaptServiceName(DiscoverDefaultServiceName());
-
 		protected string ParseServiceName(ConfigurationKeyValue kv)
 		{
 			var nameInConfig = kv.Value;
@@ -841,7 +839,7 @@ namespace Elastic.Apm.Config
 
 			_logger?.Info()?.Log("The agent was started without a service name. The service name will be automatically discovered.");
 
-			var discoveredName = GetDefaultNameServiceName();
+			var discoveredName = AdaptServiceName(DiscoverServiceName());
 			if (discoveredName != null)
 			{
 				_logger?.Info()

--- a/src/Elastic.Apm/Config/AbstractConfigurationReader.cs
+++ b/src/Elastic.Apm/Config/AbstractConfigurationReader.cs
@@ -786,7 +786,7 @@ namespace Elastic.Apm.Config
 			}
 		}
 
-		private AssemblyName DiscoverEntryAssemblyName()
+		private static AssemblyName DiscoverEntryAssemblyName()
 		{
 			var entryAssemblyName = Assembly.GetEntryAssembly()?.GetName();
 			if (entryAssemblyName != null && !IsMsOrElastic(entryAssemblyName.GetPublicKeyToken()))
@@ -795,7 +795,9 @@ namespace Elastic.Apm.Config
 			return null;
 		}
 
-		protected virtual string DiscoverServiceName()
+		protected virtual string DiscoverServiceName() => DiscoverDefaultServiceName();
+
+		private static string DiscoverDefaultServiceName()
 		{
 			var entryAssemblyName = DiscoverEntryAssemblyName();
 			if (entryAssemblyName != null) return entryAssemblyName.Name;
@@ -812,10 +814,12 @@ namespace Elastic.Apm.Config
 			return null;
 		}
 
-		internal static string AdaptServiceName(string originalName) =>
+		private static string AdaptServiceName(string originalName) =>
 			originalName != null
 				? Regex.Replace(originalName, "[^a-zA-Z0-9 _-]", "_")
 				: null;
+
+		internal static string GetDefaultNameServiceName() => AdaptServiceName(DiscoverDefaultServiceName());
 
 		protected string ParseServiceName(ConfigurationKeyValue kv)
 		{
@@ -837,7 +841,7 @@ namespace Elastic.Apm.Config
 
 			_logger?.Info()?.Log("The agent was started without a service name. The service name will be automatically discovered.");
 
-			var discoveredName = AdaptServiceName(DiscoverServiceName());
+			var discoveredName = GetDefaultNameServiceName();
 			if (discoveredName != null)
 			{
 				_logger?.Info()

--- a/src/Elastic.Apm/Config/AbstractConfigurationReader.cs
+++ b/src/Elastic.Apm/Config/AbstractConfigurationReader.cs
@@ -814,7 +814,7 @@ namespace Elastic.Apm.Config
 			return null;
 		}
 
-		private static string AdaptServiceName(string originalName) =>
+		internal static string AdaptServiceName(string originalName) =>
 			originalName != null
 				? Regex.Replace(originalName, "[^a-zA-Z0-9 _-]", "_")
 				: null;

--- a/test/Elastic.Apm.Azure.Functions.Tests/AzureFunctionsTestFixture.cs
+++ b/test/Elastic.Apm.Azure.Functions.Tests/AzureFunctionsTestFixture.cs
@@ -98,4 +98,5 @@ public class AzureFunctionsTestFixture : IDisposable
 	}
 
 	internal void ClearTransaction() => _apmServer.ClearState();
+	internal MetadataDto GetMetaData() => _apmServer.ReceivedData.Metadata.First();
 }

--- a/test/Elastic.Apm.Azure.Functions.Tests/AzureFunctionsTests.cs
+++ b/test/Elastic.Apm.Azure.Functions.Tests/AzureFunctionsTests.cs
@@ -56,6 +56,7 @@ public class AzureFunctionsTests : IClassFixture<AzureFunctionsTestFixture>, IDi
 
 		attempt.Should().BeLessThan(maxAttempts, $"Could not connect to function running on {url}");
 		var transaction = _azureFunctionsTestFixture.WaitForTransaction(transactionName);
+		Assert_MetaData(_azureFunctionsTestFixture.GetMetaData());
 		Assert_ColdStart(transaction);
 		return transaction;
 	}
@@ -84,6 +85,17 @@ public class AzureFunctionsTests : IClassFixture<AzureFunctionsTestFixture>, IDi
 	{
 		transaction.FaaS.ColdStart.Should().Be(_isFirst);
 		_isFirst = false;
+	}
+
+	private void Assert_MetaData(MetadataDto metaData)
+	{
+		metaData.Cloud.Provider.Should().Be("azure");
+		metaData.Cloud.Service.Name.Should().Be("functions");
+		metaData.Service.Name.Should().Be("testfaas");
+		metaData.Service.Runtime.Name.Should().Be("dotnet-isolated");
+		metaData.Service.Framework.Name.Should().Be("Azure Functions");
+		metaData.Service.Framework.Version.Should().Be("4");
+		metaData.Service.Node.ConfiguredName.Should().Be("20367ea8-70b9-41b4-a552-b2a826b3aa0b");
 	}
 
 	[Fact]

--- a/test/Elastic.Apm.Tests/Cloud/AzureFunctionsMetadataProviderTests.cs
+++ b/test/Elastic.Apm.Tests/Cloud/AzureFunctionsMetadataProviderTests.cs
@@ -41,6 +41,7 @@ public class AzureFunctionsMetadataProviderTests
 		metadata.Account.Should().NotBeNull();
 		metadata.Account.Id.Should().Be("d2cd53b3-acdc-4964-9563-3f5201556a81");
 		metadata.Provider.Should().Be("azure");
+		metadata.Service.Name.Should().Be("functions");
 		metadata.Instance.Name.Should().Be("wolfgangfaas");
 		metadata.Project.Should().NotBeNull();
 		metadata.Project.Name.Should().Be("wolfgangfaas_group");


### PR DESCRIPTION
This PR implements the latest changes made to the [Azure Functions spec](https://github.com/elastic/apm/pull/716):
* Set `service.name` to `WEBSITE_SITE_NAME` (if no explicit service name was provided in the configuration).
* Set `cloud.service.name` to `functions`
* Set `service.node.configured_name` to `WEBSITE_INSTANCE_ID`.