### PR TITLE
Elastic.Apm.Ingest, new PayloadSender implementation

### DIFF
--- a/build/scripts/Build.fs
+++ b/build/scripts/Build.fs
@@ -21,6 +21,7 @@ open Tooling
 
 module Build =
     
+    //TODO remove oldDiagnosticSourceVersion
     let private oldDiagnosticSourceVersion = SemVer.parse "4.6.0"
     let private diagnosticSourceVersion6 = SemVer.parse "6.0.0"
     

--- a/src/Elastic.Apm/Api/IError.cs
+++ b/src/Elastic.Apm/Api/IError.cs
@@ -12,7 +12,7 @@ namespace Elastic.Apm.Api
 	/// Represents an error which was captured by the agent.
 	/// </summary>
 	[Specification("error.json")]
-	public interface IError
+	public interface IError : IIntakeRoot
 	{
 		/// <summary>
 		/// The culprit that caused this error.

--- a/src/Elastic.Apm/Api/IIntakeRoot.cs
+++ b/src/Elastic.Apm/Api/IIntakeRoot.cs
@@ -1,0 +1,8 @@
+// Licensed to Elasticsearch B.V under
+// one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+namespace Elastic.Apm.Api;
+
+public interface IIntakeRoot { }

--- a/src/Elastic.Apm/Api/IMetricSet.cs
+++ b/src/Elastic.Apm/Api/IMetricSet.cs
@@ -12,7 +12,7 @@ namespace Elastic.Apm.Api
 	/// Data captured by the agent representing a metric occurring in a monitored service
 	/// </summary>
 	[Specification("metricset.json")]
-	public interface IMetricSet
+	public interface IMetricSet : IIntakeRoot
 	{
 		/// <summary>
 		/// List of captured metrics as key - value pairs

--- a/src/Elastic.Apm/Api/ISpan.cs
+++ b/src/Elastic.Apm/Api/ISpan.cs
@@ -10,7 +10,7 @@ namespace Elastic.Apm.Api
 	/// An event captured by an agent occurring in a monitored service
 	/// </summary>
 	[Specification("span.json")]
-	public interface ISpan : IExecutionSegment
+	public interface ISpan : IExecutionSegment, IIntakeRoot
 	{
 		/// <summary>
 		/// The action of the span.

--- a/src/Elastic.Apm/Api/ITransaction.cs
+++ b/src/Elastic.Apm/Api/ITransaction.cs
@@ -19,7 +19,7 @@ namespace Elastic.Apm.Api
 	/// provide different transaction implementations.
 	/// </remarks>
 	[Specification("transaction.json")]
-	public interface ITransaction : IExecutionSegment
+	public interface ITransaction : IExecutionSegment, IIntakeRoot
 	{
 		/// <summary>
 		/// Contains data related to FaaS (Function as a Service) events.

--- a/src/Elastic.Apm/Elastic.Apm.csproj
+++ b/src/Elastic.Apm/Elastic.Apm.csproj
@@ -68,7 +68,8 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(DiagnosticSourceVersion)' == ''">
-    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="5.0.0" />
+    <!--- TODO BUMP Elastic.Transport down to 6.0.0 -->
+    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="6.0.1" />
   </ItemGroup>
   <!-- DiagnosticSourceVersion MsBuild property can be used to compile the agent against a specific version of
        System.Diagnostics.DiagnosticSource. Used when creating the ElasticApmAgentStartupHook zip file to
@@ -84,6 +85,7 @@
     <PackageReference Include="System.Diagnostics.PerformanceCounter" Version="6.0.1" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="Elastic.Ingest.Transport" Version="0.5.5" />
     <PackageReference Include="System.Threading.Tasks.Dataflow" Version="4.9.0" />
     <!-- Used by Ben.Demystifier -->
     <PackageReference Include="System.Reflection.Metadata" Version="5.0.0" />

--- a/src/Elastic.Apm/Ingest/ApmChannel.cs
+++ b/src/Elastic.Apm/Ingest/ApmChannel.cs
@@ -34,7 +34,9 @@ internal static class ApmChannelStatics
 
 	public static readonly JsonSerializerOptions SerializerOptions = new()
 	{
-		DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull, MaxDepth = 64, Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
+		DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+		MaxDepth = 64,
+		Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
 	};
 }
 
@@ -82,17 +84,20 @@ public class ApmChannel
 
 	public virtual void QueueError(IError error)
 	{
-		if (TryFilter(error, out var e)) TryWrite(e);
+		if (TryFilter(error, out var e))
+			TryWrite(e);
 	}
 
 	public virtual void QueueSpan(ISpan span)
 	{
-		if (TryFilter(span, out var s)) TryWrite(s);
+		if (TryFilter(span, out var s))
+			TryWrite(s);
 	}
 
 	public virtual void QueueTransaction(ITransaction transaction)
 	{
-		if (TryFilter(transaction, out var t)) TryWrite(t);
+		if (TryFilter(transaction, out var t))
+			TryWrite(t);
 	}
 
 	//retry if APM server returns 429
@@ -159,7 +164,8 @@ public class ApmChannel
 		await WriteStanzaToStreamAsync(stream, ctx).ConfigureAwait(false);
 		foreach (var @event in b)
 		{
-			if (@event == null) continue;
+			if (@event == null)
+				continue;
 
 			var type = @event switch
 			{

--- a/src/Elastic.Apm/Ingest/ApmChannel.cs
+++ b/src/Elastic.Apm/Ingest/ApmChannel.cs
@@ -1,0 +1,137 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Text.Encodings.Web;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Threading;
+using System.Threading.Tasks;
+using Elastic.Apm.Api;
+using Elastic.Apm.Report;
+using Elastic.Channels;
+using Elastic.Ingest.Transport;
+using Elastic.Transport;
+
+namespace Elastic.Apm.Ingest;
+
+internal static class ApmChannelStatics
+{
+	public static readonly byte[] LineFeed = { (byte)'\n' };
+
+	public static readonly DefaultRequestParameters RequestParams = new()
+	{
+		RequestConfiguration = new RequestConfiguration { ContentType = "application/x-ndjson" }
+	};
+
+	public static readonly JsonSerializerOptions SerializerOptions = new()
+	{
+		DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull, MaxDepth = 64, Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
+	};
+}
+
+/// <summary>
+/// An <see cref="TransportChannelBase{TChannelOptions,TEvent,TResponse,TBulkResponseItem}"/> implementation that sends V2 intake API data
+/// to APM server.
+/// </summary>
+public class ApmChannel
+	: TransportChannelBase<ApmChannelOptions, IIntakeRoot, EventIntakeResponse, IntakeErrorItem>
+	, IPayloadSender
+{
+	/// <inheritdoc cref="ApmChannel"/>
+	public ApmChannel(ApmChannelOptions options) : base(options) { }
+
+	void IPayloadSender.QueueError(IError error) => TryWrite(error);
+
+	void IPayloadSender.QueueMetrics(IMetricSet metrics) => TryWrite(metrics);
+
+	void IPayloadSender.QueueSpan(ISpan span) => TryWrite(span);
+
+	void IPayloadSender.QueueTransaction(ITransaction transaction) => TryWrite(transaction);
+
+	//retry if APM server returns 429
+	/// <inheritdoc cref="ResponseItemsBufferedChannelBase{TChannelOptions,TEvent,TResponse,TBulkResponseItem}.Retry"/>
+	protected override bool Retry(EventIntakeResponse response) => response.ApiCallDetails.HttpStatusCode == 429;
+
+	/// <inheritdoc cref="ResponseItemsBufferedChannelBase{TChannelOptions,TEvent,TResponse,TBulkResponseItem}.RetryAllItems"/>
+	protected override bool RetryAllItems(EventIntakeResponse response) => response.ApiCallDetails.HttpStatusCode == 429;
+
+	//APM does not return the status for all events sent. Therefor we always return an empty set for individual items to retry
+	/// <inheritdoc cref="ResponseItemsBufferedChannelBase{TChannelOptions,TEvent,TResponse,TBulkResponseItem}.Zip"/>
+	protected override List<(IIntakeRoot, IntakeErrorItem)> Zip(EventIntakeResponse response, IReadOnlyCollection<IIntakeRoot> page) =>
+		_emptyZip;
+
+	private readonly List<(IIntakeRoot, IntakeErrorItem)> _emptyZip = new();
+
+	/// <inheritdoc cref="ResponseItemsBufferedChannelBase{TChannelOptions,TEvent,TResponse,TBulkResponseItem}.RetryEvent"/>
+	protected override bool RetryEvent((IIntakeRoot, IntakeErrorItem) @event) => false;
+
+	/// <inheritdoc cref="ResponseItemsBufferedChannelBase{TChannelOptions,TEvent,TResponse,TBulkResponseItem}.RejectEvent"/>
+	protected override bool RejectEvent((IIntakeRoot, IntakeErrorItem) @event) => false;
+
+	/// <inheritdoc cref="BufferedChannelBase{TChannelOptions,TEvent,TResponse}.ExportAsync"/>
+	protected override Task<EventIntakeResponse> ExportAsync(HttpTransport transport, ArraySegment<IIntakeRoot> page, CancellationToken ctx = default) =>
+		transport.RequestAsync<EventIntakeResponse>(HttpMethod.POST, "/intake/v2/events",
+			PostData.StreamHandler(page,
+				(_, _) =>
+				{
+					/* NOT USED */
+				},
+				async (b, stream, ctx) => { await WriteBufferToStreamAsync(b, stream, ctx).ConfigureAwait(false); })
+			, ApmChannelStatics.RequestParams, ctx);
+
+	private async Task WriteStanzaToStreamAsync(Stream stream, CancellationToken ctx)
+	{
+		// {"metadata":{"process":{"pid":1234,"title":"/usr/lib/jvm/java-10-openjdk-amd64/bin/java","ppid":1,"argv":["-v"]},
+		// "system":{"architecture":"amd64","detected_hostname":"8ec7ceb99074","configured_hostname":"host1","platform":"Linux","container":{"id":"8ec7ceb990749e79b37f6dc6cd3628633618d6ce412553a552a0fa6b69419ad4"},
+		// "kubernetes":{"namespace":"default","pod":{"uid":"b17f231da0ad128dc6c6c0b2e82f6f303d3893e3","name":"instrumented-java-service"},"node":{"name":"node-name"}}},
+		// "service":{"name":"1234_service-12a3","version":"4.3.0","node":{"configured_name":"8ec7ceb990749e79b37f6dc6cd3628633618d6ce412553a552a0fa6b69419ad4"},"environment":"production","language":{"name":"Java","version":"10.0.2"},
+		// "agent":{"version":"1.10.0","name":"java","ephemeral_id":"e71be9ac-93b0-44b9-a997-5638f6ccfc36"},"framework":{"name":"spring","version":"5.0.0"},"runtime":{"name":"Java","version":"10.0.2"}},"labels":{"group":"experimental","ab_testing":true,"segment":5}}}
+		// TODO cache
+		var p = Process.GetCurrentProcess();
+		var metadata = new
+		{
+			metadata = new
+			{
+				process = new { pid = p.Id, title = p.ProcessName },
+				service = new
+				{
+					name = System.Text.RegularExpressions.Regex.Replace(p.ProcessName, "[^a-zA-Z0-9 _-]", "_"),
+					version = "1.0.0",
+					agent = new { name = "dotnet", version = "0.0.1" }
+				}
+			}
+		};
+		await JsonSerializer.SerializeAsync(stream, metadata, metadata.GetType(), ApmChannelStatics.SerializerOptions, ctx)
+			.ConfigureAwait(false);
+		await stream.WriteAsync(ApmChannelStatics.LineFeed, 0, 1, ctx).ConfigureAwait(false);
+	}
+
+	private async Task WriteBufferToStreamAsync(IReadOnlyCollection<IIntakeRoot> b, Stream stream, CancellationToken ctx)
+	{
+		await WriteStanzaToStreamAsync(stream, ctx).ConfigureAwait(false);
+		foreach (var @event in b)
+		{
+			if (@event == null) continue;
+
+			var type = @event switch
+			{
+				ITransaction => "transaction",
+				ISpan => "span",
+				IError => "error",
+				IMetricSet => "metricset",
+				_ => "unknown"
+			};
+			var dictionary = new Dictionary<string, object>() { { type, @event } };
+
+			await JsonSerializer.SerializeAsync(stream, dictionary, dictionary.GetType(), ApmChannelStatics.SerializerOptions, ctx)
+				.ConfigureAwait(false);
+
+			await stream.WriteAsync(ApmChannelStatics.LineFeed, 0, 1, ctx).ConfigureAwait(false);
+		}
+	}
+}

--- a/src/Elastic.Apm/Ingest/ApmChannelOptions.cs
+++ b/src/Elastic.Apm/Ingest/ApmChannelOptions.cs
@@ -2,6 +2,7 @@
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
 
+using System;
 using Elastic.Apm.Api;
 using Elastic.Ingest.Transport;
 using Elastic.Transport;
@@ -14,5 +15,11 @@ namespace Elastic.Apm.Ingest;
 public class ApmChannelOptions : TransportChannelOptionsBase<IIntakeRoot, EventIntakeResponse, IntakeErrorItem>
 {
 	/// <inheritdoc cref="ApmChannelOptions"/>
-	public ApmChannelOptions(HttpTransport transport) : base(transport) { }
+	private ApmChannelOptions(HttpTransport transport) : base(transport) { }
+
+	public ApmChannelOptions(Uri serverEndpoint, TransportClient transportClient = null)
+		: this(new DefaultHttpTransport(new TransportConfiguration(new SingleNodePool(serverEndpoint), connection: transportClient!)))
+	{
+
+	}
 }

--- a/src/Elastic.Apm/Ingest/ApmChannelOptions.cs
+++ b/src/Elastic.Apm/Ingest/ApmChannelOptions.cs
@@ -1,0 +1,18 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using Elastic.Apm.Api;
+using Elastic.Ingest.Transport;
+using Elastic.Transport;
+
+namespace Elastic.Apm.Ingest;
+
+/// <summary>
+/// Channel options for <see cref="ApmChannel"/>
+/// </summary>
+public class ApmChannelOptions : TransportChannelOptionsBase<IIntakeRoot, EventIntakeResponse, IntakeErrorItem>
+{
+	/// <inheritdoc cref="ApmChannelOptions"/>
+	public ApmChannelOptions(HttpTransport transport) : base(transport) { }
+}

--- a/src/Elastic.Apm/Ingest/IngestResponse.cs
+++ b/src/Elastic.Apm/Ingest/IngestResponse.cs
@@ -1,0 +1,34 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+using Elastic.Transport;
+
+namespace Elastic.Apm.Ingest;
+
+/// <summary> </summary>
+public class EventIntakeResponse : TransportResponse
+{
+	/// <summary> </summary>
+	[JsonPropertyName("accepted")]
+	public long Accepted { get; set; }
+
+	/// <summary> </summary>
+	[JsonPropertyName("errors")]
+	//[JsonConverter(typeof(ResponseItemsConverter))]
+	public IReadOnlyCollection<IntakeErrorItem> Errors { get; set; } = null!;
+}
+
+/// <summary> </summary>
+public class IntakeErrorItem
+{
+	/// <summary> </summary>
+	[JsonPropertyName("message")]
+	public string Message { get; set; } = null!;
+
+	/// <summary> </summary>
+	[JsonPropertyName("document")]
+	public string Document { get; set; } = null!;
+}

--- a/src/Elastic.Apm/Libraries/Newtonsoft.Json/Utilities/NullableAttributes.cs
+++ b/src/Elastic.Apm/Libraries/Newtonsoft.Json/Utilities/NullableAttributes.cs
@@ -26,6 +26,7 @@
 #endregion
 
 #nullable enable
+#if !NET6_0_OR_GREATER
 namespace System.Diagnostics.CodeAnalysis
 {
 	/// <summary>Specifies that an output will not be null even if the corresponding type allows it.</summary>
@@ -78,3 +79,4 @@ namespace System.Diagnostics.CodeAnalysis
 		public bool ParameterValue { get; }
 	}
 }
+#endif

--- a/src/Elastic.Ingest.Apm/Elastic.Ingest.Apm.csproj
+++ b/src/Elastic.Ingest.Apm/Elastic.Ingest.Apm.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net7.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Elastic.Ingest.Transport" Version="0.5.5" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Elastic.Apm\Elastic.Apm.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Folder Include="Model\" />
+  </ItemGroup>
+
+</Project>

--- a/src/startuphook/Elastic.Apm.StartupHook.Loader/Elastic.Apm.StartupHook.Loader.csproj
+++ b/src/startuphook/Elastic.Apm.StartupHook.Loader/Elastic.Apm.StartupHook.Loader.csproj
@@ -1,8 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-      <!-- TODO make this netstandard 2.0 and ref System.Runtime.Loader -->
-        <TargetFramework>netcoreapp2.2</TargetFramework>
+        <TargetFramework>netstandard2.0</TargetFramework>
         <IsPackable>false</IsPackable>
     </PropertyGroup>
 
@@ -18,6 +17,10 @@
       <Compile Include="..\ElasticApmAgentStartupHook\StartupHookLogger.cs">
         <Link>StartupHookLogger.cs</Link>
       </Compile>
+    </ItemGroup>
+
+    <ItemGroup>
+      <PackageReference Include="System.Runtime.Loader" Version="4.3.0" />
     </ItemGroup>
   
 </Project>

--- a/test/Elastic.Apm.Tests.Utilities/MockPayloadSender.cs
+++ b/test/Elastic.Apm.Tests.Utilities/MockPayloadSender.cs
@@ -19,7 +19,7 @@ using Elastic.Apm.Report;
 using Elastic.Transport;
 using FluentAssertions;
 
-#nullable  enable
+#nullable enable
 namespace Elastic.Apm.Tests.Utilities
 {
 	internal class MockPayloadSender : ApmChannel
@@ -67,44 +67,48 @@ namespace Elastic.Apm.Tests.Utilities
 			switch (item)
 			{
 				case IError error:
-					 _errors.Add(error);
-					 _errorWaitHandle.Set();
-					 break;
+					_errors.Add(error);
+					_errorWaitHandle.Set();
+					break;
 				case ITransaction transaction:
-					 _transactions.Add(transaction);
-					 _transactionWaitHandle.Set();
-					 break;
+					_transactions.Add(transaction);
+					_transactionWaitHandle.Set();
+					break;
 				case ISpan span:
-					 _spans.Add(span);
-					 _spanWaitHandle.Set();
-					 break;
+					_spans.Add(span);
+					_spanWaitHandle.Set();
+					break;
 				case IMetricSet metricSet:
-					 _metrics.Add(metricSet);
-					 _metricSetWaitHandle.Set();
-					 break;
+					_metrics.Add(metricSet);
+					_metricSetWaitHandle.Set();
+					break;
 			}
 			return written;
 		}
 
 		public override void QueueError(IError error)
 		{
-			lock (_errorLock) base.QueueError(error);
+			lock (_errorLock)
+				base.QueueError(error);
 		}
 
 		public override void QueueTransaction(ITransaction transaction)
 		{
-			lock (_transactionLock) base.QueueTransaction(transaction);
+			lock (_transactionLock)
+				base.QueueTransaction(transaction);
 		}
 
 		public override void QueueSpan(ISpan span)
 		{
 			VerifySpan(span);
-			lock (_spanLock) base.QueueSpan(span);
+			lock (_spanLock)
+				base.QueueSpan(span);
 		}
 
 		public override void QueueMetrics(IMetricSet metricSet)
 		{
-			lock (_metricsLock) base.QueueMetrics(metricSet);
+			lock (_metricsLock)
+				base.QueueMetrics(metricSet);
 		}
 
 

--- a/test/azure/applications/Elastic.AzureFunctionApp.InProcess/Elastic.AzureFunctionApp.InProcess.csproj
+++ b/test/azure/applications/Elastic.AzureFunctionApp.InProcess/Elastic.AzureFunctionApp.InProcess.csproj
@@ -8,7 +8,7 @@
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="4.1.1" />
+    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="4.2.0" />
   </ItemGroup>
   <ItemGroup>
     <None Update="host.json">

--- a/test/azure/applications/Elastic.AzureFunctionApp.Isolated/Elastic.AzureFunctionApp.Isolated.csproj
+++ b/test/azure/applications/Elastic.AzureFunctionApp.Isolated/Elastic.AzureFunctionApp.Isolated.csproj
@@ -8,11 +8,11 @@
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="1.8.0"/>
-    <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.7.0"/>
+    <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="1.19.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.14.1" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.0.13"/>
-    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Timer" Version="4.1.0"/>
-    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Storage.Queues" Version="5.0.0"/>
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Timer" Version="4.2.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Storage.Queues" Version="5.2.0" />
   </ItemGroup>
   <ItemGroup>
     <None Update="host.json">

--- a/test/opentelemetry/Elastic.Apm.OpenTelemetry.Tests/OpenTelemetryTests.cs
+++ b/test/opentelemetry/Elastic.Apm.OpenTelemetry.Tests/OpenTelemetryTests.cs
@@ -24,10 +24,10 @@ public class OpenTelemetryTests
 				   configuration: new MockConfiguration(openTelemetryBridgeEnabled: "true"))))
 			OTSamples.Sample2(agent.Tracer);
 
-		payloadSender.FirstTransaction.Name.Should().Be("Sample2");
+		payloadSender.FirstTransaction!.Name.Should().Be("Sample2");
 		payloadSender.Spans.Should().HaveCount(2);
 
-		payloadSender.FirstSpan.Name.Should().Be("foo");
+		payloadSender.FirstSpan!.Name.Should().Be("foo");
 		payloadSender.Spans.ElementAt(1).Name.Should().Be("ElasticApmSpan");
 
 		payloadSender.FirstSpan.ParentId.Should().Be(payloadSender.FirstTransaction.Id);
@@ -39,7 +39,7 @@ public class OpenTelemetryTests
 	private void AssertOnTraceIds(MockPayloadSender payloadSender)
 	{
 		foreach (var span in payloadSender.Spans)
-			span.TraceId.Should().Be(payloadSender.FirstTransaction.TraceId);
+			span.TraceId.Should().Be(payloadSender.FirstTransaction!.TraceId);
 	}
 
 	[Fact]
@@ -50,10 +50,10 @@ public class OpenTelemetryTests
 				   configuration: new MockConfiguration(openTelemetryBridgeEnabled: "true"))))
 			OTSamples.Sample3(agent.Tracer);
 
