### PR TITLE
Rename config to enable/disable OTel bridge

### DIFF
--- a/src/Elastic.Apm/AgentComponents.cs
+++ b/src/Elastic.Apm/AgentComponents.cs
@@ -67,7 +67,7 @@ namespace Elastic.Apm
 
 #if NET5_0_OR_GREATER
 				ElasticActivityListener activityListener = null;
-				if (ConfigurationReader.EnableOpenTelemetryBridge)
+				if (ConfigurationReader.OpenTelemetryBridgeEnabled)
 				{
 					activityListener = new ElasticActivityListener(this, HttpTraceConfiguration);
 
@@ -116,7 +116,7 @@ namespace Elastic.Apm
 					breakdownMetricsProvider);
 
 #if NET5_0_OR_GREATER
-				if (ConfigurationReader.EnableOpenTelemetryBridge)
+				if (ConfigurationReader.OpenTelemetryBridgeEnabled)
 				{
 					// If the server version is not known yet, we enable the listener - and then the callback will do the version check once we have the version
 					if (ApmServerInfo.Version == null || ApmServerInfo?.Version == new ElasticVersion(0, 0, 0, null))

--- a/src/Elastic.Apm/BackendComm/CentralConfig/CentralConfigurationFetcher.cs
+++ b/src/Elastic.Apm/BackendComm/CentralConfig/CentralConfigurationFetcher.cs
@@ -264,7 +264,7 @@ namespace Elastic.Apm.BackendComm.CentralConfig
 
 			public IReadOnlyList<WildcardMatcher> DisableMetrics => _wrapped.DisableMetrics;
 			public bool Enabled => _wrapped.Enabled;
-			public bool EnableOpenTelemetryBridge => _wrapped.EnableOpenTelemetryBridge;
+			public bool OpenTelemetryBridgeEnabled => _wrapped.OpenTelemetryBridgeEnabled;
 
 			public string Environment => _wrapped.Environment;
 			public IReadOnlyCollection<string> ExcludedNamespaces => _wrapped.ExcludedNamespaces;

--- a/src/Elastic.Apm/Config/AbstractConfigurationReader.cs
+++ b/src/Elastic.Apm/Config/AbstractConfigurationReader.cs
@@ -225,16 +225,18 @@ namespace Elastic.Apm.Config
 			return true;
 		}
 
-		protected bool ParseEnableOpenTelemetryBridge(ConfigurationKeyValue kv)
+		protected bool ParseOpenTelemetryBridgeEnabled(ConfigurationKeyValue kv)
 		{
-			if (kv == null || string.IsNullOrEmpty(kv.Value)) return DefaultValues.EnableOpenTelemetryBridge;
+			if (kv == null || string.IsNullOrEmpty(kv.Value)) return DefaultValues.OpenTelemetryBridgeEnabled;
 
 			if (bool.TryParse(kv.Value, out var isOTelEnabled))
 				return isOTelEnabled;
 
 			_logger?.Warning()
-				?.Log("Failed parsing value for 'EnableOpenTelemetryBridge' setting to 'bool'. Received value: {receivedValue}", kv.Value);
-			return DefaultValues.EnableOpenTelemetryBridge;
+				?.Log(
+					"Failed parsing value for 'OpenTelemetryBridgeEnabled' setting to 'bool'. Received value: {receivedValue}",
+					kv.Value);
+			return DefaultValues.OpenTelemetryBridgeEnabled;
 		}
 
 		protected bool ParseRecording(ConfigurationKeyValue kv)

--- a/src/Elastic.Apm/Config/AbstractConfigurationWithEnvFallbackReader.cs
+++ b/src/Elastic.Apm/Config/AbstractConfigurationWithEnvFallbackReader.cs
@@ -175,7 +175,7 @@ namespace Elastic.Apm.Config
 			ParseVerifyServerCert(Read(KeyNames.VerifyServerCert, EnvVarNames.VerifyServerCert));
 
 		public bool EnableOpenTelemetryBridge =>
