### PR TITLE
feat: upgrade version mongoDb driver

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -39,8 +39,8 @@
     <PackageVersion Include="Grpc.Tools" Version="2.62.0" PrivateAssets="All" IncludeAssets="runtime; build; native; contentfiles; analyzers; buildtransitive" />
     <PackageVersion Include="JetBrains.Profiler.Api" Version="1.4.0" />
     <PackageVersion Include="JunitXml.TestLogger" Version="3.1.12" PrivateAssets="All" />
-    <PackageVersion Include="MongoDB.Driver" Version="2.28.0" />
-    <PackageVersion Include="MongoDB.Driver.Core" Version="2.28.0" />
+    <PackageVersion Include="MongoDB.Driver" Version="3.0.0" />
+    <PackageVersion Include="MongoDB.Driver.Core" Version="2.30.0" />
     <PackageVersion Include="Moq" Version="4.20.70" />
     <PackageVersion Include="MySql.Data" Version="8.0.32.1" />
     <PackageVersion Include="MySql.Data.EntityFrameworkCore" Version="8.0.22" />


### PR DESCRIPTION
when using mongodb driver 3.0 there is a conflict in the IEventSubscriber interface.