### PR TITLE
Fix agent-zip for 5.0.0

### DIFF
--- a/build/scripts/Build.fs
+++ b/build/scripts/Build.fs
@@ -224,7 +224,7 @@ module Build =
         |> Seq.iter (copyDllsAndPdbs agentDir)
             
         // assemblies compiled against "current" version of System.Diagnostics.DiagnosticSource    
-        !! (Paths.BuildOutput "Elastic.Apm.StartupHook.Loader/netcoreapp2.2")
+        !! (Paths.BuildOutput "Elastic.Apm.StartupHook.Loader/netstandard2.0")
         ++ (Paths.BuildOutput "Elastic.Apm/netstandard2.0")
         |> Seq.filter Path.isDirectory
         |> Seq.map DirectoryInfo


### PR DESCRIPTION
`Elastic.Apm.StartupHook.Loader` is now only producing `netstandard2.0` output, so the build process must be updated to pull the files from the corresponding directory.

Fixes #2335