### PR TITLE
Clarify 64 bit only support in the profiler docs.

### DIFF
--- a/docs/setup-auto-instrumentation.asciidoc
+++ b/docs/setup-auto-instrumentation.asciidoc
@@ -31,7 +31,9 @@ This approach works with the following
 .NET 5+
 |===
 
-and instruments the following assemblies
+NOTE: The Profiler based agent only supports 64 bit applications. 32 bit applications aren't supported by our builds.
+
+It instruments the following assemblies
 
 include::integrations.asciidoc[]
 

--- a/docs/setup-auto-instrumentation.asciidoc
+++ b/docs/setup-auto-instrumentation.asciidoc
@@ -31,7 +31,8 @@ This approach works with the following
 .NET 5+
 |===
 
-NOTE: The Profiler based agent only supports 64 bit applications. 32 bit applications aren't supported by our builds.
+NOTE: The Profiler based agent only supports 64 bit applications. 32 bit applications aren't supported.
+
 
 It instruments the following assemblies
 


### PR DESCRIPTION
As discussed in our weekly meeting - to avoid misunderstandings we clearly state that 32 bit is not supported by the profiler based agent.