### PR TITLE
github-action: timeout the tests job if longer than 30 minutes

### DIFF
--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -50,7 +50,8 @@ jobs:
   
   tests:
     runs-on: ubuntu-latest
-    
+    timeout-minutes: 30
+
     steps:
       - uses: actions/checkout@v4
       - name: Bootstrap Action Workspace

--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -31,6 +31,7 @@ env:
 jobs:
   tests:
     runs-on: windows-2022
+    timeout-minutes: 30
         
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Otherwise, some [executions](https://github.com/elastic/apm-agent-dotnet/actions/workflows/test-linux.yml) get stalled for 6 hours.

<img width="1421" alt="image" src="https://github.com/elastic/apm-agent-dotnet/assets/2871786/7875d02d-9e80-47e9-b105-594777b3f41e">

