### PR TITLE
Update high watermark settings for Elasticsearch Integration tests

### DIFF
--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -148,6 +148,8 @@ jobs:
 
     - name: 'Tests: Profiler'
       uses: ./.github/workflows/test
+      #temporarily disable profiler tests
+      if: false
       with:
           name: 'profiler'
           project: 'test/profiler/Elastic.Apm.Profiler.Managed.Tests/Elastic.Apm.Profiler.Managed.Tests.csproj'

--- a/test/instrumentations/Elastic.Clients.Elasticsearch.Tests/Elastic.Clients.Elasticsearch.Tests.csproj
+++ b/test/instrumentations/Elastic.Clients.Elasticsearch.Tests/Elastic.Clients.Elasticsearch.Tests.csproj
@@ -16,5 +16,10 @@
     <ProjectReference Include="$(SrcInstrumentations)\Elastic.Apm.Elasticsearch\Elastic.Apm.Elasticsearch.csproj" />
     <ProjectReference Include="$(SolutionRoot)\src\Elastic.Apm\Elastic.Apm.csproj" />
     <ProjectReference Include="$(SolutionRoot)\test\Elastic.Apm.Tests.Utilities\Elastic.Apm.Tests.Utilities.csproj" />
+    <ProjectReference Include="..\..\integrations\Elastic.Apm.AspNetCore.Tests\Elastic.Apm.AspNetCore.Tests.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Update="xunit.runner.json" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 </Project>

--- a/test/instrumentations/Elastic.Clients.Elasticsearch.Tests/ElasticsearchTestFixture.cs
+++ b/test/instrumentations/Elastic.Clients.Elasticsearch.Tests/ElasticsearchTestFixture.cs
@@ -3,17 +3,13 @@
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
 
-using DotNet.Testcontainers.Builders;
-using DotNet.Testcontainers.Configurations;
 using DotNet.Testcontainers.Containers;
 using Elastic.Transport;
-using Microsoft.Extensions.Logging;
 using Testcontainers.Elasticsearch;
 using Xunit;
 using Xunit.Abstractions;
 using Xunit.Sdk;
 using HttpMethod = Elastic.Transport.HttpMethod;
-using ILogger = Microsoft.Extensions.Logging.ILogger;
 
 namespace Elastic.Clients.Elasticsearch.Tests;
 
@@ -74,23 +70,5 @@ public sealed class ElasticsearchTestFixture : IAsyncLifetime
 			await Container.StopAsync();
 			await Container.DisposeAsync();
 		}
-	}
-
-	private class MessageSinkLogger : ILogger
-	{
-		private readonly IMessageSink _messageSink;
-
-		public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
-
-		public MessageSinkLogger(IMessageSink sink)
-		{
-			_messageSink = sink;
-			_messageSink.OnMessage(new DiagnosticMessage($"Started {nameof(MessageSinkLogger)}"));
-		}
-
-		public bool IsEnabled(LogLevel logLevel) => true;
-
-		public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter) =>
-			_messageSink.OnMessage(new DiagnosticMessage(formatter(state, exception)));
 	}
 }

--- a/test/instrumentations/Elastic.Clients.Elasticsearch.Tests/ElasticsearchTestFixture.cs
+++ b/test/instrumentations/Elastic.Clients.Elasticsearch.Tests/ElasticsearchTestFixture.cs
@@ -12,6 +12,7 @@ using Testcontainers.Elasticsearch;
 using Xunit;
 using Xunit.Abstractions;
 using Xunit.Sdk;
+using HttpMethod = Elastic.Transport.HttpMethod;
 using ILogger = Microsoft.Extensions.Logging.ILogger;
 
 namespace Elastic.Clients.Elasticsearch.Tests;
@@ -26,7 +27,8 @@ public sealed class ElasticsearchTestFixture : IAsyncLifetime
 	public ElasticsearchTestFixture(IMessageSink sink)
 	{
 		_sink = sink;
-		Container = new ElasticsearchBuilder().Build();
+		Container = new ElasticsearchBuilder()
+			.Build();
 	}
 
 
