### PR TITLE
Support OnExecuteRequestStep available in new .NET versions for IIS modules.

### DIFF
--- a/src/integrations/Elastic.Apm.AspNetFullFramework/ElasticApmModule.cs
+++ b/src/integrations/Elastic.Apm.AspNetFullFramework/ElasticApmModule.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.Data.SqlClient;
 using System.Linq;
+using System.Reflection;
 using System.Security.Claims;
 using System.Threading;
 using System.Web;
@@ -34,6 +35,8 @@ namespace Elastic.Apm.AspNetFullFramework
 		// ReSharper disable once RedundantDefaultMemberInitializer
 		private static readonly DbgInstanceNameGenerator DbgInstanceNameGenerator = new();
 		private static readonly LazyContextualInit InitOnceHelper = new();
+		private static readonly MethodInfo OnExecuteRequestStepMethodInfo = typeof(HttpApplication).GetMethod("OnExecuteRequestStep");
+
 
 		private readonly string _dbgInstanceName;
 		private HttpApplication _application;
@@ -44,6 +47,7 @@ namespace Elastic.Apm.AspNetFullFramework
 
 		private Func<object, string> _routeDataTemplateGetter;
 		private Func<object, decimal> _routePrecedenceGetter;
+
 
 		public ElasticApmModule() =>
 			// ReSharper disable once ImpureMethodCallOnReadonlyValueField
@@ -101,6 +105,15 @@ namespace Elastic.Apm.AspNetFullFramework
 			if (!Agent.Config.Enabled)
 				return;
 
+			if (!HttpRuntime.UsingIntegratedPipeline)
+			{
+				_logger.Error()
+					?.Log("Skipping Initialization. Elastic APM Module requires the application pool to run under an Integrated Pipeline."
+						+ " .NET runtime: {DotNetRuntimeDescription}; IIS: {IisVersion}",
+						PlatformDetection.DotNetRuntimeDescription, HttpRuntime.IISVersion);
+				return;
+			}
+
 			if (isInitedByThisCall)
 			{
 				_logger.Debug()
@@ -114,6 +127,76 @@ namespace Elastic.Apm.AspNetFullFramework
 			_application.BeginRequest += OnBeginRequest;
 			_application.EndRequest += OnEndRequest;
 			_application.Error += OnError;
+
+			if (OnExecuteRequestStepMethodInfo != null)
+			{
+				// OnExecuteRequestStep is available starting with 4.7.1
+				try
+				{
+					OnExecuteRequestStepMethodInfo.Invoke(application, new object[] { (Action<HttpContextBase, Action>)OnExecuteRequestStep });
+				}
+				catch (Exception e)
+				{
+					 _logger.Error()
+						  ?.LogException(e, "Failed to invoke OnExecuteRequestStep. .NET runtime: {DotNetRuntimeDescription}; IIS: {IisVersion}",
+							  PlatformDetection.DotNetRuntimeDescription, HttpRuntime.IISVersion);
+				}
+			}
+		}
+
+		private void RestoreContextIfNeeded(HttpContextBase context)
+		{
+			string EventName() => Enum.GetName(typeof(RequestNotification), context.CurrentNotification);
+
+			if (Agent.Instance == null)
+			{
+				_logger.Trace()?.Log($"Agent.Instance is null during {nameof(OnExecuteRequestStep)}:{EventName()}.");
+				return;
+			}
+			if (Agent.Instance.Tracer == null)
+			{
+				_logger.Trace()?.Log($"Agent.Instance.Tracer is null during {nameof(OnExecuteRequestStep)}:{EventName()}.");
+				return;
+			}
+
+			var transaction = Agent.Instance?.Tracer?.CurrentTransaction;
+			if (transaction != null) return;
+
+			var transactionInCurrent = HttpContext.Current?.Items[HttpContextCurrentExecutionSegmentsContainer.CurrentTransactionKey] is not null;
+			var transactionInApplicationInstance = context.Items[HttpContextCurrentExecutionSegmentsContainer.CurrentTransactionKey] is not null;
+			var spanInCurrent = HttpContext.Current?.Items[HttpContextCurrentExecutionSegmentsContainer.CurrentSpanKey] is not null;
+			var spanInApplicationInstance = context.Items[HttpContextCurrentExecutionSegmentsContainer.CurrentSpanKey] is not null;
+
+			_logger.Trace()?
+				.Log($"{nameof(ITracer.CurrentTransaction)} is null during {nameof(OnExecuteRequestStep)}:{EventName()}. "
+					+ $"(HttpContext.Current Span: {spanInCurrent}, Transaction: {transactionInCurrent})"
+					+ $"(ApplicationContext Span: {spanInApplicationInstance}, Transaction: {transactionInApplicationInstance})");
+
+			if (HttpContext.Current == null)
+			{
+				_logger.Trace()?.Log($"HttpContext.Current is null during {nameof(OnExecuteRequestStep)}:{EventName()}. Unable to attempt to restore transaction");
+				return;
+			}
+
+			if (!transactionInCurrent && transactionInApplicationInstance)
+			{
+				HttpContext.Current.Items[HttpContextCurrentExecutionSegmentsContainer.CurrentTransactionKey] =
+					context.Items[HttpContextCurrentExecutionSegmentsContainer.CurrentTransactionKey];
+				_logger.Trace()?.Log($"Restored transaction to HttpContext.Current.Items {nameof(OnExecuteRequestStep)}:{EventName()}");
+			}
+			if (!spanInCurrent && spanInApplicationInstance)
+			{
+				HttpContext.Current.Items[HttpContextCurrentExecutionSegmentsContainer.CurrentSpanKey] =
+					context.Items[HttpContextCurrentExecutionSegmentsContainer.CurrentSpanKey];
+				_logger.Trace()?.Log($"Restored span to HttpContext.Current.Items {nameof(OnExecuteRequestStep)}:{EventName()}");
+			}
+
+		}
+
+		private void OnExecuteRequestStep(HttpContextBase context, Action step)
+		{
+			RestoreContextIfNeeded(context);
+			step();
 		}
 
 		private void OnBeginRequest(object sender, EventArgs e)

