### PR TITLE
Improve OTel bridge compatibility with existing Azure instrumentation

### DIFF
--- a/src/Elastic.Apm/DiagnosticListeners/KnownListeners.cs
+++ b/src/Elastic.Apm/DiagnosticListeners/KnownListeners.cs
@@ -9,18 +9,18 @@ namespace Elastic.Apm.DiagnosticListeners
 {
 	internal static class KnownListeners
 	{
+		// Known activity names
 		public const string MicrosoftAspNetCoreHostingHttpRequestIn = "Microsoft.AspNetCore.Hosting.HttpRequestIn";
 		public const string SystemNetHttpHttpRequestOut = "System.Net.Http.HttpRequestOut";
 		public const string SystemNetHttpDesktopHttpRequestOut = "System.Net.Http.Desktop.HttpRequestOut";
 		public const string ApmTransactionActivityName = "ElasticApm.Transaction";
 
-
-		public static HashSet<string> KnownListenersList => new()
-		{
+		public static HashSet<string> SkippedActivityNamesSet =>
+		[
 			MicrosoftAspNetCoreHostingHttpRequestIn,
 			SystemNetHttpHttpRequestOut,
 			SystemNetHttpDesktopHttpRequestOut,
 			ApmTransactionActivityName
-		};
+		];
 	}
 }

--- a/src/Elastic.Apm/Model/Transaction.cs
+++ b/src/Elastic.Apm/Model/Transaction.cs
@@ -28,7 +28,7 @@ internal class Transaction : ITransaction
 	internal static readonly string ApmTransactionActivityName = "ElasticApm.Transaction";
 
 #if NET
-	private static readonly ActivitySource ElasticApmActivitySource = new("Elastic.Apm");
+	internal static readonly ActivitySource ElasticApmActivitySource = new("Elastic.Apm");
 #endif
 
 	internal readonly TraceState _traceState;
@@ -147,7 +147,6 @@ internal class Transaction : ITransaction
 		var shouldRestartTrace = configuration.TraceContinuationStrategy == ConfigConsts.SupportedValues.Restart ||
 			(configuration.TraceContinuationStrategy == ConfigConsts.SupportedValues.RestartExternal
 				&& (distributedTracingData?.TraceState == null || distributedTracingData is { TraceState: { SampleRate: null } }));
-
 
 		// For each new transaction, start an Activity if we're not ignoring them.
 		// If Activity.Current is not null, the started activity will be a child activity,
@@ -552,11 +551,11 @@ internal class Transaction : ITransaction
 #endif
 		if (shouldRestartTrace)
 		{
-			activity.SetParentId(ActivityTraceId.CreateRandom(), ActivitySpanId.CreateRandom(),
+			activity?.SetParentId(ActivityTraceId.CreateRandom(), ActivitySpanId.CreateRandom(),
 				Activity.Current != null ? Activity.Current.ActivityTraceFlags : ActivityTraceFlags.None);
 		}
-		activity.SetIdFormat(ActivityIdFormat.W3C);
-		activity.Start();
+		activity?.SetIdFormat(ActivityIdFormat.W3C);
+		activity?.Start();
 		return activity;
 	}
 

--- a/src/Elastic.Apm/Model/Transaction.cs
+++ b/src/Elastic.Apm/Model/Transaction.cs
@@ -1,5 +1,4 @@
-// Licensed to Elasticsearch B.V under
-// one or more agreements.
+// Licensed to Elasticsearch B.V under one or more agreements.
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
 
@@ -29,6 +28,13 @@ internal class Transaction : ITransaction
 
 #if NET
 	internal static readonly ActivitySource ElasticApmActivitySource = new("Elastic.Apm");
+
+	// This simply ensures our transaction activity is always created.
+	internal static readonly ActivityListener Listener = new()
+	{
+		ShouldListenTo = s => s.Name == ElasticApmActivitySource.Name,
+		Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData
+	};
 #endif
 
 	internal readonly TraceState _traceState;