-			ParseEnableOpenTelemetryBridge(Read(KeyNames.EnableOpenTelemetryBridge, EnvVarNames.EnableOpenTelemetryBridge));
+			ParseEnableOpenTelemetryBridge(Read(KeyNames.OpentelemetryBridgeEnabled, EnvVarNames.EnableOpenTelemetryBridge));
 
 		public ConfigurationKeyValue Get(ConfigurationItem item) =>
 			Read(item.ConfigurationKeyName, item.ConfigurationKeyName);

--- a/src/Elastic.Apm/Config/AbstractConfigurationWithEnvFallbackReader.cs
+++ b/src/Elastic.Apm/Config/AbstractConfigurationWithEnvFallbackReader.cs
@@ -174,8 +174,9 @@ namespace Elastic.Apm.Config
 		public virtual bool VerifyServerCert =>
 			ParseVerifyServerCert(Read(KeyNames.VerifyServerCert, EnvVarNames.VerifyServerCert));
 
-		public bool EnableOpenTelemetryBridge =>
-			ParseEnableOpenTelemetryBridge(Read(KeyNames.OpentelemetryBridgeEnabled, EnvVarNames.EnableOpenTelemetryBridge));
+		public bool OpenTelemetryBridgeEnabled =>
+			ParseOpenTelemetryBridgeEnabled(Read(KeyNames.OpentelemetryBridgeEnabled,
+				EnvVarNames.OpenTelemetryBridgeEnabled));
 
 		public ConfigurationKeyValue Get(ConfigurationItem item) =>
 			Read(item.ConfigurationKeyName, item.ConfigurationKeyName);

--- a/src/Elastic.Apm/Config/ConfigConsts.cs
+++ b/src/Elastic.Apm/Config/ConfigConsts.cs
@@ -26,7 +26,7 @@ namespace Elastic.Apm.Config
 			public const bool CaptureHeaders = true;
 			public const bool CentralConfig = true;
 			public const string CloudProvider = SupportedValues.CloudProviderAuto;
-			public const bool EnableOpenTelemetryBridge = false;
+			public const bool OpenTelemetryBridgeEnabled = false;
 			public const string ExitSpanMinDuration = "0ms";
 			public const int ExitSpanMinDurationInMilliseconds = 0;
 			public const int FlushIntervalInMilliseconds = 10_000; // 10 seconds
@@ -131,7 +131,7 @@ namespace Elastic.Apm.Config
 			public const string CloudProvider = Prefix + "CLOUD_PROVIDER";
 			public const string DisableMetrics = Prefix + "DISABLE_METRICS";
 			public const string Enabled = Prefix + "ENABLED";
-			public const string EnableOpenTelemetryBridge = Prefix + "OPENTELEMETRY_BRIDGE_ENABLED";
+			public const string OpenTelemetryBridgeEnabled = Prefix + "OPENTELEMETRY_BRIDGE_ENABLED";
 			public const string Environment = Prefix + "ENVIRONMENT";
 			public const string ExcludedNamespaces = Prefix + "EXCLUDED_NAMESPACES";
 			public const string ExitSpanMinDuration = Prefix + "EXIT_SPAN_MIN_DURATION";

--- a/src/Elastic.Apm/Config/ConfigConsts.cs
+++ b/src/Elastic.Apm/Config/ConfigConsts.cs
@@ -131,7 +131,7 @@ namespace Elastic.Apm.Config
 			public const string CloudProvider = Prefix + "CLOUD_PROVIDER";
 			public const string DisableMetrics = Prefix + "DISABLE_METRICS";
 			public const string Enabled = Prefix + "ENABLED";
-			public const string EnableOpenTelemetryBridge = Prefix + "ENABLEOPENTELEMETRYBRIDGE";
+			public const string EnableOpenTelemetryBridge = Prefix + "OPENTELEMETRY_BRIDGE_ENABLED";
 			public const string Environment = Prefix + "ENVIRONMENT";
 			public const string ExcludedNamespaces = Prefix + "EXCLUDED_NAMESPACES";
 			public const string ExitSpanMinDuration = Prefix + "EXIT_SPAN_MIN_DURATION";
