### PR TITLE
action(post-release): use fetch-depth, quoting and fix git commands

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -133,11 +133,12 @@ jobs:
         run: |
           echo "as long as there is a major.x branch"
           existed_in_local=$(git ls-remote --heads origin ${TARGET_BRANCH})
-          if [ -z ${existed_in_local} ]; then
+          if [ -z "${existed_in_local}" ]; then
             echo -e "::warning::Target branch '${TARGET_BRANCH}' does not exist."
             exit 0
           fi
-          git checkout ${TARGET_BRANCH} -b ${NEW_BRANCH}
+          git branch -D $TARGET_BRANCH
+          git checkout -b ${NEW_BRANCH}
           git format-patch -k --stdout ${TARGET_BRANCH}...main -- docs CHANGELOG.asciidoc | git am -3 -k
           git push origin ${NEW_BRANCH}
           gh pr create \
@@ -151,7 +152,7 @@ jobs:
         run: |
           echo "as long as there is no a major.x branch"
           existed_in_local=$(git ls-remote --heads origin ${TARGET_BRANCH})
-          if [ -n ${existed_in_local} ]; then
+          if [ -n "${existed_in_local}" ]; then
             echo -e "::warning::Target branch '${TARGET_BRANCH}' does exist."
             exit 0
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -137,7 +137,7 @@ jobs:
             echo -e "::warning::Target branch '${TARGET_BRANCH}' does not exist."
             exit 0
           fi
-          git branch -D $TARGET_BRANCH
+          git checkout $TARGET_BRANCH
           git checkout -b ${NEW_BRANCH}
           git format-patch -k --stdout ${TARGET_BRANCH}...main -- docs CHANGELOG.asciidoc | git am -3 -k
           git push origin ${NEW_BRANCH}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -129,6 +129,9 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Setup git config
+        uses: elastic/apm-pipeline-library/.github/actions/setup-git@current
+
       - name: Create GitHub Pull Request if minor release.
         run: |
           echo "as long as there is a major.x branch"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,8 +5,9 @@ on:
     types: [published]
 
 permissions:
-    contents: write
-    issues: write
+  contents: write
+  issues: write
+  pull-requests: write
 
 env:
   NUGET_PACKAGES: ${{ github.workspace }}/.nuget/packages

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -143,7 +143,7 @@ jobs:
           fi
           git checkout $TARGET_BRANCH
           git checkout -b ${NEW_BRANCH}
-          git format-patch -k --stdout ${TARGET_BRANCH}...main -- docs CHANGELOG.asciidoc | git am -3 -k
+          git format-patch -k --stdout ${TARGET_BRANCH}...origin/main -- docs CHANGELOG.asciidoc | git am -3 -k
           git push origin ${NEW_BRANCH}
           gh pr create \
             --title "post-release: ${GIT_TAG}" \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -127,7 +127,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          depth: 0
+          fetch-depth: 0
 
       - name: Create GitHub Pull Request if minor release.
         run: |


### PR DESCRIPTION
`depth` is not a valid argument... :/

> Set fetch-depth: 0 to fetch all history for all branches and tag

In addition I fixed some quoting and git commands

### Test

This [build](https://github.com/v1v/apm-agent-dotnet/actions/runs/6574569969/job/17859906727) is the one testing the post-release steps. 👼 for not testing this earlier :/ 

https://github.com/v1v/apm-agent-dotnet/pull/40 was created automatically (i used some cosmetic changes to validate this)