### PR TITLE
Update to .NET 9 SDK and bump some dependencies

### DIFF
--- a/.github/.github.csproj
+++ b/.github/.github.csproj
@@ -1,8 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>$(LatestNetVersion)</TargetFramework>
     <IsPackable>False</IsPackable>
     <ImplicitUsings>disable</ImplicitUsings>
   </PropertyGroup>
-
 </Project>

--- a/.github/workflows/bootstrap/action.yml
+++ b/.github/workflows/bootstrap/action.yml
@@ -22,8 +22,7 @@ outputs:
   major-version:
     description: "The current major version number, semver"
     value: ${{ steps.dotnet.outputs.major-version }}
-  
-    
+
 runs:
   using: "composite"
   steps:
@@ -45,8 +44,8 @@ runs:
       uses: actions/setup-dotnet@v4
       with:
         dotnet-version: |
-          6.0.x
           8.0.x
+          9.0.x
 
     - id: dotnet
       shell: bash

--- a/.github/workflows/install-dependencies/action.yml
+++ b/.github/workflows/install-dependencies/action.yml
@@ -59,7 +59,7 @@
         if: "${{ inputs.azure == 'true' && runner.os == 'Linux' }}"
         shell: bash
         run: |
-          wget -q https://packages.microsoft.com/config/ubuntu/20.04/packages-microsoft-prod.deb
+          wget -q https://packages.microsoft.com/config/ubuntu/22.04/packages-microsoft-prod.deb
           sudo dpkg -i packages-microsoft-prod.deb
           sudo apt-get update
           sudo apt-get install azure-functions-core-tools-4
@@ -67,7 +67,7 @@
       - name: 'Windows: Azure functions core tools'
         if: "${{ inputs.azure == 'true' && runner.os == 'Windows' }}"
         shell: cmd
-        run: choco install azure-functions-core-tools -y --no-progress -r --version 4.0.4829
+        run: choco install azure-functions-core-tools -y --no-progress -r --version 4.0.6610
           
       # TEST CONTAINERS CLOUD
       # If no PR event or if a PR event that's caused by a non-fork and non dependabot actor

--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -114,7 +114,6 @@ jobs:
       - name: Add msbuild to PATH
         uses: microsoft/setup-msbuild@6fb02220983dee41ce7ae257b6f4d8f9bf5ed4ce # v2
 
-
       - name: Clean the application
         run: msbuild /t:Clean /p:Configuration=Release
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
-  <!-- Root Directory Build Properties -->
-  <PropertyGroup>
+
+  <PropertyGroup Label="Root Directory Build Properties">
     <LangVersion>latest</LangVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>NU1701,NU1503,NU1608,CS8002,</NoWarn>
@@ -23,11 +23,16 @@
     <WarnOnPackingNonPackableProject>false</WarnOnPackingNonPackableProject>
     <IsPackable>false</IsPackable>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+    <LatestNetVersion>net9.0</LatestNetVersion>
+    <NetMinimumSupportedVersion>net8.0</NetMinimumSupportedVersion>
+    <NetFrameworkMinimumSupportedVersion>net462</NetFrameworkMinimumSupportedVersion>
+    <NetStandardMinimumSupportedVersion>netstandard2.0</NetStandardMinimumSupportedVersion>
   </PropertyGroup>
-  <!-- MinVer Configuration -->
-  <PropertyGroup>
+
+  <PropertyGroup Label="MinVer Configuration">
     <MinVerTagPrefix>v</MinVerTagPrefix>
     <MinVerDefaultPreReleaseIdentifiers>canary.0</MinVerDefaultPreReleaseIdentifiers>
     <MinVerMinimumMajorMinor>0.1</MinVerMinimumMajorMinor>
   </PropertyGroup>
+
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -99,10 +99,10 @@
     <PackageVersion Include="Microsoft.Azure.Cosmos" Version="3.0.0" />
     <PackageVersion Include="Microsoft.Azure.DocumentDB.Core" Version="2.22.0" />
     <PackageVersion Include="Microsoft.Azure.Functions.Extensions" Version="1.0.0" />
-    <PackageVersion Include="Microsoft.Azure.Functions.Worker" Version="1.20.0"/>
-    <PackageVersion Include="Microsoft.Azure.Functions.Worker.Core" Version="1.6.0" />
-    <PackageVersion Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.1.0"/>
-    <PackageVersion Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.16.1"/>
+    <PackageVersion Include="Microsoft.Azure.Functions.Worker" Version="2.0.0"/>
+    <PackageVersion Include="Microsoft.Azure.Functions.Worker.Core" Version="2.0.0" />
+    <PackageVersion Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.2.0"/>
+    <PackageVersion Include="Microsoft.Azure.Functions.Worker.Sdk" Version="2.0.0"/>
     <PackageVersion Include="Microsoft.Azure.ServiceBus" Version="3.0.0" />
     <PackageVersion Include="Microsoft.Azure.Storage.Blob" Version="11.2.2" />
     <PackageVersion Include="Microsoft.Data.SqlClient" Version="5.1.5" />
@@ -120,7 +120,7 @@
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Configuration" Version="8.0.0" />
     
-    <PackageVersion Include="Microsoft.NET.Sdk.Functions" Version="4.1.1" />
+    <PackageVersion Include="Microsoft.NET.Sdk.Functions" Version="4.6.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
     <PackageVersion Include="Microsoft.Owin.Host.SystemWeb" Version="4.1.1" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -2,10 +2,9 @@
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
-  
   <ItemGroup>
     <GlobalPackageReference Include="MinVer" Version="4.3.0" PrivateAssets="All" />
-    <GlobalPackageReference Condition="'$(TargetFramework)' == 'net462'" Include="Microsoft.NETFramework.ReferenceAssemblies.net462" Version="1.0.3" PrivateAssets="all"/>
+    <GlobalPackageReference Condition="'$(TargetFramework)' == 'net462'" Include="Microsoft.NETFramework.ReferenceAssemblies.net462" Version="1.0.3" PrivateAssets="all" />
   </ItemGroup>
   <!-- Community Packages -->
   <ItemGroup>
@@ -54,15 +53,15 @@
     <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.7.0" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.8.1" />
     <PackageVersion Include="Oracle.ManagedDataAccess" Version="21.13.0" />
-    <PackageVersion Include="Oracle.ManagedDataAccess.Core" Version="3.21.90"/>
+    <PackageVersion Include="Oracle.ManagedDataAccess.Core" Version="3.21.90" />
     <PackageVersion Include="Polly" Version="7.2.1" />
-    <PackageVersion Include="Proc" Version="0.6.2"/>
+    <PackageVersion Include="Proc" Version="0.6.2" />
     <PackageVersion Include="RabbitMQ.Client" Version="6.8.1" />
