### PR TITLE
action: post-release steps

### DIFF
--- a/.github/workflows/bootstrap/action.yml
+++ b/.github/workflows/bootstrap/action.yml
@@ -48,9 +48,10 @@ runs:
       run: |
         dotnet --list-sdks
         dotnet tool restore
-        echo "Version Number: $(dotnet minver -t=v -p=canary.0 -v=e)"
-        echo "AGENT_VERSION=$(dotnet minver -t=v -p=canary.0 -v=e)" >> $GITHUB_ENV
-        echo "agent-version=$(dotnet minver -t=v -p=canary.0 -v=e)" >> $GITHUB_OUTPUT
+        AGENT_VERSION=$(dotnet minver -t=v -p=canary.0 -v=e)
+        echo "Version Number: ${AGENT_VERSION}"
+        echo "AGENT_VERSION=${AGENT_VERSION}" >> $GITHUB_ENV
+        echo "agent-version=${AGENT_VERSION}" >> $GITHUB_OUTPUT
   
       
     # Setup git config

--- a/.github/workflows/bootstrap/action.yml
+++ b/.github/workflows/bootstrap/action.yml
@@ -15,6 +15,9 @@ outputs:
   agent-version:
     description: "The current agent version number"
     value: ${{ steps.dotnet.outputs.agent-version }}
+  major-version:
+    description: "The current major version number, semver"
+    value: ${{ steps.dotnet.outputs.major-version }}
     
 runs:
   using: "composite"
@@ -52,6 +55,7 @@ runs:
         echo "Version Number: ${AGENT_VERSION}"
         echo "AGENT_VERSION=${AGENT_VERSION}" >> $GITHUB_ENV
         echo "agent-version=${AGENT_VERSION}" >> $GITHUB_OUTPUT
+        echo "major-version=$(echo ${AGENT_VERSION} | cut -d"." -f1)" >> $GITHUB_OUTPUT
   
       
     # Setup git config

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -131,6 +131,7 @@ jobs:
 
       - name: Create GitHub Pull Request if minor release.
         run: |
+          # as long as there is a major.x branch
           existed_in_local=$(git ls-remote --heads origin ${TARGET_BRANCH})
           if [ -z ${existed_in_local} ]; then
             echo "Target branch '${TARGET_BRANCH}' does not exist."
@@ -145,6 +146,13 @@ jobs:
             --base "$TARGET_BRANCH" \
             --repo "${{ github.repository }}"
 
-      - name: Create GitHub Pull Request if major release
+      - name: Create branch if major release
         run: |
-          echo 'TBC'
+          # as long as there is no a major.x branch
+          existed_in_local=$(git ls-remote --heads origin ${TARGET_BRANCH})
+          if [ -n ${existed_in_local} ]; then
+            echo "Target branch '${TARGET_BRANCH}' does exist."
+            exit 0
+          fi
+          git branch -D $TARGET_BRANCH
+          git push origin $TARGET_BRANCH

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,8 @@ permissions:
 
 env:
   NUGET_PACKAGES: ${{ github.workspace }}/.nuget/packages
+  JOB_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+  SLACK_CHANNEL: "#apm-agent-dotnet"
 
 jobs:
   release:
@@ -71,10 +73,10 @@ jobs:
         url: ${{ secrets.VAULT_ADDR }}
         roleId: ${{ secrets.VAULT_ROLE_ID }}
         secretId: ${{ secrets.VAULT_SECRET_ID }}
-        channel: "#apm-agent-dotnet"
+        channel: ${{ env.SLACK_CHANNEL }}
         message: |
           :large_green_circle: [${{ github.repository }}] Release *${{ github.ref_name }}* published.
