### PR TITLE
Update troubleshooting section of docs

### DIFF
--- a/docs/troubleshooting.asciidoc
+++ b/docs/troubleshooting.asciidoc
@@ -82,37 +82,6 @@ named my_log_file.log:
 ----
 <1> Define listeners under a source with name `"Elastic.Apm"` to capture agent logs
 
-In rare situations, a critical exception may occur before the `IApmLogger` is available. To avoid crashing the application, such exceptions 
-will be caught and the module code will emit a Trace message to any available listeners in such situations. If you are missing 
-application traces after registering the `ElasticApmModule`, you can temporarily enable a listener to catch all other trace events.
-
-[source,xml]
-----
-<configuration>
-  <!-- other sections .... -->
-  <system.diagnostics>
-    <trace autoflush="true">
-      <listeners>
-        <add name="everything"
-          type="System.Diagnostics.TextWriterTraceListener"
-          initializeData="everything_logfile.log" /> <1>
-        <remove name="Default" />
-      </listeners>
-    </trace>
-    <sources>
-      <source name="Elastic.Apm">
-      <listeners>
-        <add name="file" 
-          type="System.Diagnostics.TextWriterTraceListener" 
-          initializeData="my_log_file.log" />
-      </listeners>
-    </source>
-    </sources>
-  </system.diagnostics>
-</configuration>  
-----
-<1> Check the `everything_logfile.log` for any critical exception logs that may indicate a failure to initialize the Agent.
-
 [float]
 [[collect-logs-class-other-logging-systems]]
 ===== Other logging systems

--- a/docs/troubleshooting.asciidoc
+++ b/docs/troubleshooting.asciidoc
@@ -50,7 +50,7 @@ ASP.NET (classic) does not have a predefined logging system. By default, the age
 emit log messages to a 
 https://docs.microsoft.com/en-us/dotnet/api/system.diagnostics.tracesource[`System.Diagnostics.TraceSource`] 
 with the source name `"Elastic.Apm"`. The TraceSource adheres to the log levels defined in the
-APM agent configuration.
+APM agent configuration. Typically, you will configure a preferred log level using an application setting in `web.config`.
 
 [IMPORTANT]
 --
@@ -67,7 +67,7 @@ named my_log_file.log:
 ----
 <configuration>
   <!-- other sections .... -->
-<system.diagnostics>
+  <system.diagnostics>
   <sources>
     <source name="Elastic.Apm"> <1>
       <listeners>
@@ -81,6 +81,37 @@ named my_log_file.log:
 </configuration>  
 ----
 <1> Define listeners under a source with name `"Elastic.Apm"` to capture agent logs
+
+In rare situations, a critical exception may occur before the `IApmLogger` is available. To protect the application, such exceptions will be caught
+to avoid crashing the application. The module code will emit a Trace message to any available listeners in such situations. If you are missing 
+application traces after registering the `ElasticApmModule`, you can temporarily enable a listener to catch all other trace events.
+
+[source,xml]
+----
+<configuration>
+  <!-- other sections .... -->
+  <system.diagnostics>
+    <trace autoflush="true">
+      <listeners>
+        <add name="everything"
+          type="System.Diagnostics.TextWriterTraceListener"
+          initializeData="everything_logfile.log" /> <1>
+        <remove name="Default" />
+      </listeners>
+    </trace>
+    <sources>
+      <source name="Elastic.Apm"> <1>
+      <listeners>
+        <add name="file" 
+          type="System.Diagnostics.TextWriterTraceListener" 
+          initializeData="my_log_file.log" />
+      </listeners>
+    </source>
+    </sources>
+  </system.diagnostics>
+</configuration>  
+----
+<1> Check the `everything_logfile.log` for any critical exception logs that may indicate a failure to initialize the Agent.
 
 [float]
 [[collect-logs-class-other-logging-systems]]

--- a/docs/troubleshooting.asciidoc
+++ b/docs/troubleshooting.asciidoc
@@ -82,8 +82,8 @@ named my_log_file.log:
 ----
 <1> Define listeners under a source with name `"Elastic.Apm"` to capture agent logs
 
-In rare situations, a critical exception may occur before the `IApmLogger` is available. To protect the application, such exceptions will be caught
-to avoid crashing the application. The module code will emit a Trace message to any available listeners in such situations. If you are missing 
+In rare situations, a critical exception may occur before the `IApmLogger` is available. To avoid crashing the application, such exceptions 
+will be caught and the module code will emit a Trace message to any available listeners in such situations. If you are missing 
 application traces after registering the `ElasticApmModule`, you can temporarily enable a listener to catch all other trace events.
 
 [source,xml]
@@ -100,7 +100,7 @@ application traces after registering the `ElasticApmModule`, you can temporarily
       </listeners>
     </trace>
     <sources>
-      <source name="Elastic.Apm"> <1>
+      <source name="Elastic.Apm">
       <listeners>
         <add name="file" 
           type="System.Diagnostics.TextWriterTraceListener" 


### PR DESCRIPTION
This adds extra detail to explain how to capture early trace events which may occur in rare circumstances should an exception be thrown before an `IApmLogger` is available in ASP.NET Full Framework scenarios.