### PR TITLE
Add elastic_apm_profiler as not built project to solution

### DIFF
--- a/ElasticApmAgent.sln
+++ b/ElasticApmAgent.sln
@@ -191,6 +191,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Elastic.AzureFunctionApp.Is
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Elastic.Clients.Elasticsearch.Tests", "test\Elastic.Clients.Elasticsearch.Tests\Elastic.Clients.Elasticsearch.Tests.csproj", "{E6217549-8C21-4E95-BDF2-E782922CD104}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "elastic_apm_profiler", "src\elastic_apm_profiler\elastic_apm_profiler.csproj", "{236B392A-53BE-46FD-9831-C66AE0A962F1}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -501,6 +503,8 @@ Global
 		{E6217549-8C21-4E95-BDF2-E782922CD104}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{E6217549-8C21-4E95-BDF2-E782922CD104}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{E6217549-8C21-4E95-BDF2-E782922CD104}.Release|Any CPU.Build.0 = Release|Any CPU
+		{236B392A-53BE-46FD-9831-C66AE0A962F1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{236B392A-53BE-46FD-9831-C66AE0A962F1}.Release|Any CPU.ActiveCfg = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -582,6 +586,7 @@ Global
 		{8E3D94CD-3378-4431-8956-07644A64D4E8} = {267A241E-571F-458F-B04C-B6C4DE79E735}
 		{9879E646-63ED-474C-905B-1B469403F0A5} = {3C791D9C-6F19-4F46-B367-2EC0F818762D}
 		{E6217549-8C21-4E95-BDF2-E782922CD104} = {267A241E-571F-458F-B04C-B6C4DE79E735}
+		{236B392A-53BE-46FD-9831-C66AE0A962F1} = {3734A52F-2222-454B-BF58-1BA5C1F29D77}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {69E02FD9-C9DE-412C-AB6B-5B8BECC6BFA5}

--- a/src/elastic_apm_profiler/elastic_apm_profiler.csproj
+++ b/src/elastic_apm_profiler/elastic_apm_profiler.csproj
@@ -1,0 +1,16 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <SignAssembly>false</SignAssembly>
+    <NoPackageAnalysis>true</NoPackageAnalysis>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+    <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
+    <IntermediateOutputPath>$(ProjectDir)</IntermediateOutputPath>
+  </PropertyGroup>
+  <ItemGroup>
+    
+  </ItemGroup>
+
+</Project>

--- a/src/elastic_apm_profiler/src/lib.rs
+++ b/src/elastic_apm_profiler/src/lib.rs
@@ -11,11 +11,11 @@ extern crate com;
 #[macro_use]
 extern crate num_derive;
 
-mod error;
 mod ffi;
 mod profiler;
 
 pub mod cil;
+mod error;
 pub mod interfaces;
 
 use com::CLSID;


### PR DESCRIPTION
Purely developer experience related no functional changes:

Includes the rust profiler as project in `ElasticApmAgent.sln` that is not built by MSBUILD:
![image](https://user-images.githubusercontent.com/245275/220401507-4407cbaf-7662-4157-9151-62052cf92d07.png)

However installing the rust plugin for Intellij (Rider) https://plugins.jetbrains.com/plugin/8182-rust will allow us to quickly edit/compile and analyse the rust code as well. 

![image](https://user-images.githubusercontent.com/245275/220401563-f848b03d-8f99-45b7-b35b-5bea900e80a3.png) 

![image](https://user-images.githubusercontent.com/245275/220402450-824d111f-0ef6-4409-a411-699926f4a537.png)