-          Build: (<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|here>)
+          Build: (<${{ env.JOB_URL }}|here>)
           Release URL: (<https://github.com/elastic/apm-agent-dotnet/releases/tag/${{ github.ref_name }}|${{ github.ref_name }}>)"
 
     - if: ${{ failure() }}
@@ -83,10 +85,10 @@ jobs:
         url: ${{ secrets.VAULT_ADDR }}
         roleId: ${{ secrets.VAULT_ROLE_ID }}
         secretId: ${{ secrets.VAULT_SECRET_ID }}
-        channel: "#apm-agent-dotnet"
+        channel: ${{ env.SLACK_CHANNEL }}
         message: |
           :large_yellow_circle: [${{ github.repository }}] Release *${{ github.ref_name }}* could not be published.
-          Build: (<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|here>)
+          Build: (<${{ env.JOB_URL }}|here>)
           
   release-windows:
     runs-on: windows-2022

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,10 +93,13 @@ jobs:
   release-windows:
     runs-on: windows-2022
     needs: [ 'release']
+    outputs:
+      agent-version: ${{ steps.bootstrap.outputs.agent-version }}
 
     steps:
       - uses: actions/checkout@v3
       - name: Bootstrap Action Workspace
+        id: bootstrap
         uses: ./.github/workflows/bootstrap
         with:
           rust: 'true'
@@ -110,3 +113,32 @@ jobs:
         continue-on-error: true #continue for now until we see it working in action
         run: |
           gh release upload ${{ github.ref_name }} "build/output/elastic_apm_profiler_*.zip"
+
+  post-release:
+    needs: [ 'release-windows']
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GIT_TAG: v${{ needs.release-windows.outputs.agent-version }}
+      NEW_BRANCH: update/${{ needs.release-windows.outputs.agent-version }}
+      TARGET_BRANCH: 1.x
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          depth: 0
+
+      - name: Create GitHub Pull Request with the post-release steps
+        run: |
+          git checkout $GIT_TAG -b ${NEW_BRANCH}
+          git push origin ${NEW_BRANCH}
+          gh pr create \
+            --title "post-release: ${GIT_TAG}" \
+            --body "Generated automatically with ${JOB_URL}" \
+            --head "elastic:${NEW_BRANCH}" \
+            --base "$TARGET_BRANCH" \
+            --repo "${{ github.repository }}"
+
+      - name: Create GitHub Pull Request if major release
+        run: |
+          echo 'TBC'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -131,10 +131,10 @@ jobs:
 
       - name: Create GitHub Pull Request if minor release.
         run: |
-          # as long as there is a major.x branch
+          echo "as long as there is a major.x branch"
           existed_in_local=$(git ls-remote --heads origin ${TARGET_BRANCH})
           if [ -z ${existed_in_local} ]; then
-            echo "Target branch '${TARGET_BRANCH}' does not exist."
+            echo -e "::warning::Target branch '${TARGET_BRANCH}' does not exist."
             exit 0
           fi
           git checkout $GIT_TAG -b ${NEW_BRANCH}
@@ -148,10 +148,10 @@ jobs:
 
       - name: Create branch if major release
         run: |
-          # as long as there is no a major.x branch
+          echo "as long as there is no a major.x branch"
           existed_in_local=$(git ls-remote --heads origin ${TARGET_BRANCH})
           if [ -n ${existed_in_local} ]; then
-            echo "Target branch '${TARGET_BRANCH}' does exist."
+            echo -e "::warning::Target branch '${TARGET_BRANCH}' does exist."
             exit 0
           fi
           git branch -D $TARGET_BRANCH

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -137,7 +137,8 @@ jobs:
             echo -e "::warning::Target branch '${TARGET_BRANCH}' does not exist."
             exit 0
           fi
-          git checkout $GIT_TAG -b ${NEW_BRANCH}
+          git checkout ${TARGET_BRANCH} -b ${NEW_BRANCH}
+          git format-patch -k --stdout ${TARGET_BRANCH}...main -- docs CHANGELOG.asciidoc | git am -3 -k
           git push origin ${NEW_BRANCH}
           gh pr create \
             --title "post-release: ${GIT_TAG}" \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,6 +95,7 @@ jobs:
     needs: [ 'release']
     outputs:
       agent-version: ${{ steps.bootstrap.outputs.agent-version }}
+      major-version: ${{ steps.bootstrap.outputs.major-version }}
 
     steps:
       - uses: actions/checkout@v3
@@ -121,15 +122,20 @@ jobs:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       GIT_TAG: v${{ needs.release-windows.outputs.agent-version }}
       NEW_BRANCH: update/${{ needs.release-windows.outputs.agent-version }}
-      TARGET_BRANCH: 1.x
+      TARGET_BRANCH: ${{ needs.release-windows.outputs.major-version }}.x
 
     steps:
       - uses: actions/checkout@v4
         with:
           depth: 0
 
-      - name: Create GitHub Pull Request with the post-release steps
+      - name: Create GitHub Pull Request if minor release.
         run: |
+          existed_in_local=$(git ls-remote --heads origin ${TARGET_BRANCH})
+          if [ -z ${existed_in_local} ]; then
+            echo "Target branch '${TARGET_BRANCH}' does not exist."
+            exit 0
+          fi
           git checkout $GIT_TAG -b ${NEW_BRANCH}
           git push origin ${NEW_BRANCH}
           gh pr create \

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -66,11 +66,9 @@ git checkout v1.24.0 -b 1.x
 git push --force  upstream 1.x
 ```
 
-#### For a major release
-
-> **NOTE**: The steps below are not yet automated with GitHub actions.
-
 In case of a major release, we need to create the `<major>.x` branch from the currently released tag and push the new `<major>.x` branch.
+
+#### For a major release
 
 Additionally, in case of a major version release, we need to create a PR in [elastic/docs](https://github.com/elastic/docs).
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -36,13 +36,16 @@ Creating a release will trigger the [release Github Action](.github/workflows/re
 
 ### Attaching files on GitHub
 
+> **NOTE**: The steps below are now automated with GitHub actions.
+
 We attach 2 files to the release on GitHub:
 - `ElasticApmAgent_<major>.<minor>.<bug>(-<suffix>)?.zip`: This is the startup-hook based agent.
 - `elastic_apm_profiler_<major>.<minor>.<bug>(-<suffix>)?.zip`: This is the profiler-based agent. The CI currently generates 2 profiler zip files, one for Windows (with `libelastic_apm_profiler.dll`), and one for Linux (with `libelastic_apm_profiler.so`). The only difference in the zip files is the native agent, the remaining files are the same. We copy the 2 native files into a folder with the remaining files and zip that folder as `elastic_apm_profiler_<major>.<minor>.<bug>(-<suffix>)?.zip` which we attach to the release.
 
-The steps above are now automated.
 
 ### Updating the documentation
+
+> **NOTE**: The steps below are now automated with GitHub actions.
 
 Each major version has a `<major>.x` branch in the repository (e.g. for major version `1` we have the branch `1.x`).
 
@@ -62,6 +65,10 @@ git branch -D 1.x
 git checkout v1.24.0 -b 1.x
 git push --force  upstream 1.x
 ```
+
+#### For a major release
+
+> **NOTE**: The steps below are not yet automated with GitHub actions.
 
 In case of a major release, we need to create the `<major>.x` branch from the currently released tag and push the new `<major>.x` branch.
 


### PR DESCRIPTION
### What

Automate the post-release steps so the `<major>.x` gets updated through a Pull Request. Create `<major>.x` if it's not available.

### Why

More automation that follows the github branch protection.

### Further details

I need to figure out how to test this out.