@@ -45,6 +47,24 @@ public sealed class ElasticsearchTestFixture : IAsyncLifetime
 		Client = new ElasticsearchClient(settings);
 		if (Client == null)
 			throw new Exception("`new ElasticsearchClient(settings)` returned `null`");
+
+		//Increase Elasticsearch high disk watermarks, Github Actions container typically has around
+		//~7GB free (8%) of the available space.
+		var response = await Client.Transport.RequestAsync<StringResponse>(HttpMethod.PUT, "_cluster/settings", PostData.String(@"{
+			""persistent"": {
+				""cluster.routing.allocation.disk.watermark.low"": ""90%"",
+				""cluster.routing.allocation.disk.watermark.low.max_headroom"": ""100GB"",
+				""cluster.routing.allocation.disk.watermark.high"": ""98%"",
+				""cluster.routing.allocation.disk.watermark.high.max_headroom"": ""2GB"",
+				""cluster.routing.allocation.disk.watermark.flood_stage"": ""99%"",
+				""cluster.routing.allocation.disk.watermark.flood_stage.max_headroom"": ""1GB"",
+				""cluster.routing.allocation.disk.watermark.flood_stage.frozen"": ""99%"",
+				""cluster.routing.allocation.disk.watermark.flood_stage.frozen.max_headroom"": ""1GB""
+			}
+		}"));
+
+		if (!response.ApiCallDetails.HasSuccessfulStatusCode)
+			throw new Exception(response.ToString());
 	}
 
 	async Task IAsyncLifetime.DisposeAsync()

--- a/test/instrumentations/Elastic.Clients.Elasticsearch.Tests/ElasticsearchTestFixture.cs
+++ b/test/instrumentations/Elastic.Clients.Elasticsearch.Tests/ElasticsearchTestFixture.cs
@@ -3,22 +3,41 @@
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
 
+using DotNet.Testcontainers.Builders;
+using DotNet.Testcontainers.Configurations;
 using DotNet.Testcontainers.Containers;
 using Elastic.Transport;
+using Microsoft.Extensions.Logging;
 using Testcontainers.Elasticsearch;
 using Xunit;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+using ILogger = Microsoft.Extensions.Logging.ILogger;
 
 namespace Elastic.Clients.Elasticsearch.Tests;
 
 public sealed class ElasticsearchTestFixture : IAsyncLifetime
 {
-	public ElasticsearchContainer Container { get; } = new ElasticsearchBuilder().Build();
+	private readonly IMessageSink _sink;
+	public ElasticsearchContainer Container { get; }
 
 	public ElasticsearchClient? Client { get; private set; }
+
+	public ElasticsearchTestFixture(IMessageSink sink)
+	{
+		_sink = sink;
+		Container = new ElasticsearchBuilder().Build();
+	}
+
 
 	public async Task InitializeAsync()
 	{
 		await Container.StartAsync();
+
+		var (stdOut, stdErr) = await Container.GetLogsAsync();
+
+		_sink.OnMessage(new DiagnosticMessage(stdOut));
+		_sink.OnMessage(new DiagnosticMessage(stdErr));
 
 		var settings = new ElasticsearchClientSettings(new Uri(Container.GetConnectionString()));
 		settings.ServerCertificateValidationCallback(CertificateValidations.AllowAll);
@@ -35,5 +54,23 @@ public sealed class ElasticsearchTestFixture : IAsyncLifetime
 			await Container.StopAsync();
 			await Container.DisposeAsync();
 		}
+	}
+
+	private class MessageSinkLogger : ILogger
+	{
+		private readonly IMessageSink _messageSink;
+
+		public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+
+		public MessageSinkLogger(IMessageSink sink)
+		{
+			_messageSink = sink;
+			_messageSink.OnMessage(new DiagnosticMessage($"Started {nameof(MessageSinkLogger)}"));
+		}
+
+		public bool IsEnabled(LogLevel logLevel) => true;
+
+		public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter) =>
+			_messageSink.OnMessage(new DiagnosticMessage(formatter(state, exception)));
 	}
 }