-    <PackageVersion Include="RichardSzalay.MockHttp" Version="6.0.0"/>
+    <PackageVersion Include="RichardSzalay.MockHttp" Version="6.0.0" />
     <PackageVersion Include="SQLite.CodeFirst" Version="1.5.3.29" />
     <PackageVersion Include="SharpZipLib" Version="1.3.3" />
-    <PackageVersion Include="SpecFlow.Tools.MsBuild.Generation" Version="3.5.5"/>
-    <PackageVersion Include="SpecFlow.xUnit" Version="3.5.5"/>
+    <PackageVersion Include="SpecFlow.Tools.MsBuild.Generation" Version="3.5.5" />
+    <PackageVersion Include="SpecFlow.xUnit" Version="3.5.5" />
     <PackageVersion Include="StackExchange.Redis" Version="2.7.20" />
     <PackageVersion Include="Swashbuckle.AspNetCore" Version="6.5.0" />
     <PackageVersion Include="Testcontainers.Elasticsearch" Version="3.7.0" />
@@ -78,7 +77,6 @@
     <PackageVersion Include="xunit" Version="2.7.0" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.5.7" PrivateAssets="All" IncludeAssets="runtime; build; native; contentfiles; analyzers; buildtransitive" />
   </ItemGroup>
-  
   <!-- Microsoft/System packages -->
   <ItemGroup>
     <PackageVersion Include="Microsoft.AspNet.Identity.EntityFramework" Version="2.2.3" />
@@ -98,19 +96,18 @@
     <PackageVersion Include="Microsoft.AspNetCore.Routing.Abstractions" Version="2.2.0" />
     <PackageVersion Include="Microsoft.Azure.Cosmos" Version="3.0.0" />
     <PackageVersion Include="Microsoft.Azure.DocumentDB.Core" Version="2.22.0" />
-    <PackageVersion Include="Microsoft.Azure.Functions.Extensions" Version="1.0.0" />
-    <PackageVersion Include="Microsoft.Azure.Functions.Worker" Version="2.0.0"/>
+    <PackageVersion Include="Microsoft.Azure.Functions.Extensions" Version="1.1.0" />
+    <PackageVersion Include="Microsoft.Azure.Functions.Worker" Version="2.0.0" />
     <PackageVersion Include="Microsoft.Azure.Functions.Worker.Core" Version="2.0.0" />
-    <PackageVersion Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.2.0"/>
-    <PackageVersion Include="Microsoft.Azure.Functions.Worker.Sdk" Version="2.0.0"/>
+    <PackageVersion Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.2.0" />
+    <PackageVersion Include="Microsoft.Azure.Functions.Worker.Sdk" Version="2.0.0" />
     <PackageVersion Include="Microsoft.Azure.ServiceBus" Version="3.0.0" />
     <PackageVersion Include="Microsoft.Azure.Storage.Blob" Version="11.2.2" />
     <PackageVersion Include="Microsoft.Data.SqlClient" Version="5.1.5" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="8.0.2" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational" Version="6.0.0" PrivateAssets="All"/>
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational" Version="6.0.0" PrivateAssets="All" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.2" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.2" />
-    
     <PackageVersion Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.UserSecrets" Version="8.0.0" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
@@ -119,7 +116,6 @@
     <PackageVersion Include="Microsoft.Extensions.Logging" Version="8.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Configuration" Version="8.0.0" />
-    
     <PackageVersion Include="Microsoft.NET.Sdk.Functions" Version="4.6.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
     <PackageVersion Include="Microsoft.Owin.Host.SystemWeb" Version="4.1.1" />
@@ -128,14 +124,14 @@
     <PackageVersion Include="MicrosoftAspNetCore.Http" Version="2.1.22" />
     <PackageVersion Include="System.CommandLine" Version="2.0.0-beta1.20427.1" />
     <PackageVersion Include="System.Data.SQLite" Version="1.0.112" />
-    <PackageVersion Include="System.Data.SqlClient" Version="4.8.6"/>
+    <PackageVersion Include="System.Data.SqlClient" Version="4.8.6" />
     <PackageVersion Include="System.Diagnostics.DiagnosticSource" Version="5.0.0" />
     <PackageVersion Include="System.Diagnostics.PerformanceCounter" Version="6.0.1" />
     <PackageVersion Include="System.IO.FileSystem.AccessControl" Version="4.7.0" />
     <PackageVersion Include="System.Reflection.Emit" Version="4.3.0" />
     <PackageVersion Include="System.Reflection.Emit.Lightweight" Version="4.3.0" />
     <PackageVersion Include="System.Reflection.Metadata" Version="5.0.0" />
-    <PackageVersion Include="System.Runtime.Loader" Version="4.3.0"/>
+    <PackageVersion Include="System.Runtime.Loader" Version="4.3.0" />
     <PackageVersion Include="System.Threading.Tasks.Dataflow" Version="4.9.0" />
     <PackageVersion Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
   </ItemGroup>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -24,12 +24,12 @@
     <PackageVersion Include="Elasticsearch.Net" Version="7.17.5" />
     <PackageVersion Include="Elasticsearch.Net.VirtualizedCluster" Version="7.6.1" />
     <PackageVersion Include="EntityFramework" Version="6.3.0" PrivateAssets="All" />
-    <PackageVersion Include="Fake.Core.Environment" Version="6.0.0" />
-    <PackageVersion Include="Fake.Core.SemVer" Version="6.0.0" />
-    <PackageVersion Include="Fake.DotNet.MsBuild" Version="6.0.0" />
-    <PackageVersion Include="Fake.IO.FileSystem" Version="6.0.0" />
-    <PackageVersion Include="Fake.IO.Zip" Version="6.0.0" />
-    <PackageVersion Include="Fake.Tools.Git" Version="6.0.0" />
+    <PackageVersion Include="Fake.Core.Environment" Version="6.1.3" />
+    <PackageVersion Include="Fake.Core.SemVer" Version="6.1.3" />
+    <PackageVersion Include="Fake.DotNet.MsBuild" Version="6.1.3" />
+    <PackageVersion Include="Fake.IO.FileSystem" Version="6.1.3" />
+    <PackageVersion Include="Fake.IO.Zip" Version="6.1.3" />
+    <PackageVersion Include="Fake.Tools.Git" Version="6.1.3" />
     <PackageVersion Include="FluentAssertions" Version="5.6.0" />
     <PackageVersion Include="FluentAssertions.Analyzers" Version="0.11.4" />
     <PackageVersion Include="GitHubActionsTestLogger" Version="2.4.1" PrivateAssets="All" />
