### PR TITLE
Add test-reporter workflow again

### DIFF
--- a/.github/workflows/test-reporter.yml
+++ b/.github/workflows/test-reporter.yml
@@ -1,0 +1,22 @@
+on:
+  workflow_run:
+    workflows:
+      - jan-junit-test
+    types:
+      - completed
+
+permissions:
+  contents: read
+  actions: read
+  checks: write
+
+jobs:
+  report:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: elastic/oblt-actions/test-report@v1
+        with:
+          artifact: /test-results(.*)/
+          name: 'Test Repot $1'
+          path: "**/*.xml"
+          reporter: java-junit


### PR DESCRIPTION
Followed up from https://github.com/elastic/apm-agent-dotnet/pull/2438

This can be enabled again since we migrated to v4