### PR TITLE
Do not read claims from SqlRoleProvider under classic ASP.NET

### DIFF
--- a/src/integrations/Elastic.Apm.AspNetFullFramework/Elastic.Apm.AspNetFullFramework.csproj
+++ b/src/integrations/Elastic.Apm.AspNetFullFramework/Elastic.Apm.AspNetFullFramework.csproj
@@ -18,6 +18,7 @@
     <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
     <Reference Include="System.Web" />
+    <Reference Include="System.Web.ApplicationServices" />
     <ProjectReference Include="..\..\Elastic.Apm\Elastic.Apm.csproj" />
   </ItemGroup>
 

--- a/src/integrations/Elastic.Apm.AspNetFullFramework/ElasticApmModule.cs
+++ b/src/integrations/Elastic.Apm.AspNetFullFramework/ElasticApmModule.cs
@@ -631,9 +631,8 @@ namespace Elastic.Apm.AspNetFullFramework
 				return;
 
 			var user = new User { UserName = userIdentity.Name };
-			var sqlProviderConfigured = System.Web.Security.Membership.Providers.Cast<object>().Any(provider => provider.GetType().Name == "SqlMembershipProvider");
-
-			if (!sqlProviderConfigured && context.User is ClaimsPrincipal claimsPrincipal)
+			var sqlRoleProvider = System.Web.Security.Roles.Providers.Cast<object>().Any(provider => provider.GetType().Name == "SqlRoleProvider");
+			if (!sqlRoleProvider && context.User is ClaimsPrincipal claimsPrincipal)
 			{
 				try
 				{

--- a/src/integrations/Elastic.Apm.AspNetFullFramework/ElasticApmModule.cs
+++ b/src/integrations/Elastic.Apm.AspNetFullFramework/ElasticApmModule.cs
@@ -631,8 +631,9 @@ namespace Elastic.Apm.AspNetFullFramework
 				return;
 
 			var user = new User { UserName = userIdentity.Name };
+			var sqlProviderConfigured = System.Web.Security.Membership.Providers.Cast<object>().Any(provider => provider.GetType().Name == "SqlMembershipProvider");
 
-			if (context.User is ClaimsPrincipal claimsPrincipal)
+			if (!sqlProviderConfigured && context.User is ClaimsPrincipal claimsPrincipal)
 			{
 				try
 				{


### PR DESCRIPTION
Otherwise `SqlRoleProvider` potentially tries to ensure a local database is created to provide 


```
[2024-06-13 12:41:39.959 +08:00][55][Error] - {ElasticApmModule.#4} Processing EndRequest event failed +-> Exception: System.Web.HttpException: Unable to connect to SQL Server database.
   at System.Web.DataAccess.SqlConnectionHelper.CreateMdfFile(String fullFileName, String dataDir, String connectionString)
   at System.Web.DataAccess.SqlConnectionHelper.EnsureDBFile(String connectionString)
   at System.Web.DataAccess.SqlConnectionHelper.GetConnection(String connectionString, Boolean revertImpersonation)
   at System.Web.Security.SqlRoleProvider.GetRolesForUser(String username)
   at System.Web.Security.RolePrincipal.GetRoles()
   at System.Web.Security.RoleClaimProvider.<get_Claims>d__4.MoveNext()
   at System.Security.Claims.ClaimsIdentity.<get_Claims>d__51.MoveNext()
   at System.Security.Claims.ClaimsPrincipal.<get_Claims>d__37.MoveNext()
   at System.Linq.Enumerable.FirstOrDefault[TSource](IEnumerable`1 source, Func`2 predicate)
   at Elastic.Apm.AspNetFullFramework.ElasticApmModule.<FillSampledTransactionContextUser>g__GetClaimWithFallbackValue|32_0(ClaimsPrincipal principal, String claimType, String fallbackClaimType)
   at Elastic.Apm.AspNetFullFramework.ElasticApmModule.FillSampledTransactionContextUser(HttpContext context, ITransaction transaction)
   at Elastic.Apm.AspNetFullFramework.ElasticApmModule.ProcessEndRequest(Object sender)
   at Elastic.Apm.AspNetFullFramework.ElasticApmModule.OnEndRequest(Object sender, EventArgs e)
```