### PR TITLE
Adding filters should not force initialization of Agent.

### DIFF
--- a/src/Elastic.Apm/Agent.cs
+++ b/src/Elastic.Apm/Agent.cs
@@ -74,7 +74,8 @@ namespace Elastic.Apm
 				agent.Logger?.Trace()
 					?.Log("Initialization - Agent instance initialized. Callstack: {callstack}", new StackTrace().ToString());
 
-				if (agent.Components.PayloadSender is not IPayloadSenderWithFilters sender) return agent;
+				if (agent.Components.PayloadSender is not IPayloadSenderWithFilters sender)
+					return agent;
 
 				ErrorFilters.ForEach(f => sender.AddFilter(f));
 				TransactionFilters.ForEach(f => sender.AddFilter(f));

--- a/src/Elastic.Apm/Agent.cs
+++ b/src/Elastic.Apm/Agent.cs
@@ -39,7 +39,6 @@ namespace Elastic.Apm
 	internal class ApmAgent : IApmAgent, IDisposable
 	{
 		internal readonly CompositeDisposable Disposables = new();
-
 		internal ApmAgent(AgentComponents agentComponents) => Components = agentComponents ?? new AgentComponents();
 
 		internal ICentralConfigurationFetcher CentralConfigurationFetcher => Components.CentralConfigurationFetcher;
@@ -72,15 +71,29 @@ namespace Elastic.Apm
 			lock (InitializationLock)
 			{
 				var agent = new ApmAgent(Components);
-
 				agent.Logger?.Trace()
 					?.Log("Initialization - Agent instance initialized. Callstack: {callstack}", new StackTrace().ToString());
+
+				if (agent.Components.PayloadSender is not IPayloadSenderWithFilters sender) return agent;
+
+				ErrorFilters.ForEach(f => sender.AddFilter(f));
+				TransactionFilters.ForEach(f => sender.AddFilter(f));
+				SpanFilters.ForEach(f => sender.AddFilter(f));
+				agent.Logger?.Trace()
+					?.Log(@"Initialization - Added filters to agent (errors:{{ErrorFilters}}, transactions:{TransactionFilters} spans:{SpanFilters}",
+						ErrorFilters.Count, TransactionFilters.Count, SpanFilters.Count);
 
 				return agent;
 			}
 		});
 
 		private static readonly object InitializationLock = new object();
+
+		private static readonly List<Func<IError, IError>> ErrorFilters = [];
+
+		private static readonly List<Func<ISpan, ISpan>> SpanFilters = [];
+
+		private static readonly List<Func<ITransaction, ITransaction>> TransactionFilters = [];
 
 		internal static AgentComponents Components { get; private set; }
 
@@ -114,7 +127,16 @@ namespace Elastic.Apm
 		/// <code>true</code> if the filter was added successfully, <code>false</code> otherwise. In case the method
 		/// returns <code>false</code> the filter won't be called.
 		/// </returns>
-		public static bool AddFilter(Func<ITransaction, ITransaction> filter) => CheckAndAddFilter(p => p.TransactionFilters.Add(filter));
+		public static bool AddFilter(Func<ITransaction, ITransaction> filter)
+		{
+			if (!IsConfigured)
+			{
+				TransactionFilters.Add(filter);
+				return true;
+			}
+
+			return CheckAndAddFilter(p => p.AddFilter(filter));
+		}
 
 		/// <summary>
 		/// Adds a filter which gets called before each span gets sent to APM Server.
@@ -133,7 +155,16 @@ namespace Elastic.Apm
 		/// <code>true</code> if the filter was added successfully, <code>false</code> otherwise. In case the method
 		/// returns <code>false</code> the filter won't be called.
 		/// </returns>
-		public static bool AddFilter(Func<ISpan, ISpan> filter) => CheckAndAddFilter(p => p.SpanFilters.Add(filter));
+		public static bool AddFilter(Func<ISpan, ISpan> filter)
+		{
+			if (!IsConfigured)
+			{
+				SpanFilters.Add(filter);
+				return true;
+			}
+
+			return CheckAndAddFilter(p => p.AddFilter(filter));
+		}
 
 		/// <summary>
 		/// Adds a filter which gets called before each error gets sent to APM Server.
@@ -152,15 +183,23 @@ namespace Elastic.Apm
 		/// <code>true</code> if the filter was added successfully, <code>false</code> otherwise. In case the method
 		/// returns <code>false</code> the filter won't be called.
 		/// </returns>
-		public static bool AddFilter(Func<IError, IError> filter) => CheckAndAddFilter(p => p.ErrorFilters.Add(filter));
-
-		private static bool CheckAndAddFilter(Action<PayloadSenderV2> action)
+		public static bool AddFilter(Func<IError, IError> filter)
 		{
-			if (!(Instance.PayloadSender is PayloadSenderV2 payloadSenderV2))
+			if (!IsConfigured)
+			{
+				ErrorFilters.Add(filter);
+				return true;
+			}
+
+			return CheckAndAddFilter(p => p.AddFilter(filter));
+		}
+
+		private static bool CheckAndAddFilter(Func<IPayloadSenderWithFilters, bool> action)
+		{
+			if (Instance.PayloadSender is not IPayloadSenderWithFilters sender)
 				return false;
 
-			action(payloadSenderV2);
-			return true;
+			return action(sender);
 		}
 
 		/// <summary>