@@ -183,7 +183,7 @@ namespace Elastic.Apm.Config
 			public const string CloudProvider = Prefix + nameof(CloudProvider);
 			public const string DisableMetrics = Prefix + nameof(DisableMetrics);
 			public const string Enabled = Prefix + nameof(Enabled);
-			public const string EnableOpenTelemetryBridge = Prefix + nameof(EnableOpenTelemetryBridge);
+			public const string OpentelemetryBridgeEnabled = Prefix + nameof(OpentelemetryBridgeEnabled);
 			public const string Environment = Prefix + nameof(Environment);
 			public const string ExcludedNamespaces = Prefix + nameof(ExcludedNamespaces);
 			public const string ExitSpanMinDuration = Prefix + nameof(ExitSpanMinDuration);

--- a/src/Elastic.Apm/Config/ConfigurationMetaData.cs
+++ b/src/Elastic.Apm/Config/ConfigurationMetaData.cs
@@ -17,7 +17,7 @@ namespace Elastic.Apm.Config
 		CloudProvider,
 		DisableMetrics,
 		Enabled,
-		EnableOpenTelemetryBridge,
+		OpenTelemetryBridgeEnabled,
 		Environment,
 		ExcludedNamespaces,
 		ExitSpanMinDuration,
@@ -129,7 +129,7 @@ namespace Elastic.Apm.Config
 			new(ConfigurationItemId.DisableMetrics, ConfigConsts.EnvVarNames.DisableMetrics,
 				ConfigConsts.KeyNames.DisableMetrics),
 			new(ConfigurationItemId.Enabled, ConfigConsts.EnvVarNames.Enabled, ConfigConsts.KeyNames.Enabled), new(
-				ConfigurationItemId.EnableOpenTelemetryBridge, ConfigConsts.EnvVarNames.EnableOpenTelemetryBridge,
+				ConfigurationItemId.OpenTelemetryBridgeEnabled, ConfigConsts.EnvVarNames.OpenTelemetryBridgeEnabled,
 				ConfigConsts.KeyNames.OpentelemetryBridgeEnabled),
 			new(ConfigurationItemId.Environment, ConfigConsts.EnvVarNames.Environment,
 				ConfigConsts.KeyNames.Environment),