@@ -42,6 +42,7 @@
     <PackageVersion Include="MongoDB.Driver" Version="2.28.0" />
     <PackageVersion Include="MongoDB.Driver.Core" Version="2.28.0" />
     <PackageVersion Include="Moq" Version="4.20.70" />
+    <PackageVersion Include="MSBuild.StructuredLogger" Version="2.2.386" />
     <PackageVersion Include="MySql.Data" Version="8.0.32.1" />
     <PackageVersion Include="MySql.Data.EntityFrameworkCore" Version="8.0.22" />
     <PackageVersion Include="NEST" Version="7.17.5" />

--- a/benchmarks/Elastic.Apm.Benchmarks/Elastic.Apm.Benchmarks.csproj
+++ b/benchmarks/Elastic.Apm.Benchmarks/Elastic.Apm.Benchmarks.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>$(LatestNetVersion)</TargetFramework>
     <IsTestProject>false</IsTestProject>
   </PropertyGroup>
 

--- a/benchmarks/Elastic.Apm.Profiling/Elastic.Apm.Profiling.csproj
+++ b/benchmarks/Elastic.Apm.Profiling/Elastic.Apm.Profiling.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>$(LatestNetVersion)</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsTestProject>false</IsTestProject>

--- a/build/build.fsproj
+++ b/build/build.fsproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>$(LatestNetVersion)</TargetFramework>
     <OutputType>Exe</OutputType>
     <NoWarn>$(NoWarn);NU1701</NoWarn>
     <IsPackable>false</IsPackable>
@@ -25,21 +25,17 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Bullseye" />
-    <PackageReference Include="System.CommandLine" />
-
     <PackageReference Include="Fake.Core.Environment" />
     <PackageReference Include="Fake.Core.SemVer" />
     <PackageReference Include="Fake.DotNet.MsBuild" />
     <PackageReference Include="Fake.IO.FileSystem" />
     <PackageReference Include="Fake.IO.Zip" />
     <PackageReference Include="Fake.Tools.Git" />
-
+    <PackageReference Include="MSBuild.StructuredLogger" />
     <PackageReference Include="Newtonsoft.Json" />
-
     <PackageReference Include="Octokit" />
     <PackageReference Include="Proc" />
-    
-    
+    <PackageReference Include="System.CommandLine" />
   </ItemGroup>
 
 </Project>

--- a/build/scripts/Build.fs
+++ b/build/scripts/Build.fs
@@ -76,7 +76,6 @@ module Build =
                     Properties = [
                         "Configuration", "Release"
                         "Optimize", "True"
-                        "dummy", "test" // See https://github.com/fsprojects/FAKE/issues/2738
                     ]
                     // current version of Fake MSBuild module does not support latest bin log file
                     // version of MSBuild in VS 16.8, so disable for now.
@@ -143,8 +142,6 @@ module Build =
         if isWindows && not isCI then msBuild "Build" aspNetFullFramework
         copyBinRelease()
         
-    /// Runs dotnet build on all .NET core projects in the solution.
-    /// When running on Windows and not CI, also runs MSBuild Build on .NET Framework
     let Test (suite: TestSuite) =
         let sln = 
             match suite with
@@ -182,7 +179,7 @@ module Build =
             @ (match logger with None -> [] | Some l -> [l])
             @ ["--"; "RunConfiguration.CollectSourceInformation=true"]
             
-        DotNet.ExecWithTimeout command (TimeSpan.FromMinutes 30)
+        DotNet.ExecWithTimeout command (TimeSpan.FromMinutes (30 : int64))
 
     /// Builds the CLR profiler and supporting .NET managed assemblies
     let BuildProfiler () =
@@ -221,11 +218,11 @@ module Build =
           
     let Clean () =
         Shell.cleanDir Paths.BuildOutputFolder
-        dotnet "clean" Paths.Solution       
+        dotnet "clean" Paths.Solution
         if isWindows && not isCI then msBuild "Clean" aspNetFullFramework
         
     let CleanProfiler () =
-        Cargo.ExecWithTimeout ["make"; "clean"; "--disable-check-for-update"] (TimeSpan.FromMinutes 10)
+        Cargo.ExecWithTimeout ["make"; "clean"; "--disable-check-for-update"] (TimeSpan.FromMinutes (10 : int64))
 
     /// Restores all packages for the solution
     let ToolRestore () =

--- a/build/scripts/TestEnvironment.fs
+++ b/build/scripts/TestEnvironment.fs
@@ -3,8 +3,8 @@ namespace Scripts
 open System.Runtime.InteropServices
 open Fake.Core
 
-module TestEnvironment =    
-    let isCI = Environment.hasEnvironVar "BUILD_ID" 
+module TestEnvironment =
+    let isCI = Environment.hasEnvironVar "GITHUB_ACTIONS" 
     let isWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
     let isLinux = RuntimeInformation.IsOSPlatform(OSPlatform.Linux)
     

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.100",
+    "version": "9.0.100",
     "rollForward": "latestFeature",
     "allowPrerelease": false
   }

--- a/src/profiler/Elastic.Apm.Profiler.IntegrationsGenerator/Elastic.Apm.Profiler.IntegrationsGenerator.csproj
+++ b/src/profiler/Elastic.Apm.Profiler.IntegrationsGenerator/Elastic.Apm.Profiler.IntegrationsGenerator.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>$(LatestNetVersion)</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/src/profiler/Elastic.Apm.Profiler.Managed/integrations.yml
+++ b/src/profiler/Elastic.Apm.Profiler.Managed/integrations.yml
@@ -10,7 +10,7 @@
       minimum_version: 4.0.0
       maximum_version: 4.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.27.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.30.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteNonQueryAsyncIntegration
       action: CallTargetModification
   - target:
@@ -23,7 +23,7 @@
       minimum_version: 4.0.0
       maximum_version: 5.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.27.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.30.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteNonQueryAsyncIntegration
       action: CallTargetModification
   - target:
@@ -37,7 +37,7 @@
       minimum_version: 4.0.0
       maximum_version: 4.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.27.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.30.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteReaderWithBehaviorAsyncIntegration
       action: CallTargetModification
   - target:
@@ -51,7 +51,7 @@
       minimum_version: 4.0.0
       maximum_version: 5.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.27.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.30.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteReaderWithBehaviorAsyncIntegration
       action: CallTargetModification
   - target:
@@ -64,7 +64,7 @@
       minimum_version: 4.0.0
       maximum_version: 4.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.27.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.30.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteScalarAsyncIntegration
       action: CallTargetModification
   - target:
@@ -77,7 +77,7 @@
       minimum_version: 4.0.0
       maximum_version: 5.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.27.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.30.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteScalarAsyncIntegration
       action: CallTargetModification
 - name: AspNet
