### PR TITLE
Prevent server certificate callback runtime exception

### DIFF
--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -704,6 +704,12 @@ Verification can be disabled by changing this setting to false.
 | `true`                  | Boolean
 |============
 
+[NOTE]
+====
+This configuration setting has no effect on .NET Framework versions 4.6.2-4.7.1. 
+We recommend upgrading to .NET Framework 4.7.2 or newer to use this configuration setting.
+====
+
 [float]
 [[config-server-cert]]
 ==== `ServerCert` (added[1.9])
@@ -725,6 +731,12 @@ the trust store, such as a self-signed certificate.
 | Default                 | Type
 | `<none>`                  | String
 |============
+
+[NOTE]
+====
+This configuration setting has no effect on .NET Framework versions 4.6.2-4.7.1. 
+We recommend upgrading to .NET Framework 4.7.2 or newer to use this configuration setting.
+====
 
 [float]
 [[config-flush-interval]]

--- a/docs/setup-auto-instrumentation.asciidoc
+++ b/docs/setup-auto-instrumentation.asciidoc
@@ -20,7 +20,7 @@ This approach works with the following
 
 |x64 
 
-|.NET Framework 4.6.2+
+|.NET Framework 4.6.2+*
 
 .NET Core 2.1+
 
@@ -30,6 +30,8 @@ This approach works with the following
 
 .NET 5+
 |===
+
+_* Due to binding issues introduced by Microsoft, we recommend at least .NET Framework 4.7.2 for best compatibility._
 
 NOTE: The Profiler based agent only supports 64-bit applications. 32-bit applications aren't supported.
 

--- a/docs/supported-technologies.asciidoc
+++ b/docs/supported-technologies.asciidoc
@@ -28,7 +28,15 @@ the agent will not capture transactions.
 === .NET versions
 
 The agent works on every .NET flavor and version that supports .NET Standard 2.0.
-This means .NET Core 2.0 or newer, and .NET Framework 4.6.2 or newer.
+This means .NET Core 2.0 or newer, and .NET Framework 4.6.2* or newer.
+
+[IMPORTANT]
+====
+While this library should work on .NET Core 2.0+, we limit our support to only those 
+versions currently supported by Microsoft - .NET 6.0+ currently.
+====
+
+_* Due to binding issues introduced by Microsoft, we recommend at least .NET Framework 4.7.2 for best compatibility._
 
 [float]
 [[supported-web-frameworks]]

--- a/docs/supported-technologies.asciidoc
+++ b/docs/supported-technologies.asciidoc
@@ -30,13 +30,13 @@ the agent will not capture transactions.
 The agent works on every .NET flavor and version that supports .NET Standard 2.0.
 This means .NET Core 2.0 or newer, and .NET Framework 4.6.2* or newer.
 
+_* Due to binding issues introduced by Microsoft, we recommend at least .NET Framework 4.7.2 for best compatibility._
+
 [IMPORTANT]
 ====
-While this library should work on .NET Core 2.0+, we limit our support to only those 
-versions currently supported by Microsoft - .NET 6.0+ currently.
+While this library *should* work on .NET Core 2.0+, we limit our support to only those 
+versions currently supported by Microsoft - .NET 6.0 and newer.
 ====
-
-_* Due to binding issues introduced by Microsoft, we recommend at least .NET Framework 4.7.2 for best compatibility._
 
 [float]
 [[supported-web-frameworks]]

--- a/src/Elastic.Apm/Elastic.Apm.csproj
+++ b/src/Elastic.Apm/Elastic.Apm.csproj
@@ -1,6 +1,6 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net462;net6.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net462;net472;net6.0</TargetFrameworks>
     <IsPackable>true</IsPackable>
   </PropertyGroup>
   <PropertyGroup>
@@ -67,6 +67,11 @@
     <Reference Include="System.Configuration" />
   </ItemGroup>
 
+  <ItemGroup Condition="'$(TargetFramework)'=='net472'">
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Configuration" />
+  </ItemGroup>
+
   <ItemGroup Condition="'$(DiagnosticSourceVersion)' == ''">
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="5.0.0" />
   </ItemGroup>
@@ -83,6 +88,7 @@
   <ItemGroup Condition="'$(TargetFramework)' != 'netstandard2.0'">
     <PackageReference Include="System.Diagnostics.PerformanceCounter" Version="6.0.1" />
   </ItemGroup>
+  
   <ItemGroup>
     <PackageReference Include="System.Threading.Tasks.Dataflow" Version="4.9.0" />
     <!-- Used by Ben.Demystifier -->

