### PR TITLE
Move logging caching over to ConditionalWeaktable as fix for #2234

### DIFF
--- a/src/Elastic.Apm/Logging/IApmLoggingExtensions.cs
+++ b/src/Elastic.Apm/Logging/IApmLoggingExtensions.cs
@@ -78,7 +78,7 @@ internal static class LoggingExtensions
 #else
 		lock (_lock)
 		{
-			if (!Formatters.TryGetValue(message, out var f))
+			if (Formatters.TryGetValue(message, out var f))
 				return f;
 			Formatters.Add(message, formatter);
 			return formatter;

--- a/src/Elastic.Apm/Logging/IApmLoggingExtensions.cs
+++ b/src/Elastic.Apm/Logging/IApmLoggingExtensions.cs
@@ -68,7 +68,8 @@ internal static class LoggingExtensions
 
 	private static LogValuesFormatter GetOrAddFormatter(string message, IReadOnlyCollection<object> args)
 	{
-		if (Formatters.TryGetValue(message, out var formatter)) return formatter;
+		if (Formatters.TryGetValue(message, out var formatter))
+			return formatter;
 
 		formatter = new LogValuesFormatter(message, args);
 #if NET6_0_OR_GREATER
@@ -77,7 +78,8 @@ internal static class LoggingExtensions
 #else
 		lock (_lock)
 		{
-			if (!Formatters.TryGetValue(message, out var f)) return f;
+			if (!Formatters.TryGetValue(message, out var f))
+				return f;
 			Formatters.Add(message, formatter);
 			return formatter;
 		}

--- a/src/Elastic.Apm/Logging/IApmLoggingExtensions.cs
+++ b/src/Elastic.Apm/Logging/IApmLoggingExtensions.cs
@@ -3,157 +3,177 @@
 // See the LICENSE file in the project root for more information
 
 using System;
-using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using Elastic.Apm.Helpers;
 
-namespace Elastic.Apm.Logging
+namespace Elastic.Apm.Logging;
+
+internal static class LoggingExtensions
 {
-	internal static class LoggingExtensions
+	private static ConditionalWeakTable<string, LogValuesFormatter> Formatters { get; } = new();
+
+	internal static ScopedLogger Scoped(this IApmLogger logger, string scope) => new(logger is ScopedLogger s ? s.Logger : logger, scope);
+
+	private static void DoLog(this IApmLogger logger, LogLevel level, string message, Exception e, params object[] args)
 	{
-		private static ConcurrentDictionary<string, LogValuesFormatter> Formatters { get; } = new ConcurrentDictionary<string, LogValuesFormatter>();
-
-		internal static ScopedLogger Scoped(this IApmLogger logger, string scope) =>
-			new ScopedLogger(logger is ScopedLogger s ? s.Logger : logger, scope);
-
-		private static void DoLog(this IApmLogger logger, LogLevel level, string message, Exception e, params object[] args)
+		try
 		{
+			var formatter = logger is ScopedLogger sl
+				? sl.GetOrAddFormatter(message, args)
+				: GetOrAddFormatter(message, args);
+
+			var logValues = formatter.GetState(args);
+
+			logger?.Log(level, logValues, e, static (l, _) => l.Formatter.Format(l.Args));
+		}
+		catch (Exception exception)
+		{
+			// For now we will just print it to System.Diagnostics.Trace
+			// In the future we should consider error counters to increment and log periodically on a worker thread
 			try
 			{
-				var formatter = logger is ScopedLogger sl
-					? sl.GetOrAddFormatter(message, args)
-					: Formatters.GetOrAdd(message, s => new LogValuesFormatter(s, args));
+				var newLine = Environment.NewLine + "Elastic APM .NET Agent: ";
+				var currentStackTraceFrames = new StackTrace(true).GetFrames();
+				var currentStackTrace = currentStackTraceFrames == null
+					? " N/A"
+					: newLine + string.Join("", currentStackTraceFrames.Select(f => "    " + f));
 
-				var logValues = formatter.GetState(args);
-
-				logger?.Log(level, logValues, e, (_, _) => formatter.Format(args));
+				System.Diagnostics.Trace.WriteLine("Elastic APM .NET Agent: [CRITICAL] Exception thrown by logging implementation."
+					+ $" Log message: `{message.AsNullableToString()}'."
+					+ $" args.Length: {args.Length}."
+					+ $" Current thread: {DbgUtils.CurrentThreadDesc}"
+					+ newLine
+					+ $"+-> Exception (exception): {exception.GetType().FullName}: {exception.Message}{newLine}{exception.StackTrace}"
+					+ (e != null
+						? newLine + $"+-> Exception (e): {e.GetType().FullName}: {e.Message}{newLine}{e.StackTrace}"
+						: $"e: {ObjectExtensions.NullAsString}")
+					+ newLine
+					+ "+-> Current stack trace:" + currentStackTrace
+				);
 			}
-			catch (Exception exception)
+			catch (Exception)
 			{
-				// For now we will just print it to System.Diagnostics.Trace
-				// In the future we should consider error counters to increment and log periodically on a worker thread
-				try
-				{
-					var newLine = Environment.NewLine + "Elastic APM .NET Agent: ";
-					var currentStackTraceFrames = new StackTrace(true).GetFrames();
-					var currentStackTrace = currentStackTraceFrames == null
-						? " N/A"
-						: newLine + string.Join("", currentStackTraceFrames.Select(f => "    " + f));
-
-					System.Diagnostics.Trace.WriteLine("Elastic APM .NET Agent: [CRITICAL] Exception thrown by logging implementation."
-						+ $" Log message: `{message.AsNullableToString()}'."
-						+ $" args.Length: {args.Length}."
-						+ $" Current thread: {DbgUtils.CurrentThreadDesc}"
-						+ newLine
-						+ $"+-> Exception (exception): {exception.GetType().FullName}: {exception.Message}{newLine}{exception.StackTrace}"
-						+ (e != null
-							? newLine + $"+-> Exception (e): {e.GetType().FullName}: {e.Message}{newLine}{e.StackTrace}"
-							: $"e: {ObjectExtensions.NullAsString}")
-						+ newLine
-						+ "+-> Current stack trace:" + currentStackTrace
-					);
-				}
-				catch (Exception)
-				{
-					// ignored
-				}
+				// ignored
 			}
 		}
+	}
 
-		/// <summary>
-		/// Depending on the two parameters it either returns a MaybeLogger instance or null.
-		/// </summary>
-		/// <param name="logger">The logger you want to log with</param>
-		/// <param name="level">The level to compare with</param>
-		/// <returns>If the return value is not null you can call <see cref="MaybeLogger.Log" /> to log</returns>
-		internal static MaybeLogger? IfLevel(this IApmLogger logger, LogLevel level) =>
-			logger.IsEnabled(level) ? new MaybeLogger(logger, level) : (MaybeLogger?)null;
+#if !NET6_0_OR_GREATER
+	private static readonly object _lock = new();
+#endif
 
-		/// <summary>
-		/// If the logger has a loglevel, which is higher than or equal to Trace then it returns a MaybeLogger instance,
-		/// otherwise it returns null.
-		/// By using the return value with `?.` you can avoid executing code that is not necessary to execute
-		/// in case the log won't be printed because the loglevel would not allow it.
-		/// </summary>
-		/// <param name="logger">The logger instance you want to log with</param>
-		/// <returns>Either a MaybeLogger or null</returns>
-		internal static MaybeLogger? Trace(this IApmLogger logger) => IfLevel(logger, LogLevel.Trace);
+	private static LogValuesFormatter GetOrAddFormatter(string message, IReadOnlyCollection<object> args)
+	{
+		if (Formatters.TryGetValue(message, out var formatter)) return formatter;
 
-		/// <summary>
-		/// If the logger has a loglevel, which is higher than or equal to Debug then it returns a MaybeLogger instance,
-		/// otherwise it returns null.
-		/// By using the return value with `?.` you can avoid executing code that is not necessary to execute
-		/// in case the log won't be printed because the loglevel would not allow it.
-		/// </summary>
-		/// <param name="logger">The logger instance you want to log with</param>
-		/// <returns>Either a MaybeLogger or null</returns>
-		internal static MaybeLogger? Debug(this IApmLogger logger) => IfLevel(logger, LogLevel.Debug);
-
-		/// <summary>
-		/// If the logger has a loglevel, which is higher than Info then it returns a MaybeLogger instance,
-		/// otherwise it returns null.
-		/// By using the return value with `?.` you can avoid executing code that is not necessary to execute
-		/// in case the log won't be printed because the loglevel would not allow it.
-		/// </summary>
-		/// <param name="logger">The logger instance you want to log with</param>
-		/// <returns>Either a MaybeLogger or null</returns>
-		internal static MaybeLogger? Info(this IApmLogger logger) => IfLevel(logger, LogLevel.Information);
-
-		/// <summary>
-		/// If the logger has a loglevel, which is higher than or equal to Warning then it returns a MaybeLogger instance,
-		/// otherwise it returns null.
-		/// By using the return value with `?.` you can avoid executing code that is not necessary to execute
-		/// in case the log won't be printed because the loglevel would not allow it.
-		/// </summary>
-		/// <param name="logger">The logger instance you want to log with</param>
-		/// <returns>Either a MaybeLogger or null</returns>
-		internal static MaybeLogger? Warning(this IApmLogger logger) => IfLevel(logger, LogLevel.Warning);
-
-		/// <summary>
-		/// If the logger has a loglevel, which is higher than or equal to Error then it returns a MaybeLogger instance,
-		/// otherwise it returns null.
-		/// By using the return value with `?.` you can avoid executing code that is not necessary to execute
-		/// in case the log won't be printed because the loglevel would not allow it.
-		/// </summary>
-		/// <param name="logger">The logger instance you want to log with</param>
-		/// <returns>Either a MaybeLogger or null</returns>
-		internal static MaybeLogger? Error(this IApmLogger logger) => IfLevel(logger, LogLevel.Error);
-
-		/// <summary>
-		/// If the logger has a loglevel, which is higher than or equal to Critical then it returns a MaybeLogger instance,
-		/// otherwise it returns null.
-		/// By using the return value with `?.` you can avoid executing code that is not necessary to execute
-		/// in case the log won't be printed because the loglevel would not allow it.
-		/// </summary>
-		/// <param name="logger">The logger instance you want to log with</param>
-		/// <returns>Either a MaybeLogger or null</returns>
-		internal static MaybeLogger? Critical(this IApmLogger logger) => IfLevel(logger, LogLevel.Critical);
-
-		internal readonly struct MaybeLogger
+		formatter = new LogValuesFormatter(message, args);
+#if NET6_0_OR_GREATER
+		Formatters.AddOrUpdate(message, formatter);
+		return formatter;
+#else
+		lock (_lock)
 		{
-			private readonly IApmLogger _logger;
-			private readonly LogLevel _level;
+			if (!Formatters.TryGetValue(message, out var f)) return f;
+			Formatters.Add(message, formatter);
+			return formatter;
+		}
+#endif
+	}
 
-			public MaybeLogger(IApmLogger logger, LogLevel level) => (_logger, _level) = (logger, level);
+	/// <summary>
+	/// Depending on the two parameters it either returns a MaybeLogger instance or null.
+	/// </summary>
+	/// <param name="logger">The logger you want to log with</param>
+	/// <param name="level">The level to compare with</param>
+	/// <returns>If the return value is not null you can call <see cref="MaybeLogger.Log" /> to log</returns>
+	internal static MaybeLogger? IfLevel(this IApmLogger logger, LogLevel level) =>
+		logger.IsEnabled(level) ? new MaybeLogger(logger, level) : (MaybeLogger?)null;
 
-			public void Log(string message, params object[] args) => _logger.DoLog(_level, message, null, args);
+	/// <summary>
+	/// If the logger has a loglevel, which is higher than or equal to Trace then it returns a MaybeLogger instance,
+	/// otherwise it returns null.
+	/// By using the return value with `?.` you can avoid executing code that is not necessary to execute
+	/// in case the log won't be printed because the loglevel would not allow it.
+	/// </summary>
+	/// <param name="logger">The logger instance you want to log with</param>
+	/// <returns>Either a MaybeLogger or null</returns>
+	internal static MaybeLogger? Trace(this IApmLogger logger) => IfLevel(logger, LogLevel.Trace);
 
-			public void LogException(Exception exception, string message, params object[] args) =>
-				_logger.DoLog(_level, message, exception, args);
+	/// <summary>
+	/// If the logger has a loglevel, which is higher than or equal to Debug then it returns a MaybeLogger instance,
+	/// otherwise it returns null.
+	/// By using the return value with `?.` you can avoid executing code that is not necessary to execute
+	/// in case the log won't be printed because the loglevel would not allow it.
+	/// </summary>
+	/// <param name="logger">The logger instance you want to log with</param>
+	/// <returns>Either a MaybeLogger or null</returns>
+	internal static MaybeLogger? Debug(this IApmLogger logger) => IfLevel(logger, LogLevel.Debug);
 
-			public void LogExceptionWithCaller(Exception exception,
-				[CallerMemberName] string method = "",
-				[CallerFilePath] string filePath = "",
-				[CallerLineNumber] int lineNumber = 0
-			)
-			{
-				var file = string.IsNullOrEmpty(filePath) ? string.Empty : new FileInfo(filePath).Name;
-				_logger?.DoLog(_level, "{ExceptionName} in {Method} ({File}:{LineNumber}): {ExceptionMessage}", exception,
-					exception?.GetType().Name, method, file, lineNumber, exception?.Message);
-			}
+	/// <summary>
+	/// If the logger has a loglevel, which is higher than Info then it returns a MaybeLogger instance,
+	/// otherwise it returns null.
+	/// By using the return value with `?.` you can avoid executing code that is not necessary to execute
+	/// in case the log won't be printed because the loglevel would not allow it.
+	/// </summary>
+	/// <param name="logger">The logger instance you want to log with</param>
+	/// <returns>Either a MaybeLogger or null</returns>
+	internal static MaybeLogger? Info(this IApmLogger logger) => IfLevel(logger, LogLevel.Information);
+
+	/// <summary>
+	/// If the logger has a loglevel, which is higher than or equal to Warning then it returns a MaybeLogger instance,
+	/// otherwise it returns null.
+	/// By using the return value with `?.` you can avoid executing code that is not necessary to execute
+	/// in case the log won't be printed because the loglevel would not allow it.
+	/// </summary>
+	/// <param name="logger">The logger instance you want to log with</param>
+	/// <returns>Either a MaybeLogger or null</returns>
+	internal static MaybeLogger? Warning(this IApmLogger logger) => IfLevel(logger, LogLevel.Warning);
+
+	/// <summary>
+	/// If the logger has a loglevel, which is higher than or equal to Error then it returns a MaybeLogger instance,
+	/// otherwise it returns null.
+	/// By using the return value with `?.` you can avoid executing code that is not necessary to execute
+	/// in case the log won't be printed because the loglevel would not allow it.
+	/// </summary>
+	/// <param name="logger">The logger instance you want to log with</param>
+	/// <returns>Either a MaybeLogger or null</returns>
+	internal static MaybeLogger? Error(this IApmLogger logger) => IfLevel(logger, LogLevel.Error);
+
+	/// <summary>
+	/// If the logger has a loglevel, which is higher than or equal to Critical then it returns a MaybeLogger instance,
+	/// otherwise it returns null.
+	/// By using the return value with `?.` you can avoid executing code that is not necessary to execute
+	/// in case the log won't be printed because the loglevel would not allow it.
+	/// </summary>
+	/// <param name="logger">The logger instance you want to log with</param>
+	/// <returns>Either a MaybeLogger or null</returns>
+	internal static MaybeLogger? Critical(this IApmLogger logger) => IfLevel(logger, LogLevel.Critical);
+
+	internal readonly struct MaybeLogger
+	{
+		private readonly IApmLogger _logger;
+		private readonly LogLevel _level;
+
+		public MaybeLogger(IApmLogger logger, LogLevel level) => (_logger, _level) = (logger, level);
+
+		public void Log(string message, params object[] args) => _logger.DoLog(_level, message, null, args);
+
+		public void LogException(Exception exception, string message, params object[] args) =>
+			_logger.DoLog(_level, message, exception, args);
+
+		public void LogExceptionWithCaller(Exception exception,
+			[CallerMemberName] string method = "",
+			[CallerFilePath] string filePath = "",
+			[CallerLineNumber] int lineNumber = 0
+		)
+		{
+			var file = string.IsNullOrEmpty(filePath) ? string.Empty : new FileInfo(filePath).Name;
+			_logger?.DoLog(_level, "{ExceptionName} in {Method} ({File}:{LineNumber}): {ExceptionMessage}", exception,
+				exception?.GetType().Name, method, file, lineNumber, exception?.Message);
 		}
 	}
 }

--- a/src/Elastic.Apm/Logging/LogValuesFormatter.cs
+++ b/src/Elastic.Apm/Logging/LogValuesFormatter.cs
@@ -195,12 +195,20 @@ namespace Elastic.Apm.Logging
 					args[offset + i] = new KeyValuePair<string, object>(ValueNames[j], values[i]);
 			}
 
-			return new LogValues(args);
+			return new LogValues(this, values, args);
 		}
 
 		public class LogValues : ReadOnlyCollection<KeyValuePair<string, object>>
 		{
-			public LogValues(IList<KeyValuePair<string, object>> list) : base(list) { }
+			internal LogValuesFormatter Formatter { get; }
+			internal object[] Args { get; }
+
+			public LogValues(LogValuesFormatter formatter, object[] args, IList<KeyValuePair<string, object>> list)
+				: base(list)
+			{
+				Formatter = formatter;
+				Args = args;
+			}
 		}
 	}
 }