-		payloadSender.FirstTransaction.Name.Should().Be("Sample3");
+		payloadSender.FirstTransaction!.Name.Should().Be("Sample3");
 		payloadSender.Spans.Should().HaveCount(2);
 
-		payloadSender.FirstSpan.Name.Should().Be("ElasticApmSpan");
+		payloadSender.FirstSpan!.Name.Should().Be("ElasticApmSpan");
 		payloadSender.Spans.ElementAt(1).Name.Should().Be("foo");
 
 		payloadSender.Spans.ElementAt(1).ParentId.Should().Be(payloadSender.FirstTransaction.Id);
@@ -72,10 +72,10 @@ public class OpenTelemetryTests
 				   configuration: new MockConfiguration(openTelemetryBridgeEnabled: "true"))))
 			OTSamples.Sample4(agent.Tracer);
 
-		payloadSender.FirstTransaction.Name.Should().Be("Sample4");
+		payloadSender.FirstTransaction!.Name.Should().Be("Sample4");
 		payloadSender.Spans.Should().HaveCount(2);
 
-		payloadSender.FirstSpan.Name.Should().Be("ElasticApmSpan");
+		payloadSender.FirstSpan!.Name.Should().Be("ElasticApmSpan");
 		payloadSender.Spans.ElementAt(1).Name.Should().Be("foo");
 
 		payloadSender.Spans.ElementAt(1).ParentId.Should().Be(payloadSender.FirstTransaction.Id);
