### PR TITLE
github-actions: use ephemeral tokens

### DIFF
--- a/.github/workflows/addToProject.yml
+++ b/.github/workflows/addToProject.yml
@@ -11,10 +11,21 @@ jobs:
     if: github.event.issue && github.event.issue.milestone
     runs-on: ubuntu-latest
     steps:
+      - name: Get token
+        id: get_token
+        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2.1.0
+        with:
+          app_id: ${{ secrets.OBS_AUTOMATION_APP_ID }}
+          private_key: ${{ secrets.OBS_AUTOMATION_APP_PEM }}
+          permissions: >-
+            {
+              "organization_projects": "write",
+              "issues": "read"
+            }
 
       - name: Get project data
         env:
-          GITHUB_TOKEN: ${{ secrets.APM_TECH_USER_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.get_token.outputs.token }}
           TEAM: .NET
           ORGANIZATION: elastic
           PROJECT_NUMBER: 595
@@ -50,7 +61,7 @@ jobs:
 
       - name: Add issue to project
         env:
-          GITHUB_TOKEN: ${{ secrets.APM_TECH_USER_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.get_token.outputs.token }}
           ISSUE_ID: ${{ github.event.issue.node_id }}
         run: |
           item_id="$( gh api graphql -f query='
@@ -66,7 +77,7 @@ jobs:
 
       - name: Set fields
         env:
-          GITHUB_TOKEN: ${{ secrets.APM_TECH_USER_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.get_token.outputs.token }}
         run: |
           gh api graphql -f query='
             mutation (

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -15,13 +15,23 @@ jobs:
   triage:
     runs-on: ubuntu-latest
     steps:
-      
+    - name: Get token
+      id: get_token
+      uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2.1.0
+      with:
+        app_id: ${{ secrets.OBS_AUTOMATION_APP_ID }}
+        private_key: ${{ secrets.OBS_AUTOMATION_APP_PEM }}
+        permissions: >-
+          {
+            "members": "read"
+          }
+
     - id: is_elastic_member
       uses: elastic/oblt-actions/github/is-member-of@v1
       with:
         github-org: "elastic"
         github-user: ${{ github.actor }}
-        github-token: ${{ secrets.APM_TECH_USER_TOKEN }}
+        github-token: ${{ steps.get_token.outputs.token }}
 
     - name: Add community and triage labels
       if: contains(steps.is_elastic_member.outputs.result, 'false') && github.actor != 'dependabot[bot]'


### PR DESCRIPTION
Use ephemeral github tokens instead of a finer-grained token