### PR TITLE
Remove invalid profiler method integrations

### DIFF
--- a/build/build.fsproj
+++ b/build/build.fsproj
@@ -28,12 +28,12 @@
     <PackageReference Include="Bullseye" Version="3.5.0" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta1.20427.1" />
 
-    <PackageReference Include="Fake.Core.Environment" Version="5.20.4" />
-    <PackageReference Include="Fake.Core.SemVer" Version="5.20.4" />
-    <PackageReference Include="Fake.DotNet.MsBuild" Version="5.20.4" />
-    <PackageReference Include="Fake.IO.FileSystem" Version="5.20.4" />
-    <PackageReference Include="Fake.IO.Zip" Version="5.20.4" />
-    <PackageReference Include="Fake.Tools.Git" Version="5.20.4" />
+    <PackageReference Include="Fake.Core.Environment" Version="6.0.0" />
+    <PackageReference Include="Fake.Core.SemVer" Version="6.0.0" />
+    <PackageReference Include="Fake.DotNet.MsBuild" Version="6.0.0" />
+    <PackageReference Include="Fake.IO.FileSystem" Version="6.0.0" />
+    <PackageReference Include="Fake.IO.Zip" Version="6.0.0" />
+    <PackageReference Include="Fake.Tools.Git" Version="6.0.0" />
 
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
 

--- a/build/scripts/Build.fs
+++ b/build/scripts/Build.fs
@@ -70,13 +70,14 @@ module Build =
         DotNet.Exec [target; projectOrSln; "-c"; "Release"; "-v"; "q"; "--nologo"]
         
     let private msBuild target projectOrSln =
