### PR TITLE
Remove redundant header sanitization code

### DIFF
--- a/src/Elastic.Apm.AspNetCore/WebRequestTransactionCreator.cs
+++ b/src/Elastic.Apm.AspNetCore/WebRequestTransactionCreator.cs
@@ -123,13 +123,9 @@ namespace Elastic.Apm.AspNetCore
 			}
 		}
 
-		private static Dictionary<string, string> GetHeaders(IHeaderDictionary headers, IConfiguration configuration) =>
-			configuration.CaptureHeaders && headers != null
-				? headers.ToDictionary(header => header.Key,
-					header => WildcardMatcher.IsAnyMatch(configuration.SanitizeFieldNames, header.Key)
-						? Apm.Consts.Redacted
-						: header.Value.ToString())
-				: null;
+		private static Dictionary<string, string> GetHeaders(IHeaderDictionary headers,
+			IConfigurationReader configuration) =>
+			configuration.CaptureHeaders ? headers.ToDictionary(h => h.Key, h => h.Value.ToString()) : null;
 
 		private static string GetRawUrl(HttpRequest httpRequest, IApmLogger logger)
 		{
@@ -137,7 +133,7 @@ namespace Elastic.Apm.AspNetCore
 			{
 				var rawPathAndQuery = httpRequest.HttpContext.Features.Get<IHttpRequestFeature>()?.RawTarget;
 
-				if (!string.IsNullOrEmpty(rawPathAndQuery) && rawPathAndQuery.Count() > 0 && rawPathAndQuery[0] != '/')
+				if (!string.IsNullOrEmpty(rawPathAndQuery) && rawPathAndQuery.Any() && rawPathAndQuery[0] != '/')
 					return rawPathAndQuery;
 
 				return rawPathAndQuery == null ? null : UriHelper.BuildAbsolute(httpRequest.Scheme, httpRequest.Host, rawPathAndQuery);

--- a/src/Elastic.Apm.AspNetFullFramework/ElasticApmModule.cs
+++ b/src/Elastic.Apm.AspNetFullFramework/ElasticApmModule.cs
@@ -230,9 +230,7 @@ namespace Elastic.Apm.AspNetFullFramework
 			{
 				Socket = new Socket { RemoteAddress = request.UserHostAddress },
 				HttpVersion = GetHttpVersion(request.ServerVariables["SERVER_PROTOCOL"]),
-				Headers = _isCaptureHeadersEnabled
-					? ConvertHeaders(request.Unvalidated.Headers, (transaction as Transaction)?.Configuration)
-					: null
+				Headers = _isCaptureHeadersEnabled ? ConvertHeaders(request.Unvalidated.Headers) : null
 			};
 		}
 
@@ -251,17 +249,14 @@ namespace Elastic.Apm.AspNetFullFramework
 			}
 		}
 
-		private static Dictionary<string, string> ConvertHeaders(NameValueCollection headers, IConfiguration configuration)
+		private static Dictionary<string, string> ConvertHeaders(NameValueCollection headers)
 		{
 			var convertedHeaders = new Dictionary<string, string>(headers.Count);
 			foreach (var key in headers.AllKeys)
 			{
 				var value = headers.Get(key);
 				if (value != null)
-				{
-					convertedHeaders.Add(key,
-						WildcardMatcher.IsAnyMatch(configuration?.SanitizeFieldNames, key) ? Consts.Redacted : value);
-				}
+					convertedHeaders.Add(key,value);
 			}
 			return convertedHeaders;
 		}
@@ -398,7 +393,7 @@ namespace Elastic.Apm.AspNetFullFramework
 			{
 				Finished = true,
 				StatusCode = response.StatusCode,
-				Headers = _isCaptureHeadersEnabled ? ConvertHeaders(response.Headers, (transaction as Transaction)?.Configuration) : null
+				Headers = _isCaptureHeadersEnabled ? ConvertHeaders(response.Headers) : null
 			};
 
 		private void FillSampledTransactionContextUser(HttpContext context, ITransaction transaction)

--- a/src/Elastic.Apm/Report/PayloadSenderV2.cs
+++ b/src/Elastic.Apm/Report/PayloadSenderV2.cs
@@ -132,6 +132,7 @@ namespace Elastic.Apm.Report
 			// with this, stack trace demystification and conversion to the intake API model happens on a non-application thread:
 			spanFilters.Add(new SpanStackTraceCapturingFilter(logger, apmServerInfo).Filter);
 			errorFilters.Add(new ErrorContextSanitizerFilter().Filter);
+			errorFilters.Add(new HeaderDictionarySanitizerFilter().Filter);
 		}
 
 		private bool _getApmServerVersion;

--- a/test/Elastic.Apm.Tests.Utilities/MockPayloadSender.cs
+++ b/test/Elastic.Apm.Tests.Utilities/MockPayloadSender.cs
@@ -229,6 +229,8 @@ namespace Elastic.Apm.Tests.Utilities
 		{
 			lock (_errorLock)
 			{
+				error = _errorFilters.Aggregate(error,
+					(current, filter) => filter(current));
 				_errors.Add(error);
 				_errorWaitHandle.Set();
 			}


### PR DESCRIPTION
As HTTP headers are sanitized generically in `PayloadSender` we can remove the explicit sanitation in `WebRequestTransactionCreator` (as suggested [here](https://github.com/elastic/apm-agent-dotnet/pull/1950#discussion_r1053696287)).