--- a/src/azure/Elastic.Apm.Azure.ServiceBus/AzureMessagingServiceBusDiagnosticListener.cs
+++ b/src/azure/Elastic.Apm.Azure.ServiceBus/AzureMessagingServiceBusDiagnosticListener.cs
@@ -126,10 +126,9 @@ namespace Elastic.Apm.Azure.ServiceBus
 
 			_onMessageCurrent = currentSegment switch
 			{
-				Span span => span.StartSpanInternal(name, ApiConstants.TypeMessaging, ServiceBus.SubType, action.ToLowerInvariant(),
-					id: activity.SpanId.ToString()),
+				Span span => span.StartSpanInternal(name, ApiConstants.TypeMessaging, ServiceBus.SubType, action.ToLowerInvariant()),
 				Transaction transaction => transaction.StartSpanInternal(name, ApiConstants.TypeMessaging, ServiceBus.SubType,
-					action.ToLowerInvariant(), id: activity.SpanId.ToString()),
+					action.ToLowerInvariant()),
 				_ => _onMessageCurrent
 			};
 		}

--- a/test/Elastic.Apm.Tests/ActivityIntegrationTests.cs
+++ b/test/Elastic.Apm.Tests/ActivityIntegrationTests.cs
@@ -27,7 +27,7 @@ namespace Elastic.Apm.Tests
 #if NET
 			var listener = new ActivityListener
 			{
-				ShouldListenTo = _ => true,
+				ShouldListenTo = a => a.Name == "Elastic.Apm",
 				Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData,
 				ActivityStarted = activity => { },
 				ActivityStopped = activity => { }

--- a/test/Elastic.Apm.Tests/ActivityIntegrationTests.cs
+++ b/test/Elastic.Apm.Tests/ActivityIntegrationTests.cs
@@ -2,7 +2,6 @@
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
 
-using System;
 using System.Diagnostics;
 using System.Linq;
 using System.Threading;
@@ -11,7 +10,6 @@ using Elastic.Apm.Tests.Utilities;
 using Elastic.Apm.Tests.Utilities.XUnit;
 using FluentAssertions;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Elastic.Apm.Tests
 {
@@ -26,21 +24,42 @@ namespace Elastic.Apm.Tests
 		[Fact]
 		public void ElasticTransactionReusesTraceIdFromCurrentActivity()
 		{
-			Activity.DefaultIdFormat = ActivityIdFormat.W3C;
+#if NET
+			var listener = new ActivityListener
+			{
+				ShouldListenTo = _ => true,
+				Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData,
+				ActivityStarted = activity => { },
+				ActivityStopped = activity => { }
+			};
 
-			var activity = new Activity("UnitTestActivity");
-			activity.Start();
+			ActivitySource.AddActivityListener(listener);
+#endif
 
-			Activity.Current.TraceId.Should().Be(activity.TraceId);
+			try
+			{
+				Activity.DefaultIdFormat = ActivityIdFormat.W3C;
 
-			var payloadSender = new MockPayloadSender();
-			using (var agent = new ApmAgent(new TestAgentComponents(payloadSender: payloadSender)))
-				agent.Tracer.CaptureTransaction("TestTransaction", "Test", () => Thread.Sleep(10));
+				var activity = new Activity("UnitTestActivity");
+				activity.Start();
 
-			payloadSender.FirstTransaction.TraceId.Should().Be(activity.TraceId.ToString());
-			payloadSender.FirstTransaction.ParentId.Should().BeNullOrEmpty();
+				Activity.Current.TraceId.Should().Be(activity.TraceId);
 
-			activity.Stop();
+				var payloadSender = new MockPayloadSender();
+				using (var agent = new ApmAgent(new TestAgentComponents(payloadSender: payloadSender)))
+					agent.Tracer.CaptureTransaction("TestTransaction", "Test", () => Thread.Sleep(10));
+
+				payloadSender.FirstTransaction.TraceId.Should().Be(activity.TraceId.ToString());
+				payloadSender.FirstTransaction.ParentId.Should().BeNullOrEmpty();
+
+				activity.Stop();
+			}
+			catch
+			{
+#if NET
+				listener.Dispose();
+#endif
+			}
 		}
 
 		/// <summary>
@@ -147,7 +166,8 @@ namespace Elastic.Apm.Tests
 			payloadSender.Transactions[0].Id.Should().NotBe(payloadSender.Transactions[1].Id);
 			activity.Stop();
 		}
-#if NET5_0_OR_GREATER
+
+#if NET
 		/// <summary>
 		/// Makes sure that transactions on the same Activity are part of the same trace.
 		/// </summary>
@@ -188,8 +208,6 @@ namespace Elastic.Apm.Tests
 
 			var sampledSpans = payloadSender.Spans.Where(t => t.IsSampled).ToArray();
 			sampledSpans.Length.Should().Be(sampled.Length);
-
-
 		}
 #endif
 	}