@@ -93,7 +93,7 @@
       minimum_version: 4.0.0
       maximum_version: 4.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.27.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.30.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AspNet.ElasticApmModuleIntegration
       action: CallTargetModification
 - name: Kafka
@@ -107,7 +107,7 @@
       minimum_version: 1.4.0
       maximum_version: 1.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.27.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.30.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.Kafka.KafkaConsumerCloseIntegration
       action: CallTargetModification
   - target:
@@ -120,7 +120,7 @@
       minimum_version: 1.4.0
       maximum_version: 1.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.27.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.30.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.Kafka.KafkaConsumerConsumeIntegration
       action: CallTargetModification
   - target:
@@ -132,7 +132,7 @@
       minimum_version: 1.4.0
       maximum_version: 1.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.27.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.30.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.Kafka.KafkaConsumerDisposeIntegration
       action: CallTargetModification
   - target:
@@ -144,7 +144,7 @@
       minimum_version: 1.4.0
       maximum_version: 1.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.27.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.30.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.Kafka.KafkaConsumerUnsubscribeIntegration
       action: CallTargetModification
   - target:
@@ -159,7 +159,7 @@
       minimum_version: 1.4.0
       maximum_version: 1.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.27.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.30.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.Kafka.KafkaProduceAsyncIntegration
       action: CallTargetModification
   - target:
@@ -175,7 +175,7 @@
       minimum_version: 1.4.0
       maximum_version: 1.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.27.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.30.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.Kafka.KafkaProduceSyncDeliveryHandlerIntegration
       action: CallTargetModification
   - target:
@@ -190,7 +190,7 @@
       minimum_version: 1.4.0
       maximum_version: 1.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.27.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.30.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.Kafka.KafkaProduceSyncIntegration
       action: CallTargetModification
 - name: MySqlCommand
@@ -205,7 +205,7 @@
       minimum_version: 6.7.0
       maximum_version: 8.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.27.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.30.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteNonQueryAsyncIntegration
       action: CallTargetModification
   - target:
@@ -217,7 +217,7 @@
       minimum_version: 6.7.0
       maximum_version: 8.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.27.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.30.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteNonQueryIntegration
       action: CallTargetModification
   - target:
@@ -230,7 +230,7 @@
       minimum_version: 6.7.0
       maximum_version: 8.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.27.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.30.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteReaderAsyncIntegration
       action: CallTargetModification
   - target:
@@ -242,7 +242,7 @@
       minimum_version: 6.7.0
       maximum_version: 8.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.27.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.30.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteReaderIntegration
       action: CallTargetModification
   - target:
@@ -256,7 +256,7 @@
       minimum_version: 6.7.0
       maximum_version: 8.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.27.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.30.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteReaderWithBehaviorAsyncIntegration
       action: CallTargetModification
   - target:
@@ -270,7 +270,7 @@
       minimum_version: 6.7.0
       maximum_version: 8.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.27.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.30.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteReaderWithBehaviorAsyncIntegration
       action: CallTargetModification
   - target:
@@ -283,7 +283,7 @@
       minimum_version: 6.7.0
       maximum_version: 8.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.27.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.30.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteReaderWithBehaviorIntegration
       action: CallTargetModification
   - target:
@@ -296,7 +296,7 @@
       minimum_version: 6.7.0
       maximum_version: 8.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.27.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.30.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteReaderWithBehaviorIntegration
       action: CallTargetModification
   - target:
@@ -309,7 +309,7 @@
       minimum_version: 6.7.0
       maximum_version: 8.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.27.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.30.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteScalarAsyncIntegration
       action: CallTargetModification
   - target:
@@ -321,7 +321,7 @@
       minimum_version: 6.7.0
       maximum_version: 8.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.27.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.30.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteScalarIntegration
       action: CallTargetModification
 - name: NpgsqlCommand
@@ -336,7 +336,7 @@
       minimum_version: 4.0.0
       maximum_version: 7.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.27.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.30.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteNonQueryAsyncIntegration
       action: CallTargetModification
   - target:
@@ -348,7 +348,7 @@
       minimum_version: 4.0.0
       maximum_version: 7.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.27.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.30.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteNonQueryIntegration
       action: CallTargetModification
   - target:
@@ -361,7 +361,7 @@
       minimum_version: 4.0.0
       maximum_version: 7.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.27.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.30.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteReaderAsyncIntegration
       action: CallTargetModification
   - target:
@@ -375,7 +375,7 @@
       minimum_version: 4.0.0
       maximum_version: 7.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.27.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.30.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteReaderWithBehaviorAsyncIntegration
       action: CallTargetModification
   - target:
@@ -388,7 +388,7 @@
       minimum_version: 4.0.0
       maximum_version: 7.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.27.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.30.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteReaderWithBehaviorAsyncIntegration
       action: CallTargetModification
   - target:
@@ -402,7 +402,7 @@
       minimum_version: 4.0.0
       maximum_version: 7.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.27.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.30.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteReaderWithBehaviorAsyncIntegration
       action: CallTargetModification
   - target:
@@ -415,7 +415,7 @@
       minimum_version: 4.0.0
       maximum_version: 7.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.27.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.30.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteReaderWithBehaviorIntegration
       action: CallTargetModification
   - target:
@@ -428,7 +428,7 @@
       minimum_version: 4.0.0
       maximum_version: 7.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.27.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.30.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteReaderWithBehaviorIntegration
       action: CallTargetModification
   - target:
@@ -441,7 +441,7 @@
       minimum_version: 4.0.0
       maximum_version: 7.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.27.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.30.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteScalarAsyncIntegration
       action: CallTargetModification
   - target:
@@ -453,7 +453,7 @@
       minimum_version: 4.0.0
       maximum_version: 7.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.27.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.30.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteScalarIntegration
       action: CallTargetModification
 - name: OracleCommand
@@ -468,7 +468,7 @@
       minimum_version: 4.122.0
       maximum_version: 4.122.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.27.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.30.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteNonQueryAsyncIntegration
       action: CallTargetModification
   - target:
@@ -481,7 +481,7 @@
       minimum_version: 2.0.0
       maximum_version: 3.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.27.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.30.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteNonQueryAsyncIntegration
       action: CallTargetModification
   - target:
@@ -493,7 +493,7 @@
       minimum_version: 4.122.0
       maximum_version: 4.122.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.27.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.30.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteNonQueryIntegration
       action: CallTargetModification
   - target:
@@ -505,7 +505,7 @@
       minimum_version: 2.0.0
       maximum_version: 3.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.27.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.30.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteNonQueryIntegration
       action: CallTargetModification
   - target:
@@ -518,7 +518,7 @@
       minimum_version: 4.122.0
       maximum_version: 4.122.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.27.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.30.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteReaderAsyncIntegration
       action: CallTargetModification
   - target:
@@ -531,7 +531,7 @@
       minimum_version: 2.0.0
       maximum_version: 3.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.27.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.30.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteReaderAsyncIntegration
       action: CallTargetModification
   - target:
@@ -543,7 +543,7 @@
       minimum_version: 4.122.0
       maximum_version: 4.122.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.27.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.30.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteReaderIntegration
       action: CallTargetModification
   - target:
@@ -555,7 +555,7 @@
       minimum_version: 2.0.0
       maximum_version: 3.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.27.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.30.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteReaderIntegration
       action: CallTargetModification
   - target:
@@ -569,7 +569,7 @@
       minimum_version: 4.122.0
       maximum_version: 4.122.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.27.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.30.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteReaderWithBehaviorAsyncIntegration
       action: CallTargetModification
   - target:
@@ -583,7 +583,7 @@
       minimum_version: 2.0.0
       maximum_version: 3.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.27.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.30.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteReaderWithBehaviorAsyncIntegration
       action: CallTargetModification
   - target:
@@ -597,7 +597,7 @@
       minimum_version: 4.122.0
       maximum_version: 4.122.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.27.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.30.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteReaderWithBehaviorAsyncIntegration
       action: CallTargetModification
   - target:
@@ -611,7 +611,7 @@
       minimum_version: 2.0.0
       maximum_version: 3.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.27.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.30.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteReaderWithBehaviorAsyncIntegration
       action: CallTargetModification
   - target:
@@ -624,7 +624,7 @@
       minimum_version: 4.122.0
       maximum_version: 4.122.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.27.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.30.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteReaderWithBehaviorIntegration
       action: CallTargetModification
   - target:
@@ -637,7 +637,7 @@
       minimum_version: 2.0.0
       maximum_version: 3.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.27.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.30.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteReaderWithBehaviorIntegration
       action: CallTargetModification
   - target:
@@ -650,7 +650,7 @@
       minimum_version: 4.122.0
       maximum_version: 4.122.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.27.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.30.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteReaderWithBehaviorIntegration
       action: CallTargetModification
   - target:
@@ -663,7 +663,7 @@
       minimum_version: 2.0.0
       maximum_version: 3.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.27.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.30.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteReaderWithBehaviorIntegration
       action: CallTargetModification
   - target:
@@ -676,7 +676,7 @@
       minimum_version: 4.122.0
       maximum_version: 4.122.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.27.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.30.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteScalarAsyncIntegration
       action: CallTargetModification
   - target:
@@ -689,7 +689,7 @@
       minimum_version: 2.0.0
       maximum_version: 3.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.27.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.30.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteScalarAsyncIntegration
       action: CallTargetModification
   - target:
@@ -701,7 +701,7 @@
       minimum_version: 4.122.0
       maximum_version: 4.122.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.27.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.30.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteScalarIntegration
       action: CallTargetModification
   - target:
@@ -713,7 +713,7 @@
       minimum_version: 2.0.0
       maximum_version: 3.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.27.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.30.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteScalarIntegration
       action: CallTargetModification
 - name: RabbitMQ
@@ -734,7 +734,7 @@
       minimum_version: 3.6.9
       maximum_version: 6.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.27.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.30.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.RabbitMq.BasicDeliverIntegration
       action: CallTargetModification
   - target:
@@ -748,7 +748,7 @@
       minimum_version: 3.6.9
       maximum_version: 6.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.27.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.30.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.RabbitMq.BasicGetIntegration
       action: CallTargetModification
   - target:
@@ -765,7 +765,7 @@
       minimum_version: 3.6.9
       maximum_version: 6.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.27.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.30.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.RabbitMq.BasicPublishIntegration
       action: CallTargetModification
 - name: SqlCommand
@@ -780,7 +780,7 @@
       minimum_version: 4.0.0
       maximum_version: 4.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.27.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.30.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteNonQueryAsyncIntegration
       action: CallTargetModification
   - target:
@@ -793,7 +793,7 @@
       minimum_version: 4.0.0
       maximum_version: 4.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.27.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.30.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteNonQueryAsyncIntegration
       action: CallTargetModification
   - target:
@@ -806,7 +806,7 @@
       minimum_version: 1.0.0
       maximum_version: 5.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.27.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.30.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteNonQueryAsyncIntegration
       action: CallTargetModification
   - target:
@@ -818,7 +818,7 @@
       minimum_version: 4.0.0
       maximum_version: 4.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.27.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.30.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteNonQueryIntegration
       action: CallTargetModification
   - target:
@@ -830,7 +830,7 @@
       minimum_version: 4.0.0
       maximum_version: 4.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.27.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.30.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteNonQueryIntegration
       action: CallTargetModification
   - target:
@@ -842,7 +842,7 @@
       minimum_version: 1.0.0
       maximum_version: 5.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.27.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.30.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteNonQueryIntegration
       action: CallTargetModification
   - target:
@@ -855,7 +855,7 @@
       minimum_version: 4.0.0
       maximum_version: 4.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.27.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.30.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteReaderAsyncIntegration
       action: CallTargetModification
   - target:
@@ -868,7 +868,7 @@
       minimum_version: 4.0.0
       maximum_version: 4.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.27.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.30.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteReaderAsyncIntegration
       action: CallTargetModification
   - target:
@@ -881,7 +881,7 @@
       minimum_version: 1.0.0
       maximum_version: 5.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.27.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.30.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteReaderAsyncIntegration
       action: CallTargetModification
   - target:
@@ -893,7 +893,7 @@
       minimum_version: 4.0.0
       maximum_version: 4.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.27.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.30.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteReaderIntegration
       action: CallTargetModification
   - target:
@@ -905,7 +905,7 @@
       minimum_version: 4.0.0
       maximum_version: 4.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.27.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.30.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteReaderIntegration
       action: CallTargetModification
   - target:
@@ -917,7 +917,7 @@
       minimum_version: 1.0.0
       maximum_version: 5.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.27.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.30.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteReaderIntegration
       action: CallTargetModification
   - target:
@@ -931,7 +931,7 @@
       minimum_version: 4.0.0
       maximum_version: 4.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.27.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.30.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteReaderWithBehaviorAsyncIntegration
       action: CallTargetModification
   - target:
@@ -945,7 +945,7 @@
       minimum_version: 4.0.0
       maximum_version: 4.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.27.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.30.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteReaderWithBehaviorAsyncIntegration
       action: CallTargetModification
   - target:
