### PR TITLE
Address a few synchronization issues in the codebase

### DIFF
--- a/src/Elastic.Apm/ApmAgentExtensions.cs
+++ b/src/Elastic.Apm/ApmAgentExtensions.cs
@@ -109,8 +109,14 @@ namespace Elastic.Apm
 			if (_isDisposed)
 				throw new ObjectDisposedException(nameof(CompositeDisposable));
 
-			_disposables.Add(disposable);
-			return this;
+			lock (_lock)
+			{
+				 if (_isDisposed)
+					 throw new ObjectDisposedException(nameof(CompositeDisposable));
+
+				 _disposables.Add(disposable);
+				 return this;
+			}
 		}
 
 		public void Dispose()

--- a/src/Elastic.Apm/ApmAgentExtensions.cs
+++ b/src/Elastic.Apm/ApmAgentExtensions.cs
@@ -111,11 +111,11 @@ namespace Elastic.Apm
 
 			lock (_lock)
 			{
-				 if (_isDisposed)
-					 throw new ObjectDisposedException(nameof(CompositeDisposable));
+				if (_isDisposed)
+					throw new ObjectDisposedException(nameof(CompositeDisposable));
 
-				 _disposables.Add(disposable);
-				 return this;
+				_disposables.Add(disposable);
+				return this;
 			}
 		}
 

--- a/src/Elastic.Apm/Libraries/Newtonsoft.Json/Converters/BinaryConverter.cs
+++ b/src/Elastic.Apm/Libraries/Newtonsoft.Json/Converters/BinaryConverter.cs
@@ -45,7 +45,7 @@ namespace Elastic.Apm.Libraries.Newtonsoft.Json.Converters
 #if HAVE_LINQ
         private const string BinaryTypeName = "System.Data.Linq.Binary";
         private const string BinaryToArrayName = "ToArray";
-        private static ReflectionObject? _reflectionObject;
+        private ReflectionObject? _reflectionObject;
 #endif
 
         /// <summary>
@@ -89,7 +89,7 @@ namespace Elastic.Apm.Libraries.Newtonsoft.Json.Converters
         }
 
 #if HAVE_LINQ
-        private static void EnsureReflectionObject(Type t)
+        private void EnsureReflectionObject(Type t)
         {
             if (_reflectionObject == null)
             {

--- a/src/profiler/Elastic.Apm.Profiler.Managed/DuckTyping/ILHelpersExtensions.cs
+++ b/src/profiler/Elastic.Apm.Profiler.Managed/DuckTyping/ILHelpersExtensions.cs
@@ -21,7 +21,7 @@ namespace Elastic.Apm.Profiler.Managed.DuckTyping
 	/// </summary>
 	internal static class ILHelpersExtensions
 	{
-		private static List<DynamicMethod> _dynamicMethods = new List<DynamicMethod>();
+		private static readonly List<DynamicMethod> _dynamicMethods = new();
 
 		internal static DynamicMethod GetDynamicMethodForIndex(int index)
 		{

--- a/src/profiler/Elastic.Apm.Profiler.Managed/Reflection/ModuleLookup.cs
+++ b/src/profiler/Elastic.Apm.Profiler.Managed/Reflection/ModuleLookup.cs
@@ -22,14 +22,16 @@ namespace Elastic.Apm.Profiler.Managed.Reflection
 		/// </summary>
 		private const int MaxFailures = 50;
 
-		private static ManualResetEventSlim _populationResetEvent = new ManualResetEventSlim(initialState: true);
-		private static ConcurrentDictionary<Guid, Module> _modules = new ConcurrentDictionary<Guid, Module>();
+		private static readonly ManualResetEventSlim _populationResetEvent = new(initialState: true);
+		private static readonly ConcurrentDictionary<Guid, Module> _modules = new();
 
-		private static int _failures;
-		private static bool _shortCircuitLogicHasLogged = false;
+		private static long _failures;
 
 		public static Module GetByPointer(long moduleVersionPointer) =>
 			Get(Marshal.PtrToStructure<Guid>(new IntPtr(moduleVersionPointer)));
+
+		private static readonly object _logLock = new();
+		private static bool _shortCircuitLogicHasLogged = false;
 
 		public static Module Get(Guid moduleVersionId)
 		{
@@ -44,15 +46,18 @@ namespace Elastic.Apm.Profiler.Managed.Reflection
 			if (_modules.TryGetValue(moduleVersionId, out value))
 				return value;
 
-			if (_failures >= MaxFailures)
+			var failures = Interlocked.Read(ref _failures);
+			if (failures >= MaxFailures)
 			{
-				// For some unforeseeable reason we have failed on a lot of AppDomain lookups
-				if (!_shortCircuitLogicHasLogged)
+				if (_shortCircuitLogicHasLogged) return null;
+				lock (_logLock)
 				{
+					if (_shortCircuitLogicHasLogged) return null;
 					Logger.Log(LogLevel.Warn,
 						"Elastic APM is unable to continue attempting module lookups for this AppDomain. Falling back to legacy method lookups.");
-				}
+					_shortCircuitLogicHasLogged = true;
 
+				}
 				return null;
 			}
 
@@ -65,7 +70,7 @@ namespace Elastic.Apm.Profiler.Managed.Reflection
 			}
 			catch (Exception ex)
 			{
-				_failures++;
+				Interlocked.Increment(ref _failures);
 				Logger.Log(LogLevel.Error, ex, "Error when populating modules.");
 			}
 			finally

--- a/src/profiler/Elastic.Apm.Profiler.Managed/Reflection/ModuleLookup.cs
+++ b/src/profiler/Elastic.Apm.Profiler.Managed/Reflection/ModuleLookup.cs
@@ -49,10 +49,12 @@ namespace Elastic.Apm.Profiler.Managed.Reflection
 			var failures = Interlocked.Read(ref _failures);
 			if (failures >= MaxFailures)
 			{
-				if (_shortCircuitLogicHasLogged) return null;
+				if (_shortCircuitLogicHasLogged)
+					return null;
 				lock (_logLock)
 				{
-					if (_shortCircuitLogicHasLogged) return null;
+					if (_shortCircuitLogicHasLogged)
+						return null;
 					Logger.Log(LogLevel.Warn,
 						"Elastic APM is unable to continue attempting module lookups for this AppDomain. Falling back to legacy method lookups.");
 					_shortCircuitLogicHasLogged = true;


### PR DESCRIPTION
- ensure Add() is locked on composite disposable
- Ensure _dynamicMethods is readonly in ILHelpersExtensions
- fix synchronization issue in ModuleLookup
- _reflectionObject should not be static in BinaryConverter