--- a/src/Elastic.Apm/Config/ConfigurationMetaData.cs
+++ b/src/Elastic.Apm/Config/ConfigurationMetaData.cs
@@ -130,7 +130,7 @@ namespace Elastic.Apm.Config
 				ConfigConsts.KeyNames.DisableMetrics),
 			new(ConfigurationItemId.Enabled, ConfigConsts.EnvVarNames.Enabled, ConfigConsts.KeyNames.Enabled), new(
 				ConfigurationItemId.EnableOpenTelemetryBridge, ConfigConsts.EnvVarNames.EnableOpenTelemetryBridge,
-				ConfigConsts.KeyNames.EnableOpenTelemetryBridge),
+				ConfigConsts.KeyNames.OpentelemetryBridgeEnabled),
 			new(ConfigurationItemId.Environment, ConfigConsts.EnvVarNames.Environment,
 				ConfigConsts.KeyNames.Environment),
 			new(ConfigurationItemId.ExcludedNamespaces, ConfigConsts.EnvVarNames.ExcludedNamespaces,

--- a/src/Elastic.Apm/Config/ConfigurationSnapshotFromReader.cs
+++ b/src/Elastic.Apm/Config/ConfigurationSnapshotFromReader.cs
@@ -31,7 +31,7 @@ namespace Elastic.Apm.Config
 		public string Description { get; }
 		public IReadOnlyList<WildcardMatcher> DisableMetrics => _content.DisableMetrics;
 		public bool Enabled => _content.Enabled;
-		public bool EnableOpenTelemetryBridge => _content.EnableOpenTelemetryBridge;
+		public bool OpenTelemetryBridgeEnabled => _content.OpenTelemetryBridgeEnabled;
 		public string Environment => _content.Environment;
 		public IReadOnlyCollection<string> ExcludedNamespaces => _content.ExcludedNamespaces;
 		public double ExitSpanMinDuration => _content.ExitSpanMinDuration;

--- a/src/Elastic.Apm/Config/EnvironmentConfigurationReader.cs
+++ b/src/Elastic.Apm/Config/EnvironmentConfigurationReader.cs
@@ -49,7 +49,9 @@ namespace Elastic.Apm.Config
 		public string Description => Origin;
 		public IReadOnlyList<WildcardMatcher> DisableMetrics => ParseDisableMetrics(Read(ConfigConsts.EnvVarNames.DisableMetrics));
 		public bool Enabled => ParseEnabled(Read(ConfigConsts.EnvVarNames.Enabled));
-		public bool EnableOpenTelemetryBridge => ParseEnableOpenTelemetryBridge(Read(ConfigConsts.EnvVarNames.EnableOpenTelemetryBridge));
+
+		public bool OpenTelemetryBridgeEnabled =>
+			ParseOpenTelemetryBridgeEnabled(Read(ConfigConsts.EnvVarNames.OpenTelemetryBridgeEnabled));
 
 		public string Environment => ParseEnvironment(Read(ConfigConsts.EnvVarNames.Environment));
 

--- a/src/Elastic.Apm/Config/IConfigurationReader.cs
+++ b/src/Elastic.Apm/Config/IConfigurationReader.cs
@@ -80,7 +80,7 @@ namespace Elastic.Apm.Config
 		/// Enables OpenTelemetry bridging. If this is set to <code>true</code>, the agent will automatically capture every
 		/// <see cref="System.Diagnostics.Activity" /> as part of a trace captured in Elastic APM.
 		/// </summary>
-		bool EnableOpenTelemetryBridge { get; }
+		bool OpenTelemetryBridgeEnabled { get; }
 
 		/// <summary>
 		/// The name of the environment this service is deployed in.

--- a/test/Elastic.Apm.Feature.Tests/OpenTelemetryBridgeStepDefinitions.cs
+++ b/test/Elastic.Apm.Feature.Tests/OpenTelemetryBridgeStepDefinitions.cs
@@ -23,8 +23,9 @@ namespace Elastic.Apm.Feature.Tests
 		{
 			var mockPaylodSender = new MockPayloadSender();
 			_scenarioContext.Add("payloadSender", mockPaylodSender);
-			using (var agent = new ApmAgent(new TestAgentComponents(configuration: new MockConfiguration(enableOpenTelemetryBridge: "true"),
-				apmServerInfo: MockApmServerInfo.Version716, payloadSender: mockPaylodSender)))
+			using (var agent = new ApmAgent(new TestAgentComponents(
+				       configuration: new MockConfiguration(openTelemetryBridgeEnabled: "true"),
+				       apmServerInfo: MockApmServerInfo.Version716, payloadSender: mockPaylodSender)))
 			{
 				_scenarioContext.Add("agent", agent);
 			}

--- a/test/Elastic.Apm.Feature.Tests/TestConfiguration.cs
+++ b/test/Elastic.Apm.Feature.Tests/TestConfiguration.cs
@@ -64,6 +64,6 @@ namespace Elastic.Apm.Feature.Tests
 		public double TransactionSampleRate { get; set; } = DefaultValues.TransactionSampleRate;
 		public bool UseElasticTraceparentHeader { get; set; } = DefaultValues.UseElasticTraceparentHeader;
 		public bool VerifyServerCert { get; set; } = DefaultValues.VerifyServerCert;
-		public bool EnableOpenTelemetryBridge { get; set; }
+		public bool OpenTelemetryBridgeEnabled { get; set; }
 	}
 }

--- a/test/Elastic.Apm.Tests.Utilities/MockConfiguration.cs
+++ b/test/Elastic.Apm.Tests.Utilities/MockConfiguration.cs
@@ -26,7 +26,7 @@ namespace Elastic.Apm.Tests.Utilities
 		private readonly string _description;
 		private readonly string _disableMetrics;
 		private readonly string _enabled;
-		private readonly string _enableOpenTelemetryBridge;
+		private readonly string _openTelemetryBridgeEnabled;
 		private readonly string _environment;
 		private readonly string _excludedNamespaces;
 		private readonly string _exitSpanMinDuration;