--- a/src/integrations/Elastic.Apm.AspNetFullFramework/ElasticApmModule.cs
+++ b/src/integrations/Elastic.Apm.AspNetFullFramework/ElasticApmModule.cs
@@ -137,9 +137,9 @@ namespace Elastic.Apm.AspNetFullFramework
 				}
 				catch (Exception e)
 				{
-					 _logger.Error()
-						  ?.LogException(e, "Failed to invoke OnExecuteRequestStep. .NET runtime: {DotNetRuntimeDescription}; IIS: {IisVersion}",
-							  PlatformDetection.DotNetRuntimeDescription, HttpRuntime.IISVersion);
+					_logger.Error()
+						 ?.LogException(e, "Failed to invoke OnExecuteRequestStep. .NET runtime: {DotNetRuntimeDescription}; IIS: {IisVersion}",
+							 PlatformDetection.DotNetRuntimeDescription, HttpRuntime.IISVersion);
 				}
 			}
 		}
@@ -160,7 +160,8 @@ namespace Elastic.Apm.AspNetFullFramework
 			}
 
 			var transaction = Agent.Instance?.Tracer?.CurrentTransaction;
-			if (transaction != null) return;
+			if (transaction != null)
+				return;
 
 			var transactionInCurrent = HttpContext.Current?.Items[HttpContextCurrentExecutionSegmentsContainer.CurrentTransactionKey] is not null;
 			var transactionInApplicationInstance = context.Items[HttpContextCurrentExecutionSegmentsContainer.CurrentTransactionKey] is not null;

--- a/src/integrations/Elastic.Apm.AspNetFullFramework/HttpContextCurrentExecutionSegmentsContainer.cs
+++ b/src/integrations/Elastic.Apm.AspNetFullFramework/HttpContextCurrentExecutionSegmentsContainer.cs
@@ -15,10 +15,10 @@ namespace Elastic.Apm.AspNetFullFramework
 	/// </summary>
 	internal sealed class HttpContextCurrentExecutionSegmentsContainer : ICurrentExecutionSegmentsContainer
 	{
-		private readonly AsyncLocal<ISpan> _currentSpan = new AsyncLocal<ISpan>();
-		private readonly AsyncLocal<ITransaction> _currentTransaction = new AsyncLocal<ITransaction>();
+		private readonly AsyncLocal<ISpan> _currentSpan = new();
+		private readonly AsyncLocal<ITransaction> _currentTransaction = new();
 
-		private const string CurrentSpanKey = "Elastic.Apm.Agent.CurrentSpan";
+		internal const string CurrentSpanKey = "Elastic.Apm.Agent.CurrentSpan";
 		internal const string CurrentTransactionKey = "Elastic.Apm.Agent.CurrentTransaction";
 
 		public ISpan CurrentSpan


### PR DESCRIPTION
This more aggressively logs and attempts to restore HttpContext items.

This also more gracefully exits if we detect the module running under classic pipeline mode