-        MSBuild.build (fun p ->
+        MSBuild.build (fun (p: MSBuildParams) ->
                 { p with
                     Verbosity = Some(Quiet)
                     Targets = [target]
                     Properties = [
                         "Configuration", "Release"
                         "Optimize", "True"
+                        "dummy", "test" // See https://github.com/fsprojects/FAKE/issues/2738
                     ]
                     // current version of Fake MSBuild module does not support latest bin log file
                     // version of MSBuild in VS 16.8, so disable for now.

--- a/src/profiler/Elastic.Apm.Profiler.Managed/Integrations/AdoNet/CommandExecuteNonQueryWithBehaviorIntegration.cs
+++ b/src/profiler/Elastic.Apm.Profiler.Managed/Integrations/AdoNet/CommandExecuteNonQueryWithBehaviorIntegration.cs
@@ -20,14 +20,7 @@ namespace Elastic.Apm.Profiler.Managed.Integrations.AdoNet
 	/// CallTarget instrumentation for:
 	/// int [Command].ExecuteNonQuery(CommandBehavior)
 	/// </summary>
-	[InstrumentMySqlAttribute(Method = ExecuteNonQuery, ReturnType = ClrTypeNames.Int32, ParameterTypes = new[] { AdoNetTypeNames.CommandBehavior })]
-	[InstrumentOracleManagedDataAccess(Method = ExecuteNonQuery, ReturnType = ClrTypeNames.Int32, ParameterTypes = new[] { AdoNetTypeNames.CommandBehavior })]
-	[InstrumentOracleManagedDataAccessCore(Method = ExecuteNonQuery, ReturnType = ClrTypeNames.Int32, ParameterTypes = new[] { AdoNetTypeNames.CommandBehavior })]
-	[InstrumentMicrosoftDataSqlite(Method = ExecuteNonQuery, ReturnType = ClrTypeNames.Int32, ParameterTypes = new[] { AdoNetTypeNames.CommandBehavior })]
 	[InstrumentSystemDataSqlite(Method = ExecuteNonQuery, ReturnType = ClrTypeNames.Int32, ParameterTypes = new[] { AdoNetTypeNames.CommandBehavior })]
-	[InstrumentSystemDataSql(Method = ExecuteNonQuery, ReturnType = ClrTypeNames.Int32, ParameterTypes = new[] { AdoNetTypeNames.CommandBehavior })]
-	[InstrumentSystemDataSqlClient(Method = ExecuteNonQuery, ReturnType = ClrTypeNames.Int32, ParameterTypes = new[] { AdoNetTypeNames.CommandBehavior })]
-	[InstrumentMicrosoftDataSqlClient(Method = ExecuteNonQuery, ReturnType = ClrTypeNames.Int32, ParameterTypes = new[] { AdoNetTypeNames.CommandBehavior })]
 	public class CommandExecuteNonQueryWithBehaviorIntegration
 	{
 		/// <summary>

--- a/src/profiler/Elastic.Apm.Profiler.Managed/Integrations/AdoNet/CommandExecuteScalarWithBehaviorIntegration.cs
+++ b/src/profiler/Elastic.Apm.Profiler.Managed/Integrations/AdoNet/CommandExecuteScalarWithBehaviorIntegration.cs
@@ -20,19 +20,7 @@ namespace Elastic.Apm.Profiler.Managed.Integrations.AdoNet
 	/// CallTarget instrumentation for:
 	/// object [Command].ExecuteScalar(CommandBehavior)
 	/// </summary>
-	[InstrumentMySqlAttribute(Method = ExecuteScalar, ReturnType = ClrTypeNames.Object, ParameterTypes = new[] { AdoNetTypeNames.CommandBehavior })]
-	[InstrumentOracleManagedDataAccess(Method = ExecuteScalar, ReturnType = ClrTypeNames.Object,
-		ParameterTypes = new[] { AdoNetTypeNames.CommandBehavior })]
-	[InstrumentOracleManagedDataAccessCore(Method = ExecuteScalar, ReturnType = ClrTypeNames.Object,
-		ParameterTypes = new[] { AdoNetTypeNames.CommandBehavior })]
-	[InstrumentMicrosoftDataSqlite(Method = ExecuteScalar, ReturnType = ClrTypeNames.Object,
-		ParameterTypes = new[] { AdoNetTypeNames.CommandBehavior })]
 	[InstrumentSystemDataSqlite(Method = ExecuteScalar, ReturnType = ClrTypeNames.Object, ParameterTypes = new[] { AdoNetTypeNames.CommandBehavior })]
-	[InstrumentSystemDataSql(Method = ExecuteScalar, ReturnType = ClrTypeNames.Object, ParameterTypes = new[] { AdoNetTypeNames.CommandBehavior })]
-	[InstrumentSystemDataSqlClient(Method = ExecuteScalar, ReturnType = ClrTypeNames.Object,
-		ParameterTypes = new[] { AdoNetTypeNames.CommandBehavior })]
-	[InstrumentMicrosoftDataSqlClient(Method = ExecuteScalar, ReturnType = ClrTypeNames.Object,
-		ParameterTypes = new[] { AdoNetTypeNames.CommandBehavior })]
 	public class CommandExecuteScalarWithBehaviorIntegration
 	{
 		/// <summary>

--- a/src/profiler/Elastic.Apm.Profiler.Managed/integrations.yml
+++ b/src/profiler/Elastic.Apm.Profiler.Managed/integrations.yml
@@ -10,7 +10,7 @@
       minimum_version: 4.0.0
       maximum_version: 4.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.26.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.27.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteNonQueryAsyncIntegration
       action: CallTargetModification
   - target:
@@ -23,7 +23,7 @@
       minimum_version: 4.0.0
       maximum_version: 5.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.26.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.27.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteNonQueryAsyncIntegration
       action: CallTargetModification
   - target:
@@ -37,7 +37,7 @@
       minimum_version: 4.0.0
       maximum_version: 4.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.26.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.27.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteReaderWithBehaviorAsyncIntegration
       action: CallTargetModification
   - target:
@@ -51,7 +51,7 @@
       minimum_version: 4.0.0
       maximum_version: 5.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.26.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.27.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteReaderWithBehaviorAsyncIntegration
       action: CallTargetModification
   - target:
@@ -64,7 +64,7 @@
       minimum_version: 4.0.0
       maximum_version: 4.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.26.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.27.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteScalarAsyncIntegration
       action: CallTargetModification
   - target:
@@ -77,7 +77,7 @@
       minimum_version: 4.0.0
       maximum_version: 5.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.26.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.27.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteScalarAsyncIntegration
       action: CallTargetModification
 - name: AspNet
@@ -93,7 +93,7 @@
       minimum_version: 4.0.0
       maximum_version: 4.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.26.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.27.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AspNet.ElasticApmModuleIntegration
       action: CallTargetModification
 - name: Kafka
@@ -107,7 +107,7 @@
       minimum_version: 1.4.0
       maximum_version: 1.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.26.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.27.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.Kafka.KafkaConsumerCloseIntegration
       action: CallTargetModification
   - target:
@@ -120,7 +120,7 @@
       minimum_version: 1.4.0
       maximum_version: 1.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.26.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.27.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.Kafka.KafkaConsumerConsumeIntegration
       action: CallTargetModification
   - target:
@@ -132,7 +132,7 @@
       minimum_version: 1.4.0
       maximum_version: 1.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.26.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.27.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.Kafka.KafkaConsumerDisposeIntegration
       action: CallTargetModification
   - target:
@@ -144,7 +144,7 @@
       minimum_version: 1.4.0
       maximum_version: 1.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.26.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.27.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.Kafka.KafkaConsumerUnsubscribeIntegration
       action: CallTargetModification
   - target:
@@ -159,7 +159,7 @@
       minimum_version: 1.4.0
       maximum_version: 1.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.26.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.27.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.Kafka.KafkaProduceAsyncIntegration
       action: CallTargetModification
   - target:
@@ -175,7 +175,7 @@
       minimum_version: 1.4.0
       maximum_version: 1.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.26.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.27.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.Kafka.KafkaProduceSyncDeliveryHandlerIntegration
       action: CallTargetModification
   - target:
@@ -190,7 +190,7 @@
       minimum_version: 1.4.0
       maximum_version: 1.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.26.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.27.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.Kafka.KafkaProduceSyncIntegration
       action: CallTargetModification
 - name: MySqlCommand
@@ -205,7 +205,7 @@
       minimum_version: 6.7.0
       maximum_version: 8.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.26.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.27.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteNonQueryAsyncIntegration
       action: CallTargetModification
   - target:
@@ -217,21 +217,8 @@
       minimum_version: 6.7.0
       maximum_version: 8.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.26.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.27.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteNonQueryIntegration
-      action: CallTargetModification
-  - target:
-      assembly: MySql.Data
-      type: MySql.Data.MySqlClient.MySqlCommand
-      method: ExecuteNonQuery
-      signature_types:
-      - System.Int32
-      - System.Data.CommandBehavior
-      minimum_version: 6.7.0
-      maximum_version: 8.*.*
-    wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.26.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
-      type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteNonQueryWithBehaviorIntegration
       action: CallTargetModification
   - target:
       assembly: MySql.Data
@@ -243,7 +230,7 @@
       minimum_version: 6.7.0
       maximum_version: 8.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.26.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.27.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteReaderAsyncIntegration
       action: CallTargetModification
   - target:
@@ -255,7 +242,7 @@
       minimum_version: 6.7.0
       maximum_version: 8.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.26.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.27.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteReaderIntegration
       action: CallTargetModification
   - target:
@@ -269,7 +256,7 @@
       minimum_version: 6.7.0
       maximum_version: 8.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.26.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.27.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteReaderWithBehaviorAsyncIntegration
       action: CallTargetModification
   - target:
@@ -283,7 +270,7 @@
       minimum_version: 6.7.0
       maximum_version: 8.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.26.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.27.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteReaderWithBehaviorAsyncIntegration
       action: CallTargetModification
   - target:
@@ -296,7 +283,7 @@
       minimum_version: 6.7.0
       maximum_version: 8.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.26.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.27.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteReaderWithBehaviorIntegration
       action: CallTargetModification
   - target:
@@ -309,7 +296,7 @@
       minimum_version: 6.7.0
       maximum_version: 8.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.26.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.27.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteReaderWithBehaviorIntegration
       action: CallTargetModification
   - target:
@@ -322,7 +309,7 @@
       minimum_version: 6.7.0
       maximum_version: 8.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.26.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.27.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteScalarAsyncIntegration
       action: CallTargetModification
   - target:
@@ -334,21 +321,8 @@
       minimum_version: 6.7.0
       maximum_version: 8.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.26.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.27.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteScalarIntegration
-      action: CallTargetModification
-  - target:
-      assembly: MySql.Data
-      type: MySql.Data.MySqlClient.MySqlCommand
-      method: ExecuteScalar
-      signature_types:
-      - System.Object
-      - System.Data.CommandBehavior
-      minimum_version: 6.7.0
-      maximum_version: 8.*.*
-    wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.26.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
-      type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteScalarWithBehaviorIntegration
       action: CallTargetModification
 - name: NpgsqlCommand
   method_replacements:
@@ -362,7 +336,7 @@
       minimum_version: 4.0.0
       maximum_version: 7.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.26.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.27.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteNonQueryAsyncIntegration
       action: CallTargetModification
   - target:
@@ -374,7 +348,7 @@
       minimum_version: 4.0.0
       maximum_version: 7.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.26.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.27.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteNonQueryIntegration
       action: CallTargetModification
   - target:
@@ -387,7 +361,7 @@
       minimum_version: 4.0.0
       maximum_version: 7.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.26.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.27.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteReaderAsyncIntegration
       action: CallTargetModification
   - target:
@@ -401,7 +375,7 @@
       minimum_version: 4.0.0
       maximum_version: 7.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.26.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.27.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteReaderWithBehaviorAsyncIntegration
       action: CallTargetModification
   - target:
@@ -414,7 +388,7 @@
       minimum_version: 4.0.0
       maximum_version: 7.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.26.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.27.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteReaderWithBehaviorAsyncIntegration
       action: CallTargetModification
   - target:
@@ -428,7 +402,7 @@
       minimum_version: 4.0.0
       maximum_version: 7.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.26.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.27.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteReaderWithBehaviorAsyncIntegration
       action: CallTargetModification
   - target:
@@ -441,7 +415,7 @@
       minimum_version: 4.0.0
       maximum_version: 7.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.26.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.27.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteReaderWithBehaviorIntegration
       action: CallTargetModification
   - target:
@@ -454,7 +428,7 @@
       minimum_version: 4.0.0
       maximum_version: 7.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.26.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.27.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteReaderWithBehaviorIntegration
       action: CallTargetModification
   - target:
@@ -467,7 +441,7 @@
       minimum_version: 4.0.0
       maximum_version: 7.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.26.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.27.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteScalarAsyncIntegration
       action: CallTargetModification
   - target:
@@ -479,7 +453,7 @@
       minimum_version: 4.0.0
       maximum_version: 7.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.26.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.27.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteScalarIntegration
       action: CallTargetModification
 - name: OracleCommand
@@ -494,7 +468,7 @@
       minimum_version: 4.122.0
       maximum_version: 4.122.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.26.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.27.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteNonQueryAsyncIntegration
       action: CallTargetModification
   - target:
@@ -507,7 +481,7 @@
       minimum_version: 2.0.0
       maximum_version: 3.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.26.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.27.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteNonQueryAsyncIntegration
       action: CallTargetModification
   - target:
@@ -519,7 +493,7 @@
       minimum_version: 4.122.0
       maximum_version: 4.122.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.26.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.27.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteNonQueryIntegration
       action: CallTargetModification
   - target:
@@ -531,34 +505,8 @@
       minimum_version: 2.0.0
       maximum_version: 3.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.26.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.27.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteNonQueryIntegration
-      action: CallTargetModification
-  - target:
-      assembly: Oracle.ManagedDataAccess
-      type: Oracle.ManagedDataAccess.Client.OracleCommand
-      method: ExecuteNonQuery
-      signature_types:
-      - System.Int32
-      - System.Data.CommandBehavior
-      minimum_version: 4.122.0
-      maximum_version: 4.122.*
-    wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.26.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
-      type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteNonQueryWithBehaviorIntegration
-      action: CallTargetModification
-  - target:
-      assembly: Oracle.ManagedDataAccess
-      type: Oracle.ManagedDataAccess.Client.OracleCommand
-      method: ExecuteNonQuery
-      signature_types:
-      - System.Int32
-      - System.Data.CommandBehavior
-      minimum_version: 2.0.0
-      maximum_version: 3.*.*
-    wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.26.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
-      type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteNonQueryWithBehaviorIntegration
       action: CallTargetModification
   - target:
       assembly: Oracle.ManagedDataAccess
@@ -570,7 +518,7 @@
       minimum_version: 4.122.0
       maximum_version: 4.122.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.26.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.27.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteReaderAsyncIntegration
       action: CallTargetModification
   - target:
@@ -583,7 +531,7 @@
       minimum_version: 2.0.0
       maximum_version: 3.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.26.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.27.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteReaderAsyncIntegration
       action: CallTargetModification
   - target:
@@ -595,7 +543,7 @@
       minimum_version: 4.122.0
       maximum_version: 4.122.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.26.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.27.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteReaderIntegration
       action: CallTargetModification
   - target:
@@ -607,7 +555,7 @@
       minimum_version: 2.0.0
       maximum_version: 3.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.26.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.27.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteReaderIntegration
       action: CallTargetModification
   - target:
@@ -621,7 +569,7 @@
       minimum_version: 4.122.0
       maximum_version: 4.122.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.26.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.27.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteReaderWithBehaviorAsyncIntegration
       action: CallTargetModification
   - target:
@@ -635,7 +583,7 @@
       minimum_version: 2.0.0
       maximum_version: 3.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.26.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.27.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteReaderWithBehaviorAsyncIntegration
       action: CallTargetModification
   - target:
@@ -649,7 +597,7 @@
       minimum_version: 4.122.0
       maximum_version: 4.122.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.26.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.27.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteReaderWithBehaviorAsyncIntegration
       action: CallTargetModification
   - target:
@@ -663,7 +611,7 @@
       minimum_version: 2.0.0
       maximum_version: 3.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.26.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.27.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteReaderWithBehaviorAsyncIntegration
       action: CallTargetModification
   - target:
@@ -676,7 +624,7 @@
       minimum_version: 4.122.0
       maximum_version: 4.122.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.26.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.27.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteReaderWithBehaviorIntegration
       action: CallTargetModification
   - target:
@@ -689,7 +637,7 @@
       minimum_version: 2.0.0
       maximum_version: 3.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.26.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.27.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteReaderWithBehaviorIntegration
       action: CallTargetModification
   - target:
@@ -702,7 +650,7 @@
       minimum_version: 4.122.0
       maximum_version: 4.122.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.26.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.27.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteReaderWithBehaviorIntegration
       action: CallTargetModification
   - target:
@@ -715,7 +663,7 @@
       minimum_version: 2.0.0
       maximum_version: 3.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.26.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.27.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteReaderWithBehaviorIntegration
       action: CallTargetModification
   - target:
@@ -728,7 +676,7 @@
       minimum_version: 4.122.0
       maximum_version: 4.122.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.26.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.27.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteScalarAsyncIntegration
       action: CallTargetModification
   - target:
@@ -741,7 +689,7 @@
       minimum_version: 2.0.0
       maximum_version: 3.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.26.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.27.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteScalarAsyncIntegration
       action: CallTargetModification
   - target:
@@ -753,7 +701,7 @@
       minimum_version: 4.122.0
       maximum_version: 4.122.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.26.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.27.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteScalarIntegration
       action: CallTargetModification
   - target:
@@ -765,34 +713,8 @@
       minimum_version: 2.0.0
       maximum_version: 3.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.26.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.27.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteScalarIntegration
-      action: CallTargetModification
-  - target:
-      assembly: Oracle.ManagedDataAccess
-      type: Oracle.ManagedDataAccess.Client.OracleCommand
-      method: ExecuteScalar
-      signature_types:
-      - System.Object
-      - System.Data.CommandBehavior
-      minimum_version: 4.122.0
-      maximum_version: 4.122.*
-    wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.26.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
-      type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteScalarWithBehaviorIntegration
-      action: CallTargetModification
-  - target:
-      assembly: Oracle.ManagedDataAccess
-      type: Oracle.ManagedDataAccess.Client.OracleCommand
-      method: ExecuteScalar
-      signature_types:
-      - System.Object
-      - System.Data.CommandBehavior
-      minimum_version: 2.0.0
-      maximum_version: 3.*.*
-    wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.26.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
-      type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteScalarWithBehaviorIntegration
       action: CallTargetModification
 - name: RabbitMQ
   method_replacements:
@@ -812,7 +734,7 @@
       minimum_version: 3.6.9
       maximum_version: 6.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.26.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.27.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.RabbitMq.BasicDeliverIntegration
       action: CallTargetModification
   - target:
@@ -826,7 +748,7 @@
       minimum_version: 3.6.9
       maximum_version: 6.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.26.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.27.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.RabbitMq.BasicGetIntegration
       action: CallTargetModification
   - target:
@@ -843,7 +765,7 @@
       minimum_version: 3.6.9
       maximum_version: 6.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.26.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.27.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.RabbitMq.BasicPublishIntegration
       action: CallTargetModification
 - name: SqlCommand
@@ -858,7 +780,7 @@
       minimum_version: 4.0.0
       maximum_version: 4.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.26.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.27.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteNonQueryAsyncIntegration
       action: CallTargetModification
   - target:
@@ -871,7 +793,7 @@
       minimum_version: 4.0.0
       maximum_version: 4.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.26.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.27.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteNonQueryAsyncIntegration
       action: CallTargetModification
   - target:
@@ -884,7 +806,7 @@
       minimum_version: 1.0.0
       maximum_version: 5.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.26.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.27.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteNonQueryAsyncIntegration
       action: CallTargetModification
   - target:
@@ -896,7 +818,7 @@
       minimum_version: 4.0.0
       maximum_version: 4.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.26.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.27.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteNonQueryIntegration
       action: CallTargetModification
   - target:
@@ -908,7 +830,7 @@
       minimum_version: 4.0.0
       maximum_version: 4.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.26.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.27.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteNonQueryIntegration
       action: CallTargetModification
   - target:
@@ -920,47 +842,8 @@
       minimum_version: 1.0.0
       maximum_version: 5.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.26.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.27.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteNonQueryIntegration
-      action: CallTargetModification
-  - target:
-      assembly: System.Data
-      type: System.Data.SqlClient.SqlCommand
-      method: ExecuteNonQuery
-      signature_types:
-      - System.Int32
-      - System.Data.CommandBehavior
-      minimum_version: 4.0.0
-      maximum_version: 4.*.*
-    wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.26.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
-      type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteNonQueryWithBehaviorIntegration
-      action: CallTargetModification
-  - target:
-      assembly: System.Data.SqlClient
-      type: System.Data.SqlClient.SqlCommand
-      method: ExecuteNonQuery
-      signature_types:
-      - System.Int32
-      - System.Data.CommandBehavior
-      minimum_version: 4.0.0
-      maximum_version: 4.*.*
-    wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.26.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
-      type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteNonQueryWithBehaviorIntegration
-      action: CallTargetModification
-  - target:
-      assembly: Microsoft.Data.SqlClient
-      type: Microsoft.Data.SqlClient.SqlCommand
-      method: ExecuteNonQuery
-      signature_types:
-      - System.Int32
-      - System.Data.CommandBehavior
-      minimum_version: 1.0.0
-      maximum_version: 5.*.*
-    wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.26.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
-      type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteNonQueryWithBehaviorIntegration
       action: CallTargetModification
   - target:
       assembly: System.Data
@@ -972,7 +855,7 @@
       minimum_version: 4.0.0
       maximum_version: 4.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.26.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.27.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteReaderAsyncIntegration
       action: CallTargetModification
   - target:
@@ -985,7 +868,7 @@
       minimum_version: 4.0.0
       maximum_version: 4.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.26.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.27.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteReaderAsyncIntegration
       action: CallTargetModification
   - target:
@@ -998,7 +881,7 @@
       minimum_version: 1.0.0
       maximum_version: 5.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.26.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.27.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteReaderAsyncIntegration
       action: CallTargetModification
   - target:
@@ -1010,7 +893,7 @@
       minimum_version: 4.0.0
       maximum_version: 4.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.26.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.27.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteReaderIntegration
       action: CallTargetModification
   - target:
@@ -1022,7 +905,7 @@
       minimum_version: 4.0.0
       maximum_version: 4.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.26.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.27.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteReaderIntegration
       action: CallTargetModification
   - target:
@@ -1034,7 +917,7 @@
       minimum_version: 1.0.0
       maximum_version: 5.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.26.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.27.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteReaderIntegration
       action: CallTargetModification
   - target:
@@ -1048,7 +931,7 @@
       minimum_version: 4.0.0
       maximum_version: 4.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.26.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.27.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteReaderWithBehaviorAsyncIntegration
       action: CallTargetModification
   - target:
@@ -1062,7 +945,7 @@
       minimum_version: 4.0.0
       maximum_version: 4.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.26.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.27.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteReaderWithBehaviorAsyncIntegration
       action: CallTargetModification
   - target:
@@ -1076,7 +959,7 @@
       minimum_version: 1.0.0
       maximum_version: 5.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.26.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.27.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteReaderWithBehaviorAsyncIntegration
       action: CallTargetModification
   - target:
@@ -1090,7 +973,7 @@
       minimum_version: 4.0.0
       maximum_version: 4.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.26.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.27.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteReaderWithBehaviorAsyncIntegration
       action: CallTargetModification
   - target:
@@ -1104,7 +987,7 @@
       minimum_version: 4.0.0
       maximum_version: 4.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.26.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.27.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteReaderWithBehaviorAsyncIntegration
       action: CallTargetModification
   - target:
@@ -1118,7 +1001,7 @@
       minimum_version: 1.0.0
       maximum_version: 5.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.26.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.27.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteReaderWithBehaviorAsyncIntegration
       action: CallTargetModification
   - target:
@@ -1131,7 +1014,7 @@
       minimum_version: 4.0.0
       maximum_version: 4.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.26.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.27.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteReaderWithBehaviorIntegration
       action: CallTargetModification
   - target:
@@ -1144,7 +1027,7 @@
       minimum_version: 4.0.0
       maximum_version: 4.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.26.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.27.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteReaderWithBehaviorIntegration
       action: CallTargetModification
   - target:
@@ -1157,7 +1040,7 @@
       minimum_version: 1.0.0
       maximum_version: 5.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.26.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.27.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteReaderWithBehaviorIntegration
       action: CallTargetModification
   - target:
@@ -1170,7 +1053,7 @@
       minimum_version: 4.0.0
       maximum_version: 4.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.26.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.27.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteReaderWithBehaviorIntegration
       action: CallTargetModification
   - target:
@@ -1183,7 +1066,7 @@
       minimum_version: 4.0.0
       maximum_version: 4.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.26.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.27.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteReaderWithBehaviorIntegration
       action: CallTargetModification
   - target:
@@ -1196,7 +1079,7 @@
       minimum_version: 1.0.0
       maximum_version: 5.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.26.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.27.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteReaderWithBehaviorIntegration
       action: CallTargetModification
   - target:
@@ -1209,7 +1092,7 @@
       minimum_version: 4.0.0
       maximum_version: 4.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.26.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.27.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteScalarAsyncIntegration
       action: CallTargetModification
   - target:
@@ -1222,7 +1105,7 @@
       minimum_version: 4.0.0
       maximum_version: 4.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.26.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.27.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteScalarAsyncIntegration
       action: CallTargetModification
   - target:
@@ -1235,7 +1118,7 @@
       minimum_version: 1.0.0
       maximum_version: 5.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.26.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.27.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteScalarAsyncIntegration
       action: CallTargetModification
   - target:
@@ -1247,7 +1130,7 @@
       minimum_version: 4.0.0
       maximum_version: 4.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.26.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.27.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteScalarIntegration
       action: CallTargetModification
   - target:
@@ -1259,7 +1142,7 @@
       minimum_version: 4.0.0
       maximum_version: 4.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.26.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.27.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteScalarIntegration
       action: CallTargetModification
   - target:
@@ -1271,47 +1154,8 @@
       minimum_version: 1.0.0
       maximum_version: 5.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.26.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.27.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteScalarIntegration
-      action: CallTargetModification
-  - target:
-      assembly: System.Data
-      type: System.Data.SqlClient.SqlCommand
-      method: ExecuteScalar
-      signature_types:
-      - System.Object
-      - System.Data.CommandBehavior
-      minimum_version: 4.0.0
-      maximum_version: 4.*.*
-    wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.26.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
-      type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteScalarWithBehaviorIntegration
-      action: CallTargetModification
-  - target:
-      assembly: System.Data.SqlClient
-      type: System.Data.SqlClient.SqlCommand
-      method: ExecuteScalar
-      signature_types:
-      - System.Object
-      - System.Data.CommandBehavior
-      minimum_version: 4.0.0
-      maximum_version: 4.*.*
-    wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.26.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
-      type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteScalarWithBehaviorIntegration
-      action: CallTargetModification
-  - target:
-      assembly: Microsoft.Data.SqlClient
-      type: Microsoft.Data.SqlClient.SqlCommand
-      method: ExecuteScalar
-      signature_types:
-      - System.Object
-      - System.Data.CommandBehavior
-      minimum_version: 1.0.0
-      maximum_version: 5.*.*
-    wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.26.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
-      type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteScalarWithBehaviorIntegration
       action: CallTargetModification
 - name: SqliteCommand
   method_replacements:
@@ -1325,7 +1169,7 @@
       minimum_version: 2.0.0
       maximum_version: 8.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.26.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.27.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteNonQueryAsyncIntegration
       action: CallTargetModification
   - target:
@@ -1338,7 +1182,7 @@
       minimum_version: 1.0.0
       maximum_version: 2.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.26.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.27.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteNonQueryAsyncIntegration
       action: CallTargetModification
   - target:
@@ -1350,7 +1194,7 @@
       minimum_version: 2.0.0
       maximum_version: 8.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.26.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.27.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteNonQueryIntegration
       action: CallTargetModification
   - target:
@@ -1362,21 +1206,8 @@
       minimum_version: 1.0.0
       maximum_version: 2.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.26.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.27.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteNonQueryIntegration
-      action: CallTargetModification
-  - target:
-      assembly: Microsoft.Data.Sqlite
-      type: Microsoft.Data.Sqlite.SqliteCommand
-      method: ExecuteNonQuery
-      signature_types:
-      - System.Int32
-      - System.Data.CommandBehavior
-      minimum_version: 2.0.0
-      maximum_version: 8.*.*
-    wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.26.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
-      type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteNonQueryWithBehaviorIntegration
       action: CallTargetModification
   - target:
       assembly: System.Data.SQLite
@@ -1388,7 +1219,7 @@
       minimum_version: 1.0.0
       maximum_version: 2.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.26.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.27.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteNonQueryWithBehaviorIntegration
       action: CallTargetModification
   - target:
@@ -1401,7 +1232,7 @@
       minimum_version: 2.0.0
       maximum_version: 8.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.26.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.27.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteReaderAsyncIntegration
       action: CallTargetModification
   - target:
@@ -1414,7 +1245,7 @@
       minimum_version: 1.0.0
       maximum_version: 2.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.26.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.27.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteReaderAsyncIntegration
       action: CallTargetModification
   - target:
@@ -1426,7 +1257,7 @@
       minimum_version: 2.0.0
       maximum_version: 8.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.26.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.27.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteReaderIntegration
       action: CallTargetModification
   - target:
@@ -1438,7 +1269,7 @@
       minimum_version: 1.0.0
       maximum_version: 2.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.26.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.27.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteReaderIntegration
       action: CallTargetModification
   - target:
@@ -1452,7 +1283,7 @@
       minimum_version: 2.0.0
       maximum_version: 8.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.26.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.27.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteReaderWithBehaviorAsyncIntegration
       action: CallTargetModification
   - target:
@@ -1466,7 +1297,7 @@
       minimum_version: 1.0.0
       maximum_version: 2.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.26.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.27.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteReaderWithBehaviorAsyncIntegration
       action: CallTargetModification
   - target:
@@ -1480,7 +1311,7 @@
       minimum_version: 2.0.0
       maximum_version: 8.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.26.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.27.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteReaderWithBehaviorAsyncIntegration
       action: CallTargetModification
   - target:
@@ -1493,7 +1324,7 @@
       minimum_version: 2.0.0
       maximum_version: 8.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.26.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.27.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteReaderWithBehaviorIntegration
       action: CallTargetModification
   - target:
@@ -1506,7 +1337,7 @@
       minimum_version: 1.0.0
       maximum_version: 2.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.26.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.27.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteReaderWithBehaviorIntegration
       action: CallTargetModification
   - target:
@@ -1519,7 +1350,7 @@
       minimum_version: 2.0.0
       maximum_version: 8.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.26.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.27.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteReaderWithBehaviorIntegration
       action: CallTargetModification
   - target:
@@ -1532,7 +1363,7 @@
       minimum_version: 2.0.0
       maximum_version: 8.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.26.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.27.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteScalarAsyncIntegration
       action: CallTargetModification
   - target:
@@ -1545,7 +1376,7 @@
       minimum_version: 1.0.0
       maximum_version: 2.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.26.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.27.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteScalarAsyncIntegration
       action: CallTargetModification
   - target:
@@ -1557,7 +1388,7 @@
       minimum_version: 2.0.0
       maximum_version: 8.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.26.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.27.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteScalarIntegration
       action: CallTargetModification
   - target:
@@ -1569,21 +1400,8 @@
       minimum_version: 1.0.0
       maximum_version: 2.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.26.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.27.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteScalarIntegration
-      action: CallTargetModification
-  - target:
-      assembly: Microsoft.Data.Sqlite
-      type: Microsoft.Data.Sqlite.SqliteCommand
-      method: ExecuteScalar
-      signature_types:
-      - System.Object
-      - System.Data.CommandBehavior
-      minimum_version: 2.0.0
-      maximum_version: 8.*.*
-    wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.26.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
-      type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteScalarWithBehaviorIntegration
       action: CallTargetModification
   - target:
       assembly: System.Data.SQLite
@@ -1595,6 +1413,6 @@
       minimum_version: 1.0.0
       maximum_version: 2.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.26.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.27.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteScalarWithBehaviorIntegration
       action: CallTargetModification


### PR DESCRIPTION
In a default .NET Framework ASP.NET app, when adding the profiler auto-instrumentation, the profiler logs report:

```
[ERROR] No rejit method found for target: System.Data.SqlClient.SqlCommand.ExecuteNonQuery
[ERROR] No rejit method found for target: System.Data.SqlClient.SqlCommand.ExecuteScalar
```

On review, this is due to the instrumentation attempting to locate overloads of these methods accepting `CommandBehavior`. The only library where these seem to apply is `System.Data.SQLite`.