### PR TITLE
Prevent sending activation_method in metadata for 8.7.0

### DIFF
--- a/src/Elastic.Apm/BackendComm/BackendCommUtils.cs
+++ b/src/Elastic.Apm/BackendComm/BackendCommUtils.cs
@@ -37,7 +37,7 @@ namespace Elastic.Apm.BackendComm
 				CombineAbsoluteAndRelativeUrls(baseUrl, "intake/v2/events");
 
 			/// <summary>
-			/// Builds the absolute URL that points to APM server's intake API endpoint which is used by agents to send events.
+			/// Builds the absolute URL that points to APM server information API endpoint
 			/// </summary>
 			/// <param name="baseUrl">Absolute URL pointing to APM Server's base for API endpoints.</param>
 			internal static Uri BuildApmServerInformationUrl(Uri baseUrl) =>

--- a/src/Elastic.Apm/BackendComm/BackendCommUtils.cs
+++ b/src/Elastic.Apm/BackendComm/BackendCommUtils.cs
@@ -37,6 +37,13 @@ namespace Elastic.Apm.BackendComm
 				CombineAbsoluteAndRelativeUrls(baseUrl, "intake/v2/events");
 
 			/// <summary>
+			/// Builds the absolute URL that points to APM server's intake API endpoint which is used by agents to send events.
+			/// </summary>
+			/// <param name="baseUrl">Absolute URL pointing to APM Server's base for API endpoints.</param>
+			internal static Uri BuildApmServerInformationUrl(Uri baseUrl) =>
+				CombineAbsoluteAndRelativeUrls(baseUrl, "/");
+
+			/// <summary>
 			/// Builds the absolute URL that points to APM server's central-config API endpoint which is used by agents to fetch configuration.
 			/// Configuration is selected by the backend based on the agent's service.name and service.environment.
 			/// </summary>

--- a/src/Elastic.Apm/Report/PayloadSenderV2.cs
+++ b/src/Elastic.Apm/Report/PayloadSenderV2.cs
@@ -56,8 +56,8 @@ namespace Elastic.Apm.Report
 		private string _cachedMetadataJsonLine;
 		private long _eventQueueCount;
 
