### PR TITLE
[Automation] Update JSON specs

### DIFF
--- a/test/Elastic.Apm.Tests.Utilities/TestResources/json-specs/container_metadata_discovery.json
+++ b/test/Elastic.Apm.Tests.Utilities/TestResources/json-specs/container_metadata_discovery.json
@@ -1,0 +1,65 @@
+{
+  "cgroup_v1_underscores": {
+    "files": {
+      "/proc/self/cgroup": [
+        "1:name=systemd:/kubepods.slice/kubepods-burstable.slice/kubepods-burstable-pod90d81341_92de_11e7_8cf2_507b9d4141fa.slice/crio-2227daf62df6694645fee5df53c1f91271546a9560e8600a525690ae252b7f63.scope"
+      ]
+    },
+    "containerId": "2227daf62df6694645fee5df53c1f91271546a9560e8600a525690ae252b7f63",
+    "podId": "90d81341-92de-11e7-8cf2-507b9d4141fa"
+  },
+  "cgroup_v1_openshift": {
+    "files": {
+      "/proc/self/cgroup": [
+        "9:freezer:/kubepods.slice/kubepods-pod22949dce_fd8b_11ea_8ede_98f2b32c645c.slice/docker-b15a5bdedd2e7645c3be271364324321b908314e4c77857bbfd32a041148c07f.scope"
+      ]
+    },
+    "containerId": "b15a5bdedd2e7645c3be271364324321b908314e4c77857bbfd32a041148c07f",
+    "podId": "22949dce-fd8b-11ea-8ede-98f2b32c645c"
+  },
+  "cgroup_v1_ubuntu": {
+    "files": {
+      "/proc/self/cgroup": [
+        "1:name=systemd:/user.slice/user-1000.slice/user@1000.service/apps.slice/apps-org.gnome.Terminal.slice/vte-spawn-75bc72bd-6642-4cf5-b62c-0674e11bfc84.scope"
+      ]
+    },
+    "containerId": null,
+    "podId": null
+  },
+  "cgroup_v1_awsEcs": {
+    "files": {
+      "/proc/self/cgroup": [
+        "1:name=systemd:/ecs/03752a671e744971a862edcee6195646/03752a671e744971a862edcee6195646-4015103728"
+      ]
+    },
+    "containerId": "03752a671e744971a862edcee6195646-4015103728",
+    "podId": null
+  },
+  "cgroup_v2": {
+    "files": {
+      "/proc/self/cgroup": [
+        "0::/"
+      ],
+      "/proc/self/mountinfo": [
+        "3984 3905 0:73 / / rw,relatime shared:1863 master:1733 - overlay overlay rw,lowerdir=/var/lib/docker/overlay2/l/KEX7CWLHQCXQY2RHPGTXJ3C26N:/var/lib/docker/overlay2/l/2PVS7JRTRSTVZS4KSUAFML3BIV:/var/lib/docker/overlay2/l/52M7ARM4JDVHCJAYUI6JIKBO4B,upperdir=/var/lib/docker/overlay2/267f825fb89e584605bf161177451879c0ba8b15f7df9b51fb7843c7beb9ed25/diff,workdir=/var/lib/docker/overlay2/267f825fb89e584605bf161177451879c0ba8b15f7df9b51fb7843c7beb9ed25/work",
+        "3985 3984 0:77 / /proc rw,nosuid,nodev,noexec,relatime shared:1864 - proc proc rw",
+        "3986 3984 0:78 / /dev rw,nosuid shared:1865 - tmpfs tmpfs rw,size=65536k,mode=755,inode64",
+        "3987 3986 0:79 / /dev/pts rw,nosuid,noexec,relatime shared:1866 - devpts devpts rw,gid=5,mode=620,ptmxmode=666",
+        "3988 3984 0:80 / /sys ro,nosuid,nodev,noexec,relatime shared:1870 - sysfs sysfs ro",
+        "3989 3988 0:30 / /sys/fs/cgroup rw,nosuid,nodev,noexec,relatime shared:1871 - cgroup2 cgroup rw",
+        "3990 3986 0:76 / /dev/mqueue rw,nosuid,nodev,noexec,relatime shared:1867 - mqueue mqueue rw",
+        "3991 3986 0:81 / /dev/shm rw,nosuid,nodev,noexec,relatime shared:1868 - tmpfs shm rw,size=65536k,inode64",
+        "3992 3984 253:1 /var/lib/docker/volumes/9d18ce5b36572d85358fa936afe5a4bf95cca5c822b04941aa08c6118f6e0d33/_data /var rw,relatime shared:1872 master:1 - ext4 /dev/mapper/vgubuntu-root rw,errors=remount-ro",
+        "3993 3984 0:82 / /run rw,nosuid,nodev,noexec,relatime shared:1873 - tmpfs tmpfs rw,inode64",
+        "3994 3984 0:83 / /tmp rw,nosuid,nodev,noexec,relatime shared:1874 - tmpfs tmpfs rw,inode64",
+        "3995 3984 253:1 /usr/lib/modules /usr/lib/modules ro,relatime shared:1875 - ext4 /dev/mapper/vgubuntu-root rw,errors=remount-ro",
+        "3996 3984 253:1 /var/lib/docker/containers/6548c6863fb748e72d1e2a4f824fde92f720952d062dede1318c2d6219a672d6/resolv.conf /etc/resolv.conf rw,relatime shared:1876 - ext4 /dev/mapper/vgubuntu-root rw,errors=remount-ro",
+        "3997 3984 253:1 /var/lib/docker/containers/6548c6863fb748e72d1e2a4f824fde92f720952d062dede1318c2d6219a672d6/hostname /etc/hostname rw,relatime shared:1877 - ext4 /dev/mapper/vgubuntu-root rw,errors=remount-ro",
+        "3998 3984 253:1 /var/lib/docker/containers/6548c6863fb748e72d1e2a4f824fde92f720952d062dede1318c2d6219a672d6/hosts /etc/hosts rw,relatime shared:1878 - ext4 /dev/mapper/vgubuntu-root rw,errors=remount-ro"
+      ]
+    },
+    "containerId": "6548c6863fb748e72d1e2a4f824fde92f720952d062dede1318c2d6219a672d6",
+    "podId": null
+  }
+}
+


