### PR TITLE
github-action: run snapshoty for main and if success

### DIFF
--- a/.github/workflows/snapshoty.yml
+++ b/.github/workflows/snapshoty.yml
@@ -8,10 +8,16 @@ on:
     workflows: ['test-linux']
     types:
       - completed
+    branches:
+      - main
+
+permissions:
+  contents: read
 
 jobs:
   upload:
     runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
     - uses: actions/checkout@v4
       


### PR DESCRIPTION
This should avoid issues when the workflow-run runs for PRs or any other events.