### PR TITLE
json-specs: cgroup_parsing has been removed

### DIFF
--- a/.ci/updatecli.d/update-json-specs.yml
+++ b/.ci/updatecli.d/update-json-specs.yml
@@ -24,10 +24,10 @@ sources:
       - findsubmatch:
           pattern: "[0-9a-f]{40}"
 
-  cgroup_parsing.json:
+  container_metadata_discovery.json:
     kind: file
     spec:
-      file: https://raw.githubusercontent.com/elastic/apm/main/tests/agents/json-specs/cgroup_parsing.json
+      file: https://raw.githubusercontent.com/elastic/apm/main/tests/agents/json-specs/container_metadata_discovery.json
   service_resource_inference.json:
     kind: file
     spec:
@@ -71,13 +71,13 @@ actions:
         * https://github.com/elastic/apm/commit/{{ source "sha" }}
 
 targets:
-  cgroup_parsing.json:
-    name: cgroup_parsing.json
+  container_metadata_discovery.json:
+    name: container_metadata_discovery.json
     scmid: default
-    sourceid: cgroup_parsing.json
+    sourceid: container_metadata_discovery.json
     kind: file
     spec:
-      file: test/Elastic.Apm.Tests.Utilities/TestResources/json-specs/cgroup_parsing.json
+      file: test/Elastic.Apm.Tests.Utilities/TestResources/json-specs/container_metadata_discovery.json
   service_resource_inference.json:
     name: service_resource_inference.json
     scmid: default


### PR DESCRIPTION
## What

I created an empty json file so the `updatecli` will be the one updating it in the next run.

## Why

Fix the failures when updating the json-specs using `updatecli`

## Further details

Likely `test/Elastic.Apm.Tests/SystemInfoHelperTests.cs` will need to be adjusted since `cgroup_parsing.json` does not exist anymore in the `elastic/apm.git`

## Issues

Caused by https://github.com/elastic/apm/pull/807