### PR TITLE
github-actions: dependabot cannot use the id-token:write

### DIFF
--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -79,7 +79,7 @@ jobs:
     needs: [ 'format', 'tests' ]
     if: |
       github.event_name != 'pull_request'
-      || github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false
+      || github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false && github.actor != 'dependabot[bot]'
     env:
       ARM_CLIENT_ID: ${{ secrets.ARM_CLIENT_ID }}
       ARM_SUBSCRIPTION_ID: ${{ secrets.ARM_SUBSCRIPTION_ID }}


### PR DESCRIPTION
For security reason, we don't access secrets when running any dependabot PR. For the same reason, the `id-token: write` is not an option when the actor is dependabot.