### PR TITLE
Extend release action to automatically upload artifacts to release.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,7 +57,7 @@ jobs:
     - name: Attach Profiler And Startup Hooks
       continue-on-error: true #continue for now until we see it working in action
       run: |
-        gh release upload ${{ github.ref_name }} "ElasticApmAgent_*.zip" "elastic_apm_profiler_*.zip"
+        gh release upload ${{ github.ref_name }} "build/output/ElasticApmAgent_*.zip" "build/output/elastic_apm_profiler_*.zip"
 
     - if: ${{ success() }}
       uses: elastic/apm-pipeline-library/.github/actions/slack-message@current
@@ -93,11 +93,11 @@ jobs:
         with:
           rust: 'true'
 
-      - name: Package
-        run: ./build.sh pack
+      - name: Build profiler
+        run: ./build.bat profiler-zip
 
       - name: Attach Profiler
         continue-on-error: true #continue for now until we see it working in action
         run: |
-          gh release upload ${{ github.ref_name }} "elastic_apm_profiler_*.zip"
+          gh release upload ${{ github.ref_name }} "build/output/elastic_apm_profiler_*.zip"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,7 +83,7 @@ jobs:
           Build: (<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|here>)
           
   release-windows:
-    runs-on: ubuntu-latest
+    runs-on: windows-2022
     needs: [ 'release']
 
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,6 +53,11 @@ jobs:
         .ci/linux/push_docker.sh
       env:
         TAG_NAME: ${{ github.ref_name }}
+        
+    - name: Attach Profiler And Startup Hooks
+      continue-on-error: true #continue for now until we see it working in action
+      run: |
+        gh release upload ${{ github.ref_name }} "ElasticApmAgent_*.zip" "elastic_apm_profiler_*.zip"
 
     - if: ${{ success() }}
       uses: elastic/apm-pipeline-library/.github/actions/slack-message@current
@@ -76,3 +81,23 @@ jobs:
         message: |
           :large_yellow_circle: [${{ github.repository }}] Release *${{ github.ref_name }}* could not be published.
           Build: (<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|here>)
+          
+  release-windows:
+    runs-on: ubuntu-latest
+    needs: [ 'release']
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Bootstrap Action Workspace
+        uses: ./.github/workflows/bootstrap
+        with:
+          rust: 'true'
+
+      - name: Package
+        run: ./build.sh pack
+
+      - name: Attach Profiler
+        continue-on-error: true #continue for now until we see it working in action
+        run: |
+          gh release upload ${{ github.ref_name }} "elastic_apm_profiler_*.zip"
+


### PR DESCRIPTION
Uploads the profiler and startup hooks from the linux build.

Adds a windows build after the full release runs to also attach the
windows profiler build to the release.