-		private ElasticVersion _brokenActivationMethodVersion;
-		private string _cachedActionvationMethod;
+		private readonly ElasticVersion _brokenActivationMethodVersion;
+		private readonly string _cachedActivationMethod
 
 		public PayloadSenderV2(
 			IApmLogger logger,
@@ -91,7 +91,7 @@ namespace Elastic.Apm.Report
 			_metadata = new Metadata { Service = service, System = System };
 			foreach (var globalLabelKeyValue in configuration.GlobalLabels)
 				_metadata.Labels.Add(globalLabelKeyValue.Key, globalLabelKeyValue.Value);
-			_cachedActionvationMethod = _metadata.Service?.Agent.ActivationMethod;
+			_cachedActivationMethod = _metadata.Service?.Agent.ActivationMethod;
 			ResetActivationMethodIfKnownBrokenApmServer();
 
 			if (configuration.MaxQueueEventCount < configuration.MaxBatchEventCount)
@@ -245,7 +245,7 @@ namespace Elastic.Apm.Report
 
 		private void ResetActivationMethodIfKnownBrokenApmServer()
 		{
-			// if we are on a known apm-server version that breaks metrics intake wit activation method
+			// if we are on a known apm-server version that breaks metrics intake with activation method
 			if (_apmServerInfo?.Version == _brokenActivationMethodVersion)
 			{
 				// remove activation method since we know apm-server 8.7.0 rejects it
@@ -254,9 +254,9 @@ namespace Elastic.Apm.Report
 				_cachedMetadataJsonLine = null;
 			}
 			// else if activation method was unset but now the server has been upgraded re-apply activation method
-			else if (_metadata.Service.Agent.ActivationMethod == null && _cachedActionvationMethod != null)
+			else if (_metadata.Service.Agent.ActivationMethod == null && _cachedActivationMethod != null)
 			{
-				_metadata.Service.Agent.ActivationMethod = _cachedActionvationMethod;
+				_metadata.Service.Agent.ActivationMethod = _cachedActivationMethod;
 				_cachedMetadataJsonLine = null;
 			}
 		}

--- a/src/Elastic.Apm/Report/PayloadSenderV2.cs
+++ b/src/Elastic.Apm/Report/PayloadSenderV2.cs
@@ -56,6 +56,9 @@ namespace Elastic.Apm.Report
 		private string _cachedMetadataJsonLine;
 		private long _eventQueueCount;
 
+		private ElasticVersion _brokenActivationMethodVersion;
+		private string _cachedActionvationMethod;
+
 		public PayloadSenderV2(
 			IApmLogger logger,
 			IConfiguration configuration,
@@ -76,17 +79,20 @@ namespace Elastic.Apm.Report
 			_logger = logger?.Scoped(ThisClassName + (dbgName == null ? "" : $" (dbgName: `{dbgName}')"));
 			_payloadItemSerializer = new PayloadItemSerializer();
 			_configuration = configuration;
+			_brokenActivationMethodVersion = new ElasticVersion(8, 7, 0);
 
 			_intakeV2EventsAbsoluteUrl = BackendCommUtils.ApmServerEndpoints.BuildIntakeV2EventsAbsoluteUrl(configuration.ServerUrl);
 
 			System = system;
 
 			_cloudMetadataProviderCollection = new CloudMetadataProviderCollection(configuration.CloudProvider, _logger, environmentVariables);
-			_apmServerInfo = apmServerInfo;
+			_apmServerInfo = apmServerInfo ?? new ApmServerInfo();
 			_serverInfoCallback = serverInfoCallback;
 			_metadata = new Metadata { Service = service, System = System };
 			foreach (var globalLabelKeyValue in configuration.GlobalLabels)
 				_metadata.Labels.Add(globalLabelKeyValue.Key, globalLabelKeyValue.Value);
+			_cachedActionvationMethod = _metadata.Service?.Agent.ActivationMethod;
+			ResetActivationMethodIfKnownBrokenApmServer();
 
 			if (configuration.MaxQueueEventCount < configuration.MaxBatchEventCount)
 			{
@@ -229,11 +235,30 @@ namespace Elastic.Apm.Report
 					.GetAwaiter()
 					.GetResult();
 				_getApmServerVersion = true;
+				ResetActivationMethodIfKnownBrokenApmServer();
 			}
 
 			var batch = ReceiveBatch();
 			if (batch != null)
 				ProcessQueueItems(batch);
+		}
+
+		private void ResetActivationMethodIfKnownBrokenApmServer()
+		{
+			// if we are on a known apm-server version that breaks metrics intake wit activation method
+			if (_apmServerInfo?.Version == _brokenActivationMethodVersion)
+			{
+				// remove activation method since we know apm-server 8.7.0 rejects it
+				// and may cause metrics to be dropped
+				_metadata.Service.Agent.ActivationMethod = null;
+				_cachedMetadataJsonLine = null;
+			}
+			// else if activation method was unset but now the server has been upgraded re-apply activation method
+			else if (_metadata.Service.Agent.ActivationMethod == null && _cachedActionvationMethod != null)
+			{
+				_metadata.Service.Agent.ActivationMethod = _cachedActionvationMethod;
+				_cachedMetadataJsonLine = null;
+			}
 		}
 
 		private object[] ReceiveBatch()

--- a/src/Elastic.Apm/Report/PayloadSenderV2.cs
+++ b/src/Elastic.Apm/Report/PayloadSenderV2.cs
@@ -57,7 +57,7 @@ namespace Elastic.Apm.Report
 		private long _eventQueueCount;
 
 		private readonly ElasticVersion _brokenActivationMethodVersion;
-		private readonly string _cachedActivationMethod
+		private readonly string _cachedActivationMethod;
 
 		public PayloadSenderV2(
 			IApmLogger logger,

--- a/src/Elastic.Apm/ServerInfo/ElasticVersion.cs
+++ b/src/Elastic.Apm/ServerInfo/ElasticVersion.cs
@@ -68,12 +68,12 @@ namespace Elastic.Apm.ServerInfo
 			Prerelease = prerelease;
 		}
 
-		public ElasticVersion(int major, int minor, int patch, string prerelease)
+		public ElasticVersion(int major, int minor, int patch, string prerelease = null)
 		{
 			Major = major;
 			Minor = minor;
 			Patch = patch;
-			Prerelease = prerelease;
+			Prerelease = prerelease ?? string.Empty;
 		}
 
 		public int Major { get; }

--- a/test/Elastic.Apm.Tests/BackendCommTests/ServiceActivationTests.cs
+++ b/test/Elastic.Apm.Tests/BackendCommTests/ServiceActivationTests.cs
@@ -7,27 +7,18 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
-using System.Net.Http.Headers;
 using System.Text;
 using System.Threading;
-using System.Threading.Tasks;
 using Elastic.Apm.Api;
 using Elastic.Apm.BackendComm;
-using Elastic.Apm.Config;
-using Elastic.Apm.Helpers;
 using Elastic.Apm.Logging;
 using Elastic.Apm.Model;
 using Elastic.Apm.Report;
-using Elastic.Apm.ServerInfo;
 using Elastic.Apm.Tests.Utilities;
 using FluentAssertions;
-using FluentAssertions.Extensions;
 using Xunit;
 using Xunit.Abstractions;
-using static Elastic.Apm.Tests.Utilities.FluentAssertionsUtils;
-using MockHttpMessageHandler = Elastic.Apm.Tests.Utilities.MockHttpMessageHandler;
 using RichardSzalay.MockHttp;
-using System = Elastic.Apm.Api.System;
 
 namespace Elastic.Apm.Tests.BackendCommTests
 {
@@ -48,7 +39,6 @@ namespace Elastic.Apm.Tests.BackendCommTests
 			requests.Count.Should().Be(3);
 
 			requests.Last().Should().NotContain("activation_method");
-
 		}
 
 		[Fact]
@@ -58,7 +48,6 @@ namespace Elastic.Apm.Tests.BackendCommTests
 			requests.Count.Should().Be(3);
 
 			requests.Last().Should().Contain("activation_method");
-
 		}
 
 		private List<string> FakeServerInformationCallAndEnqueue(string version)