--- a/test/azure/Elastic.Apm.Azure.Storage.Tests/AzureQueueStorageDiagnosticListenerTests.cs
+++ b/test/azure/Elastic.Apm.Azure.Storage.Tests/AzureQueueStorageDiagnosticListenerTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics;
 using System.Threading.Tasks;
 using Azure.Storage.Queues;
 using Elastic.Apm.Api;
@@ -20,6 +21,21 @@ namespace Elastic.Apm.Azure.Storage.Tests
 		private readonly ApmAgent _agent;
 		private readonly IDisposable _subscription;
 		private readonly ITestOutputHelper _output;
+
+#if NET
+		static AzureQueueStorageDiagnosticListenerTests()
+		{
+			var listener = new ActivityListener
+			{
+				ShouldListenTo = a => a.Name == "Elastic.Apm",
+				Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData,
+				ActivityStarted = activity => { },
+				ActivityStopped = activity => { }
+			};
+
+			ActivitySource.AddActivityListener(listener);
+		}
+#endif
 
 		public AzureQueueStorageDiagnosticListenerTests(AzureStorageTestEnvironment environment, ITestOutputHelper output)
 		{

--- a/test/instrumentations/Elastic.Apm.SqlClient.Tests/SqlServerFixture.cs
+++ b/test/instrumentations/Elastic.Apm.SqlClient.Tests/SqlServerFixture.cs
@@ -3,6 +3,7 @@
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
 
+using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using Testcontainers.MsSql;
 using Xunit;
@@ -22,8 +23,19 @@ namespace Elastic.Apm.SqlClient.Tests
 		public SqlServerFixture(IMessageSink sink)
 		{
 			_sink = sink;
-			_container = new MsSqlBuilder()
-				.Build();
+
+			// see: https://blog.rufer.be/2024/09/22/workaround-fix-testcontainers-sql-error-docker-dotnet-dockerapiexception-docker-api-responded-with-status-codeconflict/
+			if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+			{
+				_container = new MsSqlBuilder()
+					.WithImage("mcr.microsoft.com/mssql/server:2022-latest")
+					.Build();
+			}
+			else
+			{
+				_container = new MsSqlBuilder()
+					.Build();
+			}
 		}
 
 		public async Task InitializeAsync()

--- a/test/profiler/Elastic.Apm.Profiler.Managed.Tests/AdoNet/SqlServerFixture.cs
+++ b/test/profiler/Elastic.Apm.Profiler.Managed.Tests/AdoNet/SqlServerFixture.cs
@@ -3,6 +3,7 @@
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
 
+using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using Testcontainers.MsSql;
 using Xunit;
@@ -14,7 +15,23 @@ namespace Elastic.Apm.Profiler.Managed.Tests.AdoNet
 
 	public sealed class SqlServerFixture : IAsyncLifetime
 	{
-		private readonly MsSqlContainer _container = new MsSqlBuilder().Build();
+		private readonly MsSqlContainer _container;
+
+		public SqlServerFixture()
+		{
+			// see: https://blog.rufer.be/2024/09/22/workaround-fix-testcontainers-sql-error-docker-dotnet-dockerapiexception-docker-api-responded-with-status-codeconflict/
+			if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+			{
+				_container = new MsSqlBuilder()
+					.WithImage("mcr.microsoft.com/mssql/server:2022-latest")
+					.Build();
+			}
+			else
+			{
+				_container = new MsSqlBuilder()
+					.Build();
+			}
+		}
 
 		public string ConnectionString => _container.GetConnectionString();
 


### PR DESCRIPTION
This ensures that the Azure SDK instrumentation doesn't use the existing `Activity` span ID, which, when combined with the OTel bridge, can lead to spans being parented by themselves.

This also enhances the logic of the OTel bridge so that we skip span creation for activities coming from the Azure SDK libraries if our Azure instrumentation assemblies are loaded. This ensures we don't create essentially repeated child spans.

Fixes #2454