### PR TITLE
Make snapshotty reuse build artifacts.

### DIFF
--- a/.github/workflows/snapshoty.yml
+++ b/.github/workflows/snapshoty.yml
@@ -4,78 +4,28 @@
 name: snapshoty
 
 on:
-  push:
-    branches:
-    - main
-    paths-ignore:
-    - '*.md'
-    - '*.asciidoc'
-    - 'docs/**'
+  workflow_run:
+    workflows: ['test-linux']
+    types:
+      - completed
 
 jobs:
-  linux-package:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v3
-    - name: Bootstrap Action Workspace
-      uses: ./.github/workflows/bootstrap
-      with:
-          rust: 'true'
-
-    - name: Package
-      run: .ci/linux/release.sh
-
-    - uses: actions/upload-artifact@v3
-      with:
-        name: snapshoty-linux
-        path: build/output/*
-        retention-days: 1
-
-  windows-package:
-    runs-on: windows-latest
-
-    steps:
-    - uses: actions/checkout@v3
-    - name: Bootstrap Action Workspace
-      uses: ./.github/workflows/bootstrap
-
-    - name: Tools
-      run: .ci\\windows\\tools.ps1
-
-    - name: Build
-      run: .ci\\windows\\dotnet.bat
-      shell: cmd
-
-    - name: Build agent
-      run: .\\build.bat agent-zip
-      shell: cmd
-
-    - name: Build profiler
-      run: .\\build.bat profiler-zip
-      shell: cmd
-
-    - uses: actions/upload-artifact@v3
-      with:
-        name: snapshoty-windows
-        path: build/output/*
-        retention-days: 1
-
   upload:
     runs-on: ubuntu-latest
-    needs: [linux-package, windows-package]
     steps:
-
     - uses: actions/checkout@v3
       
+    # used by opbeans .NET to reference the on commit nuget packages
+    # TODO: update opbeans to use our feedz.io packages
     - uses: actions/download-artifact@v3
       with:
         name: snapshoty-linux
         path: build/output
 
-    - uses: actions/download-artifact@v3
-      with:
-        name: snapshoty-windows
-        path: build/output
+    # - uses: actions/download-artifact@v3
+    #   with:
+    #     name: snapshoty-windows
+    #     path: build/output
 
     - name: Display structure of downloaded files
       run: find build -type f

--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -34,6 +34,14 @@ jobs:
     
     - name: Package
       run: .ci/linux/release.sh 
+      
+    - uses: actions/upload-artifact@v3
+      if: github.event_name == 'push' && startswith(github.ref, 'refs/heads')
+      with:
+          name: snapshoty-linux
+          path: build/output/*
+          retention-days: 1
+
 
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-windows-core.yml
+++ b/.github/workflows/test-windows-core.yml
@@ -65,6 +65,13 @@ jobs:
       with:
         name: test-results
         path: test/**/junit-*.xml
+        
+    - uses: actions/upload-artifact@v3
+      with:
+          name: snapshoty-windows
+          path: build/output/*
+          retention-days: 1
+
 
   startup-hook-test:
     runs-on: windows-2022


### PR DESCRIPTION
Now runs when `test-linux` completes, and that workflow uploads the artifacts for the snapshotty workflow to stage for internal usage
