### PR TITLE
github-actions: use ephemeral github tokens

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,6 @@ on:
 permissions:
   contents: write
   issues: write
-  pull-requests: write
 
 env:
   NUGET_PACKAGES: ${{ github.workspace }}/.nuget/packages
@@ -173,10 +172,28 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Get token
+        id: get_token
+        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2.1.0
+        with:
+          app_id: ${{ secrets.OBS_AUTOMATION_APP_ID }}
+          private_key: ${{ secrets.OBS_AUTOMATION_APP_PEM }}
+          permissions: >-
+            {
+              "contents": "write",
+              "pull_requests": "write"
+            }
+          repositories: >-
+            ["apm-agent-dotnet"]
+
       - name: Setup git config
         uses: elastic/oblt-actions/git/setup@v1
+        with:
+          github-token: ${{ steps.get_token.outputs.token }}
 
       - name: Create GitHub Pull Request if minor release.
+        env:
+          GH_TOKEN: ${{ steps.get_token.outputs.token }}
         run: |
           echo "as long as there is a major.x branch"
           existed_in_local=$(git ls-remote --heads origin ${TARGET_BRANCH})

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,8 +5,7 @@ on:
     types: [published]
 
 permissions:
-  contents: write
-  issues: write
+  contents: read
 
 env:
   NUGET_PACKAGES: ${{ github.workspace }}/.nuget/packages
@@ -162,16 +161,10 @@ jobs:
     needs: [ 'release-windows']
     runs-on: ubuntu-latest
     env:
-      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       GIT_TAG: v${{ needs.release-windows.outputs.agent-version }}
       NEW_BRANCH: update/${{ needs.release-windows.outputs.agent-version }}
       TARGET_BRANCH: ${{ needs.release-windows.outputs.major-version }}.x
-
     steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
       - name: Get token
         id: get_token
         uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2.1.0
@@ -185,6 +178,11 @@ jobs:
             }
           repositories: >-
             ["apm-agent-dotnet"]
+
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ steps.get_token.outputs.token }}
 
       - name: Setup git config
         uses: elastic/oblt-actions/git/setup@v1


### PR DESCRIPTION
Use the temporary GitHub tokens generated with the GitHub app.

See https://github.com/elastic/apm-agent-dotnet/pull/2464