@@ -959,7 +959,7 @@
       minimum_version: 1.0.0
       maximum_version: 5.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.27.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.30.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteReaderWithBehaviorAsyncIntegration
       action: CallTargetModification
   - target:
@@ -973,7 +973,7 @@
       minimum_version: 4.0.0
       maximum_version: 4.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.27.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.30.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteReaderWithBehaviorAsyncIntegration
       action: CallTargetModification
   - target:
@@ -987,7 +987,7 @@
       minimum_version: 4.0.0
       maximum_version: 4.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.27.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.30.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteReaderWithBehaviorAsyncIntegration
       action: CallTargetModification
   - target:
@@ -1001,7 +1001,7 @@
       minimum_version: 1.0.0
       maximum_version: 5.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.27.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.30.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteReaderWithBehaviorAsyncIntegration
       action: CallTargetModification
   - target:
@@ -1014,7 +1014,7 @@
       minimum_version: 4.0.0
       maximum_version: 4.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.27.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.30.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteReaderWithBehaviorIntegration
       action: CallTargetModification
   - target:
@@ -1027,7 +1027,7 @@
       minimum_version: 4.0.0
       maximum_version: 4.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.27.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.30.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteReaderWithBehaviorIntegration
       action: CallTargetModification
   - target:
@@ -1040,7 +1040,7 @@
       minimum_version: 1.0.0
       maximum_version: 5.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.27.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.30.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteReaderWithBehaviorIntegration
       action: CallTargetModification
   - target:
@@ -1053,7 +1053,7 @@
       minimum_version: 4.0.0
       maximum_version: 4.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.27.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.30.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteReaderWithBehaviorIntegration
       action: CallTargetModification
   - target:
@@ -1066,7 +1066,7 @@
       minimum_version: 4.0.0
       maximum_version: 4.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.27.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.30.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteReaderWithBehaviorIntegration
       action: CallTargetModification
   - target:
@@ -1079,7 +1079,7 @@
       minimum_version: 1.0.0
       maximum_version: 5.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.27.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.30.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteReaderWithBehaviorIntegration
       action: CallTargetModification
   - target:
@@ -1092,7 +1092,7 @@
       minimum_version: 4.0.0
       maximum_version: 4.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.27.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.30.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteScalarAsyncIntegration
       action: CallTargetModification
   - target:
@@ -1105,7 +1105,7 @@
       minimum_version: 4.0.0
       maximum_version: 4.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.27.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.30.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteScalarAsyncIntegration
       action: CallTargetModification
   - target:
@@ -1118,7 +1118,7 @@
       minimum_version: 1.0.0
       maximum_version: 5.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.27.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.30.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteScalarAsyncIntegration
       action: CallTargetModification
   - target:
@@ -1130,7 +1130,7 @@
       minimum_version: 4.0.0
       maximum_version: 4.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.27.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.30.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteScalarIntegration
       action: CallTargetModification
   - target:
@@ -1142,7 +1142,7 @@
       minimum_version: 4.0.0
       maximum_version: 4.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.27.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.30.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteScalarIntegration
       action: CallTargetModification
   - target:
@@ -1154,7 +1154,7 @@
       minimum_version: 1.0.0
       maximum_version: 5.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.27.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.30.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteScalarIntegration
       action: CallTargetModification
 - name: SqliteCommand
@@ -1169,7 +1169,7 @@
       minimum_version: 2.0.0
       maximum_version: 8.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.27.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.30.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteNonQueryAsyncIntegration
       action: CallTargetModification
   - target:
@@ -1182,7 +1182,7 @@
       minimum_version: 1.0.0
       maximum_version: 2.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.27.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.30.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteNonQueryAsyncIntegration
       action: CallTargetModification
   - target:
@@ -1194,7 +1194,7 @@
       minimum_version: 2.0.0
       maximum_version: 8.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.27.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.30.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteNonQueryIntegration
       action: CallTargetModification
   - target:
@@ -1206,7 +1206,7 @@
       minimum_version: 1.0.0
       maximum_version: 2.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.27.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.30.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteNonQueryIntegration
       action: CallTargetModification
   - target:
@@ -1219,7 +1219,7 @@
       minimum_version: 1.0.0
       maximum_version: 2.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.27.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.30.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteNonQueryWithBehaviorIntegration
       action: CallTargetModification
   - target:
@@ -1232,7 +1232,7 @@
       minimum_version: 2.0.0
       maximum_version: 8.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.27.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.30.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteReaderAsyncIntegration
       action: CallTargetModification
   - target:
@@ -1245,7 +1245,7 @@
       minimum_version: 1.0.0
       maximum_version: 2.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.27.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.30.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteReaderAsyncIntegration
       action: CallTargetModification
   - target:
@@ -1257,7 +1257,7 @@
       minimum_version: 2.0.0
       maximum_version: 8.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.27.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.30.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteReaderIntegration
       action: CallTargetModification
   - target:
@@ -1269,7 +1269,7 @@
       minimum_version: 1.0.0
       maximum_version: 2.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.27.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.30.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteReaderIntegration
       action: CallTargetModification
   - target:
@@ -1283,7 +1283,7 @@
       minimum_version: 2.0.0
       maximum_version: 8.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.27.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.30.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteReaderWithBehaviorAsyncIntegration
       action: CallTargetModification
   - target:
@@ -1297,7 +1297,7 @@
       minimum_version: 1.0.0
       maximum_version: 2.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.27.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.30.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteReaderWithBehaviorAsyncIntegration
       action: CallTargetModification
   - target:
@@ -1311,7 +1311,7 @@
       minimum_version: 2.0.0
       maximum_version: 8.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.27.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.30.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteReaderWithBehaviorAsyncIntegration
       action: CallTargetModification
   - target:
@@ -1324,7 +1324,7 @@
       minimum_version: 2.0.0
       maximum_version: 8.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.27.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.30.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteReaderWithBehaviorIntegration
       action: CallTargetModification
   - target:
@@ -1337,7 +1337,7 @@
       minimum_version: 1.0.0
       maximum_version: 2.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.27.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.30.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteReaderWithBehaviorIntegration
       action: CallTargetModification
   - target:
@@ -1350,7 +1350,7 @@
       minimum_version: 2.0.0
       maximum_version: 8.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.27.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.30.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteReaderWithBehaviorIntegration
       action: CallTargetModification
   - target:
@@ -1363,7 +1363,7 @@
       minimum_version: 2.0.0
       maximum_version: 8.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.27.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.30.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteScalarAsyncIntegration
       action: CallTargetModification
   - target:
@@ -1376,7 +1376,7 @@
       minimum_version: 1.0.0
       maximum_version: 2.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.27.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.30.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteScalarAsyncIntegration
       action: CallTargetModification
   - target:
@@ -1388,7 +1388,7 @@
       minimum_version: 2.0.0
       maximum_version: 8.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.27.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.30.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteScalarIntegration
       action: CallTargetModification
   - target:
@@ -1400,7 +1400,7 @@
       minimum_version: 1.0.0
       maximum_version: 2.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.27.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.30.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteScalarIntegration
       action: CallTargetModification
   - target:
@@ -1413,6 +1413,6 @@
       minimum_version: 1.0.0
       maximum_version: 2.*.*
     wrapper:
-      assembly: Elastic.Apm.Profiler.Managed, Version=1.27.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
+      assembly: Elastic.Apm.Profiler.Managed, Version=1.30.0.0, Culture=neutral, PublicKeyToken=ae7400d2c189cf22
       type: Elastic.Apm.Profiler.Managed.Integrations.AdoNet.CommandExecuteScalarWithBehaviorIntegration
       action: CallTargetModification

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -4,11 +4,11 @@
   <PropertyGroup>
     <!-- Always generate debug symbols this allows fluent symbols exception messages to include variable names -->
     <DebugSymbols>True</DebugSymbols>
-    
+
     <!-- Elastic.Apm.AspNetFullFramework is completely self managed since it needs a lot of special care (for now) -->
     <IsRegularTestProject Condition="$([System.Text.RegularExpressions.Regex]::IsMatch($(ProjectName), '^(.*)Tests$'))">true</IsRegularTestProject>
   </PropertyGroup>
-  
+
   <ItemGroup>
     <!-- use xunit config for all test files. Allow assemblies to run in parallel -->
     <Content Include="$(SolutionRoot)\xunit.runner.json" CopyToOutputDirectory="PreserveNewest" Condition="'$(IsRegularTestProject)' == 'true'" />
@@ -20,11 +20,9 @@
 
   <ItemGroup Condition="$([System.Text.RegularExpressions.Regex]::IsMatch($(ProjectName), '^(.*)Tests$'))">
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
-    
     <PackageReference Include="JunitXml.TestLogger" PrivateAssets="All" />
     <PackageReference Include="GitHubActionsTestLogger" PrivateAssets="All" />
     <PackageReference Include="Nullean.VsTest.Pretty.TestLogger" PrivateAssets="All" />
-
     <PackageReference Include="FluentAssertions" />
     <PackageReference Include="FluentAssertions.Analyzers"  />
     <PackageReference Include="xunit" />

--- a/test/azure/Elastic.Apm.Azure.Functions.Tests/AzureFunctionsInProcessTests.cs
+++ b/test/azure/Elastic.Apm.Azure.Functions.Tests/AzureFunctionsInProcessTests.cs
@@ -17,7 +17,6 @@ public class AzureFunctionsInProcessTests : AzureFunctionsTestBase, IClassFixtur
 	public AzureFunctionsInProcessTests(ITestOutputHelper output, InProcessContext context)
 		: base(output, context) { }
 
-
 	[Fact]
 	public async Task Invoke_Http_Ok()
 	{

--- a/test/azure/applications/Elastic.Apm.AzureFunctionApp.Core/Elastic.Apm.AzureFunctionApp.Core.csproj
+++ b/test/azure/applications/Elastic.Apm.AzureFunctionApp.Core/Elastic.Apm.AzureFunctionApp.Core.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
+    <TargetFramework>$(NetMinimumSupportedVersion)</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>

--- a/test/azure/applications/Elastic.AzureFunctionApp.InProcess/Elastic.AzureFunctionApp.InProcess.csproj
+++ b/test/azure/applications/Elastic.AzureFunctionApp.InProcess/Elastic.AzureFunctionApp.InProcess.csproj
@@ -8,7 +8,7 @@
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Sdk.Functions"/>
+    <PackageReference Include="Microsoft.NET.Sdk.Functions" />
   </ItemGroup>
   <ItemGroup>
     <None Update="host.json">

--- a/test/azure/applications/Elastic.AzureFunctionApp.InProcess/Elastic.AzureFunctionApp.InProcess.csproj
+++ b/test/azure/applications/Elastic.AzureFunctionApp.InProcess/Elastic.AzureFunctionApp.InProcess.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>$(NetMinimumSupportedVersion)</TargetFramework>
     <AzureFunctionsVersion>v4</AzureFunctionsVersion>
     <OutputType>Library</OutputType>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/test/azure/applications/Elastic.AzureFunctionApp.InProcess/local.settings.json
+++ b/test/azure/applications/Elastic.AzureFunctionApp.InProcess/local.settings.json
@@ -5,9 +5,8 @@
     "FUNCTIONS_WORKER_RUNTIME": "dotnet",
     "FUNCTIONS_EXTENSION_VERSION": "4",
     "WEBSITE_OWNER_NAME": "abcd1234-abcd-acdc-1234-112233445566+testfaas_group-CentralUSwebspace-Linux",
-    "WEBSITE_SITE_NAME": "testfaas"
-    // Include this breaks on the latest version of func - Excluding it for now.
-    //"WEBSITE_INSTANCE_ID": "20367ea8-70b9-41b4-a552-b2a826b3aa0b"
+    "WEBSITE_SITE_NAME": "testfaas",
+    "FUNCTIONS_INPROC_NET8_ENABLED": "1"
   },
   "Host": {
     "LocalHttpPort": 17073

--- a/test/azure/applications/Elastic.AzureFunctionApp.Isolated/Elastic.AzureFunctionApp.Isolated.csproj
+++ b/test/azure/applications/Elastic.AzureFunctionApp.Isolated/Elastic.AzureFunctionApp.Isolated.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>$(NetMinimumSupportedVersion)</TargetFramework>
     <AzureFunctionsVersion>v4</AzureFunctionsVersion>
     <OutputType>Exe</OutputType>
     <ImplicitUsings>enable</ImplicitUsings>
@@ -8,10 +8,6 @@
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>
-    <!-- 
-    The versions below are NOT the latest but anything newer breaks when attempting to run func
-    See: https://github.com/Azure/azure-functions-core-tools/issues/3594
-    -->
     <PackageReference Include="Microsoft.Azure.Functions.Worker"/>
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk"/>
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http"/>

--- a/test/azure/applications/Elastic.AzureFunctionApp.Isolated/local.settings.json
+++ b/test/azure/applications/Elastic.AzureFunctionApp.Isolated/local.settings.json
@@ -5,8 +5,6 @@
     "FUNCTIONS_WORKER_RUNTIME": "dotnet-isolated",
     "FUNCTIONS_EXTENSION_VERSION": "4",
     "WEBSITE_OWNER_NAME": "abcd1234-abcd-acdc-1234-112233445566+testfaas_group-CentralUSwebspace-Linux",
-    "WEBSITE_SITE_NAME": "testfaas",
-    // Include this breaks on the latest version of func - Excluding it for now.
-    //"WEBSITE_INSTANCE_ID": "20367ea8-70b9-41b4-a552-b2a826b3aa0b"
+    "WEBSITE_SITE_NAME": "testfaas"
   }
 }

