### PR TITLE
Exclude default processes and services

### DIFF
--- a/docs/setup-auto-instrumentation.asciidoc
+++ b/docs/setup-auto-instrumentation.asciidoc
@@ -392,11 +392,25 @@ For example, `dotnet.exe;powershell.exe`. Can be used in scenarios where profile
 environment variables have a global scope that would end up auto-instrumenting
 applications that should not be.
 
+The following processes are _*always*_ excluded from profiling by default.
+
+* powershell.exe
+* ServerManager.exe
+* ReportingServicesService.exe
+* RSHostingService.exe
+* RSMananagement.exe
+* RSPortal.exe
+* RSConfigTool.exe
+
 `ELASTIC_APM_PROFILER_EXCLUDE_SERVICE_NAMES` _(optional)_::
 
 A semi-colon separated list of APM service names to exclude from auto-instrumentation.
 Values defined are checked against the value of <<config-service-name,`ELASTIC_APM_SERVICE_NAME`>>
 environment variable.
+
+The following service names are _*always*_ excluded from profiling by default.
+
+* SQLServerReportingServices
 
 `ELASTIC_OTEL_LOG_LEVEL` _(optional)_::
 

--- a/src/profiler/elastic_apm_profiler/src/profiler/env.rs
+++ b/src/profiler/elastic_apm_profiler/src/profiler/env.rs
@@ -53,6 +53,22 @@ const ELASTIC_APM_LOG_DIRECTORY_ENV_VAR: &str = "ELASTIC_APM_LOG_DIRECTORY";
 
 const ELASTIC_APM_SERVICE_NAME_ENV_VAR: &str = "ELASTIC_APM_SERVICE_NAME";
 
+// These are opinionated defaults for processes that should be excluded from profiling.
+const DEFAULT_EXCLUDED_PROCESSES: &[&str] = &[
+    "powershell.exe",
+    "ServerManager.exe",
+    "ReportingServicesService.exe",
+    "RSHostingService.exe",
+    "RSMananagement.exe",
+    "RSPortal.exe",
+    "RSConfigTool.exe"
+];
+
+// These are opinionated defaults for services that should be excluded from profiling.
+const DEFAULT_EXCLUDED_SERVICE_NAMES: &[&str] = &[
+    "SQLServerReportingServices" // We have reports that this "breaks" when running in IIS with global profiling enabled
+];
+
 pub static ELASTIC_APM_PROFILER_LOG_IL: Lazy<bool> =
     Lazy::new(|| read_bool_env_var(ELASTIC_APM_PROFILER_LOG_IL_ENV_VAR, false));
 
@@ -134,11 +150,17 @@ fn read_semicolon_separated_env_var(key: &str) -> Option<Vec<String>> {
 }
 
 pub fn get_exclude_processes() -> Option<Vec<String>> {
-    read_semicolon_separated_env_var(ELASTIC_APM_PROFILER_EXCLUDE_PROCESSES_ENV_VAR)
+    let mut processes = read_semicolon_separated_env_var(ELASTIC_APM_PROFILER_EXCLUDE_PROCESSES_ENV_VAR)
+        .unwrap_or_else(Vec::new);
+    processes.extend(DEFAULT_EXCLUDED_PROCESSES.iter().map(|s| s.to_string()));
+    Some(processes)
 }
 
 pub fn get_exclude_service_names() -> Option<Vec<String>> {
-    read_semicolon_separated_env_var(ELASTIC_APM_PROFILER_EXCLUDE_SERVICE_NAMES_ENV_VAR)
+    let mut services = read_semicolon_separated_env_var(ELASTIC_APM_PROFILER_EXCLUDE_SERVICE_NAMES_ENV_VAR)
+        .unwrap_or_else(Vec::new);
+    services.extend(DEFAULT_EXCLUDED_SERVICE_NAMES.iter().map(|s| s.to_string()));
+    Some(services)
 }
 
 pub fn get_service_name() -> Option<String> {

--- a/src/profiler/elastic_apm_profiler/src/profiler/mod.rs
+++ b/src/profiler/elastic_apm_profiler/src/profiler/mod.rs
@@ -522,7 +522,7 @@ impl Profiler {
 
         if let Some(exclude_process_names) = env::get_exclude_processes() {
             for exclude_process_name in exclude_process_names {
-                if process_file_name == exclude_process_name {
+                if process_file_name.to_lowercase() == exclude_process_name.to_lowercase() {
                     log::info!(
                         "Initialize: process name {} matches excluded name {}. Profiler disabled",
                         &process_file_name,
@@ -536,7 +536,7 @@ impl Profiler {
         if let Some(exclude_service_names) = env::get_exclude_service_names() {
             if let Some(service_name) = env::get_service_name() {
                 for exclude_service_name in exclude_service_names {
-                    if service_name == exclude_service_name {
+                    if service_name.to_lowercase() == exclude_service_name.to_lowercase() {
                         log::info!(
                             "Initialize: service name {} matches excluded name {}. Profiler disabled",
                             &service_name,


### PR DESCRIPTION
This also updates the comparison for excluded process and service names to be case insensitive.