@@ -74,7 +74,7 @@ namespace Elastic.Apm.Tests.Utilities
 			string captureHeaders = null,
 			string centralConfig = null,
 			string description = null,
-			string enableOpenTelemetryBridge = null,
+			string openTelemetryBridgeEnabled = null,
 			string exitSpanMinDuration = null,
 			string transactionSampleRate = null,
 			string transactionMaxSpans = null,
@@ -122,7 +122,7 @@ namespace Elastic.Apm.Tests.Utilities
 			_captureHeaders = captureHeaders;
 			_centralConfig = centralConfig;
 			_description = description;
-			_enableOpenTelemetryBridge = enableOpenTelemetryBridge;
+			_openTelemetryBridgeEnabled = openTelemetryBridgeEnabled;
 			_transactionSampleRate = transactionSampleRate;
 			_transactionMaxSpans = transactionMaxSpans;
 			_metricsInterval = metricsInterval;
@@ -179,8 +179,9 @@ namespace Elastic.Apm.Tests.Utilities
 
 		public bool Enabled => ParseEnabled(Kv(EnvVarNames.Enabled, _enabled, Origin));
 
-		public bool EnableOpenTelemetryBridge =>
-			ParseEnableOpenTelemetryBridge(Kv(EnvVarNames.EnableOpenTelemetryBridge, _enableOpenTelemetryBridge, Origin));
+		public bool OpenTelemetryBridgeEnabled =>
+			ParseOpenTelemetryBridgeEnabled(Kv(EnvVarNames.OpenTelemetryBridgeEnabled, _openTelemetryBridgeEnabled,
+				Origin));
 
 		public string Environment => ParseEnvironment(Kv(EnvVarNames.Environment, _environment, Origin));
 

--- a/test/Elastic.Apm.Tests/ConstructorTests.cs
+++ b/test/Elastic.Apm.Tests/ConstructorTests.cs
@@ -131,7 +131,7 @@ public class ConstructorTests
 
 		public bool VerifyServerCert => ConfigConsts.DefaultValues.VerifyServerCert;
 
-		public bool EnableOpenTelemetryBridge => ConfigConsts.DefaultValues.EnableOpenTelemetryBridge;
+		public bool OpenTelemetryBridgeEnabled => ConfigConsts.DefaultValues.OpenTelemetryBridgeEnabled;
 
 		public bool TraceContextIgnoreSampledFalse => ConfigConsts.DefaultValues.TraceContextIgnoreSampledFalse;
 

--- a/test/Elastic.Apm.Tests/OpenTelemetryTests.cs
+++ b/test/Elastic.Apm.Tests/OpenTelemetryTests.cs
@@ -24,7 +24,8 @@ namespace Elastic.Apm.Tests
 		{
 			var payloadSender = new MockPayloadSender();
 			using (var agent = new ApmAgent(new TestAgentComponents(payloadSender: payloadSender, apmServerInfo: MockApmServerInfo.Version716,
-					   configuration: new MockConfiguration(enableOpenTelemetryBridge: "true")))) OTSamples.Sample2(agent.Tracer);
+				       configuration: new MockConfiguration(openTelemetryBridgeEnabled: "true"))))
+				OTSamples.Sample2(agent.Tracer);
 
 			payloadSender.FirstTransaction.Name.Should().Be("Sample2");
 			payloadSender.Spans.Should().HaveCount(2);
@@ -48,7 +49,8 @@ namespace Elastic.Apm.Tests
 		{
 			var payloadSender = new MockPayloadSender();
 			using (var agent = new ApmAgent(new TestAgentComponents(payloadSender: payloadSender, apmServerInfo: MockApmServerInfo.Version716,
-					   configuration: new MockConfiguration(enableOpenTelemetryBridge: "true")))) OTSamples.Sample3(agent.Tracer);
+				       configuration: new MockConfiguration(openTelemetryBridgeEnabled: "true"))))
+				OTSamples.Sample3(agent.Tracer);
 
 			payloadSender.FirstTransaction.Name.Should().Be("Sample3");
 			payloadSender.Spans.Should().HaveCount(2);