--- a/test/integrations/applications/SampleAspNetCoreApp/SampleAspNetCoreApp.csproj
+++ b/test/integrations/applications/SampleAspNetCoreApp/SampleAspNetCoreApp.csproj
@@ -1,28 +1,20 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <PlatformTarget>AnyCPU</PlatformTarget>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" />
   </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net8.0'">
+  <ItemGroup>
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" />
     <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" />
     <PackageReference Include="Microsoft.AspNetCore.Identity.UI" />
     <PackageReference Include="Microsoft.Extensions.Logging" />
     <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" />
-  </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" VersionOverride="6.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" VersionOverride="6.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Identity.UI" VersionOverride="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging" VersionOverride="6.0.0" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" />
-    <PackageReference Include="OpenTelemetry.Extensions.Hosting" VersionOverride="1.4.0" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Data\" />

--- a/test/integrations/applications/SampleConsoleNetCoreApp/SampleConsoleNetCoreApp.csproj
+++ b/test/integrations/applications/SampleConsoleNetCoreApp/SampleConsoleNetCoreApp.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
+        <TargetFrameworks>net8.0</TargetFrameworks>
     </PropertyGroup>
 
     <ItemGroup>

--- a/test/integrations/applications/WebApiSample/WebApiSample.csproj
+++ b/test/integrations/applications/WebApiSample/WebApiSample.csproj
@@ -1,7 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/test/profiler/Elastic.Apm.Profiler.Managed.Tests/AdoNet/AdoNetTestData.cs
+++ b/test/profiler/Elastic.Apm.Profiler.Managed.Tests/AdoNet/AdoNetTestData.cs
@@ -20,7 +20,6 @@ namespace Elastic.Apm.Profiler.Managed.Tests.AdoNet
 		{
 			// TODO: Add x64/x86 options. macOS and Linux do not support x86
 			yield return new object[] { "net8.0" };
-			yield return new object[] { "net6.0" };
 		}
 
 		IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();

--- a/test/profiler/applications/Elastic.Apm.AdoNet/Elastic.Apm.AdoNet.csproj
+++ b/test/profiler/applications/Elastic.Apm.AdoNet/Elastic.Apm.AdoNet.csproj
@@ -1,14 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-      <TargetFrameworks>net462;net6.0;net8.0</TargetFrameworks>
+      <TargetFrameworks>net462;net8.0</TargetFrameworks>
     </PropertyGroup>
 
     <ItemGroup>
       <ProjectReference Include="$(SolutionRoot)\src\Elastic.Apm\Elastic.Apm.csproj" />
       <ProjectReference Include="..\Elastic.Apm.AdoNet.NetStandard\Elastic.Apm.AdoNet.NetStandard.csproj" />
     </ItemGroup>
-  
-  
 
 </Project>

--- a/test/profiler/applications/MySqlDataSample/MySqlDataSample.csproj
+++ b/test/profiler/applications/MySqlDataSample/MySqlDataSample.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net462;net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net462;net8.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/profiler/applications/NpgsqlSample/NpgsqlSample.csproj
+++ b/test/profiler/applications/NpgsqlSample/NpgsqlSample.csproj
@@ -3,7 +3,7 @@
     <PropertyGroup>
         <NpgsqlVersion Condition="'$(NpgsqlVersion)'==''">5.0.18</NpgsqlVersion>
         <OutputType>Exe</OutputType>
-        <TargetFrameworks>net462;net6.0;net8.0</TargetFrameworks>
+        <TargetFrameworks>net462;net8.0</TargetFrameworks>
     </PropertyGroup>
 
     <ItemGroup>

--- a/test/profiler/applications/OracleManagedDataAccessCoreSample/OracleManagedDataAccessCoreSample.csproj
+++ b/test/profiler/applications/OracleManagedDataAccessCoreSample/OracleManagedDataAccessCoreSample.csproj
@@ -2,8 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
-
+    <TargetFrameworks>net8.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/profiler/applications/SqlClientSample/SqlClientSample.csproj
+++ b/test/profiler/applications/SqlClientSample/SqlClientSample.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <SqlVersion Condition="'$(SqlVersion)'==''">4.8.6</SqlVersion>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net462;net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net462;net8.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/profiler/applications/SqliteSample/SqliteSample.csproj
+++ b/test/profiler/applications/SqliteSample/SqliteSample.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <SqliteVersion Condition="'$(SqliteVersion)'==''">8.0.2</SqliteVersion>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net462;net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net462;net8.0</TargetFrameworks>
     <PlatformTarget>x64</PlatformTarget>
   </PropertyGroup>
 

--- a/test/startuphook/Elastic.Apm.StartupHook.Sample/Elastic.Apm.StartupHook.Sample.csproj
+++ b/test/startuphook/Elastic.Apm.StartupHook.Sample/Elastic.Apm.StartupHook.Sample.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/test/startuphook/Elastic.Apm.StartupHook.Sample/README.md
+++ b/test/startuphook/Elastic.Apm.StartupHook.Sample/README.md
@@ -3,7 +3,6 @@
 This sample application is a default ASP.NET (Core) application
 configured to run with 
 
-- `net6.0`
 - `net8.0`
 
 target frameworks that can be used to try out the [Elastic APM

--- a/test/startuphook/Elastic.Apm.StartupHook.Tests/StartupHookTests.cs
+++ b/test/startuphook/Elastic.Apm.StartupHook.Tests/StartupHookTests.cs
@@ -27,7 +27,6 @@ namespace Elastic.Apm.StartupHook.Tests
 		// NOTE: We test the two latest supported LTS releases.
 		private static IEnumerable<(string TargetFramework, string RuntimeName, string Version, string ShortVersion)> GetDotNetFrameworkVersionInfos()
 		{
-			yield return ("net6.0", ".NET 6", "6.0.0.0", "60");
 			yield return ("net8.0", ".NET 8", "8.0.0.0", "80");
 		}
 


### PR DESCRIPTION
- Bumps to the latest .NET 9 SDK and updates build and infrastructure projects to target .NET 9. 
- Introduces properties for .NET targets and switches build and infra projects to use them.
- Updates some build dependencies to remove some older workarounds.

In follow-up PRs, we will address switching samples to .NET, updating the tests accordingly and removing unsupported TFMs. The docs project TFM will also be bumped in a separate PR to avoid skipping of tests.