### PR TITLE
action: snapshoty

### DIFF
--- a/.ci/snapshoty.yml
+++ b/.ci/snapshoty.yml
@@ -36,14 +36,14 @@ artifacts:
     # Files pattern to match
     files_pattern: 'elastic_apm_profiler_(?P<app_version>\d+\.\d+\.\d+)-(?P<revision>\w+)-(?P<os>\w+)-(?P<arch>\w+)\.zip'
     # File layout on GCS bucket
-    output_pattern: '{project}/{github_branch_name}/elastic-apm-dotnet-profiler-{app_version}-{app_version}-{os}-{arch}-{github_git_commit_short}.jar'
+    output_pattern: '{project}/{github_branch_name}/elastic-apm-dotnet-profiler-{app_version}-{app_version}-{os}-{arch}-{github_sha_short}.jar'
     # List of metadata processors to use.
     metadata: *metadata
   - path: './build/output'
     files_pattern: 'ElasticApmAgent_(?P<app_version>\d+\.\d+\.\d+)-(?P<revision>\w+)\.zip'
-    output_pattern: '{project}/{github_branch_name}/elastic-apm-dotnet-agent-{app_version}-{revision}-{github_git_commit_short}.zip'
+    output_pattern: '{project}/{github_branch_name}/elastic-apm-dotnet-agent-{app_version}-{revision}-{github_sha_short}.zip'
     metadata: *metadata
   - path: './build/output/_packages'
     files_pattern: 'Elastic\.Apm\.(?P<component>[\w\.]*)\.(?P<app_version>\d+\.\d+\.\d+)-(?P<revision>\w+)-(?P<revision_dup>\w+)-(?P<date>[\d-]+)\.nupkg'
-    output_pattern: '{project}/{github_branch_name}/elastic-apm-dotnet-{component}-{app_version}-{revision}-{github_git_commit_short}.nupkg'
+    output_pattern: '{project}/{github_branch_name}/elastic-apm-dotnet-{component}-{app_version}-{revision}-{github_sha_short}.nupkg'
     metadata: *metadata

--- a/.ci/snapshoty.yml
+++ b/.ci/snapshoty.yml
@@ -23,8 +23,10 @@ x-metadata: &metadata
     data:
       project: 'apm-agent-dotnet'
       component: 'agent'
-  # Add jenkins metadata
-  - name: 'jenkins'
+  # Add git metadata
+  - name: 'git'
+  # Add github_actions metadata
+  - name: 'github_actions'
 
 
 # List of artifacts
@@ -34,14 +36,14 @@ artifacts:
     # Files pattern to match
     files_pattern: 'elastic_apm_profiler_(?P<app_version>\d+\.\d+\.\d+)-(?P<revision>\w+)-(?P<os>\w+)-(?P<arch>\w+)\.zip'
     # File layout on GCS bucket
-    output_pattern: '{project}/{jenkins_branch_name}/elastic-apm-dotnet-profiler-{app_version}-{app_version}-{os}-{arch}-{jenkins_git_commit_short}.jar'
+    output_pattern: '{project}/{github_branch_name}/elastic-apm-dotnet-profiler-{app_version}-{app_version}-{os}-{arch}-{github_git_commit_short}.jar'
     # List of metadata processors to use.
     metadata: *metadata
   - path: './build/output'
     files_pattern: 'ElasticApmAgent_(?P<app_version>\d+\.\d+\.\d+)-(?P<revision>\w+)\.zip'
-    output_pattern: '{project}/{jenkins_branch_name}/elastic-apm-dotnet-agent-{app_version}-{revision}-{jenkins_git_commit_short}.zip'
+    output_pattern: '{project}/{github_branch_name}/elastic-apm-dotnet-agent-{app_version}-{revision}-{github_git_commit_short}.zip'
     metadata: *metadata
   - path: './build/output/_packages'
     files_pattern: 'Elastic\.Apm\.(?P<component>[\w\.]*)\.(?P<app_version>\d+\.\d+\.\d+)-(?P<revision>\w+)-(?P<revision_dup>\w+)-(?P<date>[\d-]+)\.nupkg'
-    output_pattern: '{project}/{jenkins_branch_name}/elastic-apm-dotnet-{component}-{app_version}-{revision}-{jenkins_git_commit_short}.nupkg'
+    output_pattern: '{project}/{github_branch_name}/elastic-apm-dotnet-{component}-{app_version}-{revision}-{github_git_commit_short}.nupkg'
     metadata: *metadata

