### PR TITLE
github-action: fix snapshoty

### DIFF
--- a/.github/workflows/snapshoty.yml
+++ b/.github/workflows/snapshoty.yml
@@ -17,15 +17,13 @@ jobs:
       
     # used by opbeans .NET to reference the on commit nuget packages
     # TODO: update opbeans to use our feedz.io packages
-    - uses: actions/download-artifact@v3
+    - name: Retrieve the artifact uploaded from `test-linux.yml` workflow
+      uses: actions/download-artifact@v4
       with:
         name: snapshoty-linux
         path: build/output
-
-    # - uses: actions/download-artifact@v3
-    #   with:
-    #     name: snapshoty-windows
-    #     path: build/output
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        run-id: ${{ github.event.workflow_run.id }}
 
     - name: Display structure of downloaded files
       run: find build -type f

--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -41,12 +41,12 @@ jobs:
     - name: Package
       run: ./build.sh pack
     
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       if: github.event_name == 'push' && startswith(github.ref, 'refs/heads')
       with:
-          name: snapshoty-linux
-          path: build/output/*
-          retention-days: 1
+        name: snapshoty-linux
+        path: build/output/*
+        retention-days: 1
   
   tests:
     runs-on: ubuntu-latest


### PR DESCRIPTION
### What

Fixes the snapshoty to download the artifacts from a different Workflow. `v4` supports cross workflow integrations.

### Why

https://github.com/elastic/apm-agent-dotnet/actions/runs/8971930401 

<img width="812" alt="image" src="https://github.com/elastic/apm-agent-dotnet/assets/2871786/b007ce21-6256-46eb-b778-be6c5e55d878">


### References:

* https://github.com/actions/download-artifact/issues/3#issuecomment-1894005257
* https://github.blog/changelog/2023-12-14-github-actions-artifacts-v4-is-now-generally-available/
* https://github.com/actions/download-artifact?tab=readme-ov-file#download-artifacts-from-other-workflow-runs-or-repositories