### PR TITLE
snapshoty: update regex using the new versioning

### DIFF
--- a/.ci/snapshoty.yml
+++ b/.ci/snapshoty.yml
@@ -34,16 +34,16 @@ artifacts:
   # Path to use for artifacts discovery 
   - path: './build/output'
     # Files pattern to match
-    files_pattern: 'elastic_apm_profiler_(?P<app_version>\d+\.\d+\.\d+)-(?P<revision>\w+)-(?P<os>\w+)-(?P<arch>\w+)\.zip'
+    files_pattern: 'elastic_apm_profiler_(?P<app_version>\d+\.\d+\.\d+)-(?P<revision>[\w\.]+)-(?P<os>\w+)-(?P<arch>\w+)\.zip'
     # File layout on GCS bucket
     output_pattern: '{project}/{github_branch_name}/elastic-apm-dotnet-profiler-{app_version}-{app_version}-{os}-{arch}-{github_sha_short}.jar'
     # List of metadata processors to use.
     metadata: *metadata
   - path: './build/output'
-    files_pattern: 'ElasticApmAgent_(?P<app_version>\d+\.\d+\.\d+)-(?P<revision>\w+)\.zip'
+    files_pattern: 'ElasticApmAgent_(?P<app_version>\d+\.\d+\.\d+)-(?P<revision>[\w\.]+)\.zip'
     output_pattern: '{project}/{github_branch_name}/elastic-apm-dotnet-agent-{app_version}-{revision}-{github_sha_short}.zip'
     metadata: *metadata
   - path: './build/output/_packages'
-    files_pattern: 'Elastic\.Apm\.(?P<component>[\w\.]*)\.(?P<app_version>\d+\.\d+\.\d+)-(?P<revision>\w+)-(?P<revision_dup>\w+)-(?P<date>[\d-]+)\.nupkg'
+    files_pattern: 'Elastic\.Apm(?P<component>[\w\.]*)\.(?P<app_version>\d+\.\d+\.\d+)-(?P<revision>[\w\.]+)(-(?P<revision_dup>\w+)-(?P<date>[\d-]+))?\.nupkg'
     output_pattern: '{project}/{github_branch_name}/elastic-apm-dotnet-{component}-{app_version}-{revision}-{github_sha_short}.nupkg'
     metadata: *metadata


### PR DESCRIPTION
### What

Update the regex to reflect the new versioning

### Why

There were some changes in the versioning hence `canary.[0-9]` is part of the naming.

Otherwise, snapshoty runs without doing much, [see](https://github.com/elastic/apm-agent-dotnet/actions/runs/8982103068/job/24668982242#step:5:204) 

### Test

<img width="724" alt="Screenshot 2024-05-07 at 10 43 18" src="https://github.com/elastic/apm-agent-dotnet/assets/2871786/bf134110-e82e-4d0e-b5d7-e447c7a02dbb">
<img width="745" alt="Screenshot 2024-05-07 at 10 46 32" src="https://github.com/elastic/apm-agent-dotnet/assets/2871786/14cd11a4-e5fb-4355-b90c-7959e9a3e515">
<img width="707" alt="Screenshot 2024-05-07 at 10 43 49" src="https://github.com/elastic/apm-agent-dotnet/assets/2871786/f70322b4-047a-4c76-bdda-05579ad7280b">