@@ -92,7 +92,7 @@ public class OpenTelemetryTests
 				   configuration: new MockConfiguration(openTelemetryBridgeEnabled: "true"))))
 			OTSamples.OneSpanWithAttributes();
 
-		payloadSender.FirstTransaction.Name.Should().Be("foo");
+		payloadSender.FirstTransaction!.Name.Should().Be("foo");
 		payloadSender.FirstTransaction.Otel.Should().NotBeNull();
 		payloadSender.FirstTransaction.Otel.SpanKind.Should().Be("Server");
 		payloadSender.FirstTransaction.Otel.Attributes.Should().NotBeNull();
@@ -107,13 +107,13 @@ public class OpenTelemetryTests
 				   configuration: new MockConfiguration(openTelemetryBridgeEnabled: "true"))))
 			OTSamples.TwoSpansWithAttributes();
 
-		payloadSender.FirstTransaction.Name.Should().Be("foo");
+		payloadSender.FirstTransaction!.Name.Should().Be("foo");
 		payloadSender.FirstTransaction.Otel.Should().NotBeNull();
 		payloadSender.FirstTransaction.Otel.SpanKind.Should().Be("Server");
 		payloadSender.FirstTransaction.Otel.Attributes.Should().NotBeNull();
 		payloadSender.FirstTransaction.Otel.Attributes.Should().Contain("foo1", "bar1");
 
