### PR TITLE
Update Github Actions Test reporter

### DIFF
--- a/build/scripts/Build.fs
+++ b/build/scripts/Build.fs
@@ -164,8 +164,8 @@ module Build =
         
         let logger =
             match BuildServer.isGitHubActionsBuild with
-            | true -> Some "--logger:\"GitHubActions;summary.includePassedTests=false\""
-            | fase -> None 
+            | true -> Some "--logger:\"GitHubActions;summary.includePassedTests=false;summary.includeNotFoundTests=false\""
+            | _ -> None 
             
         let filter = 
             match suite with

--- a/build/scripts/Build.fs
+++ b/build/scripts/Build.fs
@@ -183,6 +183,7 @@ module Build =
             @ (match filter with None -> [] | Some f -> ["--filter"; f])
             @ (match framework with None -> [] | Some f -> ["-f"; f])
             @ (match logger with None -> [] | Some l -> [l])
+            @ ["--"; "RunConfiguration.CollectSourceInformation=true"]
             
         DotNet.ExecWithTimeout command (TimeSpan.FromMinutes 30)
         

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -22,7 +22,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
     
     <PackageReference Include="JunitXml.TestLogger" Version="3.1.12" PrivateAssets="All" />
-    <PackageReference Include="GitHubActionsTestLogger" Version="2.3.3" PrivateAssets="All" />
+    <PackageReference Include="GitHubActionsTestLogger" Version="2.4.1" PrivateAssets="All" />
     <PackageReference Include="Nullean.VsTest.Pretty.TestLogger" Version="0.4.0" PrivateAssets="All" />
 
     <PackageReference Include="FluentAssertions" Version="5.6.0" />


### PR DESCRIPTION
See: https://github.com/Tyrrrz/GitHubActionsTestLogger/pull/26

We use --filter to selectively run test assemblies in different runs.

This produces somewhat noisy reports where assemblies are marked as (failed/succeeded) and skipped multiple times:

[elastic/apm-agent-dotnet/actions/runs/9275127823?pr=2315#summary-25519083669](https://github.com/elastic/apm-agent-dotnet/actions/runs/9275127823?pr=2315#summary-25519083669)

This new update allows us to not report filtered out assemblies.