### PR TITLE
Fix #1958 OTel bridge span's destination service may contain null res…

### DIFF
--- a/src/Elastic.Apm/OpenTelemetry/ElasticActivityListener.cs
+++ b/src/Elastic.Apm/OpenTelemetry/ElasticActivityListener.cs
@@ -321,8 +321,11 @@ namespace Elastic.Apm.OpenTelemetry
 			}
 
 			span.Context.Service = new SpanService(new Target(serviceTargetType, serviceTargetName));
-			span.Context.Destination ??= new Destination();
-			span.Context.Destination.Service = new Destination.DestinationService { Resource = resource };
+			if (resource != null)
+			{
+				span.Context.Destination ??= new Destination();
+				span.Context.Destination.Service = new Destination.DestinationService { Resource = resource };
+			}
 		}
 
 		public void Dispose() => Listener?.Dispose();

--- a/test/Elastic.Apm.Tests/OpenTelemetryTests.cs
+++ b/test/Elastic.Apm.Tests/OpenTelemetryTests.cs
@@ -188,6 +188,21 @@ namespace Elastic.Apm.Tests
 			using (var activity = src.StartActivity("foo", ActivityKind.Server)) traceId = activity.TraceId.ToString();
 			payloadSender.FirstTransaction.TraceId.Should().Be(traceId);
 		}
+
+		[Fact]
+		public void ResourceIsRequiredWhenSpanDestinationServiceIsNotNull()
+		{
+			var payloadSender = new MockPayloadSender();
+			using (var agent = new ApmAgent(new TestAgentComponents(payloadSender: payloadSender, apmServerInfo: MockApmServerInfo.Version716,
+					   configuration: new MockConfiguration(enableOpenTelemetryBridge: "true"))))
+				OTSamples.TwoSpansWithAttributes();
+
+			payloadSender.Spans.Should().NotContain(span =>
+				span.Context.Destination != null
+				&& span.Context.Destination.Service != null
+				&& span.Context.Destination.Service.Resource == null,
+				because: "Resource is required in Destination Serivce");
+		}
 	}
 }
 


### PR DESCRIPTION
Fix #1958 OTel Span's Destination with null Resource issue introduced in v1.19.0

- create Span Context's Destination only when resource is not null
- Unit test has been added to prove the fix