### PR TITLE
Added check that Open Telemetry Bridge is enable and only then display warning

### DIFF
--- a/src/Elastic.Apm/AgentComponents.cs
+++ b/src/Elastic.Apm/AgentComponents.cs
@@ -148,7 +148,7 @@ namespace Elastic.Apm
 #else
 			if (success)
 			{
-				if (serverInfo.Version >= new ElasticVersion(7, 16, 0, string.Empty))
+				if (serverInfo.Version >= new ElasticVersion(7, 16, 0, string.Empty) && (!Configuration.OpenTelemetryBridgeEnabled))
 				{
 					Logger.Info()
 						?.Log("APM Server version ready - OpenTelemetry (Activity) bridge is active. Current Server version: {version}",


### PR DESCRIPTION
Added check so that warning is only displayed when configuration is enabled. Now warning is displayed in all cases and is misleading.