@@ -69,7 +71,8 @@ namespace Elastic.Apm.Tests
 		{
 			var payloadSender = new MockPayloadSender();
 			using (var agent = new ApmAgent(new TestAgentComponents(payloadSender: payloadSender, apmServerInfo: MockApmServerInfo.Version716,
-					   configuration: new MockConfiguration(enableOpenTelemetryBridge: "true")))) OTSamples.Sample4(agent.Tracer);
+				       configuration: new MockConfiguration(openTelemetryBridgeEnabled: "true"))))
+				OTSamples.Sample4(agent.Tracer);
 
 			payloadSender.FirstTransaction.Name.Should().Be("Sample4");
 			payloadSender.Spans.Should().HaveCount(2);
@@ -88,7 +91,8 @@ namespace Elastic.Apm.Tests
 		{
 			var payloadSender = new MockPayloadSender();
 			using (var agent = new ApmAgent(new TestAgentComponents(payloadSender: payloadSender, apmServerInfo: MockApmServerInfo.Version716,
-					   configuration: new MockConfiguration(enableOpenTelemetryBridge: "true")))) OTSamples.OneSpanWithAttributes();
+				       configuration: new MockConfiguration(openTelemetryBridgeEnabled: "true"))))
+				OTSamples.OneSpanWithAttributes();
 
 			payloadSender.FirstTransaction.Name.Should().Be("foo");
 			payloadSender.FirstTransaction.Otel.Should().NotBeNull();
@@ -102,7 +106,8 @@ namespace Elastic.Apm.Tests
 		{
 			var payloadSender = new MockPayloadSender();
 			using (var agent = new ApmAgent(new TestAgentComponents(payloadSender: payloadSender, apmServerInfo: MockApmServerInfo.Version716,
-					   configuration: new MockConfiguration(enableOpenTelemetryBridge: "true")))) OTSamples.TwoSpansWithAttributes();
+				       configuration: new MockConfiguration(openTelemetryBridgeEnabled: "true"))))
+				OTSamples.TwoSpansWithAttributes();
 
 			payloadSender.FirstTransaction.Name.Should().Be("foo");
 			payloadSender.FirstTransaction.Otel.Should().NotBeNull();
@@ -122,7 +127,8 @@ namespace Elastic.Apm.Tests
 		{
 			var payloadSender = new MockPayloadSender();
 			using (var agent = new ApmAgent(new TestAgentComponents(payloadSender: payloadSender, apmServerInfo: MockApmServerInfo.Version716,
-					   configuration: new MockConfiguration(enableOpenTelemetryBridge: "true")))) OTSamples.SpanKindSample();
+				       configuration: new MockConfiguration(openTelemetryBridgeEnabled: "true"))))
+				OTSamples.SpanKindSample();
 
 			payloadSender.FirstSpan.Type.Should().Be(ApiConstants.TypeExternal);
 			payloadSender.FirstSpan.Subtype.Should().Be(ApiConstants.SubtypeHttp);
@@ -142,7 +148,7 @@ namespace Elastic.Apm.Tests
 		{
 			var payloadSender = new MockPayloadSender();
 			using (var agent = new ApmAgent(new TestAgentComponents(payloadSender: payloadSender, apmServerInfo: MockApmServerInfo.Version716,
-					   configuration: new MockConfiguration(enableOpenTelemetryBridge: "false")))) OTSamples.Sample1();
+				       configuration: new MockConfiguration(openTelemetryBridgeEnabled: "false")))) OTSamples.Sample1();
 
 			payloadSender.WaitForTransactions(TimeSpan.FromSeconds(5));
 			payloadSender.Transactions.Should().BeNullOrEmpty();
@@ -153,7 +159,8 @@ namespace Elastic.Apm.Tests
 		{
 			var payloadSender = new MockPayloadSender();
 			using (var agent = new ApmAgent(new TestAgentComponents(payloadSender: payloadSender, apmServerInfo: MockApmServerInfo.Version716,
-					   configuration: new MockConfiguration(enableOpenTelemetryBridge: "true")))) OTSamples.SpanLinkSample();
+				       configuration: new MockConfiguration(openTelemetryBridgeEnabled: "true"))))
+				OTSamples.SpanLinkSample();
 
 			payloadSender.WaitForTransactions(count: 3);
 