--- a/.github/workflows/snapshoty.yml
+++ b/.github/workflows/snapshoty.yml
@@ -11,8 +11,6 @@ on:
     - '*.md'
     - '*.asciidoc'
     - 'docs/**'
-  ## NOTE: for testing purposes
-  pull_request:
 
 jobs:
   linux-package:

--- a/.github/workflows/snapshoty.yml
+++ b/.github/workflows/snapshoty.yml
@@ -38,7 +38,8 @@ jobs:
     - uses: actions/upload-artifact@v3
       with:
         name: snapshoty-linux
-        path: build/output/
+        path: build/output/*
+        retention-days: 1
 
   windows-package:
     runs-on: windows-latest
@@ -64,8 +65,9 @@ jobs:
     - uses: actions/upload-artifact@v3
       with:
         name: snapshoty-windows
-        path: build/output/
-  
+        path: build/output/*
+        retention-days: 1
+
   upload:
     runs-on: ubuntu-latest
     needs: [linux-package, windows-package]
@@ -76,11 +78,16 @@ jobs:
     - uses: actions/download-artifact@v3
       with:
         name: snapshoty-linux
+        path: build/output
 
     - uses: actions/download-artifact@v3
       with:
         name: snapshoty-windows
-        
+        path: build/output
+
+    - name: Display structure of downloaded files
+      run: find build -type f
+
     - name: Publish snaphosts
       uses: elastic/apm-pipeline-library/.github/actions/snapshoty-simple@current
       with:

--- a/.github/workflows/snapshoty.yml
+++ b/.github/workflows/snapshoty.yml
@@ -1,0 +1,106 @@
+---
+# Publish a snapshot. A "snapshot" is a packaging of the latest *unreleased* APM agent,
+# published to a known GCS bucket for use in edge demo/test environments.
+name: Snapshoty
+
+on:
+  push:
+    branches:
+    - main
+    paths-ignore:
+    - '*.md'
+    - '*.asciidoc'
+    - 'docs/**'
+  ## NOTE: for testing purposes
+  pull_request:
+
+jobs:
+  linux-package:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Build
+      run: .ci/linux/build.sh
+
+    - name: Package
+      run: .ci/linux/release.sh true
+
+    - name: Rustup
+      run: rustup default 1.59.0
+
+    - name: Cargo make
+      run: cargo install --force cargo-make
+
+    - name: Build profiler
+      run: ./build.sh profiler-zip
+
+    - uses: actions/upload-artifact@v3
+      with:
+        name: snapshoty-linux
+        path: |
+          build/output/
+          .ci/snapshoty.yml
+
+  windows-package:
+    runs-on: windows-latest
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Tools
+      run: .ci\\windows\\tools.ps1
+
+    - name: Build
+      run: .ci\\windows\\dotnet.bat
+      shell: cmd
+
+    - name: Build agent
+      run: .\\build.bat agent-zip
+      shell: cmd
+
+    - name: Build profiler
+      run: .\\build.bat profiler-zip
+      shell: cmd
+
+    - uses: actions/upload-artifact@v3
+      with:
+        name: snapshoty-windows
+        path: build/output/
+  
+  upload:
+    runs-on: ubuntu-latest
+    needs: [linux-package, windows-package]
+    steps:
+
+    - uses: actions/download-artifact@v3
+      with:
+        name: snapshoty-linux
+
+    - name: Display structure of downloaded files
+      run: ls -R
+      working-directory: build/output/
+
+    - name: Display structure of downloaded files
+      run: ls -R
+      working-directory: .ci
+
+    - uses: actions/download-artifact@v3
+      with:
+        name: snapshoty-windows
+        
+    - name: Display structure of downloaded files
+      run: ls -R
+      working-directory: build/output/
+
+    - name: Display structure of downloaded files
+      run: ls -R
+      working-directory: .ci
+
+    - name: Publish snaphosts
+      uses: elastic/apm-pipeline-library/.github/actions/snapshoty-simple@current
+      with:
+        config: '.ci/snapshoty.yml'
+        vaultUrl: ${{ secrets.VAULT_ADDR }}
+        vaultRoleId: ${{ secrets.VAULT_ROLE_ID }}
+        vaultSecretId: ${{ secrets.VAULT_SECRET_ID }}

--- a/.github/workflows/snapshoty.yml
+++ b/.github/workflows/snapshoty.yml
@@ -38,9 +38,7 @@ jobs:
     - uses: actions/upload-artifact@v3
       with:
         name: snapshoty-linux
-        path: |
-          build/output/
-          .ci/snapshoty.yml
+        path: build/output/
 
   windows-package:
     runs-on: windows-latest
@@ -73,30 +71,16 @@ jobs:
     needs: [linux-package, windows-package]
     steps:
 
+    - uses: actions/checkout@v3
+
     - uses: actions/download-artifact@v3
       with:
         name: snapshoty-linux
-
-    - name: Display structure of downloaded files
-      run: ls -R
-      working-directory: build/output/
-
-    - name: Display structure of downloaded files
-      run: ls -R
-      working-directory: .ci
 
     - uses: actions/download-artifact@v3
       with:
         name: snapshoty-windows
         
-    - name: Display structure of downloaded files
-      run: ls -R
-      working-directory: build/output/
-
-    - name: Display structure of downloaded files
-      run: ls -R
-      working-directory: .ci
-
     - name: Publish snaphosts
       uses: elastic/apm-pipeline-library/.github/actions/snapshoty-simple@current
       with:

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -118,7 +118,6 @@ pipeline {
                     }
                     success {
                       archiveArtifacts(allowEmptyArchive: true, artifacts: "${BASE_DIR}/build/output/_packages/*.nupkg,${BASE_DIR}/build/output/*.zip")
-                      stash(allowEmpty: true, name: 'snapshoty-linux', includes: "${BASE_DIR}/.ci/snapshoty.yml,${BASE_DIR}/build/output/**", useDefaultExcludes: false)
                     }
                   }
                 }
@@ -349,7 +348,6 @@ pipeline {
                   post {
                     success {
                       archiveArtifacts(allowEmptyArchive: true, artifacts: "${BASE_DIR}/build/output/*.zip")
-                      stash(allowEmpty: true, name: 'snapshoty-windows', includes: "${BASE_DIR}/.ci/snapshoty.yml,${BASE_DIR}/build/output/**", useDefaultExcludes: false)
                     }
                     unsuccessful {
                       archiveArtifacts(allowEmptyArchive: true,
@@ -480,32 +478,6 @@ pipeline {
                     deleteDir()
                   }
                 }
-              }
-            }
-          }
-        }
-        stage('Publish snapshots') {
-          agent { label 'linux && immutable' }
-          options { skipDefaultCheckout() }
-          environment {
-            BUCKET_NAME = 'oblt-artifacts'
-            DOCKER_REGISTRY = 'docker.elastic.co'
-            DOCKER_REGISTRY_SECRET = 'secret/observability-team/ci/docker-registry/prod'
-            GCS_ACCOUNT_SECRET = 'secret/observability-team/ci/snapshoty'
-          }
-          when { branch 'main' }
-          steps {
-            withGithubNotify(context: 'Publish snapshot packages') {
-              deleteDir()
-              unstash(name: 'snapshoty-linux')
-              unstash(name: 'snapshoty-windows')
-              dir(env.BASE_DIR) {
-                snapshoty(
-                  bucket: env.BUCKET_NAME,
-                  gcsAccountSecret: env.GCS_ACCOUNT_SECRET,
-                  dockerRegistry: env.DOCKER_REGISTRY,
-                  dockerSecret: env.DOCKER_REGISTRY_SECRET
-                )
               }
             }
           }
@@ -678,7 +650,7 @@ def testTools(Closure body){
       | jq -r '.[].assets[].browser_download_url' \
       | grep 'Azure.Functions.Cli.linux-x64.4.*zip\$' \
       | head -n 1)
-    
+
     # Preserve only the filename component of the URL
     latest_v4_release_file=\${latest_v4_release_url##*/}
 

--- a/build.bat
+++ b/build.bat
@@ -1,2 +1,3 @@
 @echo Off
+SET PATH=%PATH%;C:\tools\cargo
 dotnet run --project build\scripts -- %*


### PR DESCRIPTION
### What

Use `snapshoty` in GitHub actions


### Test

https://github.com/elastic/apm-agent-dotnet/actions/runs/4018108119/jobs/6903720833 validated this PR as it was configured to run on PRs too - already removed that particular configuration

### Follow up

* Optimise the tool installation in favour of sorter executions

For instance the tool installation takes 10 minutes:

<img width="978" alt="image" src="https://user-images.githubusercontent.com/2871786/214873874-5f45c7b3-f0f6-47a4-a63a-c3b46f336043.png">

* Or even use the generated artifacts from another workflow.