### PR DESCRIPTION


### What
APM agent specs automatic sync
### Why
*Changeset*
* https://github.com/elastic/apm/commit/a3510c0484d1eeefc26ae424fdb2ebd151e3bdcd

---



<Actions>
    <action id="9c61c4e961100f21a384fb44d987b9e99ed9cc1d03149e375644fab1d90353b7">
        <h3>update-json-specs</h3>
        <details id="51b51c35f35d91535097fd9395976b0be51211da0a6db79e48824e45a55d3156">
            <summary>container_metadata_discovery.json</summary>
            <p>1 file(s) updated with &#34;{\n  \&#34;cgroup_v1_underscores\&#34;: {\n    \&#34;files\&#34;: {\n      \&#34;/proc/self/cgroup\&#34;: [\n        \&#34;1:name=systemd:/kubepods.slice/kubepods-burstable.slice/kubepods-burstable-pod90d81341_92de_11e7_8cf2_507b9d4141fa.slice/crio-2227daf62df6694645fee5df53c1f91271546a9560e8600a525690ae252b7f63.scope\&#34;\n      ]\n    },\n    \&#34;containerId\&#34;: \&#34;2227daf62df6694645fee5df53c1f91271546a9560e8600a525690ae252b7f63\&#34;,\n    \&#34;podId\&#34;: \&#34;90d81341-92de-11e7-8cf2-507b9d4141fa\&#34;\n  },\n  \&#34;cgroup_v1_openshift\&#34;: {\n    \&#34;files\&#34;: {\n      \&#34;/proc/self/cgroup\&#34;: [\n        \&#34;9:freezer:/kubepods.slice/kubepods-pod22949dce_fd8b_11ea_8ede_98f2b32c645c.slice/docker-b15a5bdedd2e7645c3be271364324321b908314e4c77857bbfd32a041148c07f.scope\&#34;\n      ]\n    },\n    \&#34;containerId\&#34;: \&#34;b15a5bdedd2e7645c3be271364324321b908314e4c77857bbfd32a041148c07f\&#34;,\n    \&#34;podId\&#34;: \&#34;22949dce-fd8b-11ea-8ede-98f2b32c645c\&#34;\n  },\n  \&#34;cgroup_v1_ubuntu\&#34;: {\n    \&#34;files\&#34;: {\n      \&#34;/proc/self/cgroup\&#34;: [\n        \&#34;1:name=systemd:/user.slice/user-1000.slice/user@1000.service/apps.slice/apps-org.gnome.Terminal.slice/vte-spawn-75bc72bd-6642-4cf5-b62c-0674e11bfc84.scope\&#34;\n      ]\n    },\n    \&#34;containerId\&#34;: null,\n    \&#34;podId\&#34;: null\n  },\n  \&#34;cgroup_v1_awsEcs\&#34;: {\n    \&#34;files\&#34;: {\n      \&#34;/proc/self/cgroup\&#34;: [\n        \&#34;1:name=systemd:/ecs/03752a671e744971a862edcee6195646/03752a671e744971a862edcee6195646-4015103728\&#34;\n      ]\n    },\n    \&#34;containerId\&#34;: \&#34;03752a671e744971a862edcee6195646-4015103728\&#34;,\n    \&#34;podId\&#34;: null\n  },\n  \&#34;cgroup_v2\&#34;: {\n    \&#34;files\&#34;: {\n      \&#34;/proc/self/cgroup\&#34;: [\n        \&#34;0::/\&#34;\n      ],\n      \&#34;/proc/self/mountinfo\&#34;: [\n        \&#34;3984 3905 0:73 / / rw,relatime shared:1863 master:1733 - overlay overlay rw,lowerdir=/var/lib/docker/overlay2/l/KEX7CWLHQCXQY2RHPGTXJ3C26N:/var/lib/docker/overlay2/l/2PVS7JRTRSTVZS4KSUAFML3BIV:/var/lib/docker/overlay2/l/52M7ARM4JDVHCJAYUI6JIKBO4B,upperdir=/var/lib/docker/overlay2/267f825fb89e584605bf161177451879c0ba8b15f7df9b51fb7843c7beb9ed25/diff,workdir=/var/lib/docker/overlay2/267f825fb89e584605bf161177451879c0ba8b15f7df9b51fb7843c7beb9ed25/work\&#34;,\n        \&#34;3985 3984 0:77 / /proc rw,nosuid,nodev,noexec,relatime shared:1864 - proc proc rw\&#34;,\n        \&#34;3986 3984 0:78 / /dev rw,nosuid shared:1865 - tmpfs tmpfs rw,size=65536k,mode=755,inode64\&#34;,\n        \&#34;3987 3986 0:79 / /dev/pts rw,nosuid,noexec,relatime shared:1866 - devpts devpts rw,gid=5,mode=620,ptmxmode=666\&#34;,\n        \&#34;3988 3984 0:80 / /sys ro,nosuid,nodev,noexec,relatime shared:1870 - sysfs sysfs ro\&#34;,\n        \&#34;3989 3988 0:30 / /sys/fs/cgroup rw,nosuid,nodev,noexec,relatime shared:1871 - cgroup2 cgroup rw\&#34;,\n        \&#34;3990 3986 0:76 / /dev/mqueue rw,nosuid,nodev,noexec,relatime shared:1867 - mqueue mqueue rw\&#34;,\n        \&#34;3991 3986 0:81 / /dev/shm rw,nosuid,nodev,noexec,relatime shared:1868 - tmpfs shm rw,size=65536k,inode64\&#34;,\n        \&#34;3992 3984 253:1 /var/lib/docker/volumes/9d18ce5b36572d85358fa936afe5a4bf95cca5c822b04941aa08c6118f6e0d33/_data /var rw,relatime shared:1872 master:1 - ext4 /dev/mapper/vgubuntu-root rw,errors=remount-ro\&#34;,\n        \&#34;3993 3984 0:82 / /run rw,nosuid,nodev,noexec,relatime shared:1873 - tmpfs tmpfs rw,inode64\&#34;,\n        \&#34;3994 3984 0:83 / /tmp rw,nosuid,nodev,noexec,relatime shared:1874 - tmpfs tmpfs rw,inode64\&#34;,\n        \&#34;3995 3984 253:1 /usr/lib/modules /usr/lib/modules ro,relatime shared:1875 - ext4 /dev/mapper/vgubuntu-root rw,errors=remount-ro\&#34;,\n        \&#34;3996 3984 253:1 /var/lib/docker/containers/6548c6863fb748e72d1e2a4f824fde92f720952d062dede1318c2d6219a672d6/resolv.conf /etc/resolv.conf rw,relatime shared:1876 - ext4 /dev/mapper/vgubuntu-root rw,errors=remount-ro\&#34;,\n        \&#34;3997 3984 253:1 /var/lib/docker/containers/6548c6863fb748e72d1e2a4f824fde92f720952d062dede1318c2d6219a672d6/hostname /etc/hostname rw,relatime shared:1877 - ext4 /dev/mapper/vgubuntu-root rw,errors=remount-ro\&#34;,\n        \&#34;3998 3984 253:1 /var/lib/docker/containers/6548c6863fb748e72d1e2a4f824fde92f720952d062dede1318c2d6219a672d6/hosts /etc/hosts rw,relatime shared:1878 - ext4 /dev/mapper/vgubuntu-root rw,errors=remount-ro\&#34;\n      ]\n    },\n    \&#34;containerId\&#34;: \&#34;6548c6863fb748e72d1e2a4f824fde92f720952d062dede1318c2d6219a672d6\&#34;,\n    \&#34;podId\&#34;: null\n  }\n}\n\n&#34;:&#xA;&#x9;* test/Elastic.Apm.Tests.Utilities/TestResources/json-specs/container_metadata_discovery.json&#xA;</p>
        </details>
    </action>
</Actions>

---

<table>
  <tr>
    <td width="77">
      <img src="https://www.updatecli.io/images/updatecli.png" alt="Updatecli logo" width="50" height="50">
    </td>
    <td>
      <p>
        Created automatically by <a href="https://www.updatecli.io/">Updatecli</a>
      </p>
      <details><summary>Options:</summary>
        <br />
        <p>Most of Updatecli configuration is done via <a href="https://www.updatecli.io/docs/prologue/quick-start/">its manifest(s)</a>.</p>
        <ul>
          <li>If you close this pull request, Updatecli will automatically reopen it, the next time it runs.</li>
          <li>If you close this pull request and delete the base branch, Updatecli will automatically recreate it, erasing all previous commits made.</li>
        </ul>
        <p>
          Feel free to report any issues at <a href="https://github.com/updatecli/updatecli/issues">github.com/updatecli/updatecli</a>.<br />
          If you find this tool useful, do not hesitate to star <a href="https://github.com/updatecli/updatecli/stargazers">our GitHub repository</a> as a sign of appreciation, and/or to tell us directly on our <a href="https://matrix.to/#/#Updatecli_community:gitter.im">chat</a>!
        </p>
      </details>
    </td>
  </tr>
</table>

