### PR TITLE
Prevent discarding of agent components if agent is disabled

### DIFF
--- a/src/Elastic.Apm.AspNetFullFramework/ElasticApmModule.cs
+++ b/src/Elastic.Apm.AspNetFullFramework/ElasticApmModule.cs
@@ -430,7 +430,8 @@ namespace Elastic.Apm.AspNetFullFramework
 		private static bool InitOnceForAllInstancesUnderLock(string dbgInstanceName) =>
 			InitOnceHelper.IfNotInited?.Init(() =>
 			{
-				SafeAgentSetup(dbgInstanceName);
+				var agentComponents = CreateAgentComponents(dbgInstanceName);
+				Agent.Setup(agentComponents);
 
 				if (!Agent.Instance.ConfigurationReader.Enabled)
 					return;
@@ -465,15 +466,6 @@ namespace Elastic.Apm.AspNetFullFramework
 			agentComponents.Service.Language = new Language { Name = "C#" }; //TODO
 
 			return agentComponents;
-		}
-
-		private static void SafeAgentSetup(string dbgInstanceName)
-		{
-			var agentComponents = CreateAgentComponents(dbgInstanceName);
-			if (!agentComponents.ConfigurationReader.Enabled)
-				return;
-
-			Agent.Setup(agentComponents);
 		}
 
 		/// <summary>


### PR DESCRIPTION
Could you take a look at this, please @gregkalapos?

It's definitely a bug that's been reported in the linked issue #1895.

If the agent is disabled via config, all the agent components get discarded and we end up with default agent components (e.g. environment-variable based configuration instead of `web.config`.based).

The change that I made now makes sure that `Agent.Setup(agentComponents)` is still called in that case.

I could find any negative side effects so far, but it is definitely a hairy change.

Also, it's not really feasible to test this other than creating a whole new sample application with a disabled agent, since the code relies on statically initialized data. So I only ran a few manual tests.