### PR TITLE
Add additional logging to outgoing http call propagation

### DIFF
--- a/ElasticApmAgent.sln.DotSettings
+++ b/ElasticApmAgent.sln.DotSettings
@@ -565,6 +565,7 @@ See the LICENSE file in the project root for more information</s:String>
 	<s:Boolean x:Key="/Default/CodeStyle/LiveTemplatesUseVar/UseVar/@EntryValue">False</s:Boolean>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=KM/@EntryIndexedValue">KM</s:String>
 	<s:Boolean x:Key="/Default/CodeStyle/Naming/CSharpNaming/ApplyAutoDetectedRules/@EntryValue">False</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EFeature_002EServices_002ECodeCleanup_002EFileHeader_002EFileHeaderSettingsMigrate/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpFileLayoutPatternsUpgrade/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpKeepExistingMigration/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpPlaceEmbeddedOnSameLineMigration/@EntryIndexedValue">True</s:Boolean>

--- a/src/Elastic.Apm/DiagnosticListeners/HttpDiagnosticListenerImplBase.cs
+++ b/src/Elastic.Apm/DiagnosticListeners/HttpDiagnosticListenerImplBase.cs
@@ -250,7 +250,7 @@ namespace Elastic.Apm.DiagnosticListeners
 			if (!RequestHeadersContain(request, TraceContext.TraceStateHeaderName)
 				&& span.OutgoingDistributedTracingData is { HasTraceState: true })
 			{
-				var traceState = TraceContext.BuildTraceparent(span.OutgoingDistributedTracingData);
+				var traceState = span.OutgoingDistributedTracingData.TraceState.ToTextHeader();
 				RequestHeadersAdd(request, TraceContext.TraceStateHeaderName, traceState);
 			}
 

--- a/src/Elastic.Apm/Report/PayloadSenderV2.cs
+++ b/src/Elastic.Apm/Report/PayloadSenderV2.cs
@@ -474,7 +474,6 @@ namespace Elastic.Apm.Report
 			{
 				try
 				{
-					_logger?.Trace()?.Log("Start executing filter on transaction");
 					var itemAfterFilter = filter(item);
 					if (itemAfterFilter != null)
 					{


### PR DESCRIPTION
In particular adds logging when
- outgoing http call is already otherwise instrumented
- Outgoing call is part of an exit span and we don't create a child span for it
