### PR TITLE
Fix bug Improper handling of exceptional conditions Newtonsoft

### DIFF
--- a/test/iis/AspNetFullFrameworkSampleApp/AspNetFullFrameworkSampleApp.csproj
+++ b/test/iis/AspNetFullFrameworkSampleApp/AspNetFullFrameworkSampleApp.csproj
@@ -93,7 +93,7 @@
     <PackageReference Include="Microsoft.AspNet.WebApi" Version="5.2.4" />
     <PackageReference Include="Microsoft.AspNet.Web.Optimization" Version="1.1.3" />
     <PackageReference Include="Microsoft.Owin.Host.SystemWeb" Version="4.1.1" />
-    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="NLog" Version="4.6.8" />
     <PackageReference Include="SQLite.CodeFirst" Version="1.5.3.29" />
     <PackageReference Include="System.Data.SQLite" Version="1.0.112" />


### PR DESCRIPTION
`JsonConvert.DeserializeObject` vulnerable to Insecure Defaults due to improper handling of expressions with high nesting level that lead to StackOverFlow exception or high CPU and RAM usage.  Deserializing methods (like `JsonConvert.DeserializeObject`) will process the input that results in burning the CPU, allocating memory, and consuming a thread of execution. Quite high nesting level (>10kk, or 9.5MB of {a:{a:{... input) is needed to achieve the latency over 10 seconds, depending on the hardware.

To mitigate the issue one either need to update Newtonsoft.Json to 13.0.1 or set MaxDepth parameter in the JsonSerializerSettings. This can be done globally with the following statement. After that the parsing of the nested input will fail fast with Newtonsoft.Json.JsonReaderException:

```
//Create a string representation of an highly nested object (JSON serialized)
int nRep = 25000;
string json = string.Concat(Enumerable.Repeat("{a:", nRep)) + "1" +
 string.Concat(Enumerable.Repeat("}", nRep));

//Parse this object (leads to high CPU/RAM consumption)
var parsedJson = JsonConvert.DeserializeObject(json);

// Methods below all throw stack overflow with nRep around 20k and higher
// string a = parsedJson.ToString();
// string b = JsonConvert.SerializeObject(parsedJson);
```

https://github.com/elastic/apm-agent-dotnet/blob/0539257e257b237f003a7e2413c2261408571bae/src/Elastic.Apm/BackendComm/CentralConfig/CentralConfigurationResponseParser.cs#L45

[WeaknessCWE-755](https://cwe.mitre.org/data/definitions/755.html)