### PR TITLE
Move Redis Profiler registration to ConditionalWeakTable

### DIFF
--- a/sample/StackExchangeRedisSample/Program.cs
+++ b/sample/StackExchangeRedisSample/Program.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Elastic.Apm;
 using Elastic.Apm.Api;
@@ -5,35 +7,42 @@ using Elastic.Apm.StackExchange.Redis;
 using StackExchange.Redis;
 using Testcontainers.Redis;
 
-namespace StackExchangeRedisSample
+// handle control+c gracefully
+var ctx = new CancellationTokenSource();
+Console.CancelKeyPress += (_, eventArgs) =>
 {
-	public class Program
+	eventArgs.Cancel = true;
+	ctx.Cancel();
+};
+
+await using var container = new RedisBuilder().Build();
+await container.StartAsync();
+
+var connection = await ConnectionMultiplexer.ConnectAsync(container.GetConnectionString());
+connection.UseElasticApm();
+
+for (var i = 0; i < 1_000_000; i++)
+{
+	if (ctx.IsCancellationRequested)
 	{
-		public static async Task Main(string[] args)
-		{
-			await using var container = new RedisBuilder().Build();
-			await container.StartAsync();
-
-			var connection = await ConnectionMultiplexer.ConnectAsync(container.GetConnectionString());
-			connection.UseElasticApm();
-
-			for (var i = 0; i < 10; i++)
-			{
-				// async
-				await Agent.Tracer.CaptureTransaction("Set and Get String", ApiConstants.TypeDb, async () =>
-				{
-					var database = connection.GetDatabase();
-					await database.StringSetAsync($"string{i}", i);
-					await database.StringGetAsync($"string{i}");
-
-					// fire and forget commands may not end up in the profiling session before
-					// transaction end, and the profiling session is finished.
-					await database.StringSetAsync($"string{i}", i, flags: CommandFlags.FireAndForget);
-					await database.StringGetAsync($"string{i}", CommandFlags.FireAndForget);
-				});
-			}
-
-			await container.StopAsync();
-		}
+		Console.WriteLine("\n Cancellation Requested.. halting...");
+		break;
 	}
+	Console.Write($"\rExecuting iteration: {i}");
+	// async
+	await Agent.Tracer.CaptureTransaction("Set and Get String", ApiConstants.TypeDb, async () =>
+	{
+		var database = connection.GetDatabase();
+		await database.StringSetAsync($"string{i}", i);
+		await database.StringGetAsync($"string{i}");
+
+		// fire and forget commands may not end up in the profiling session before
+		// transaction end, and the profiling session is finished.
+		await database.StringSetAsync($"string{i}", i, flags: CommandFlags.FireAndForget);
+		await database.StringGetAsync($"string{i}", CommandFlags.FireAndForget);
+	});
+	await Task.Delay(TimeSpan.FromMilliseconds(100));
 }
+Console.WriteLine("Stopping Redis Container...");
+await container.StopAsync();
+Console.WriteLine("Exiting");

--- a/sample/StackExchangeRedisSample/StackExchangeRedisSample.csproj
+++ b/sample/StackExchangeRedisSample/StackExchangeRedisSample.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>net7.0</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>


### PR DESCRIPTION
This should ensure we don't leak our registrations if span/transaction's Ended
event never gets called but the spans/transaction themselves get GC'ed.
