### PR TITLE
Further logging refinements in ElasticApmModule

### DIFF
--- a/src/Elastic.Apm/Logging/TraceLogger.cs
+++ b/src/Elastic.Apm/Logging/TraceLogger.cs
@@ -64,7 +64,7 @@ namespace Elastic.Apm.Logging
 				if (exception == null)
 					return;
 
-				builder.Append($"+-> {caption}: ")
+				builder.Append($" +-> {caption}: ")
 					.Append(exception.GetType().FullName)
 					.Append(": ")
 					.AppendLine(exception.Message)


### PR DESCRIPTION
This continues to work to improve the diagnostics in `ElasticApmModule` by attempting to create the logger earlier in the `Init` method. This allows any exceptions to be logged to the `IApmLogger`, which may be helpful if something critical occurs during the rest of the `Init` method.

It adds some additional log messages to trace the progress of the `Init` method.