### PR TITLE
Improve agent supportability

### DIFF
--- a/src/Elastic.Apm.AspNetFullFramework/ElasticApmModule.cs
+++ b/src/Elastic.Apm.AspNetFullFramework/ElasticApmModule.cs
@@ -21,6 +21,7 @@ using Elastic.Apm.Model;
 using TraceContext = Elastic.Apm.DistributedTracing.TraceContext;
 using Elastic.Apm.Reflection;
 using Elastic.Apm.Extensions;
+using System.Diagnostics;
 
 namespace Elastic.Apm.AspNetFullFramework
 {
@@ -422,6 +423,26 @@ namespace Elastic.Apm.AspNetFullFramework
 			_logger.Debug()?.Log("Captured user - {CapturedUser}", transaction.Context.User);
 		}
 
+		private static void CheckProfilerLogSettings(IApmLogger logger)
+		{
+			try
+			{
+				var profilerLogConfig = ProfilerLogConfig.Check(logger);
+				if (profilerLogConfig.LogLevel != LogLevel.None)
+				{
+					profilerLogConfig.TryApplyLogLevel(logger);
+					if (profilerLogConfig.LogTarget == ProfilerLogTarget.File)
+						TraceLogger.TraceSource.Listeners.Add(new TextWriterTraceListener(profilerLogConfig.LogFilePath));
+					if (profilerLogConfig.LogTarget == ProfilerLogTarget.StdOut)
+						TraceLogger.TraceSource.Listeners.Add(new TextWriterTraceListener(Console.Out));
+				}
+			}
+			catch (Exception e)
+			{
+				logger.Warning()?.LogException(e, "Evaluating profiler logging settings failed");
+			}
+		}
+
 		private static bool InitOnceForAllInstancesUnderLock(string dbgInstanceName) =>
 			InitOnceHelper.IfNotInited?.Init(() =>
 			{
@@ -452,6 +473,9 @@ namespace Elastic.Apm.AspNetFullFramework
 		private static AgentComponents CreateAgentComponents(string dbgInstanceName)
 		{
 			var rootLogger = AgentDependencies.Logger ?? CreateDefaultLogger();
+
+			CheckProfilerLogSettings(rootLogger);
+
 			var reader = ConfigHelper.CreateReader(rootLogger) ?? new FullFrameworkConfigReader(rootLogger);
 			var agentComponents = new FullFrameworkAgentComponents(rootLogger, reader);
 

--- a/src/Elastic.Apm.AspNetFullFramework/ElasticApmModule.cs
+++ b/src/Elastic.Apm.AspNetFullFramework/ElasticApmModule.cs
@@ -423,26 +423,6 @@ namespace Elastic.Apm.AspNetFullFramework
 			_logger.Debug()?.Log("Captured user - {CapturedUser}", transaction.Context.User);
 		}
 
-		private static void CheckProfilerLogSettings(IApmLogger logger)
-		{
-			try
-			{
-				var profilerLogConfig = ProfilerLogConfig.Check(logger);
-				if (profilerLogConfig.LogLevel != LogLevel.None)
-				{
-					profilerLogConfig.TryApplyLogLevel(logger);
-					if (profilerLogConfig.LogTarget == ProfilerLogTarget.File)
-						TraceLogger.TraceSource.Listeners.Add(new TextWriterTraceListener(profilerLogConfig.LogFilePath));
-					if (profilerLogConfig.LogTarget == ProfilerLogTarget.StdOut)
-						TraceLogger.TraceSource.Listeners.Add(new TextWriterTraceListener(Console.Out));
-				}
-			}
-			catch (Exception e)
-			{
-				logger.Warning()?.LogException(e, "Evaluating profiler logging settings failed");
-			}
-		}
-
 		private static bool InitOnceForAllInstancesUnderLock(string dbgInstanceName) =>
 			InitOnceHelper.IfNotInited?.Init(() =>
 			{
@@ -473,9 +453,6 @@ namespace Elastic.Apm.AspNetFullFramework
 		private static AgentComponents CreateAgentComponents(string dbgInstanceName)
 		{
 			var rootLogger = AgentDependencies.Logger ?? CreateDefaultLogger();
-
-			CheckProfilerLogSettings(rootLogger);
-
 			var reader = ConfigHelper.CreateReader(rootLogger) ?? new FullFrameworkConfigReader(rootLogger);
 			var agentComponents = new FullFrameworkAgentComponents(rootLogger, reader);
 

--- a/src/Elastic.Apm.AspNetFullFramework/ElasticApmModule.cs
+++ b/src/Elastic.Apm.AspNetFullFramework/ElasticApmModule.cs
@@ -21,7 +21,6 @@ using Elastic.Apm.Model;
 using TraceContext = Elastic.Apm.DistributedTracing.TraceContext;
 using Elastic.Apm.Reflection;
 using Elastic.Apm.Extensions;
-using System.Diagnostics;
 
 namespace Elastic.Apm.AspNetFullFramework
 {
@@ -447,7 +446,7 @@ namespace Elastic.Apm.AspNetFullFramework
 			if (!string.IsNullOrEmpty(logLevel))
 				Enum.TryParse(logLevel, true, out level);
 
-			return new TraceLogger(level);
+			return AgentComponents.CheckForProfilerLogger(new TraceLogger(level), level);
 		}
 
 		private static AgentComponents CreateAgentComponents(string dbgInstanceName)

--- a/src/Elastic.Apm/BackendComm/BackendCommUtils.cs
+++ b/src/Elastic.Apm/BackendComm/BackendCommUtils.cs
@@ -186,8 +186,10 @@ namespace Elastic.Apm.BackendComm
 			};
 #if NETFRAMEWORK
 			ServicePointManager.SecurityProtocol |= SecurityProtocolType.Tls12;
+			logger.Info()?.Log($"CreateHttpClientHandler - SslProtocols: {ServicePointManager.SecurityProtocol}");
 #else
 			httpClientHandler.SslProtocols |= SslProtocols.Tls12;
+			logger.Info()?.Log($"CreateHttpClientHandler - SslProtocols: {httpClientHandler.SslProtocols}");
 #endif
 			return httpClientHandler;
 		}

--- a/src/Elastic.Apm/Config/ProfilerLogConfig.cs
+++ b/src/Elastic.Apm/Config/ProfilerLogConfig.cs
@@ -1,0 +1,92 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System;
+using System.Collections;
+using System.Diagnostics;
+using System.IO;
+using System.Runtime.InteropServices;
+using Elastic.Apm.Helpers;
+using Elastic.Apm.Logging;
+
+namespace Elastic.Apm.Config
+{
+	internal struct ProfilerLogConfig
+	{
+		internal ProfilerLogConfig(LogLevel logLevel, ProfilerLogTarget logTarget, string logFilePath) : this()
+		{
+			LogLevel = logLevel;
+			LogTarget = logTarget;
+			LogFilePath = logFilePath;
+		}
+
+		internal ProfilerLogTarget LogTarget { get; private set; }
+		internal string LogFilePath {  get; private set; }
+		internal LogLevel LogLevel {  get; private set; }
+		internal static string GetDefaultProfilerLogDirectory()
+		{
+			if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+				return Path.Combine(Environment.GetEnvironmentVariable("PROGRAMDATA"), "elastic", "apm-agent-dotnet", "logs");
+			return "/var/log/elastic/apm-agent-dotnet";
+		}
+
+		internal void TryApplyLogLevel(IApmLogger logger)
+		{
+			if (logger is ILogLevelSwitchable switchable)
+				switchable.LogLevelSwitch.Level = LogLevel;
+			else
+				logger?.Warning()?.Log($"Logger '{logger}' is not {nameof(ILogLevelSwitchable)}");
+		}
+
+		internal static ProfilerLogConfig Check(IApmLogger logger, IDictionary environmentVariables = null)
+		{
+			environmentVariables ??= new EnvironmentVariables(logger).GetEnvironmentVariables();
+
+			string GetSafeEnvironmentVariable(string key)
+			{
+				var value = environmentVariables.Contains(key) ? environmentVariables[key]?.ToString() : null;
+				return value ?? string.Empty;
+			}
+
+			var logLevel = GetSafeEnvironmentVariable("ELASTIC_APM_PROFILER_LOG").ToLowerInvariant() switch
+			{
+				"trace" => LogLevel.Trace,
+				"debug" => LogLevel.Debug,
+				"info" => LogLevel.Information,
+				"warn" => LogLevel.Warning,
+				"error" => LogLevel.Error,
+				_ => LogLevel.None,
+			};
+
+			var logFilePath = GetSafeEnvironmentVariable("ELASTIC_APM_PROFILER_LOG_DIR");
+			if (string.IsNullOrEmpty(logFilePath))
+				logFilePath = GetDefaultProfilerLogDirectory();
+			var process = Process.GetCurrentProcess();
+			var logFileName = Path.Combine(logFilePath, $"{process.ProcessName}_{process.Id}_{Environment.TickCount}.agent.log");
+
+			var logTarget = ProfilerLogTarget.None;
+			foreach (var target in GetSafeEnvironmentVariable("ELASTIC_APM_PROFILER_LOG_TARGETS").Split(';'))
+			{
+				if (target.Equals("stdout", StringComparison.InvariantCultureIgnoreCase))
+					logTarget |= ProfilerLogTarget.StdOut;
+				else if (target.Equals("file", StringComparison.InvariantCultureIgnoreCase))
+					logTarget |= ProfilerLogTarget.File;
+			}
+			if (logTarget == ProfilerLogTarget.None)
+				logTarget= ProfilerLogTarget.File;
+
+			logger?.Trace()?.Log($"{nameof(ProfilerLogConfig)} - LogLevel: '{logLevel}',  LogTarget: '{logTarget}', LogFileName: '{logFileName}'");
+
+			return new(logLevel, logTarget, logFileName);
+		}
+	}
+
+	[Flags]
+	internal enum ProfilerLogTarget
+	{
+		None = 0,
+		File = 1,
+		StdOut = 2
+	}
+}

--- a/src/Elastic.Apm/Helpers/LogLevelUtils.cs
+++ b/src/Elastic.Apm/Helpers/LogLevelUtils.cs
@@ -1,0 +1,14 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using Elastic.Apm.Logging;
+
+namespace Elastic.Apm.Helpers
+{
+	internal static class LogLevelUtils
+	{
+		internal static LogLevel GetFinest(LogLevel logLevel1, LogLevel logLevel2) =>
+			logLevel1.CompareTo(logLevel2) <= 0 ? logLevel1 : logLevel2;
+	}
+}

--- a/src/Elastic.Apm/Logging/ConsoleLogger.cs
+++ b/src/Elastic.Apm/Logging/ConsoleLogger.cs
@@ -29,7 +29,7 @@ namespace Elastic.Apm.Logging
 
 		internal LogLevel Level => LogLevelSwitch.Level;
 
-		public static ConsoleLogger LoggerOrDefault(LogLevel? level)
+		internal static ConsoleLogger LoggerOrDefault(LogLevel? level)
 		{
 			if (level.HasValue && level.Value != DefaultValues.LogLevel)
 				return new ConsoleLogger(level.Value);

--- a/src/Elastic.Apm/Logging/ConsoleLogger.cs
+++ b/src/Elastic.Apm/Logging/ConsoleLogger.cs
@@ -67,7 +67,8 @@ namespace Elastic.Apm.Logging
 
 			static void PrintException(TextWriter writer, Exception exception, string caption)
 			{
-				if (exception == null) return;
+				if (exception == null)
+					return;
 
 				writer.Write($"+-> {caption}: ");
 				writer.Write(exception.GetType().FullName);

--- a/src/Elastic.Apm/Logging/ConsoleLogger.cs
+++ b/src/Elastic.Apm/Logging/ConsoleLogger.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to Elasticsearch B.V under one or more agreements.
+// Licensed to Elasticsearch B.V under one or more agreements.
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
 
@@ -27,7 +27,7 @@ namespace Elastic.Apm.Logging
 
 		public LogLevelSwitch LogLevelSwitch { get; }
 
-		private LogLevel Level => LogLevelSwitch.Level;
+		internal LogLevel Level => LogLevelSwitch.Level;
 
 		public static ConsoleLogger LoggerOrDefault(LogLevel? level)
 		{

--- a/src/Elastic.Apm/Logging/ConsoleLogger.cs
+++ b/src/Elastic.Apm/Logging/ConsoleLogger.cs
@@ -65,6 +65,18 @@ namespace Elastic.Apm.Logging
 			var dateTime = DateTime.Now;
 			var message = formatter(state, e);
 
+			static void PrintException(TextWriter writer, Exception exception, string caption)
+			{
+				if (exception == null) return;
+
+				writer.Write($"+-> {caption}: ");
+				writer.Write(exception.GetType().FullName);
+				writer.Write(": ");
+				writer.WriteLine(exception.Message);
+				writer.WriteLine(exception.StackTrace);
+				PrintException(writer, exception.InnerException, "Inner Exception");
+			}
+
 			lock (SyncRoot)
 			{
 				writer.Write('[');
@@ -75,14 +87,8 @@ namespace Elastic.Apm.Logging
 				writer.Write(LevelToString(level));
 				writer.Write("] - ");
 				writer.WriteLine(message);
-				if (e != null)
-				{
-					writer.Write("+-> Exception: ");
-					writer.Write(e.GetType().FullName);
-					writer.Write(": ");
-					writer.WriteLine(e.Message);
-					writer.WriteLine(e.StackTrace);
-				}
+
+				PrintException(writer, e, "Exception");
 
 				writer.Flush();
 			}

--- a/src/Elastic.Apm/Logging/TraceLogger.cs
+++ b/src/Elastic.Apm/Logging/TraceLogger.cs
@@ -18,7 +18,7 @@ namespace Elastic.Apm.Logging
 	{
 		private const string SourceName = "Elastic.Apm";
 
-		private static readonly TraceSource TraceSource;
+		internal static readonly TraceSource TraceSource;
 
 		static TraceLogger() => TraceSource = new TraceSource(SourceName);
 

--- a/src/Elastic.Apm/Logging/TraceLogger.cs
+++ b/src/Elastic.Apm/Logging/TraceLogger.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Diagnostics;
+using System.IO;
 using System.Runtime.CompilerServices;
 using System.Text;
 using System.Threading;
@@ -58,14 +59,21 @@ namespace Elastic.Apm.Logging
 				.Append("] - ")
 				.Append(message);
 
-			if (e != null)
+			static void PrintException(StringBuilder builder, Exception exception, string caption)
 			{
-				builder.Append("+-> Exception: ")
-					.Append(exceptionType)
+				if (exception == null)
+					return;
+
+				builder.Append($"+-> {caption}: ")
+					.Append(exception.GetType().FullName)
 					.Append(": ")
-					.AppendLine(e.Message)
-					.AppendLine(e.StackTrace);
+					.AppendLine(exception.Message)
+					.AppendLine(exception.StackTrace);
+
+				PrintException(builder, exception.InnerException, "Inner Exception");
 			}
+
+			PrintException(builder, e, "Exception");
 
 			var logMessage = builder.ToString();
 			for (var i = 0; i < TraceSource.Listeners.Count; i++)

--- a/test/Elastic.Apm.Tests/Config/ProfilerLogConfigTests.cs
+++ b/test/Elastic.Apm.Tests/Config/ProfilerLogConfigTests.cs
@@ -5,7 +5,6 @@
 using System.Collections;
 using Elastic.Apm.Config;
 using Elastic.Apm.Logging;
-using Elastic.Apm.Tests.Utilities;
 using FluentAssertions;
 using Xunit;
 
@@ -16,11 +15,11 @@ namespace Elastic.Apm.Tests.Config
 		[Fact]
 		public void Check_Defaults()
 		{
-			var config = ProfilerLogConfig.Check(new NoopLogger(), new Hashtable());
+			var config = ProfilerLogConfig.Check(new Hashtable());
 			config.LogLevel.Should().Be(LogLevel.None);
 			config.LogFilePath.Should().StartWith(ProfilerLogConfig.GetDefaultProfilerLogDirectory());
 			config.LogFilePath.Should().EndWith(".agent.log");
-			config.LogTarget.Should().Be(ProfilerLogTarget.File);
+			config.LogTargets.Should().Be(ProfilerLogTarget.File);
 		}
 
 		[Theory]
@@ -35,7 +34,7 @@ namespace Elastic.Apm.Tests.Config
 		public void Check_LogLevelValues_AreMappedCorrectly(string envVarValue, LogLevel logLevel)
 		{
 			var environment = new Hashtable { { "ELASTIC_APM_PROFILER_LOG", envVarValue } };
-			var config = ProfilerLogConfig.Check(new NoopLogger(), environment);
+			var config = ProfilerLogConfig.Check(environment);
 			config.LogLevel.Should().Be(logLevel);
 		}
 
@@ -46,7 +45,7 @@ namespace Elastic.Apm.Tests.Config
 		public void Check_InvalidLogLevelValues_AreMappedToNone(string envVarValue)
 		{
 			var environment = new Hashtable { { "ELASTIC_APM_PROFILER_LOG", envVarValue } };
-			var config = ProfilerLogConfig.Check(new NoopLogger(), environment);
+			var config = ProfilerLogConfig.Check(environment);
 			config.LogLevel.Should().Be(LogLevel.None);
 		}
 
@@ -54,7 +53,7 @@ namespace Elastic.Apm.Tests.Config
 		public void Check_LogDir_IsEvaluatedCorrectly()
 		{
 			var environment = new Hashtable { { "ELASTIC_APM_PROFILER_LOG_DIR", "/foo/bar" } };
-			var config = ProfilerLogConfig.Check(new NoopLogger(), environment);
+			var config = ProfilerLogConfig.Check(environment);
 			config.LogFilePath.Should().StartWith("/foo/bar");
 			config.LogFilePath.Should().EndWith(".agent.log");
 		}
@@ -76,18 +75,8 @@ namespace Elastic.Apm.Tests.Config
 		internal void Check_LogTargets_AreEvaluatedCorrectly(string envVarValue, ProfilerLogTarget targets)
 		{
 			var environment = new Hashtable { { "ELASTIC_APM_PROFILER_LOG_TARGETS", envVarValue } };
-			var config = ProfilerLogConfig.Check(new NoopLogger(), environment);
-			config.LogTarget.Should().Be(targets);
-		}
-
-		[Fact]
-		public void TryApplyLogLevel_Overrides_SetLogLegel()
-		{
-			var logger = new TestLogger(LogLevel.Warning);
-			var environment = new Hashtable { { "ELASTIC_APM_PROFILER_LOG", "trace" } };
-			var config = ProfilerLogConfig.Check(new NoopLogger(), environment);
-			config.TryApplyLogLevel(logger);
-			logger.Level.Should().Be(LogLevel.Trace);
+			var config = ProfilerLogConfig.Check(environment);
+			config.LogTargets.Should().Be(targets);
 		}
 	}
 }

--- a/test/Elastic.Apm.Tests/Config/ProfilerLogConfigTests.cs
+++ b/test/Elastic.Apm.Tests/Config/ProfilerLogConfigTests.cs
@@ -1,0 +1,93 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System.Collections;
+using Elastic.Apm.Config;
+using Elastic.Apm.Logging;
+using Elastic.Apm.Tests.Utilities;
+using FluentAssertions;
+using Xunit;
+
+namespace Elastic.Apm.Tests.Config
+{
+	public class ProfilerLogConfigTests
+	{
+		[Fact]
+		public void Check_Defaults()
+		{
+			var config = ProfilerLogConfig.Check(new NoopLogger(), new Hashtable());
+			config.LogLevel.Should().Be(LogLevel.None);
+			config.LogFilePath.Should().StartWith(ProfilerLogConfig.GetDefaultProfilerLogDirectory());
+			config.LogFilePath.Should().EndWith(".agent.log");
+			config.LogTarget.Should().Be(ProfilerLogTarget.File);
+		}
+
+		[Theory]
+		[InlineData("trace", LogLevel.Trace)]
+		[InlineData("Trace", LogLevel.Trace)]
+		[InlineData("TraCe", LogLevel.Trace)]
+		[InlineData("debug", LogLevel.Debug)]
+		[InlineData("info", LogLevel.Information)]
+		[InlineData("warn", LogLevel.Warning)]
+		[InlineData("error", LogLevel.Error)]
+		[InlineData("none", LogLevel.None)]
+		public void Check_LogLevelValues_AreMappedCorrectly(string envVarValue, LogLevel logLevel)
+		{
+			var environment = new Hashtable { { "ELASTIC_APM_PROFILER_LOG", envVarValue } };
+			var config = ProfilerLogConfig.Check(new NoopLogger(), environment);
+			config.LogLevel.Should().Be(logLevel);
+		}
+
+		[Theory]
+		[InlineData("foo")]
+		[InlineData("tracing")]
+		[InlineData(null)]
+		public void Check_InvalidLogLevelValues_AreMappedToNone(string envVarValue)
+		{
+			var environment = new Hashtable { { "ELASTIC_APM_PROFILER_LOG", envVarValue } };
+			var config = ProfilerLogConfig.Check(new NoopLogger(), environment);
+			config.LogLevel.Should().Be(LogLevel.None);
+		}
+
+		[Fact]
+		public void Check_LogDir_IsEvaluatedCorrectly()
+		{
+			var environment = new Hashtable { { "ELASTIC_APM_PROFILER_LOG_DIR", "/foo/bar" } };
+			var config = ProfilerLogConfig.Check(new NoopLogger(), environment);
+			config.LogFilePath.Should().StartWith("/foo/bar");
+			config.LogFilePath.Should().EndWith(".agent.log");
+		}
+
+		[Theory]
+		[InlineData(null, ProfilerLogTarget.File)]
+		[InlineData("", ProfilerLogTarget.File)]
+		[InlineData("foo", ProfilerLogTarget.File)]
+		[InlineData("foo,bar", ProfilerLogTarget.File)]
+		[InlineData("foo;bar", ProfilerLogTarget.File)]
+		[InlineData("file;foo;bar", ProfilerLogTarget.File)]
+		[InlineData("file", ProfilerLogTarget.File)]
+		[InlineData("stdout", ProfilerLogTarget.StdOut)]
+		[InlineData("StdOut", ProfilerLogTarget.StdOut)]
+		[InlineData("file;stdout", ProfilerLogTarget.File | ProfilerLogTarget.StdOut)]
+		[InlineData("FILE;StdOut", ProfilerLogTarget.File | ProfilerLogTarget.StdOut)]
+		[InlineData("file;stdout;file", ProfilerLogTarget.File | ProfilerLogTarget.StdOut)]
+		[InlineData("FILE;StdOut;stdout", ProfilerLogTarget.File | ProfilerLogTarget.StdOut)]
+		internal void Check_LogTargets_AreEvaluatedCorrectly(string envVarValue, ProfilerLogTarget targets)
+		{
+			var environment = new Hashtable { { "ELASTIC_APM_PROFILER_LOG_TARGETS", envVarValue } };
+			var config = ProfilerLogConfig.Check(new NoopLogger(), environment);
+			config.LogTarget.Should().Be(targets);
+		}
+
+		[Fact]
+		public void TryApplyLogLevel_Overrides_SetLogLegel()
+		{
+			var logger = new TestLogger(LogLevel.Warning);
+			var environment = new Hashtable { { "ELASTIC_APM_PROFILER_LOG", "trace" } };
+			var config = ProfilerLogConfig.Check(new NoopLogger(), environment);
+			config.TryApplyLogLevel(logger);
+			logger.Level.Should().Be(LogLevel.Trace);
+		}
+	}
+}

--- a/test/Elastic.Apm.Tests/Config/ProfilerLogConfigTests.cs
+++ b/test/Elastic.Apm.Tests/Config/ProfilerLogConfigTests.cs
@@ -16,7 +16,8 @@ namespace Elastic.Apm.Tests.Config
 		public void Check_Defaults()
 		{
 			var config = ProfilerLogConfig.Check(new Hashtable());
-			config.LogLevel.Should().Be(LogLevel.None);
+			config.IsActive.Should().BeFalse();
+			config.LogLevel.Should().Be(LogLevel.Warning);
 			config.LogFilePath.Should().StartWith(ProfilerLogConfig.GetDefaultProfilerLogDirectory());
 			config.LogFilePath.Should().EndWith(".agent.log");
 			config.LogTargets.Should().Be(ProfilerLogTarget.File);
@@ -35,18 +36,21 @@ namespace Elastic.Apm.Tests.Config
 		{
 			var environment = new Hashtable { { "ELASTIC_APM_PROFILER_LOG", envVarValue } };
 			var config = ProfilerLogConfig.Check(environment);
+			config.IsActive.Should().BeTrue();
 			config.LogLevel.Should().Be(logLevel);
 		}
 
 		[Theory]
-		[InlineData("foo")]
-		[InlineData("tracing")]
-		[InlineData(null)]
-		public void Check_InvalidLogLevelValues_AreMappedToNone(string envVarValue)
+		[InlineData(null, false)]
+		[InlineData("", false)]
+		[InlineData("foo", true)]
+		[InlineData("tracing", true)]
+		public void Check_InvalidLogLevelValues_AreMappedToDefaultWarn(string envVarValue, bool isActive)
 		{
 			var environment = new Hashtable { { "ELASTIC_APM_PROFILER_LOG", envVarValue } };
 			var config = ProfilerLogConfig.Check(environment);
-			config.LogLevel.Should().Be(LogLevel.None);
+			config.LogLevel.Should().Be(LogLevel.Warning);
+			config.IsActive.Should().Be(isActive);
 		}
 
 		[Fact]


### PR DESCRIPTION
This PR aims to improve supportability for agent/profiler-related issues we ran into recently.

## Profiler

Users typically discover and turn on the `ELASTIC_APM_PROFILER_LOG` setting when they experience issues with the profiler. However, these profiler logs alone are usually not very helpful and agent logs are also required. To avoid this extra step (described [here](https://www.elastic.co/guide/en/apm/agent/dotnet/current/troubleshooting.html)) this PR enables the following new feature:

* As soon as the `ELASTIC_APM_PROFILER_LOG` setting is present, **agent logging** will be activated as well.
	* In that case, other profiler-related settings like `ELASTIC_APM_PROFILER_LOG_DIR` and `ELASTIC_APM_PROFILER_LOG_TARGETS` will be honored as well.
* If `ELASTIC_APM_LOG_LEVEL` is also set, the most fine-grain log level of the 2 (agent vs. profiler) will be used.

## General improvements

* Full exception details (inner exceptions) are logged now.
* SSL information is logged.

Additional communication-related log messages might be added on-demand later.