### PR TITLE
Document OTel bridge

### DIFF
--- a/docs/api-opentelemetry.asciidoc
+++ b/docs/api-opentelemetry.asciidoc
@@ -19,7 +19,6 @@ In .NET, there is an https://opentelemetry.io/docs/instrumentation/net/shim/[Ope
 
 The OpenTelemetry bridge in the Elastic .NET APM Agent targets the https://learn.microsoft.com/en-us/dotnet/api/system.diagnostics.activity?view=net-5.0[Activity API]. Since the https://opentelemetry.io/docs/instrumentation/net/shim/[OpenTelemetry .NET shim] builds on top of the https://learn.microsoft.com/en-us/dotnet/api/system.diagnostics.activity?view=net-5.0[Activity API], the shim is implicitly supported as well, although we don't directly test it, because the Activity API is the recommended API.
 
-
 [float]
 [[otel-getting-started]]
 === Getting started
@@ -47,7 +46,6 @@ If you configured the agent via the `appsettings.json` file, then set `ElasticAp
     }
 }
 ----
-
 
 [float]
 [[create-activity-source-and-spans]]

--- a/docs/api-opentelemetry.asciidoc
+++ b/docs/api-opentelemetry.asciidoc
@@ -113,7 +113,7 @@ The Metrics API is currently not supported.
 [[otel-span-events]]
 ===== Span Events
 Span events (https://open-telemetry.github.io/opentelemetry-js-api/interfaces/span.html#addevent[`Span#addEvent()`])
-is not currently supported. Events will be silently dropped.
+are not currently supported. Events will be silently dropped.
 
 [float]
 [[otel-baggage]]

