### PR TITLE
Fix #2422 SetAgentActivationMethod throws CultureNotFoundException in global-invariant mode

### DIFF
--- a/src/Elastic.Apm/Api/Service.cs
+++ b/src/Elastic.Apm/Api/Service.cs
@@ -84,8 +84,9 @@ namespace Elastic.Apm.Api
 		{
 			static bool CheckForLoadedAssembly(string name)
 			{
-				return AppDomain.CurrentDomain.GetAssemblies().Any(n =>
-					n.GetName().Name.Equals(name, StringComparison.OrdinalIgnoreCase));
+				// Avoid using Assembly.GetName() which can't be used with globalization-invariant mode enabled
+				return AppDomain.CurrentDomain.GetAssemblies()
+					.Any(n => n.FullName.Split(',')[0].Equals(name, StringComparison.OrdinalIgnoreCase));
 			}
 
 			// Assume NuGet as the default.


### PR DESCRIPTION
Fixes #2422 