--- a/test/Elastic.Apm.Tests/BackendCommTests/ServiceActivationTests.cs
+++ b/test/Elastic.Apm.Tests/BackendCommTests/ServiceActivationTests.cs
@@ -1,0 +1,125 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Elastic.Apm.Api;
+using Elastic.Apm.BackendComm;
+using Elastic.Apm.Config;
+using Elastic.Apm.Helpers;
+using Elastic.Apm.Logging;
+using Elastic.Apm.Model;
+using Elastic.Apm.Report;
+using Elastic.Apm.ServerInfo;
+using Elastic.Apm.Tests.Utilities;
+using FluentAssertions;
+using FluentAssertions.Extensions;
+using Xunit;
+using Xunit.Abstractions;
+using static Elastic.Apm.Tests.Utilities.FluentAssertionsUtils;
+using MockHttpMessageHandler = Elastic.Apm.Tests.Utilities.MockHttpMessageHandler;
+using RichardSzalay.MockHttp;
+using System = Elastic.Apm.Api.System;
+
+namespace Elastic.Apm.Tests.BackendCommTests
+{
+	public class ServiceActivationTests : LoggingTestBase
+	{
+		private const string ThisClassName = nameof(ServiceActivationTests);
+
+		private readonly IApmLogger _logger;
+
+		public ServiceActivationTests(ITestOutputHelper xUnitOutputHelper) : base(xUnitOutputHelper /*, LogLevel.Debug */) =>
+			_logger = LoggerBase.Scoped(ThisClassName);
+
+
+		[Fact]
+		public void ShouldNotSendActivationMethodOnceBadVersionIsDiscovered()
+		{
+			var requests = FakeServerInformationCallAndEnqueue("8.7.0");
+			requests.Count.Should().Be(3);
+
+			requests.Last().Should().NotContain("activation_method");
+
+		}
+
+		[Fact]
+		public void ShouldSendActivationMethodOtherVersions()
+		{
+			var requests = FakeServerInformationCallAndEnqueue("8.7.1");
+			requests.Count.Should().Be(3);
+
+			requests.Last().Should().Contain("activation_method");
+
+		}
+
+		private List<string> FakeServerInformationCallAndEnqueue(string version)
+		{
+			var secretToken = "secretToken";
+			var serverUrl = "http://username:password@localhost:8200";
+
+			var config = new MockConfiguration(_logger, logLevel: "Trace", serverUrl: serverUrl, secretToken: secretToken, flushInterval: "0",
+				maxBatchEventCount: "1");
+			var service = Service.GetDefaultService(config, _logger);
+			service.Agent.ActivationMethod.Should().NotBeNullOrEmpty();
+
+			var waitHandle = new CountdownEvent(3);
+			var handler = new RichardSzalay.MockHttp.MockHttpMessageHandler();
+			var serverInformationUrl = BackendCommUtils.ApmServerEndpoints
+				.BuildApmServerInformationUrl(config.ServerUrl);
+
+			var eventsAbsoluteUrl = BackendCommUtils.ApmServerEndpoints
+				.BuildIntakeV2EventsAbsoluteUrl(config.ServerUrl);
+
+			var requests = new List<string>();
+			handler
+				.When(eventsAbsoluteUrl.AbsoluteUri)
+				.Respond(async c =>
+				{
+					if (c.Content != null)
+					{
+						var request = await c.Content.ReadAsStringAsync();
+						requests.Add(request);
+					}
+					waitHandle.Signal();
+					var response = new HttpResponseMessage(HttpStatusCode.OK);
+					var json = "{}";
+					response.Content = new StringContent(json, Encoding.UTF8, "application/json");
+					return new HttpResponseMessage(HttpStatusCode.OK);
+				});
+
+			// Agent blocks first event queue worker loop to get information ONCE
+			handler
+				.When(serverInformationUrl.AbsoluteUri)
+				.Respond(c =>
+				{
+					var response = new HttpResponseMessage(HttpStatusCode.OK);
+					var json = $@"{{
+	""build_date"": ""2021-12-18T19:59:06Z"",
+	""build_sha"": ""24fe620eeff5a19e2133c940c7e5ce1ceddb1445"",
+	""publish_ready"": true,
+	""version"": ""{version}""
+}}";
+					response.Content = new StringContent(json, Encoding.UTF8, "application/json");
+					return response;
+				});
+
+			var payloadSender = new PayloadSenderV2(_logger, config, service, new Api.System(), null, handler);
+			using var agent = new ApmAgent(new TestAgentComponents(LoggerBase, config, payloadSender));
+			agent.PayloadSender.QueueTransaction(new Transaction(agent, "TestName", "TestType"));
+			agent.PayloadSender.QueueTransaction(new Transaction(agent, "TestName", "TestType"));
+			agent.PayloadSender.QueueTransaction(new Transaction(agent, "TestName", "TestType"));
+
+			waitHandle.WaitHandle.WaitOne(TimeSpan.FromSeconds(5));
+			return requests;
+		}
+	}
+}


### PR DESCRIPTION
Implements spec change from https://github.com/elastic/apm/pull/783

Also normalizes Prerelease in ElasticVersion to always be string.Empty. The
current Equals implementation does not handle null<=>string.Empty well.

Fixes: https://github.com/elastic/apm-agent-dotnet/issues/2039
