### PR TITLE
Add more explicit logging to ApmAgent.Subscribe.

### DIFF
--- a/src/Elastic.Apm/ApmAgentExtensions.cs
+++ b/src/Elastic.Apm/ApmAgentExtensions.cs
@@ -36,7 +36,7 @@ namespace Elastic.Apm
 			var subscribersList = string.Join(", ", subscribers.Select(s => s.GetType().Name));
 
 			agent.Logger.Trace()?.Log("Agent.Subscribe(), Agent Enabled: {AgentEnabled} Subscriber count: {NumberOfSubscribers}, ({Subscribers})",
-				agent.Configuration.Enabled, subscribers.Length, subscribers);
+				agent.Configuration.Enabled, subscribers.Length, subscribersList);
 
 			if (!agent.Configuration.Enabled || subscribers.Length == 0)
 				return disposable;

--- a/src/Elastic.Apm/ApmAgentExtensions.cs
+++ b/src/Elastic.Apm/ApmAgentExtensions.cs
@@ -4,8 +4,10 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using Elastic.Apm.Api;
 using Elastic.Apm.DiagnosticSource;
+using Elastic.Apm.Logging;
 
 namespace Elastic.Apm
 {
@@ -29,7 +31,14 @@ namespace Elastic.Apm
 		public static IDisposable Subscribe(this IApmAgent agent, params IDiagnosticsSubscriber[] subscribers)
 		{
 			var disposable = new CompositeDisposable();
-			if (!agent.Configuration.Enabled || subscribers is null || subscribers.Length == 0)
+
+			subscribers ??= Array.Empty<IDiagnosticsSubscriber>();
+			var subscribersList = string.Join(", ", subscribers.Select(s => s.GetType().Name));
+
+			agent.Logger.Trace()?.Log("Agent.Subscribe(), Agent Enabled: {AgentEnabled} Subscriber count: {NumberOfSubscribers}, ({Subscribers})",
+				agent.Configuration.Enabled, subscribers.Length, subscribers);
+
+			if (!agent.Configuration.Enabled || subscribers.Length == 0)
 				return disposable;
 
 			foreach (var subscriber in subscribers)


### PR DESCRIPTION
This so that it shows up earlier during the agent setup and not when diagnosticlisteners start firing
