### PR TITLE
Profiler docs: add note about server url and secret token

### DIFF
--- a/docs/setup-auto-instrumentation.asciidoc
+++ b/docs/setup-auto-instrumentation.asciidoc
@@ -95,6 +95,9 @@ export CORECLR_PROFILER_PATH="<unzipped directory>/libelastic_apm_profiler.so" <
 export ELASTIC_APM_PROFILER_HOME="<unzipped directory>"
 export ELASTIC_APM_PROFILER_INTEGRATIONS="<unzipped directory>/integrations.yml"
 ----
+
+NOTE: In most cases you want to specify a server URL and a secret token to connect to an APM Server. For a profiler based setup, every agent configuration can be specified by environment variables. The specific name for an environment variable can be found on the <<configuration, general configuration>> page. E.g. you can specify the <<config-server-url,server URL>> by `ELASTIC_APM_SERVER_URL` and the <<config-secret-token, secret token>> by `ELASTIC_APM_SECRET_TOKEN`.
+
 <1> `<unzipped directory>` is the directory to which the zip file
 was unzipped in step 2.
 . Start your application in a context where the set environment variables are visible.


### PR DESCRIPTION
Based on feedback from multiple real-world confusions - adding a note on how to configure server url and secret token with the profiler. 