--- a/docs/api-opentelemetry.asciidoc
+++ b/docs/api-opentelemetry.asciidoc
@@ -1,0 +1,123 @@
+ifdef::env-github[]
+NOTE: For the best reading experience,
+please view this documentation at https://www.elastic.co/guide/en/apm/agent/dotnet[elastic.co]
+endif::[]
+
+[[opentelemetry-bridge]]
+== OpenTelemetry Bridge
+
+NOTE: Added as experimental in v1.13.0.
+To enable it, set <<opentelemetry-bridge-enabled, `opentelemetryBridgeEnabled`>> to `true`.
+
+NOTE: The OpenTelemetry bridge is supported on .NET 5 and newer versions.
+
+The OpenTelemetry Bridge in the Elastic .NET APM Agent bridges OpenTelemetry spans into Elastic APM transactions and spans. The Elastic APM OpenTelemetry bridge allows one to use the vendor-neutral OpenTelemetry Tracing API to manually instrument one's code, and have the Elastic .NET APM agent handle those API calls. This allows one to use the Elastic APM agent for tracing, without any vendor lock-in from adding manual tracing using the APM agent’s own <<public-api, Public API>>.
+
+OpenTelemetry in .NET is implemented via the https://learn.microsoft.com/en-us/dotnet/api/system.diagnostics.activity?view=net-5.0[Activity API].
+
+In .NET, there is an https://opentelemetry.io/docs/instrumentation/net/shim/[OpenTelemetry shim] which is built on top of the Activity API. 
+
+The OpenTelemetry bridge in the Elastic .NET APM Agent targets the https://learn.microsoft.com/en-us/dotnet/api/system.diagnostics.activity?view=net-5.0[Activity API]. Since the https://opentelemetry.io/docs/instrumentation/net/shim/[OpenTelemetry .NET shim] builds on top of the https://learn.microsoft.com/en-us/dotnet/api/system.diagnostics.activity?view=net-5.0[Activity API], the shim is implicitly supported as well, although we don't directly test it, because the Activity API is the recommended API.
+
+
+[float]
+[[otel-getting-started]]
+=== Getting started
+
+The OpenTelemetry bridge is part of the core agent pacakge (https://www.nuget.org/packages/Elastic.Apm[`Elastic.Apm`]), so you don't need to add any additional dependency.
+
+[float]
+[[otel-enable-bridge]]
+==== Enable the OpenTelemetry Bridge
+
+Currently the bridge is opt-in, so you need to enable it.
+
+If you configured the agent via environment variables, set the `ELASTIC_APM_ENABLEOPENTELEMETRYBRIDGE` environment variable to `true``.
+
+If you configured the agent via the `appsettings.json` file, then set `ElasticApm:EnableOpenTelemetryBridge` to `true`.
+
+[source,js]
+----
+{
+  "ElasticApm":
+    {
+      "ServerUrl":  "http://myapmserver:8200",
+      "SecretToken":  "apm-server-secret-token",
+      "EnableOpenTelemetryBridge": true
+    }
+}
+----
+
+
+[float]
+[[create-activity-source-and-spans]]
+==== Create an ActivitySource and start spans
+
+Once you enabled the bridge, you can create OpenTelemetry spans, or in .NET terminology you can start created new activities via the activity source and the agent will bridge those spans automatically.
+
+[source,csharp]
+----
+public static void Sample()
+{
+	var src = new ActivitySource("Test");
+	using var activity1 = src.StartActivity(nameof(Sample), ActivityKind.Server);
+	Thread.Sleep(100);
+	using var activity2 = src.StartActivity("foo");
+	Thread.Sleep(150);
+}
+----
+
+The code-snippet above creates a span called `Sample` and a child span on `Sample` called `foo`. The bridge will create a transaction from `Sample` and a child span called `foo`.
+
+[float]
+[[mixing-apis]]
+==== Mixing OpenTelemetry and the Elastic APM Public API
+
+You can also mix the Activity API with the <<public-api, Public API>>, the OpenTelemetry bridge will take care of putting the spans into the right place. The advantage of this is that if you already have some libraries that you instrumented via the <<public-api, Public API>>, but going forward, you'd like to use the vendor-independent OpenTelemetry API, you don't need to replace all Public API calls in one go.
+
+[source,csharp]
+----
+/// ElasticTransaction
+/// -
+/// ---> OTelSpan
+///           -
+///           ---> ElasticSpan
+
+var src = new ActivitySource("Test");
+tracer.CaptureTransaction( nameof(Sample4), "test", t =>
+{
+	Thread.Sleep(100);
+	using (var activity = src.StartActivity("foo"))
+	{
+		tracer.CurrentSpan.CaptureSpan("ElasticApmSpan", "test", () => Thread.Sleep(50));
+		Thread.Sleep(150);
+	}
+});
+----
+
+The code-snippet above creates a transaction with the Elastic .NET APM Agent's <<public-api, Public API>>. Then it creates an activity called `foo`. This activity is going to be a child of the previously created transaction. Then finally, a span is created again by using the Elastic .NET APM Agent's <<public-api, Public API>>. This span is going to be a child span of the OpenTelemetry span.
+
+Of course these calls don't have to be in the same method. The concept described here works across different methods, types, or libraries.
+
+[float]
+[[otel-caveats]]
+=== Caveats
+Not all features of the OpenTelemetry API are supported.
+
+[float]
+[[otel-metrics]]
+===== Metrics
+This bridge only supports the tracing API.
+The Metrics API is currently not supported.
+
+[float]
+[[otel-span-events]]
+===== Span Events
+Span events (https://open-telemetry.github.io/opentelemetry-js-api/interfaces/span.html#addevent[`Span#addEvent()`])
+is not currently supported. Events will be silently dropped.
+
+[float]
+[[otel-baggage]]
+===== Baggage
+https://open-telemetry.github.io/opentelemetry-js-api/classes/propagationapi.html[Propagating baggage]
+within or outside the process is not supported. Baggage items are silently dropped.

--- a/docs/api-opentelemetry.asciidoc
+++ b/docs/api-opentelemetry.asciidoc
@@ -6,12 +6,11 @@ endif::[]
 [[opentelemetry-bridge]]
 == OpenTelemetry Bridge
 
-NOTE: Added as experimental in v1.13.0.
-To enable it, set <<config-enable-open-telemetry-bridge, `OpentelemetryBridgeEnabled`>> to `true`.
+preview::[]
 
-NOTE: The OpenTelemetry bridge is supported on .NET 5 and newer versions.
+NOTE: This feature was added in v1.13.0. It is supported on .NET 5 and newer versions.
 
-The OpenTelemetry Bridge in the Elastic .NET APM Agent bridges OpenTelemetry spans into Elastic APM transactions and spans. The Elastic APM OpenTelemetry bridge allows one to use the vendor-neutral OpenTelemetry Tracing API to manually instrument one's code, and have the Elastic .NET APM agent handle those API calls. This allows one to use the Elastic APM agent for tracing, without any vendor lock-in from adding manual tracing using the APM agent’s own <<public-api, Public API>>.
+The OpenTelemetry Bridge in the Elastic .NET APM Agent bridges OpenTelemetry spans into Elastic APM transactions and spans. The Elastic APM OpenTelemetry bridge allows you to use the vendor-neutral OpenTelemetry Tracing API to manually instrument your code and have the Elastic .NET APM agent handle those API calls. This means you can use the Elastic APM agent for tracing, without any vendor lock-in from adding manual tracing using the APM agent’s own <<public-api, Public API>>.
 
 OpenTelemetry in .NET is implemented via the https://learn.microsoft.com/en-us/dotnet/api/system.diagnostics.activity?view=net-5.0[Activity API].
 
@@ -23,7 +22,7 @@ The OpenTelemetry bridge in the Elastic .NET APM Agent targets the https://learn
 [[otel-getting-started]]
 === Getting started
 
-The OpenTelemetry bridge is part of the core agent pacakge (https://www.nuget.org/packages/Elastic.Apm[`Elastic.Apm`]), so you don't need to add any additional dependency.
+The OpenTelemetry bridge is part of the core agent package (https://www.nuget.org/packages/Elastic.Apm[`Elastic.Apm`]), so you don't need to add an additional dependency.
 
 [float]
 [[otel-enable-bridge]]
@@ -51,7 +50,7 @@ If you configured the agent via the `appsettings.json` file, then set `ElasticAp
 [[create-activity-source-and-spans]]
 ==== Create an ActivitySource and start spans
 
-Once you enabled the bridge, you can create OpenTelemetry spans, or in .NET terminology you can start created new activities via the activity source and the agent will bridge those spans automatically.
+After enabling the bridge, you can create OpenTelemetry spans, or in .NET terminology, you can start creating new activities via the activity source, and the agent will bridge those spans automatically.
 
 [source,csharp]
 ----
@@ -65,7 +64,7 @@ public static void Sample()
 }
 ----
 
-The code-snippet above creates a span called `Sample` and a child span on `Sample` called `foo`. The bridge will create a transaction from `Sample` and a child span called `foo`.
+The code snippet above creates a span named `Sample` and a child span on `Sample` named `foo`. The bridge will create a transaction from `Sample` and a child span named `foo`.
 
 [float]
 [[mixing-apis]]
@@ -93,7 +92,7 @@ tracer.CaptureTransaction( nameof(Sample4), "test", t =>
 });
 ----
 
-The code-snippet above creates a transaction with the Elastic .NET APM Agent's <<public-api, Public API>>. Then it creates an activity called `foo`. This activity is going to be a child of the previously created transaction. Then finally, a span is created again by using the Elastic .NET APM Agent's <<public-api, Public API>>. This span is going to be a child span of the OpenTelemetry span.
+The code snippet above creates a transaction with the Elastic .NET APM Agent's <<public-api, Public API>>. Then it creates an activity called `foo`; this activity will be a child of the previously created transaction. Finally, a span is created again using the Elastic .NET APM Agent's <<public-api, Public API>>; this span will be a child span of the OpenTelemetry span.
 
 Of course these calls don't have to be in the same method. The concept described here works across different methods, types, or libraries.
 

--- a/docs/api-opentelemetry.asciidoc
+++ b/docs/api-opentelemetry.asciidoc
@@ -24,7 +24,7 @@ The OpenTelemetry bridge is part of the core agent package (https://www.nuget.or
 
 Currently the bridge is opt-in, so you need to enable it.
 
-If you configured the agent via environment variables, set the `ELASTIC_APM_ENABLEOPENTELEMETRYBRIDGE` environment variable to `true``.
+If you configured the agent via environment variables, set the `ELASTIC_APM_OPENTELEMETRY_BRIDGE_ENABLED ` environment variable to `true``.
 
 If you configured the agent via the `appsettings.json` file, then set `ElasticApm:EnableOpenTelemetryBridge` to `true`.
 

--- a/docs/api-opentelemetry.asciidoc
+++ b/docs/api-opentelemetry.asciidoc
@@ -7,7 +7,7 @@ endif::[]
 == OpenTelemetry Bridge
 
 NOTE: Added as experimental in v1.13.0.
-To enable it, set <<opentelemetry-bridge-enabled, `opentelemetryBridgeEnabled`>> to `true`.
+To enable it, set <<config-enable-open-telemetry-bridge, `OpentelemetryBridgeEnabled`>> to `true`.
 
 NOTE: The OpenTelemetry bridge is supported on .NET 5 and newer versions.
 

--- a/docs/api-opentelemetry.asciidoc
+++ b/docs/api-opentelemetry.asciidoc
@@ -12,12 +12,6 @@ NOTE: This feature was added in v1.13.0. It is supported on .NET 5 and newer ver
 
 The OpenTelemetry Bridge in the Elastic .NET APM Agent bridges OpenTelemetry spans into Elastic APM transactions and spans. The Elastic APM OpenTelemetry bridge allows you to use the vendor-neutral OpenTelemetry Tracing API to manually instrument your code and have the Elastic .NET APM agent handle those API calls. This means you can use the Elastic APM agent for tracing, without any vendor lock-in from adding manual tracing using the APM agent’s own <<public-api, Public API>>.
 
-OpenTelemetry in .NET is implemented via the https://learn.microsoft.com/en-us/dotnet/api/system.diagnostics.activity?view=net-5.0[Activity API].
-
-In .NET, there is an https://opentelemetry.io/docs/instrumentation/net/shim/[OpenTelemetry shim] which is built on top of the Activity API. 
-
-The OpenTelemetry bridge in the Elastic .NET APM Agent targets the https://learn.microsoft.com/en-us/dotnet/api/system.diagnostics.activity?view=net-5.0[Activity API]. Since the https://opentelemetry.io/docs/instrumentation/net/shim/[OpenTelemetry .NET shim] builds on top of the https://learn.microsoft.com/en-us/dotnet/api/system.diagnostics.activity?view=net-5.0[Activity API], the shim is implicitly supported as well, although we don't directly test it, because the Activity API is the recommended API.
-
 [float]
 [[otel-getting-started]]
 === Getting started
@@ -95,6 +89,14 @@ tracer.CaptureTransaction( nameof(Sample4), "test", t =>
 The code snippet above creates a transaction with the Elastic .NET APM Agent's <<public-api, Public API>>. Then it creates an activity called `foo`; this activity will be a child of the previously created transaction. Finally, a span is created again using the Elastic .NET APM Agent's <<public-api, Public API>>; this span will be a child span of the OpenTelemetry span.
 
 Of course these calls don't have to be in the same method. The concept described here works across different methods, types, or libraries.
+
+[float]
+[[supported-opentelemetry-implementations]]
+==== Supported OpenTelemetry implementations
+
+OpenTelemetry in .NET is implemented via the https://learn.microsoft.com/en-us/dotnet/api/system.diagnostics.activity?view=net-5.0[Activity API] and there is an https://opentelemetry.io/docs/instrumentation/net/shim/[OpenTelemetry shim] which follows the OpenTelemetry specification more closer. This shim is built on top of the Activity API.
+
+The OpenTelemetry bridge in the Elastic .NET APM Agent targets the https://learn.microsoft.com/en-us/dotnet/api/system.diagnostics.activity?view=net-5.0[Activity API]. Since the https://opentelemetry.io/docs/instrumentation/net/shim/[OpenTelemetry .NET shim] builds on top of the https://learn.microsoft.com/en-us/dotnet/api/system.diagnostics.activity?view=net-5.0[Activity API], the shim is implicitly supported as well, although we don't directly test it, because the Activity API is the recommended OpenTelemetry API for .NET.
 
 [float]
 [[otel-caveats]]

--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -594,15 +594,15 @@ Additionally, spans that lead to an error can't be discarded.
 
 
 [float]
-[[config-enable-open-telemetry-bridge]]
-==== `EnableOpenTelemetryBridge` (added[1.13])
+[[config-opentelemetry-bridge-enabled]]
+==== `OpentelemetryBridgeEnabled` (added[1.13])
 
 Setting this option to true will enable the <<opentelemetry-bridge, OpenTelemetry Bridge>>. This enables the use of the vendor-neutral OpenTelemetry Tracing API (the https://learn.microsoft.com/en-us/dotnet/api/system.diagnostics.activity?view=net-5.0[Activity API] in .NET) to manually instrument your code, and have the Elastic .NET APM agent handle those API calls.
 
 [options="header"]
 |============
-| Environment variable name            | IConfiguration key
-| `ELASTIC_APM_ENABLEOPENTELEMETRYBRIDGE` | `ElasticApm:EnableOpenTelemetryBridge`
+| Environment variable name                  | IConfiguration key
+| `ELASTIC_APM_OPENTELEMETRY_BRIDGE_ENABLED` | `ElasticApm:OpentelemetryBridgeEnabled`
 |============
 
 [options="header"]
@@ -1301,7 +1301,7 @@ you must instead set the `LogLevel` for the internal APM logger under the `Loggi
 | <<config-cloud-provider,`CloudProvider`>> | No | Reporter
 | <<config-disable-metrics,`DisableMetrics`>> | No | Reporter
 | <<config-enabled,`Enabled`>> | No | Core
-| <<config-enable-open-telemetry-bridge, `EnableOpenTelemetryBridge`>> | No | Core
+| <<config-opentelemetry-bridge-enabled, `OpentelemetryBridgeEnabled`>> | No | Core
 | <<config-environment,`Environment`>> | No | Core
 | <<config-excluded-namespaces,`ExcludedNamespaces`>> | No | Stacktrace
 | <<config-exit-span-min-duration,`ExitSpanMinDuration`>> | Yes | Core, Performance

--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -593,6 +593,26 @@ Additionally, spans that lead to an error can't be discarded.
 |============
 
 
+[float]
+[[config-enable-open-telemetry-bridge]]
+==== `EnableOpenTelemetryBridge` (added[1.13])
+
+Setting this option to true will enable the <<opentelemetry-bridge, OpenTelemetry Bridge>>. Briefly, the OpenTelemetry Bridge allows one to use the vendor-neutral OpenTelemetry Tracing API (which is the https://learn.microsoft.com/en-us/dotnet/api/system.diagnostics.activity?view=net-5.0[Activity API] in .NET) to manually instrument your code, and have the Elastic .NET APM agent handle those API calls.
+
+[options="header"]
+|============
+| Environment variable name            | IConfiguration key
+| `ELASTIC_APM_ENABLEOPENTELEMETRYBRIDGE` | `ElasticApm:EnableOpenTelemetryBridge`
+|============
+
+[options="header"]
+|============
+| Default  | Type
+| `false`  | Boolean
+|============
+
+
+
 [[config-reporter]]
 === Reporter configuration options
 
@@ -1281,6 +1301,7 @@ you must instead set the `LogLevel` for the internal APM logger under the `Loggi
 | <<config-cloud-provider,`CloudProvider`>> | No | Reporter
 | <<config-disable-metrics,`DisableMetrics`>> | No | Reporter
 | <<config-enabled,`Enabled`>> | No | Core
+| <<config-enable-open-telemetry-bridge, `EnableOpenTelemetryBridge`>> | No | Core
 | <<config-environment,`Environment`>> | No | Core
 | <<config-excluded-namespaces,`ExcludedNamespaces`>> | No | Stacktrace
 | <<config-exit-span-min-duration,`ExitSpanMinDuration`>> | Yes | Core, Performance

--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -597,7 +597,7 @@ Additionally, spans that lead to an error can't be discarded.
 [[config-enable-open-telemetry-bridge]]
 ==== `EnableOpenTelemetryBridge` (added[1.13])
 
-Setting this option to true will enable the <<opentelemetry-bridge, OpenTelemetry Bridge>>. Briefly, the OpenTelemetry Bridge allows one to use the vendor-neutral OpenTelemetry Tracing API (which is the https://learn.microsoft.com/en-us/dotnet/api/system.diagnostics.activity?view=net-5.0[Activity API] in .NET) to manually instrument your code, and have the Elastic .NET APM agent handle those API calls.
+Setting this option to true will enable the <<opentelemetry-bridge, OpenTelemetry Bridge>>. This enables the use of the vendor-neutral OpenTelemetry Tracing API (the https://learn.microsoft.com/en-us/dotnet/api/system.diagnostics.activity?view=net-5.0[Activity API] in .NET) to manually instrument your code, and have the Elastic .NET APM agent handle those API calls.
 
 [options="header"]
 |============

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -20,6 +20,8 @@ include::./configuration.asciidoc[]
 
 include::./public-api.asciidoc[]
 
+include::./api-opentelemetry.asciidoc[]
+
 include::./metrics.asciidoc[]
 
 include::./log-correlation.asciidoc[]


### PR DESCRIPTION
- The OTel bridge got released in v1.13.0 as experimental, but we have not documented it back then.
- This PR adds documentation including samples for the OTel Bridge.