### PR TITLE
Fixes and enhancements for Azure Functions (isolated worker)

### DIFF
--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -126,13 +126,14 @@ jobs:
 
       - name: Store crash dumps
         uses: actions/upload-artifact@v4
-        if: success() || failure()
+        if: failure()
         with:
           name: hang-dumps
           retention-days: 3
           path: |
             build/output/**/*.dmp
             build/output/**/*.xml
+            build/output/**/*.pdb
     
   startup-hook-tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -128,9 +128,11 @@ jobs:
         uses: actions/upload-artifact@v4
         if: success() || failure()
         with:
-          name: results
-          retention-days: 1
-          path: build/output/**/*.dmp
+          name: hang-dumps
+          retention-days: 3
+          path: |
+            build/output/**/*.dmp
+            build/output/**/*.xml
     
   startup-hook-tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -76,9 +76,11 @@ jobs:
         uses: actions/upload-artifact@v4
         if: success() || failure()
         with:
-          name: results
-          retention-days: 1
-          path: build/output/**/*.dmp
+          name: hang-dumps
+          retention-days: 3
+          path: |
+            build/output/**/*.dmp
+            build/output/**/*.xml
   
   startup-hook-tests:
     runs-on: windows-2022

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -84,7 +84,7 @@
     <PackageVersion Include="Microsoft.AspNet.TelemetryCorrelation" Version="1.0.7" />
     <PackageVersion Include="Microsoft.AspNet.Web.Optimization" Version="1.1.3" />
     <PackageVersion Include="Microsoft.AspNet.WebApi" Version="5.2.4" />
-    <PackageVersion Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="2.2.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="2.1.1" />
     <PackageVersion Include="Microsoft.AspNetCore.Http" Version="2.1.34" />
     <PackageVersion Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.1.1" />
     <PackageVersion Include="Microsoft.AspNetCore.Http.Extensions" Version="2.1.21" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -85,9 +85,9 @@
     <PackageVersion Include="Microsoft.AspNet.Web.Optimization" Version="1.1.3" />
     <PackageVersion Include="Microsoft.AspNet.WebApi" Version="5.2.4" />
     <PackageVersion Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="2.2.0" />
-    <PackageVersion Include="Microsoft.AspNetCore.Http" Version="2.2.2" />
-    <PackageVersion Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />
-    <PackageVersion Include="Microsoft.AspNetCore.Http.Extensions" Version="2.2.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.Http" Version="2.1.34" />
+    <PackageVersion Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.1.1" />
+    <PackageVersion Include="Microsoft.AspNetCore.Http.Extensions" Version="2.1.21" />
     <PackageVersion Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="8.0.2" />
     <PackageVersion Include="Microsoft.AspNetCore.Identity.UI" Version="8.0.2" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.2" />
@@ -95,9 +95,9 @@
     <PackageVersion Include="Microsoft.AspNetCore.Routing.Abstractions" Version="2.2.0" />
     <PackageVersion Include="Microsoft.Azure.Cosmos" Version="3.0.0" />
     <PackageVersion Include="Microsoft.Azure.DocumentDB.Core" Version="2.22.0" />
-    <PackageVersion Include="Microsoft.Azure.Functions.Extensions" Version="1.0.0" />
+    <PackageVersion Include="Microsoft.Azure.Functions.Extensions" Version="1.1.0" />
     <PackageVersion Include="Microsoft.Azure.Functions.Worker" Version="1.20.0" />
-    <PackageVersion Include="Microsoft.Azure.Functions.Worker.Core" Version="1.6.0" />
+    <PackageVersion Include="Microsoft.Azure.Functions.Worker.Core" Version="2.0.0" />
     <PackageVersion Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.1.0" />
     <PackageVersion Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.16.1" />
     <PackageVersion Include="Microsoft.Azure.ServiceBus" Version="3.0.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -96,10 +96,11 @@
     <PackageVersion Include="Microsoft.Azure.Cosmos" Version="3.0.0" />
     <PackageVersion Include="Microsoft.Azure.DocumentDB.Core" Version="2.22.0" />
     <PackageVersion Include="Microsoft.Azure.Functions.Extensions" Version="1.1.0" />
-    <PackageVersion Include="Microsoft.Azure.Functions.Worker" Version="1.20.0" />
+    <PackageVersion Include="Microsoft.Azure.Functions.Worker" Version="2.0.0" />
     <PackageVersion Include="Microsoft.Azure.Functions.Worker.Core" Version="2.0.0" />
