### PR TITLE
Change 'cloud.project.id' for GCP metadata to be the 'project-id'

### DIFF
--- a/src/Elastic.Apm/Cloud/GcpCloudMetadataProvider.cs
+++ b/src/Elastic.Apm/Cloud/GcpCloudMetadataProvider.cs
@@ -81,8 +81,7 @@ namespace Elastic.Apm.Cloud
 						},
 					Project = new CloudProject
 					{
-						Id = metadata["project"]["numericProjectId"].Value<long>().ToString(CultureInfo.InvariantCulture),
-						Name = metadata["project"]["projectId"].Value<string>()
+						Id = metadata["project"]["projectId"].Value<string>()
 					},
 					AvailabilityZone = availabilityZone,
 					Machine = new CloudMachine { Type = machineType },

--- a/test/Elastic.Apm.Tests/Cloud/GcpCloudMetadataProviderTests.cs
+++ b/test/Elastic.Apm.Tests/Cloud/GcpCloudMetadataProviderTests.cs
@@ -45,8 +45,8 @@ namespace Elastic.Apm.Tests.Cloud
 			metadata.Instance.Id.Should().Be(stubMetadata.instance.id.ToString());
 			metadata.Instance.Name.Should().Be(stubMetadata.instance.name);
 			metadata.Project.Should().NotBeNull();
-			metadata.Project.Id.Should().Be(stubMetadata.project.numericProjectId.ToString());
-			metadata.Project.Name.Should().Be(stubMetadata.project.projectId);
+			metadata.Project.Id.Should().Be(stubMetadata.project.projectId);
+			metadata.Project.Name.Should().BeNull();
 			metadata.AvailabilityZone.Should().Be("us-west3-a");
 			metadata.Region.Should().Be("us-west3");
 			metadata.Machine.Should().NotBeNull();


### PR DESCRIPTION
Closes: https://github.com/elastic/apm-agent-dotnet/issues/2177