--- a/src/Elastic.Apm/Logging/ScopedLogger.cs
+++ b/src/Elastic.Apm/Logging/ScopedLogger.cs
@@ -36,7 +36,7 @@ internal class ScopedLogger : IApmLogger
 #else
 		lock (_lock)
 		{
-			if (!Formatters.TryGetValue(message, out var f))
+			if (Formatters.TryGetValue(message, out var f))
 				return f;
 			Formatters.Add(message, formatter);
 			return formatter;

--- a/src/Elastic.Apm/Logging/ScopedLogger.cs
+++ b/src/Elastic.Apm/Logging/ScopedLogger.cs
@@ -3,27 +3,45 @@
 // See the LICENSE file in the project root for more information
 
 using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 
-namespace Elastic.Apm.Logging
+namespace Elastic.Apm.Logging;
+
+internal class ScopedLogger : IApmLogger
 {
-	internal class ScopedLogger : IApmLogger
+	public ScopedLogger(IApmLogger logger, string scope) => (Logger, Scope) = (logger, scope);
+
+	internal ConditionalWeakTable<string, LogValuesFormatter> Formatters { get; } = new();
+
+	public IApmLogger Logger { get; }
+
+#if !NET6_0_OR_GREATER
+	private readonly object _lock = new();
+#endif
+
+	public string Scope { get; }
+
+	public bool IsEnabled(LogLevel level) => Logger.IsEnabled(level);
+
+	internal LogValuesFormatter GetOrAddFormatter(string message, IReadOnlyCollection<object> args)
 	{
-		public ScopedLogger(IApmLogger logger, string scope) => (Logger, Scope) = (logger, scope);
+		if (Formatters.TryGetValue(message, out var formatter)) return formatter;
 
-		private ConcurrentDictionary<string, LogValuesFormatter> Formatters { get; } = new ConcurrentDictionary<string, LogValuesFormatter>();
-
-		public IApmLogger Logger { get; }
-
-		public string Scope { get; }
-
-		public bool IsEnabled(LogLevel level) => Logger.IsEnabled(level);
-
-		internal LogValuesFormatter GetOrAddFormatter(string message, IReadOnlyCollection<object> args)
-			=> Formatters.GetOrAdd(message, s => new LogValuesFormatter($"{{{{{{Scope}}}}}} {s}", args, Scope));
-
-		void IApmLogger.Log<TState>(LogLevel level, TState state, Exception e, Func<TState, Exception, string> formatter) =>
-			Logger.Log(level, state, e, formatter);
+		formatter = new LogValuesFormatter($"{{{{{{Scope}}}}}} {message}", args, Scope);
+#if NET6_0_OR_GREATER
+		Formatters.AddOrUpdate(message, formatter);
+		return formatter;
+#else
+		lock (_lock)
+		{
+			if (!Formatters.TryGetValue(message, out var f)) return f;
+			Formatters.Add(message, formatter);
+			return formatter;
+		}
+#endif
 	}
+
+	void IApmLogger.Log<TState>(LogLevel level, TState state, Exception e, Func<TState, Exception, string> formatter) =>
+		Logger.Log(level, state, e, formatter);
 }

--- a/src/Elastic.Apm/Logging/ScopedLogger.cs
+++ b/src/Elastic.Apm/Logging/ScopedLogger.cs
@@ -26,7 +26,8 @@ internal class ScopedLogger : IApmLogger
 
 	internal LogValuesFormatter GetOrAddFormatter(string message, IReadOnlyCollection<object> args)
 	{
-		if (Formatters.TryGetValue(message, out var formatter)) return formatter;
+		if (Formatters.TryGetValue(message, out var formatter))
+			return formatter;
 
 		formatter = new LogValuesFormatter($"{{{{{{Scope}}}}}} {message}", args, Scope);
 #if NET6_0_OR_GREATER
@@ -35,7 +36,8 @@ internal class ScopedLogger : IApmLogger
 #else
 		lock (_lock)
 		{
-			if (!Formatters.TryGetValue(message, out var f)) return f;
+			if (!Formatters.TryGetValue(message, out var f))
+				return f;
 			Formatters.Add(message, formatter);
 			return formatter;
 		}

--- a/test/Elastic.Apm.Tests/LoggerTests.cs
+++ b/test/Elastic.Apm.Tests/LoggerTests.cs
@@ -150,6 +150,28 @@ namespace Elastic.Apm.Tests
 		/// This test uses scoped logger.
 		/// </summary>
 		[Fact]
+		public void EnsureFormattersAreShared()
+		{
+			var consoleLogger = new ConsoleLogger(LogLevel.Trace, TextWriter.Null, TextWriter.Null);
+			var scopedLogger = consoleLogger.Scoped("MyTestScope");
+			for (var i = 0; i < 10; i++)
+				scopedLogger.Warning()?.Log("This is a test log from the test StructuredLogTemplateWith1MissingArgument, args: {arg1}", i);
+#if NET6_0_OR_GREATER
+			var cachedFormatterCount = scopedLogger.Formatters.Count();
+			cachedFormatterCount.Should().Be(1);
+
+			scopedLogger.Warning()?.Log("This is a test log from the test StructuredLogTemplateWith1MissingArgument, args: {arg2}", 2);
+			cachedFormatterCount = scopedLogger.Formatters.Count();
+			cachedFormatterCount.Should().Be(2);
+#endif
+
+		}
+
+		/// <summary>
+		/// Makes sure the logger does not throw in case of templates for structured logs with non-existing corresponding values.
+		/// This test uses scoped logger.
+		/// </summary>
+		[Fact]
 		public void StructuredLogTemplateWith1MissingArgument_ScopedLogger()
 		{
 			var consoleLogger = new ConsoleLogger(LogLevel.Trace, TextWriter.Null, TextWriter.Null);

--- a/test/integrations/Elastic.Apm.AspNetCore.Tests/BaggageAspNetCoreTests.cs
+++ b/test/integrations/Elastic.Apm.AspNetCore.Tests/BaggageAspNetCoreTests.cs
@@ -36,6 +36,7 @@ public class BaggageAspNetCoreTests : MultiApplicationTestBase
 
 		(await res.Content.ReadAsStringAsync()).Should().Be("[key1, value1][key2, value2][key3, value3]");
 
+		_payloadSender1.WaitForTransactions();
 		_payloadSender1.FirstTransaction.IsSampled.Should().BeTrue();
 
 		_payloadSender1.FirstTransaction.Context.Request.Headers.Should().ContainKey("baggage");
@@ -67,6 +68,7 @@ public class BaggageAspNetCoreTests : MultiApplicationTestBase
 		var res = await client.GetAsync("http://localhost:5901/Home/WriteBaggage");
 		res.IsSuccessStatusCode.Should().BeTrue();
 
+		_payloadSender1.WaitForTransactions();
 		_payloadSender1.Transactions.Should().HaveCount(1);
 
 		// Service 1 has no incoming baggage header and no captured baggage on the transaction


### PR DESCRIPTION
This also ensures we no longer use captured state in the lambda provided to `Log()` by ensuring the callback is static.
