### PR TITLE
Fix span linking for Azure ServiceBus

### DIFF
--- a/src/azure/Elastic.Apm.Azure.ServiceBus/AzureMessagingServiceBusDiagnosticListener.cs
+++ b/src/azure/Elastic.Apm.Azure.ServiceBus/AzureMessagingServiceBusDiagnosticListener.cs
@@ -126,9 +126,13 @@ namespace Elastic.Apm.Azure.ServiceBus
 
 			_onMessageCurrent = currentSegment switch
 			{
-				Span span => span.StartSpanInternal(name, ApiConstants.TypeMessaging, ServiceBus.SubType, action.ToLowerInvariant()),
+				// NOTE: We explicity set the SpanId here to match the Activity (value of the payload) to ensure that span linking on the
+				// receiver works as expected. The Azure SDK attaches the diagnostic-id and traceparent to the message automatically.
+				// On the receiving end, we need to be able to correctly link the consuming span to the producer.
+
+				Span span => span.StartSpanInternal(name, ApiConstants.TypeMessaging, ServiceBus.SubType, action.ToLowerInvariant(), id: activity.SpanId.ToString()),
 				Transaction transaction => transaction.StartSpanInternal(name, ApiConstants.TypeMessaging, ServiceBus.SubType,
-					action.ToLowerInvariant()),
+					action.ToLowerInvariant(), id: activity.SpanId.ToString()),
 				_ => _onMessageCurrent
 			};
 		}


### PR DESCRIPTION
Align span ID with activity's span ID in ServiceBus listener

The code changes in the `AzureMessagingServiceBusDiagnosticListener.cs` file within the `Elastic.Apm.Azure.ServiceBus` namespace involve modifications to how spans are started for message actions. Specifically, the `StartSpanInternal` method now includes an explicit `id` parameter set to `activity.SpanId.ToString()`. This change ensures that the span ID matches the activity's span ID, which is crucial for correctly linking the consuming span to the producer. This adjustment is necessary because the Azure SDK automatically attaches the `diagnostic-id` and `traceparent` to the message, and proper span linking on the receiver end depends on this alignment.