--- a/src/Elastic.Apm/Libraries/Newtonsoft.Json/Serialization/DefaultContractResolver.cs
+++ b/src/Elastic.Apm/Libraries/Newtonsoft.Json/Serialization/DefaultContractResolver.cs
@@ -1,4 +1,4 @@
-﻿#region License
+#region License
 
 // Copyright (c) 2007 James Newton-King
 //
@@ -1259,7 +1259,7 @@ namespace Elastic.Apm.Libraries.Newtonsoft.Json.Serialization
 			// warning - this method use to cause errors with Intellitrace. Retest in VS Ultimate after changes
 			IValueProvider valueProvider;
 
-#if !(PORTABLE40 || PORTABLE || DOTNET || NETSTANDARD2_0 || NET5_0_OR_GREATER)
+#if !(PORTABLE40 || PORTABLE || DOTNET || NET472 || NETSTANDARD2_0 || NET5_0_OR_GREATER)
             if (DynamicCodeGeneration)
             {
                 valueProvider = new DynamicValueProvider(member);

--- a/src/Elastic.Apm/Libraries/Newtonsoft.Json/Serialization/JsonTypeReflector.cs
+++ b/src/Elastic.Apm/Libraries/Newtonsoft.Json/Serialization/JsonTypeReflector.cs
@@ -1,4 +1,4 @@
-﻿#region License
+#region License
 
 // Copyright (c) 2007 James Newton-King
 //
@@ -468,7 +468,7 @@ namespace Elastic.Apm.Libraries.Newtonsoft.Json.Serialization
 		{
 			get
 			{
-#if !(PORTABLE40 || PORTABLE || DOTNET || NETSTANDARD2_0 || NET5_0_OR_GREATER)
+#if !(PORTABLE40 || PORTABLE || DOTNET || NET472 || NETSTANDARD2_0 || NET5_0_OR_GREATER)
                 if (DynamicCodeGeneration)
                 {
                     return DynamicReflectionDelegateFactory.Instance;

--- a/test/Elastic.Apm.Tests.Utilities/XUnit/DisabledOnWindowsFact.cs
+++ b/test/Elastic.Apm.Tests.Utilities/XUnit/DisabledOnWindowsFact.cs
@@ -8,6 +8,7 @@ using Xunit;
 
 namespace Elastic.Apm.Tests.Utilities.XUnit;
 
+#pragma warning disable IDE0021 // Use expression body for constructor
 public sealed class DisabledOnWindowsFact : FactAttribute
 {
 	public DisabledOnWindowsFact()
@@ -22,7 +23,18 @@ public sealed class DisabledOnFullFrameworkFact : FactAttribute
 	public DisabledOnFullFrameworkFact()
 	{
 #if NETFRAMEWORK
+
 		Skip = "This test is disabled on .NET Full Framework";
+#endif
+	}
+}
+
+public sealed class DisabledOnNet462FrameworkFact : FactAttribute
+{
+	public DisabledOnNet462FrameworkFact()
+	{
+#if NET462
+		Skip = "This test is disabled on .NET Framework 4.6.2";
 #endif
 	}
 }
@@ -58,3 +70,5 @@ public sealed class DisabledOnFullFrameworkTheory : TheoryAttribute
 #endif
 	}
 }
+
+#pragma warning restore IDE0021 // Use expression body for constructor

--- a/test/Elastic.Apm.Tests/ServerCertificateTests.cs
+++ b/test/Elastic.Apm.Tests/ServerCertificateTests.cs
@@ -16,6 +16,7 @@ using System.Threading.Tasks;
 using Elastic.Apm.Logging;
 using Elastic.Apm.Tests.MockApmServer;
 using Elastic.Apm.Tests.Utilities;
+using Elastic.Apm.Tests.Utilities.XUnit;
 using FluentAssertions;
 using Xunit;
 
@@ -72,7 +73,9 @@ namespace Elastic.Apm.Tests
 			transaction.Context.Labels.MergedDictionary.Should().ContainKey("self_signed_cert");
 		}
 
-		[Fact]
+		// We don't support certificate validation on net462 due to .NET Framework binding issues with
+		// the APIs used.
+		[DisabledOnNet462FrameworkFact]
 		public void VerifyServerCert_Should_Allow_Https_To_Apm_Server()
 		{
 			var configuration = new MockConfiguration(


### PR DESCRIPTION
On .NET Full framework <4.7.2, HttpClientHandler.ServerCertificateCustomValidationCallback is not available. Due to dependency binding issues introduced with .NET standard, the incorrect System.Net.Http package may be resolved and lead to exceptions at runtime.

This fix prevents calling this API on net462 targets which includes any .NET Framework version < .NET 4.7.2.

This introduces the net472 target so that we can resume using this API from that version, where it was included in the box.

Fixes #2212 