--- a/test/instrumentations/Elastic.Clients.Elasticsearch.Tests/ElasticsearchTests.cs
+++ b/test/instrumentations/Elastic.Clients.Elasticsearch.Tests/ElasticsearchTests.cs
@@ -208,14 +208,14 @@ public class ElasticsearchTests : IClassFixture<ElasticsearchTestFixture>
 
 		var response = await _client.IndexAsync(tweet, request => request.Index("my-tweet-index"));
 
-		response.IsSuccess().Should().BeTrue();
+		response.IsSuccess().Should().BeTrue("{0}", response.DebugInformation);
 	}
 
 	private async Task GetDocumentAsync()
 	{
 		var response = await _client.GetAsync<Tweet>(1, idx => idx.Index("my-tweet-index"));
 
-		response.IsSuccess().Should().BeTrue();
+		response.IsSuccess().Should().BeTrue("{0}", response.DebugInformation);
 		var tweet = response.Source;
 		tweet.Should().NotBeNull();
 	}
@@ -241,14 +241,14 @@ public class ElasticsearchTests : IClassFixture<ElasticsearchTestFixture>
 	private async Task UpdateDocumentAsync(Tweet tweet)
 	{
 		tweet.Message = "This is a new message";
-		var response2 = await _client.UpdateAsync<Tweet, object>("my-tweet-index", 1, u => u
+		var response = await _client.UpdateAsync<Tweet, object>("my-tweet-index", 1, u => u
 			.Doc(tweet));
-		response2.IsValidResponse.Should().BeTrue();
+		response.IsValidResponse.Should().BeTrue("{0}", response.DebugInformation);
 	}
 
 	private async Task DeleteDocumentAsync()
 	{
 		var response = await _client.DeleteAsync("my-tweet-index", 1);
-		response.IsValidResponse.Should().BeTrue();
+		response.IsValidResponse.Should().BeTrue("{0}", response.DebugInformation);
 	}
 }

--- a/test/instrumentations/Elastic.Clients.Elasticsearch.Tests/ElasticsearchTests.cs
+++ b/test/instrumentations/Elastic.Clients.Elasticsearch.Tests/ElasticsearchTests.cs
@@ -3,8 +3,11 @@
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
 
+using DotNet.Testcontainers;
+using DotNet.Testcontainers.Configurations;
 using Elastic.Apm;
 using Elastic.Apm.Api;
+using Elastic.Apm.AspNetCore.Tests;
 using Elastic.Apm.DiagnosticSource;
 using Elastic.Apm.Elasticsearch;
 using Elastic.Apm.Tests.Utilities;
@@ -20,6 +23,7 @@ public class ElasticsearchTests : IClassFixture<ElasticsearchTestFixture>
 	private readonly ITestOutputHelper _testOutputHelper;
 	private readonly ElasticsearchTestFixture _esClientListenerFixture;
 	private readonly ElasticsearchClient _client;
+
 
 	public ElasticsearchTests(ITestOutputHelper testOutputHelper, ElasticsearchTestFixture esClientListenerFixture)
 	{

--- a/test/instrumentations/Elastic.Clients.Elasticsearch.Tests/xunit.runner.json
+++ b/test/instrumentations/Elastic.Clients.Elasticsearch.Tests/xunit.runner.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://xunit.net/schema/current/xunit.runner.schema.json",
+  "diagnosticMessages": true
+}


### PR DESCRIPTION
This improves diagnostic output for testcontainers getting started and ensuring the output of docker and its console out gets pushed out over to xUnit. 

Currently only enabled for Elasticsearch.


This allow me to diagnose a failing Elasticsearch integration test that only failed on CI:

As seen here: https://github.com/elastic/apm-agent-dotnet/pull/2197

Due to the high watermark settings were too high (or low?) to run under the restricted Github Action runner's environment. 