@@ -202,7 +241,7 @@ namespace Elastic.Apm
 				agentComponents?.Logger?.Trace()
 					?.Log("Initialization - Agent.Setup called");
 
-				Components = agentComponents;
+
 				// Force initialization
 				var _ = LazyApmAgent.Value;
 			}

--- a/src/Elastic.Apm/Agent.cs
+++ b/src/Elastic.Apm/Agent.cs
@@ -239,6 +239,8 @@ namespace Elastic.Apm
 					return;
 				}
 
+				Components ??= agentComponents;
+
 				agentComponents?.Logger?.Trace()
 					?.Log("Initialization - Agent.Setup called");
 

--- a/src/Elastic.Apm/Report/IPayloadSender.cs
+++ b/src/Elastic.Apm/Report/IPayloadSender.cs
@@ -2,6 +2,8 @@
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
 
+using System;
+using System.Collections.Generic;
 using Elastic.Apm.Api;
 
 namespace Elastic.Apm.Report
@@ -15,5 +17,12 @@ namespace Elastic.Apm.Report
 		void QueueSpan(ISpan span);
 
 		void QueueTransaction(ITransaction transaction);
+	}
+
+	public interface IPayloadSenderWithFilters
+	{
+		bool AddFilter(Func<ITransaction, ITransaction> transactionFilter);
+		bool AddFilter(Func<ISpan, ISpan> spanFilter);
+		bool AddFilter(Func<IError, IError> errorFilter);
 	}
 }

--- a/src/Elastic.Apm/Report/PayloadSenderV2.cs
+++ b/src/Elastic.Apm/Report/PayloadSenderV2.cs
@@ -503,7 +503,8 @@ namespace Elastic.Apm.Report
 
 		public bool AddFilter(Func<ITransaction, ITransaction> transactionFilter)
 		{
-			if (!_allowFilterAdd) return false;
+			if (!_allowFilterAdd)
+				return false;
 
 			TransactionFilters.Add(transactionFilter);
 			return true;
@@ -511,7 +512,8 @@ namespace Elastic.Apm.Report
 
 		public bool AddFilter(Func<ISpan, ISpan> spanFilter)
 		{
-			if (!_allowFilterAdd) return false;
+			if (!_allowFilterAdd)
+				return false;
 
 			SpanFilters.Add(spanFilter);
 			return true;
@@ -519,7 +521,8 @@ namespace Elastic.Apm.Report
 
 		public bool AddFilter(Func<IError, IError> errorFilter)
 		{
-			if (!_allowFilterAdd) return false;
+			if (!_allowFilterAdd)
+				return false;
 
 			ErrorFilters.Add(errorFilter);
 			return true;

--- a/test/Elastic.Apm.Tests.Utilities/MockPayloadSender.cs
+++ b/test/Elastic.Apm.Tests.Utilities/MockPayloadSender.cs
@@ -251,7 +251,7 @@ namespace Elastic.Apm.Tests.Utilities
 		{
 			lock (_transactionLock)
 			{
-				transaction =  _transactionFilters
+				transaction = _transactionFilters
 					.Aggregate(transaction, (current, filter) => filter(current));
 				_transactions.Add(transaction);
 				_transactionWaitHandle.Set();

--- a/test/Elastic.Apm.Tests.Utilities/NoopPayloadSender.cs
+++ b/test/Elastic.Apm.Tests.Utilities/NoopPayloadSender.cs
@@ -2,12 +2,14 @@
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
 
+using System;
+using System.Collections.Generic;
 using Elastic.Apm.Api;
 using Elastic.Apm.Report;
 
 namespace Elastic.Apm.Tests.Utilities
 {
-	public class NoopPayloadSender : IPayloadSender
+	public class NoopPayloadSender : IPayloadSender, IPayloadSenderWithFilters
 	{
 		public void QueueError(IError error) { }
 
@@ -16,5 +18,12 @@ namespace Elastic.Apm.Tests.Utilities
 		public void QueueSpan(ISpan span) { }
 
 		public void QueueMetrics(IMetricSet metricSet) { }
+
+		public bool AddFilter(Func<ITransaction, ITransaction> transactionFilter) => true;
+
+		public bool AddFilter(Func<ISpan, ISpan> spanFilter) => true;
+
+		public bool AddFilter(Func<IError, IError> errorFilter) => true;
+
 	}
 }


### PR DESCRIPTION
Instead if the agent is not yet setup we simply buffer the filters until the agent gets constructed.

This allows you to add filters before initializing the static agent.

This manifested itself in the hosted service integrations (.NET Core) where the agent get's constructed slightly delayed.

And calling

```
Agent.AddFilter((ISpan span) =>
{
    return span;
});
```

Would win the race for `Agent.Instance` over the ASP.NET core integrations.