-    <PackageVersion Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.1.0" />
-    <PackageVersion Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.16.1" />
+    <PackageVersion Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.2.0" />
+    <PackageVersion Include="Microsoft.Azure.Functions.Worker.Sdk" Version="2.0.0" />
+    <PackageVersion Include="Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore" Version="2.0.0" />
     <PackageVersion Include="Microsoft.Azure.ServiceBus" Version="3.0.0" />
     <PackageVersion Include="Microsoft.Azure.Storage.Blob" Version="11.2.2" />
     <PackageVersion Include="Microsoft.Data.SqlClient" Version="5.1.5" />

--- a/src/Elastic.Apm/AgentComponents.cs
+++ b/src/Elastic.Apm/AgentComponents.cs
@@ -17,7 +17,7 @@ using Elastic.Apm.Metrics;
 using Elastic.Apm.Metrics.MetricsProvider;
 using Elastic.Apm.Report;
 using Elastic.Apm.ServerInfo;
-#if NET5_0_OR_GREATER
+#if NET8_0_OR_GREATER
 using Elastic.Apm.OpenTelemetry;
 #endif
 
@@ -60,7 +60,7 @@ namespace Elastic.Apm
 				ApmServerInfo = apmServerInfo ?? new ApmServerInfo();
 				HttpTraceConfiguration = new HttpTraceConfiguration();
 
-#if NET5_0_OR_GREATER
+#if NET8_0_OR_GREATER
 				// Initialize early because ServerInfoCallback requires it and might execute
 				// before EnsureElasticActivityStarted runs
 				ElasticActivityListener = new ElasticActivityListener(this, HttpTraceConfiguration);
@@ -81,7 +81,7 @@ namespace Elastic.Apm
 					currentExecutionSegmentsContainer ?? new CurrentExecutionSegmentsContainer(), ApmServerInfo,
 					breakdownMetricsProvider);
 
-#if NET5_0_OR_GREATER
+#if NET8_0_OR_GREATER
 				EnsureElasticActivityStarted();
 #endif
 
@@ -118,7 +118,7 @@ namespace Elastic.Apm
 
 		private void EnsureElasticActivityStarted()
 		{
-#if !NET5_0_OR_GREATER
+#if !NET8_0_OR_GREATER
 			return;
 #else
 			if (!Configuration.OpenTelemetryBridgeEnabled) return;
@@ -145,7 +145,7 @@ namespace Elastic.Apm
 
 		private void ServerInfoCallback(bool success, IApmServerInfo serverInfo)
 		{
-#if !NET5_0_OR_GREATER
+#if !NET8_0_OR_GREATER
 			return;
 #else
 			if (!Configuration.OpenTelemetryBridgeEnabled) return;
@@ -237,7 +237,7 @@ namespace Elastic.Apm
 			return fallbackLogger;
 		}
 
-#if NET5_0_OR_GREATER
+#if NET8_0_OR_GREATER
 		private ElasticActivityListener ElasticActivityListener { get; }
 #endif
 
@@ -281,7 +281,7 @@ namespace Elastic.Apm
 			if (PayloadSender is IDisposable disposablePayloadSender)
 				disposablePayloadSender.Dispose();
 			CentralConfigurationFetcher?.Dispose();
-#if NET5_0_OR_GREATER
+#if NET8_0_OR_GREATER
 			ElasticActivityListener?.Dispose();
 #endif
 		}

--- a/src/Elastic.Apm/Cloud/AzureFunctionsMetadataProvider.cs
+++ b/src/Elastic.Apm/Cloud/AzureFunctionsMetadataProvider.cs
@@ -59,7 +59,16 @@ namespace Elastic.Apm.Cloud
 					functionsExtensionVersion) ||
 				helper.NullOrEmptyVariable(AzureEnvironmentVariables.WebsiteOwnerName, websiteOwnerName) ||
 				helper.NullOrEmptyVariable(AzureEnvironmentVariables.WebsiteSiteName, websiteSiteName))
-				return new AzureFunctionsMetaData { IsValid = false };
+				return new AzureFunctionsMetaData
+				{
+					IsValid = false,
+					RegionName = regionName,
+					FunctionsExtensionVersion = functionsExtensionVersion,
+					FunctionsWorkerRuntime = functionsWorkerRuntime,
+					WebsiteSiteName = websiteSiteName,
+					WebsiteResourceGroup = websiteResourceGroup,
+					WebsiteInstanceId = websiteInstanceId,
+				};
 
 			var tokens = helper.TokenizeWebSiteOwnerName(websiteOwnerName);
 			if (!tokens.HasValue)

