### PR TITLE
snapshoty: split _packages in two types

### DIFF
--- a/.ci/snapshoty.yml
+++ b/.ci/snapshoty.yml
@@ -44,6 +44,10 @@ artifacts:
     output_pattern: '{project}/{github_branch_name}/elastic-apm-dotnet-agent-{app_version}-{revision}-{github_sha_short}.zip'
     metadata: *metadata
   - path: './build/output/_packages'
-    files_pattern: 'Elastic\.Apm(?P<component>[\w\.]*)\.(?P<app_version>\d+\.\d+\.\d+)-(?P<revision>[\w\.]+)(-(?P<revision_dup>\w+)-(?P<date>[\d-]+))?\.nupkg'
+    files_pattern: 'Elastic\.Apm\.(?P<component>[\w\.]*)\.(?P<app_version>\d+\.\d+\.\d+)-(?P<revision>[\w\.]+)(-(?P<revision_dup>\w+)-(?P<date>[\d-]+))?\.nupkg'
     output_pattern: '{project}/{github_branch_name}/elastic-apm-dotnet-{component}-{app_version}-{revision}-{github_sha_short}.nupkg'
+    metadata: *metadata
+  - path: './build/output/_packages'
+    files_pattern: 'Elastic\.Apm\.(?P<app_version>\d+\.\d+\.\d+)-(?P<revision>[\w\.]+)(-(?P<revision_dup>\w+)-(?P<date>[\d-]+))?\.nupkg'
+    output_pattern: '{project}/{github_branch_name}/elastic-apm-dotnet-{app_version}-{revision}-{github_sha_short}.nupkg'
     metadata: *metadata


### PR DESCRIPTION
Fixes

```
✓ Succeeded to load configuration
Failed to find `component` metadata
```

I tested it locally:

```
⇒ Loading configuration...
{'path': './build/output', 'files_pattern': 'elastic_apm_profiler_(?P<app_version>\\d+\\.\\d+\\.\\d+)-(?P<revision>[\\w\\.]+)-(?P<os>\\w+)-(?P<arch>\\w+)\\.zip', 'output_pattern': '{project}/foo/elastic-apm-dotnet-profiler-{app_version}-{app_version}-{os}-{arch}-foo.jar', 'metadata': [{'name': 'custom', 'data': {'project': 'apm-agent-dotnet', 'component': 'agent'}}, {'name': 'git'}]}
{'path': './build/output', 'files_pattern': 'ElasticApmAgent_(?P<app_version>\\d+\\.\\d+\\.\\d+)-(?P<revision>[\\w\\.]+)\\.zip', 'output_pattern': '{project}/foo/elastic-apm-dotnet-agent-{app_version}-{revision}-foo.zip', 'metadata': [{'name': 'custom', 'data': {'project': 'apm-agent-dotnet', 'component': 'agent'}}, {'name': 'git'}]}
{'path': './build/output/_packages', 'files_pattern': 'Elastic\\.Apm\\.(?P<component>[\\w\\.]*)\\.(?P<app_version>\\d+\\.\\d+\\.\\d+)-(?P<revision>[\\w\\.]+)(-(?P<revision_dup>\\w+)-(?P<date>[\\d-]+))?\\.nupkg', 'output_pattern': '{project}/foo/elastic-apm-dotnet-{component}-{app_version}-{revision}-foo.nupkg', 'metadata': [{'name': 'custom', 'data': {'project': 'apm-agent-dotnet', 'component': 'agent'}}, {'name': 'git'}]}
{'path': './build/output/_packages', 'files_pattern': 'Elastic\\.Apm\\.(?P<app_version>\\d+\\.\\d+\\.\\d+)-(?P<revision>[\\w\\.]+)(-(?P<revision_dup>\\w+)-(?P<date>[\\d-]+))?\\.nupkg', 'output_pattern': '{project}/foo/elastic-apm-dotnet-{app_version}-{revision}-foo.nupkg', 'metadata': [{'name': 'custom', 'data': {'project': 'apm-agent-dotnet', 'component': 'agent'}}, {'name': 'git'}]}
✓ Succeeded to load configuration
⇒ Number of artifacts to upload: 18
..
```