### PR TITLE
release: fix adding latest tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,10 +59,8 @@ jobs:
         flavor: |
           latest=auto
         tags: |
-          # set latest tag for default branch
-          type=raw,value=latest,enable={{is_default_branch}}
-          # "1.2.3" and "latest" Docker tags on push of git tag "v1.2.3"
-          type=raw,value=${{ steps.bootstrap.outputs.agent-version }}
+          # "1.2.3" and "latest" Docker tags on push of git tag "v1.2.3"          
+          type=semver,pattern={{version}},value=${{ steps.bootstrap.outputs.agent-version }}
           # "edge" Docker tag on git push to default branch
           type=edge
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,7 +59,7 @@ jobs:
         flavor: |
           latest=auto
         tags: |
-          # "1.2.3" and "latest" Docker tags on push of git tag "v1.2.3"          
+          # "1.2.3" and "latest" Docker tags on push of git tag "v1.2.3"
           type=semver,pattern={{version}},value=${{ steps.bootstrap.outputs.agent-version }}
           # "edge" Docker tag on git push to default branch
           type=edge

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,6 +59,8 @@ jobs:
         flavor: |
           latest=auto
         tags: |
+          # set latest tag for default branch
+          type=raw,value=latest,enable={{is_default_branch}}
           # "1.2.3" and "latest" Docker tags on push of git tag "v1.2.3"
           type=raw,value=${{ steps.bootstrap.outputs.agent-version }}
           # "edge" Docker tag on git push to default branch


### PR DESCRIPTION
## Context

According to https://github.com/docker/metadata-action?tab=readme-ov-file#latest-tag the latest tag is only created on specific configurations.

![image](https://github.com/user-attachments/assets/13621324-7f5c-4cb3-b289-bda5eb035889)

## What Changed

In this change, I'm replacing the type `raw` with `semver` so that the `latest` tag is created automatically.

## Testing

I was able to test and verify the correct behavior in a test repo at https://github.com/unelastisch/test-publish-docker/actions/runs/9960071835/job/27518417577, where the action is producing both the semver and the latest tag.

![image](https://github.com/user-attachments/assets/5d9ccef4-e70d-4240-bb50-3c2c63668601)

Here is the workflow file I used to reproduce it: https://github.com/unelastisch/test-publish-docker/actions/runs/9960071835/workflow