@@ -166,7 +173,8 @@ namespace Elastic.Apm.Tests
 		{
 			var payloadSender = new MockPayloadSender();
 			using (var agent = new ApmAgent(new TestAgentComponents(payloadSender: payloadSender, apmServerInfo: MockApmServerInfo.Version716,
-					   configuration: new MockConfiguration(enableOpenTelemetryBridge: "true")))) OTSamples.DistributedTraceSample();
+				       configuration: new MockConfiguration(openTelemetryBridgeEnabled: "true"))))
+				OTSamples.DistributedTraceSample();
 
 
 			payloadSender.WaitForTransactions(count: 2);
@@ -182,7 +190,7 @@ namespace Elastic.Apm.Tests
 		{
 			var payloadSender = new MockPayloadSender();
 			using var agent = new ApmAgent(new TestAgentComponents(payloadSender: payloadSender, apmServerInfo: MockApmServerInfo.Version716,
-				configuration: new MockConfiguration(enableOpenTelemetryBridge: "true")));
+				configuration: new MockConfiguration(openTelemetryBridgeEnabled: "true")));
 			var src = new ActivitySource("Test");
 			string traceId;
 			using (var activity = src.StartActivity("foo", ActivityKind.Server)) traceId = activity.TraceId.ToString();
@@ -194,14 +202,14 @@ namespace Elastic.Apm.Tests
 		{
 			var payloadSender = new MockPayloadSender();
 			using (var agent = new ApmAgent(new TestAgentComponents(payloadSender: payloadSender, apmServerInfo: MockApmServerInfo.Version716,
-					   configuration: new MockConfiguration(enableOpenTelemetryBridge: "true"))))
+				       configuration: new MockConfiguration(openTelemetryBridgeEnabled: "true"))))
 				OTSamples.TwoSpansWithAttributes();
 
 			payloadSender.Spans.Should().NotContain(span =>
 				span.Context.Destination != null
 				&& span.Context.Destination.Service != null
 				&& span.Context.Destination.Service.Resource == null,
-				because: "Resource is required in Destination Serivce");
+				"Resource is required in Destination Service");
 		}
 	}
 }

--- a/test/Elastic.Clients.Elasticsearch.Tests/ElasticsearchTests.cs
+++ b/test/Elastic.Clients.Elasticsearch.Tests/ElasticsearchTests.cs
@@ -1,11 +1,11 @@
-﻿using Elastic.Apm.Tests.Utilities;
-using Xunit;
-using Elastic.Apm;
+﻿using Elastic.Apm;
 using Elastic.Apm.Api;
 using Elastic.Apm.DiagnosticSource;
 using Elastic.Apm.Elasticsearch;
+using Elastic.Apm.Tests.Utilities;
 using Elastic.Apm.Tests.Utilities.Docker;
 using FluentAssertions;
+using Xunit;
 using Xunit.Abstractions;
 
 namespace Elastic.Clients.Elasticsearch.Tests;
@@ -170,7 +170,7 @@ public class ElasticsearchTests : IClassFixture<ElasticsearchTestFixture>
 		var payloadSender = new MockPayloadSender();
 		var agent = new ApmAgent(new TestAgentComponents(
 			new LineWriterToLoggerAdaptor(new XunitOutputToLineWriterAdaptor(_testOutputHelper)),
-			payloadSender: payloadSender, configuration: new MockConfiguration(enableOpenTelemetryBridge: "true"),
+			payloadSender: payloadSender, configuration: new MockConfiguration(openTelemetryBridgeEnabled: "true"),
 			apmServerInfo: MockApmServerInfo.Version80));
 
 		// Enable outgoing HTTP capturing and later assert that no HTTP span is captured for the es calls as defined in our spec.


### PR DESCRIPTION
Fix the name of the config which enabled/disabled Otel Bridge.

Discussion: https://github.com/elastic/apm-agent-dotnet/pull/1966#discussion_r1060551833

Spec PR: https://github.com/elastic/apm/pull/743

Let's wait with merging until the spec PR is not merged.