### PR TITLE
Prevent Span.CheckAndCaptureBaggage from failing - proposals

### DIFF
--- a/src/Elastic.Apm/Model/Span.cs
+++ b/src/Elastic.Apm/Model/Span.cs
@@ -139,7 +139,24 @@ namespace Elastic.Apm.Model
 					continue;
 
 				Otel ??= new OTel() { Attributes = new Dictionary<string, object>() };
-				Otel.Attributes.Add(baggage.Key, baggage.Value);
+
+				// original code
+				//Otel.Attributes.Add(baggage.Key, baggage.Value);
+
+				// add if not already added, fail if values differ
+				//if (!Otel.Attributes.ContainsKey(baggage.Key))
+				//	Otel.Attributes.Add(baggage.Key, baggage.Value);
+				//else if (Otel.Attributes[baggage.Key].ToString() != baggage.Value)
+				//	throw new Exception($"Baggage key {baggage.Key} already exists with a different value. Current value: '{Otel.Attributes[baggage.Key]}'; New Value: '{baggage.Value}'");
+
+				// overwrite if already added
+				//Otel.Attributes[baggage.Key] = baggage.Value;
+
+				// if exists append to existing value
+				if (Otel.Attributes.ContainsKey(baggage.Key))
+					Otel.Attributes[baggage.Key] = Otel.Attributes[baggage.Key] + "," + baggage.Value;
+				else
+					Otel.Attributes.Add(baggage.Key, baggage.Value);
 			}
 		}
 


### PR DESCRIPTION
[The original code](https://github.com/elastic/apm-agent-dotnet/blob/63b25037988aa072d064c216b08ae9d714cfaa2c/src/Elastic.Apm/Model/Span.cs#L142) is failing if a baggage already contains this key. This issue occurs for me when masstransit is retrying fail consume attempts of rabbitMq messages
```
Otel ??= new OTel() { Attributes = new Dictionary<string, object>() };
Otel.Attributes.Add(baggage.Key, baggage.Value);
```

# Example + Stacktrace
An example to reproduce this issue can be found here: 
https://github.com/fritz-net/ElasticFailingMasstransit

```
 T-FAULT rabbitmq://localhost/Dummy a4660000-5d0a-0015-47d4-08dbdd409ed2
      System.ArgumentException: An item with the same key has already been added. Key: messaging.message.conversation_id
         at System.Collections.Generic.Dictionary`2.TryInsert(TKey key, TValue value, InsertionBehavior behavior)
         at System.Collections.Generic.Dictionary`2.Add(TKey key, TValue value)
         at Elastic.Apm.Model.Span.CheckAndCaptureBaggage()
         at Elastic.Apm.Model.Span..ctor(String name, String type, String parentId, String traceId, Transaction enclosingTransaction, IPayloadSender payloadSender, IApmLogger logger, ICurrentExecutionSegmentsContainer currentExecutionSegmentsContainer, IApmServerInfo apmServerInfo, Span parentSpan, InstrumentationFlag instrumentationFlag, Boolean captureStackTraceOnStart, Nullable`1 timestamp, Boolean isExitSpan, String id, IEnumerable`1 links, Activity current)
         at Elastic.Apm.Model.Transaction.StartSpanInternal(String name, String type, String subType, String action, InstrumentationFlag instrumentationFlag, Boolean captureStackTraceOnStart, Nullable`1 timestamp, String id, Boolean isExitSpan, IEnumerable`1 links, Activity current)
         at Elastic.Apm.OpenTelemetry.ElasticActivityListener.CreateSpanForActivity(Activity activity, Int64 timestamp, List`1 spanLinks)
         at Elastic.Apm.OpenTelemetry.ElasticActivityListener.<get_ActivityStarted>b__17_0(Activity activity)
         at System.Diagnostics.SynchronizedList`1.EnumWithAction(Action`2 action, Object arg)
         at System.Diagnostics.Activity.Start()
         ...
```

# Proposal
my proposed solutions would be:
```
// A: add if not already added, fail if values differ
if (!Otel.Attributes.ContainsKey(baggage.Key))
	Otel.Attributes.Add(baggage.Key, baggage.Value);
else if (Otel.Attributes[baggage.Key].ToString() != baggage.Value)
	throw new Exception($"Baggage key {baggage.Key} already exists with a different value. Current value: '{Otel.Attributes[baggage.Key]}'; New Value: '{baggage.Value}'");

// B: overwrite if already added
Otel.Attributes[baggage.Key] = baggage.Value;

// C: if exists append to existing value
if (Otel.Attributes.ContainsKey(baggage.Key))
	Otel.Attributes[baggage.Key] = Otel.Attributes[baggage.Key] + "," + baggage.Value;
else
	Otel.Attributes.Add(baggage.Key, baggage.Value);
```

I would opt for C, since it does not loose any information while not failing like A
B has the benefit that it is not changing the format but it looses the old value.