--- a/src/Elastic.Apm/OpenTelemetry/ElasticActivityListener.cs
+++ b/src/Elastic.Apm/OpenTelemetry/ElasticActivityListener.cs
@@ -72,6 +72,17 @@ namespace Elastic.Apm.OpenTelemetry
 		private Action<Activity> ActivityStarted =>
 			activity =>
 			{
+				// Prevent recording of Azure Functions activities which are quite broken at the moment
+				// See https://github.com/Azure/azure-functions-dotnet-worker/issues/2733
+				// See https://github.com/Azure/azure-functions-dotnet-worker/issues/2875
+				// See https://github.com/Azure/azure-functions-host/issues/10641
+				// See https://github.com/Azure/azure-functions-dotnet-worker/issues/2810
+				if ((activity.Source.Name == "" && activity.DisplayName == "InvokeFunctionAsync")
+					|| (activity.Source.Name == "Microsoft.Azure.Functions.Worker"))
+				{
+					return;
+				}
+
 				// If the Elastic instrumentation for ServiceBus is present, we skip duplicating the instrumentation through the OTel bridge.
 				// Without this, we end up with some redundant spans in the trace with subtle differences.
 				if (HasServiceBusInstrumentation && activity.Tags.Any(kvp =>

--- a/src/Elastic.Apm/OpenTelemetry/ElasticActivityListener.cs
+++ b/src/Elastic.Apm/OpenTelemetry/ElasticActivityListener.cs
@@ -3,7 +3,7 @@
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
 
-#if NET5_0_OR_GREATER
+#if NET8_0_OR_GREATER
 
 using System;
 using System.Collections.Concurrent;

--- a/src/Elastic.Apm/Report/PayloadSenderV2.cs
+++ b/src/Elastic.Apm/Report/PayloadSenderV2.cs
@@ -398,7 +398,7 @@ namespace Elastic.Apm.Report
 				{
 					content.Headers.ContentType = MediaTypeHeaderValue;
 
-#if NET5_0_OR_GREATER
+#if NET8_0_OR_GREATER
 					HttpResponseMessage response;
 					try
 					{

--- a/src/azure/Elastic.Apm.Azure.Functions/ApmMiddleware.cs
+++ b/src/azure/Elastic.Apm.Azure.Functions/ApmMiddleware.cs
@@ -15,7 +15,6 @@ using Microsoft.AspNetCore.Http.Extensions;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.Functions.Worker.Http;
 using Microsoft.Azure.Functions.Worker.Middleware;
-using Microsoft.Extensions.Primitives;
 using TraceContext = Elastic.Apm.DistributedTracing.TraceContext;
 
 namespace Elastic.Apm.Azure.Functions;
@@ -182,7 +181,7 @@ public class ApmMiddleware : IFunctionsWorkerMiddleware
 		httpHeadersCollection.ToDictionary(h => h.Key, h => string.Join(",", h.Value));
 
 	private static Dictionary<string, string> CreateHeadersDictionary(IHeaderDictionary headerDictionary) =>
-		headerDictionary.ToDictionary(h => h.Key, h => string.Join(",", h.Value));
+		headerDictionary.ToDictionary(h => h.Key, h => string.Join(",", h.Value.AsEnumerable()));
 
 	private static HttpRequestData? GetHttpRequestData(FunctionContext functionContext)
 	{

--- a/src/azure/Elastic.Apm.Azure.Functions/ApmMiddleware.cs
+++ b/src/azure/Elastic.Apm.Azure.Functions/ApmMiddleware.cs
@@ -112,12 +112,12 @@ public class ApmMiddleware : IFunctionsWorkerMiddleware
 				{
 					return new($"{httpRequest.Method} {uri.AbsolutePath}", Trigger.TypeHttp,
 						TraceContext.TryExtractTracingData(traceparent, tracestate))
+					{
+						Request = new Request(httpRequest.Method, Url.FromUri(uri))
 						{
-							Request = new Request(httpRequest.Method, Url.FromUri(uri))
-							{
-								Headers = CreateHeadersDictionary(httpRequest.Headers),
-							}
-						};
+							Headers = CreateHeadersDictionary(httpRequest.Headers),
+						}
+					};
 				}
 			}
 
@@ -129,12 +129,12 @@ public class ApmMiddleware : IFunctionsWorkerMiddleware
 
 				return new($"{httpRequestData.Method} {httpRequestData.Url.AbsolutePath}", Trigger.TypeHttp,
 					TraceContext.TryExtractTracingData(traceparent, tracestate))
+				{
+					Request = new Request(httpRequestData.Method, Url.FromUri(httpRequestData.Url))
 					{
-						Request = new Request(httpRequestData.Method, Url.FromUri(httpRequestData.Url))
-						{
-							Headers = CreateHeadersDictionary(httpRequestData.Headers),
-						}
-					};
+						Headers = CreateHeadersDictionary(httpRequestData.Headers),
+					}
+				};
 			}
 		}
 		catch

--- a/src/azure/Elastic.Apm.Azure.Functions/Elastic.Apm.Azure.Functions.csproj
+++ b/src/azure/Elastic.Apm.Azure.Functions/Elastic.Apm.Azure.Functions.csproj
@@ -1,9 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net8.0</TargetFrameworks>
     <Nullable>enable</Nullable>
-
     <AssemblyName>Elastic.Apm.Azure.Functions</AssemblyName>
     <RootNamespace>Elastic.Apm.Azure.Functions</RootNamespace>
     <PackageId>Elastic.Apm.Azure.Functions</PackageId>
@@ -18,9 +17,17 @@
     <ProjectReference Include="..\..\Elastic.Apm\Elastic.Apm.csproj" />
   </ItemGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' != 'netstandard2.0'">
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="Microsoft.AspNetCore.Http"/>
     <PackageReference Include="Microsoft.AspNetCore.Http.Extensions"/>
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" />
     <PackageReference Include="Microsoft.Azure.Functions.Extensions"/>
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Core" />
   </ItemGroup>

--- a/src/integrations/Elastic.Apm.AspNetCore/Elastic.Apm.AspNetCore.csproj
+++ b/src/integrations/Elastic.Apm.AspNetCore/Elastic.Apm.AspNetCore.csproj
@@ -20,8 +20,8 @@
     <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" />
     <PackageReference Include="Microsoft.AspNetCore.Http.Extensions" />
     <PackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" />
-    <PackageReference Include="Microsoft.AspNetCore.Routing.Abstractions" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" VersionOverride="2.2.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Routing.Abstractions" VersionOverride="2.1.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" VersionOverride="2.1.1" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net8.0' ">
     <FrameworkReference Include="Microsoft.AspNetCore.App" />

--- a/src/integrations/Elastic.Apm.Extensions.Hosting/Elastic.Apm.Extensions.Hosting.csproj
+++ b/src/integrations/Elastic.Apm.Extensions.Hosting/Elastic.Apm.Extensions.Hosting.csproj
@@ -21,10 +21,10 @@
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
-    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" VersionOverride="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" VersionOverride="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" VersionOverride="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Configuration" VersionOverride="2.2.0" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" VersionOverride="2.1.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" VersionOverride="2.1.1" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" VersionOverride="2.1.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Configuration" VersionOverride="2.1.1" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Elastic.Apm.Tests.Utilities/XUnit/DockerAttributes.cs
+++ b/test/Elastic.Apm.Tests.Utilities/XUnit/DockerAttributes.cs
@@ -67,7 +67,7 @@ internal static class DockerUtils
 	{
 		try
 		{
-			var result = Proc.Start(new StartArguments("docker", "--version"));
+			var result = Proc.Start(new StartArguments("docker", "--version"), TimeSpan.FromSeconds(30));
 			HasDockerInstalled = result.ExitCode == 0;
 		}
 		catch (Exception)

--- a/test/azure/applications/Elastic.AzureFunctionApp.Isolated/Elastic.AzureFunctionApp.Isolated.csproj
+++ b/test/azure/applications/Elastic.AzureFunctionApp.Isolated/Elastic.AzureFunctionApp.Isolated.csproj
@@ -8,10 +8,6 @@
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>
-    <!-- 
-    The versions below are NOT the latest but anything newer breaks when attempting to run func
-    See: https://github.com/Azure/azure-functions-core-tools/issues/3594
-    -->
     <PackageReference Include="Microsoft.Azure.Functions.Worker"/>
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk"/>
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http"/>

--- a/test/azure/applications/Elastic.AzureFunctionApp.Isolated/Elastic.AzureFunctionApp.Isolated.csproj
+++ b/test/azure/applications/Elastic.AzureFunctionApp.Isolated/Elastic.AzureFunctionApp.Isolated.csproj
@@ -8,9 +8,11 @@
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker"/>
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk"/>
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http"/>
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore" />
   </ItemGroup>
   <ItemGroup>
     <None Update="host.json">

--- a/test/azure/applications/Elastic.AzureFunctionApp.Isolated/HttpTrigger.cs
+++ b/test/azure/applications/Elastic.AzureFunctionApp.Isolated/HttpTrigger.cs
@@ -14,7 +14,7 @@ namespace Elastic.AzureFunctionApp.Isolated;
 public static class HttpTriggers
 {
 	[Function(FunctionName.SampleHttpTrigger)]
-	public static HttpResponseData Run([HttpTrigger(AuthorizationLevel.Function, "get", "post")] HttpRequestData req,
+	public static async Task<HttpResponseData> Run([HttpTrigger(AuthorizationLevel.Function, "get", "post")] HttpRequestData req,
 		FunctionContext executionContext)
 	{
 		var logger = executionContext.GetLogger("SampleHttpTrigger");
@@ -23,11 +23,11 @@ public static class HttpTriggers
 		var response = req.CreateResponse(HttpStatusCode.OK);
 		response.Headers.Add("Content-Type", "text/plain; charset=utf-8");
 
-		response.WriteString("Hello Azure Functions!\n");
-		response.WriteString("======================\n");
+		await response.WriteStringAsync("Hello Azure Functions!\n");
+		await response.WriteStringAsync("======================\n");
 		foreach (DictionaryEntry e in Environment.GetEnvironmentVariables())
-			response.WriteString($"{e.Key} = {e.Value}\n");
-		response.WriteString("======================\n");
+			await response.WriteStringAsync($"{e.Key} = {e.Value}\n");
+		await response.WriteStringAsync("======================\n");
 
 		return response;
 	}

--- a/test/azure/applications/Elastic.AzureFunctionApp.Isolated/Program.cs
+++ b/test/azure/applications/Elastic.AzureFunctionApp.Isolated/Program.cs
@@ -6,7 +6,7 @@ using Elastic.Apm.Azure.Functions;
 using Microsoft.Extensions.Hosting;
 
 var host = new HostBuilder()
-	.ConfigureFunctionsWorkerDefaults(builder =>
+	.ConfigureFunctionsWebApplication(builder =>
 	{
 		builder.UseMiddleware<ApmMiddleware>();
 	})

--- a/test/azure/applications/Elastic.AzureFunctionApp.Isolated/host.json
+++ b/test/azure/applications/Elastic.AzureFunctionApp.Isolated/host.json
@@ -1,3 +1,12 @@
 {
-    "version": "2.0"
+  "version": "2.0",
+  "logging": {
+    "logLevel": {
+      "default": "Debug"
+    },
+    "console": {
+      "isEnabled": true,
+      "DisableColors": true
+    }
+  }
 }

--- a/test/integrations/Elastic.Apm.Extensions.Tests.Shared/ExtensionsTestHelpers.cs
+++ b/test/integrations/Elastic.Apm.Extensions.Tests.Shared/ExtensionsTestHelpers.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information
 
 using System.Diagnostics;
+using System.Runtime.InteropServices;
 using Elastic.Apm.Tests.Utilities;
 using FluentAssertions;
 using Xunit.Abstractions;
@@ -57,6 +58,11 @@ public class ExtensionsTestHelper
 
 		if (disabledViaEnvVar)
 			startInfo.Environment["ELASTIC_APM_ENABLED"] = "false";
+
+		// Adding this as the hang dumps for integration tests on Linux seem to suggest that the GcMetricsProvider is causing the hang.
+		// This is a temporary workaround until we can figure out the root cause.
+		if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+			startInfo.Environment["ELASTIC_APM_METRICS_INTERVAL"] = "0";
 
 		startInfo.ArgumentList.Add("run");
 		startInfo.ArgumentList.Add("-c");


### PR DESCRIPTION
This PR fixes several things in Azure Functions (isolated worker) which occur when using the latest templates for Azure Functions.

- Newer versions of the Functions library prefer the gRPC-based implementation, which throws when `Url` is accessed. Instead, we read these from other data on the `FunctionContext`. 
- Address Functions library changes that break distributed tracing. We now parse the original headers from the `BindingContext` instead of the request, which may contain a `traceparent` with the sampling flag set to false when the user request does not include a specific `traceparent`. 
- We explicitly don't record activities from the Azure functions library as these are pretty broken (https://github.com/Azure/azure-functions-dotnet-worker/issues/2733) and are redundant when using our middleware.
- Downgrade several packages as the newer ones are now deprecated (thanks for the confusion, Microsoft!).
- Update some outdated compiler pre-processor directives.
- The final few commits focus on CI integration test hangs on Linux. We don't have a perfect solution for those, but after reviewing the hang dumps, I've avoided some of the potential causes of the hangs. We'll monitor subsequent PRs, and if they remain stable, we will readdress the original causes.

A follow-up PR will update our documentation.

Closes #2407 
Closes #2311
Closes #2218