### PR TITLE
Relax ECS container ID regex

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -23,6 +23,13 @@ endif::[]
 [[release-notes-1.x]]
 === .NET Agent version 1.x
 
+[[release-notes-1.28.5]]
+==== 1.28.5 - 2024/08/28
+
+===== Bug fixes
+
+{pull}2430[#2430] Relax ECS container ID regex.
+
 [[release-notes-1.28.4]]
 ==== 1.28.4 - 2024/08/19
 

--- a/src/Elastic.Apm/Helpers/SystemInfoHelper.cs
+++ b/src/Elastic.Apm/Helpers/SystemInfoHelper.cs
@@ -18,7 +18,7 @@ namespace Elastic.Apm.Helpers
 	{
 		private readonly Regex _containerUidRegex = new Regex("^[0-9a-fA-F]{64}$");
 		private readonly Regex _shortenedUuidRegex = new Regex("^[0-9a-fA-F]{8}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{4,}");
-		private readonly Regex _ecsContainerIdRegex = new Regex("^[a-z0-9]{32}-[0-9]{10}$");
+		private readonly Regex _ecsContainerIdRegex = new Regex("^[a-z0-9]{32}-[0-9]{1,10}$");
 		private readonly Regex _podRegex = new Regex(
 			@"(?:^/kubepods[\S]*/pod([^/]+)$)|(?:^/kubepods\.slice/(kubepods-[^/]+\.slice/)?kubepods[^/]*-pod([^/]+)\.slice$)");
 


### PR DESCRIPTION
As agreed in the weekly team call, we will relax the ECS container ID regex in the spec since we have seen examples where the container ID suffix is shorter than the documented ten characters. 