-		payloadSender.FirstSpan.Name.Should().Be("bar");
+		payloadSender.FirstSpan!.Name.Should().Be("bar");
 		payloadSender.FirstSpan.Otel.Should().NotBeNull();
 		payloadSender.FirstSpan.Otel.SpanKind.Should().Be("Internal");
 		payloadSender.FirstSpan.Otel.Attributes.Should().NotBeNull();
@@ -128,7 +128,7 @@ public class OpenTelemetryTests
 				   configuration: new MockConfiguration(openTelemetryBridgeEnabled: "true"))))
 			OTSamples.SpanKindSample();
 
-		payloadSender.FirstSpan.Type.Should().Be(ApiConstants.TypeExternal);
+		payloadSender.FirstSpan!.Type.Should().Be(ApiConstants.TypeExternal);
 		payloadSender.FirstSpan.Subtype.Should().Be(ApiConstants.SubtypeHttp);
 
 		payloadSender.Spans.ElementAt(1).Type.Should().Be(ApiConstants.TypeDb);
@@ -178,7 +178,7 @@ public class OpenTelemetryTests
 
 		payloadSender.WaitForTransactions(count: 2);
 
-		payloadSender.FirstTransaction.TraceId.Should()
+		payloadSender.FirstTransaction!.TraceId.Should()
 			.Be(payloadSender.Transactions[1].TraceId, because: "The transactions should be under the same trace.");
 	}
 
@@ -196,7 +196,7 @@ public class OpenTelemetryTests
 		using (var activity = src.StartActivity("foo", ActivityKind.Server))
 			traceId = activity?.TraceId.ToString();
 		traceId.Should().NotBeNull();
-		payloadSender.FirstTransaction.TraceId.Should().Be(traceId);
+		payloadSender.FirstTransaction!.TraceId.Should().Be(traceId);
 	}
 
 	[Fact]


### PR DESCRIPTION
This introduces `ApmChannel` an `Elastic.Ingest.Tranport` implementation geared to APM Servers v2 intake API. 

Opening this early to iterate on as time allows. 

`MockPayloadSender` is now a subclass of `ApmChannel` so it will attempt to do the same work as it does.

Still need to work on ensuring the data that will get written is correct. 




