### PR TITLE
Ensure rustup is called before release.sh

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -497,6 +497,7 @@ pipeline {
         deleteDir()
         unstash 'source'
         dir("${BASE_DIR}"){
+          sh label: 'Rustup', script: 'rustup default 1.67.1'
           release(secret: 'secret/apm-team/ci/elastic-observability-feedz.io', withSuffix: true)
         }
       }
@@ -536,6 +537,7 @@ pipeline {
             deleteDir()
             unstash 'source'
             dir("${BASE_DIR}") {
+              sh label: 'Rustup', script: 'rustup default 1.67.1'
               release(secret: 'secret/apm-team/ci/elastic-observability-nuget')
             }
           }


### PR DESCRIPTION
Since the release target now succesfully calls it dependent targets as per:

https://github.com/elastic/apm-agent-dotnet/pull/2021/commits/79c7d490db0f3baf9e7ce3b7dce5a5dd31a53d90

It needs `rustup` to be called prior. 

Attempts to fix the build on `main`