### PR TITLE
Add logging to IHttpModule.EndRequest if transaction is null

### DIFF
--- a/src/Elastic.Apm.AspNetFullFramework/ElasticApmModule.cs
+++ b/src/Elastic.Apm.AspNetFullFramework/ElasticApmModule.cs
@@ -293,7 +293,7 @@ namespace Elastic.Apm.AspNetFullFramework
 				if (WildcardMatcher.IsAnyMatch(Agent.Instance.ConfigurationReader.TransactionIgnoreUrls, request.Unvalidated.Path))
 					return;
 
-				var hasHttpContext = HttpContext.Current?.Items[HttpContextCurrentExecutionSegmentsContainer.CurrentTransactionKey] is null;
+				var hasHttpContext = HttpContext.Current?.Items[HttpContextCurrentExecutionSegmentsContainer.CurrentTransactionKey] is not null;
 				_logger.Warning()
 					?.Log(
 						$"{nameof(ITracer.CurrentTransaction)} is null in {nameof(ProcessEndRequest)}. HttpContext for transaction: {hasHttpContext}"

--- a/src/Elastic.Apm.AspNetFullFramework/ElasticApmModule.cs
+++ b/src/Elastic.Apm.AspNetFullFramework/ElasticApmModule.cs
@@ -36,7 +36,10 @@ namespace Elastic.Apm.AspNetFullFramework
 		private readonly string _dbgInstanceName;
 		private HttpApplication _application;
 		private IApmLogger _logger;
-		private readonly Lazy<Type> _httpRouteDataInterfaceType = new Lazy<Type>(() => Type.GetType("System.Web.Http.Routing.IHttpRouteData,System.Web.Http"));
+
+		private readonly Lazy<Type> _httpRouteDataInterfaceType =
+			new Lazy<Type>(() => Type.GetType("System.Web.Http.Routing.IHttpRouteData,System.Web.Http"));
+
 		private Func<object, string> _routeDataTemplateGetter;
 		private Func<object, decimal> _routePrecedenceGetter;
 
@@ -256,7 +259,7 @@ namespace Elastic.Apm.AspNetFullFramework
 			{
 				var value = headers.Get(key);
 				if (value != null)
-					convertedHeaders.Add(key,value);
+					convertedHeaders.Add(key, value);
 			}
 			return convertedHeaders;
 		}
@@ -279,17 +282,30 @@ namespace Elastic.Apm.AspNetFullFramework
 
 		private void ProcessEndRequest(object sender)
 		{
-			var transaction = Agent.Instance.Tracer.CurrentTransaction;
-			if (transaction is null) return;
-
 			var application = (HttpApplication)sender;
 			var context = application.Context;
+			var request = context.Request;
+			var transaction = Agent.Instance.Tracer.CurrentTransaction;
+
+			if (transaction is null)
+			{
+				// We expect transaction to be null if `TransactionIgnoreUrls` matches
+				if (WildcardMatcher.IsAnyMatch(Agent.Instance.ConfigurationReader.TransactionIgnoreUrls, request.Unvalidated.Path))
+					return;
+
+				var hasHttpContext = HttpContext.Current?.Items[HttpContextCurrentExecutionSegmentsContainer.CurrentTransactionKey] is null;
+				_logger.Warning()
+					?.Log(
+						$"{nameof(ITracer.CurrentTransaction)} is null in {nameof(ProcessEndRequest)}. HttpContext for transaction: {hasHttpContext}"
+					);
+				return;
+			}
+
 			var response = context.Response;
 
 			// update the transaction name based on route values, if applicable
 			if (transaction is Transaction t && !t.HasCustomName)
 			{
-				var request = application.Request;
 				var values = request.RequestContext?.RouteData?.Values;
 				if (values?.Count > 0)
 				{
@@ -335,7 +351,9 @@ namespace Elastic.Apm.AspNetFullFramework
 										var precedence = _routePrecedenceGetter(subRoute);
 										if (precedence < minPrecedence)
 										{
-											_logger?.Trace()?.Log($"Calculating transaction name from web api attribute routing (route precedence: {precedence})");
+											_logger?.Trace()
+												?.Log(
+													$"Calculating transaction name from web api attribute routing (route precedence: {precedence})");
 											minPrecedence = precedence;
 											name = _routeDataTemplateGetter(subRoute);
 										}
@@ -367,8 +385,8 @@ namespace Elastic.Apm.AspNetFullFramework
 
 			var realTransaction = transaction as Transaction;
 			realTransaction?.SetOutcome(response.StatusCode >= 500
-					? Outcome.Failure
-					: Outcome.Success);
+				? Outcome.Failure
+				: Outcome.Success);
 
 			// Try and update transaction name with SOAP action if applicable.
 			if (realTransaction == null || !realTransaction.HasCustomName)
@@ -391,9 +409,7 @@ namespace Elastic.Apm.AspNetFullFramework
 		private static void FillSampledTransactionContextResponse(HttpResponse response, ITransaction transaction) =>
 			transaction.Context.Response = new Response
 			{
-				Finished = true,
-				StatusCode = response.StatusCode,
-				Headers = _isCaptureHeadersEnabled ? ConvertHeaders(response.Headers) : null
+				Finished = true, StatusCode = response.StatusCode, Headers = _isCaptureHeadersEnabled ? ConvertHeaders(response.Headers) : null
 			};
 
 		private void FillSampledTransactionContextUser(HttpContext context, ITransaction transaction)

--- a/src/Elastic.Apm.AspNetFullFramework/HttpContextCurrentExecutionSegmentsContainer.cs
+++ b/src/Elastic.Apm.AspNetFullFramework/HttpContextCurrentExecutionSegmentsContainer.cs
@@ -20,7 +20,7 @@ namespace Elastic.Apm.AspNetFullFramework
 		private readonly AsyncLocal<ITransaction> _currentTransaction = new AsyncLocal<ITransaction>();
 
 		private const string CurrentSpanKey = "Elastic.Apm.Agent.CurrentSpan";
-		private const string CurrentTransactionKey = "Elastic.Apm.Agent.CurrentTransaction";
+		internal const string CurrentTransactionKey = "Elastic.Apm.Agent.CurrentTransaction";
 
 		public ISpan CurrentSpan
 		{


### PR DESCRIPTION
This should not happen if we are not actively filtering the current URL.

Include a warning so it sticks out more in our logs
