### PR TITLE
Fix doc for SpanCompressionSameKindMaxDuration

### DIFF
--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -562,7 +562,7 @@ This reduces the collection, processing, and storage overhead, and removes clutt
 [options="header"]
 |============
 | Default | Type
-| `5ms`   | TimeDuration
+| `0ms`   | TimeDuration
 |============
 
 


### PR DESCRIPTION
https://github.com/elastic/apm-agent-dotnet/pull/1719 was a change in the .NET Agent after we changed the defaults in the spec.

It seems I forgot to update the doc in that PR, so the doc got out-of-sync with our spec. This PR updates the doc.

The other default changed in https://github.com/elastic/apm-agent-dotnet/pull/1719 is `SpanCompressionEnabled`, for that one the doc is correct. 