### PR TITLE
Update test dependencies

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,7 +3,7 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
   <ItemGroup>
-    <GlobalPackageReference Include="MinVer" Version="4.3.0" PrivateAssets="All" />
+    <GlobalPackageReference Include="MinVer" Version="6.0.0" PrivateAssets="All" />
     <GlobalPackageReference Condition="'$(TargetFramework)' == 'net462'" Include="Microsoft.NETFramework.ReferenceAssemblies.net462" Version="1.0.3" PrivateAssets="all" />
   </ItemGroup>
   <!-- Community Packages -->
@@ -29,18 +29,18 @@
     <PackageVersion Include="Fake.IO.FileSystem" Version="6.0.0" />
     <PackageVersion Include="Fake.IO.Zip" Version="6.0.0" />
     <PackageVersion Include="Fake.Tools.Git" Version="6.0.0" />
-    <PackageVersion Include="FluentAssertions" Version="5.6.0" />
-    <PackageVersion Include="FluentAssertions.Analyzers" Version="0.11.4" />
+    <PackageVersion Include="FluentAssertions" Version="7.0.0" />
+    <PackageVersion Include="FluentAssertions.Analyzers" Version="0.34.1" />
     <PackageVersion Include="GitHubActionsTestLogger" Version="2.4.1" PrivateAssets="All" />
     <PackageVersion Include="Google.Protobuf" Version="3.25.3" />
     <PackageVersion Include="Grpc.AspNetCore" Version="2.61.0" />
     <PackageVersion Include="Grpc.Net.ClientFactory" Version="2.61.0" />
     <PackageVersion Include="Grpc.Tools" Version="2.62.0" PrivateAssets="All" IncludeAssets="runtime; build; native; contentfiles; analyzers; buildtransitive" />
     <PackageVersion Include="JetBrains.Profiler.Api" Version="1.4.0" />
-    <PackageVersion Include="JunitXml.TestLogger" Version="3.1.12" PrivateAssets="All" />
+    <PackageVersion Include="JunitXml.TestLogger" Version="4.1.0" PrivateAssets="All" />
     <PackageVersion Include="MongoDB.Driver" Version="2.28.0" />
     <PackageVersion Include="MongoDB.Driver.Core" Version="2.28.0" />
-    <PackageVersion Include="Moq" Version="4.20.70" />
+    <PackageVersion Include="Moq" Version="4.20.72" />
     <PackageVersion Include="MySql.Data" Version="8.0.32.1" />
     <PackageVersion Include="MySql.Data.EntityFrameworkCore" Version="8.0.22" />
     <PackageVersion Include="NEST" Version="7.17.5" />
@@ -54,7 +54,7 @@
     <PackageVersion Include="Oracle.ManagedDataAccess" Version="21.13.0" />
     <PackageVersion Include="Oracle.ManagedDataAccess.Core" Version="3.21.90" />
     <PackageVersion Include="Polly" Version="7.2.1" />
-    <PackageVersion Include="Proc" Version="0.8.2" />
+    <PackageVersion Include="Proc" Version="0.9.0" />
     <PackageVersion Include="RabbitMQ.Client" Version="6.8.1" />
     <PackageVersion Include="RichardSzalay.MockHttp" Version="6.0.0" />
     <PackageVersion Include="SQLite.CodeFirst" Version="1.5.3.29" />
@@ -63,18 +63,18 @@
     <PackageVersion Include="SpecFlow.xUnit" Version="3.5.5" />
     <PackageVersion Include="StackExchange.Redis" Version="2.7.20" />
     <PackageVersion Include="Swashbuckle.AspNetCore" Version="6.5.0" />
-    <PackageVersion Include="Testcontainers.Elasticsearch" Version="3.7.0" />
-    <PackageVersion Include="Testcontainers.Kafka" Version="3.10.0" />
-    <PackageVersion Include="Testcontainers.MongoDb" Version="3.10.0" />
-    <PackageVersion Include="Testcontainers.MsSql" Version="3.10.0" />
-    <PackageVersion Include="Testcontainers.MySql" Version="3.10.0" />
-    <PackageVersion Include="Testcontainers.Oracle" Version="3.10.0" />
-    <PackageVersion Include="Testcontainers.PostgreSql" Version="3.10.0" />
-    <PackageVersion Include="Testcontainers.RabbitMq" Version="3.10.0" />
-    <PackageVersion Include="Testcontainers.Redis" Version="3.10.0" />
+    <PackageVersion Include="Testcontainers.Elasticsearch" Version="4.0.0" />
+    <PackageVersion Include="Testcontainers.Kafka" Version="4.0.0" />
+    <PackageVersion Include="Testcontainers.MongoDb" Version="4.0.0" />
+    <PackageVersion Include="Testcontainers.MsSql" Version="4.0.0" />
+    <PackageVersion Include="Testcontainers.MySql" Version="4.0.0" />
+    <PackageVersion Include="Testcontainers.Oracle" Version="4.0.0" />
+    <PackageVersion Include="Testcontainers.PostgreSql" Version="4.0.0" />
+    <PackageVersion Include="Testcontainers.RabbitMq" Version="4.0.0" />
+    <PackageVersion Include="Testcontainers.Redis" Version="4.0.0" />
     <PackageVersion Include="YamlDotNet" Version="11.2.1" />
-    <PackageVersion Include="xunit" Version="2.7.0" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="2.5.7" PrivateAssets="All" IncludeAssets="runtime; build; native; contentfiles; analyzers; buildtransitive" />
+    <PackageVersion Include="xunit" Version="2.9.2" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2" PrivateAssets="All" IncludeAssets="runtime; build; native; contentfiles; analyzers; buildtransitive" />
   </ItemGroup>
   <!-- Microsoft/System packages -->
   <ItemGroup>
@@ -117,7 +117,7 @@
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.2" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Configuration" Version="8.0.1" />
     <PackageVersion Include="Microsoft.NET.Sdk.Functions" Version="4.6.0" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageVersion Include="Microsoft.Owin.Host.SystemWeb" Version="4.1.1" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
     <PackageVersion Include="Microsoft.Web.Administration" Version="11.1.0" />

--- a/dotnet-tools.json
+++ b/dotnet-tools.json
@@ -9,7 +9,7 @@
       ]
     },
     "minver-cli": {
-      "version": "4.3.0",
+      "version": "6.0.0",
       "commands": [
         "minver"
       ]

--- a/src/Elastic.Apm/Elastic.Apm.csproj
+++ b/src/Elastic.Apm/Elastic.Apm.csproj
@@ -46,6 +46,7 @@
     <InternalsVisibleTo Include="Elastic.Apm.Extensions.Logging" Key="$(ExposedPublicKey)" />
     <InternalsVisibleTo Include="Elastic.Apm.Extensions.Logging.Tests" Key="$(ExposedPublicKey)" />
     <InternalsVisibleTo Include="Elastic.Apm.Extensions.Hosting.Tests" Key="$(ExposedPublicKey)" />
+    <InternalsVisibleTo Include="Elastic.Apm.Tests.HelpersTests" Key="$(ExposedPublicKey)" />
     <InternalsVisibleTo Include="Elastic.Apm.Azure.ServiceBus" Key="$(ExposedPublicKey)" />
     <InternalsVisibleTo Include="Elastic.Apm.Azure.ServiceBus.Tests" Key="$(ExposedPublicKey)" />
     <InternalsVisibleTo Include="Elastic.Apm.Azure.Storage" Key="$(ExposedPublicKey)" />

--- a/test/Elastic.Apm.Tests.Utilities/ShouldWaitDurationExtensions.cs
+++ b/test/Elastic.Apm.Tests.Utilities/ShouldWaitDurationExtensions.cs
@@ -9,13 +9,13 @@ namespace Elastic.Apm.Tests.Utilities
 {
 	public static class ShouldWaitDurationExtensions
 	{
-		public static AndConstraint<NumericAssertions<double>>
+		public static AndConstraint<NullableNumericAssertions<double>>
 			BeGreaterOrEqualToMinimumSleepLength(this NullableNumericAssertions<double> duration) =>
-			duration.NotBeNull().And.BeGreaterOrEqualTo(WaitHelpers.SleepLength);
+				duration.NotBeNull().And.BeGreaterOrEqualTo(WaitHelpers.SleepLength);
 
-		public static AndConstraint<NumericAssertions<double>> BeGreaterOrEqualToMinimumSleepLength(this NullableNumericAssertions<double> duration,
-			int numberOfSleeps
-		)
+		public static AndConstraint<NullableNumericAssertions<double>> BeGreaterOrEqualToMinimumSleepLength(
+			this NullableNumericAssertions<double> duration,
+			int numberOfSleeps)
 		{
 			var expectedTransactionLength = numberOfSleeps * WaitHelpers.SleepLength;
 			return duration.NotBeNull()

--- a/test/Elastic.Apm.Tests.Utilities/XUnit/DockerAttributes.cs
+++ b/test/Elastic.Apm.Tests.Utilities/XUnit/DockerAttributes.cs
@@ -67,7 +67,7 @@ internal static class DockerUtils
 	{
 		try
 		{
-			var result = Proc.Start(new StartArguments("docker", "--version"), TimeSpan.FromSeconds(30));
+			var result = Proc.Start(new StartArguments("docker", "--version") { Timeout = TimeSpan.FromSeconds(30)});
 			HasDockerInstalled = result.ExitCode == 0;
 		}
 		catch (Exception)

--- a/test/Elastic.Apm.Tests.Utilities/XUnit/DockerAttributes.cs
+++ b/test/Elastic.Apm.Tests.Utilities/XUnit/DockerAttributes.cs
@@ -67,7 +67,7 @@ internal static class DockerUtils
 	{
 		try
 		{
-			var result = Proc.Start(new StartArguments("docker", "--version") { Timeout = TimeSpan.FromSeconds(30)});
+			var result = Proc.Start(new StartArguments("docker", "--version") { Timeout = TimeSpan.FromSeconds(30) });
 			HasDockerInstalled = result.ExitCode == 0;
 		}
 		catch (Exception)

--- a/test/Elastic.Apm.Tests/BackendCommTests/CentralConfig/CentralConfigResponseParserTests.cs
+++ b/test/Elastic.Apm.Tests/BackendCommTests/CentralConfig/CentralConfigResponseParserTests.cs
@@ -305,7 +305,7 @@ namespace Elastic.Apm.Tests.BackendCommTests.CentralConfig
 						{
 							cfg.LogLevel.Should()
 								.NotBeNull()
-								.And.Be(value);
+								.And.Be((LogLevel)value);
 						})
 					};
 				}

--- a/test/Elastic.Apm.Tests/BackendCommTests/PayloadSenderTests.cs
+++ b/test/Elastic.Apm.Tests/BackendCommTests/PayloadSenderTests.cs
@@ -320,7 +320,7 @@ namespace Elastic.Apm.Tests.BackendCommTests
 
 		[Theory]
 		[MemberData(nameof(FlushInterval_test_variants))]
-		internal async void FlushInterval_test(TestArgs args, int numberOfEventsToSend)
+		internal async Task FlushInterval_test(TestArgs args, int numberOfEventsToSend)
 		{
 			var batchSentBarrier = new Barrier(2);
 			var barrierTimeout = 30.Seconds();

--- a/test/Elastic.Apm.Tests/Config/ConfigTests.cs
+++ b/test/Elastic.Apm.Tests/Config/ConfigTests.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
+using System.Threading.Tasks;
 using Elastic.Apm.Config;
 using Elastic.Apm.Helpers;
 using Elastic.Apm.Logging;
@@ -30,7 +31,7 @@ namespace Elastic.Apm.Tests.Config
 	[Collection("UsesEnvironmentVariables")]
 	public class ConfigTests : IDisposable
 	{
-		public static TheoryData GlobalLabelsValidVariantsToTest => new TheoryData<string, IReadOnlyDictionary<string, string>>
+		public static TheoryData<string, IReadOnlyDictionary<string, string>> GlobalLabelsValidVariantsToTest => new TheoryData<string, IReadOnlyDictionary<string, string>>
 		{
 			// empty string - zero key value pairs
 			{ "", new Dictionary<string, string>() },

--- a/test/Elastic.Apm.Tests/Extensions/EnumerableExtensionsTests.cs
+++ b/test/Elastic.Apm.Tests/Extensions/EnumerableExtensionsTests.cs
@@ -14,7 +14,7 @@ namespace Elastic.Apm.Tests.Extensions
 {
 	public class EnumerableExtensionsTests
 	{
-		public static TheoryData EnumerablesToTest => new TheoryData<IEnumerable<object>, object[]>
+		public static TheoryData<IEnumerable<object>, object[]> EnumerablesToTest => new TheoryData<IEnumerable<object>, object[]>
 		{
 			{ Array.Empty<object>(), Array.Empty<object>() },
 			{ Enumerable.Range(0, 0).Select(i => (object)i), Array.Empty<object>() },

--- a/test/Elastic.Apm.Tests/HelpersTests/AgentSpinLockTests.cs
+++ b/test/Elastic.Apm.Tests/HelpersTests/AgentSpinLockTests.cs
@@ -29,7 +29,7 @@ namespace Elastic.Apm.Tests.HelpersTests
 
 		public AgentSpinLockTests(ITestOutputHelper xUnitOutputHelper) : base(xUnitOutputHelper) => _logger = LoggerBase.Scoped(ThisClassName);
 
-		internal interface ISpinLockForTest
+		public interface ISpinLockForTest
 		{
 			void Release();
 
@@ -45,7 +45,7 @@ namespace Elastic.Apm.Tests.HelpersTests
 				new NoopSpinLockForTest()
 			};
 
-		public static TheoryData ThreadSafeSpinLockImpls => new TheoryData<ISpinLockForTest> { new AgentSpinLockForTest() };
+		public static TheoryData<ISpinLockForTest> ThreadSafeSpinLockImpls => [new AgentSpinLockForTest()];
 
 		[Fact]
 		public void default_value_is_false()

--- a/test/Elastic.Apm.Tests/HelpersTests/ExceptionUtilsTests.cs
+++ b/test/Elastic.Apm.Tests/HelpersTests/ExceptionUtilsTests.cs
@@ -14,7 +14,7 @@ namespace Elastic.Apm.Tests.HelpersTests
 {
 	public class ExceptionUtilsTests
 	{
-		public static TheoryData DoSwallowingExceptionsVariantsToTest => new TheoryData<string, Action>
+		public static TheoryData<string, Action> DoSwallowingExceptionsVariantsToTest => new TheoryData<string, Action>
 		{
 			{ ExceptionUtils.MethodExitingNormallyMsgFmt, () => { } },
 			{ ExceptionUtils.MethodExitingCancelledMsgFmt, () => new CancellationToken(true).ThrowIfCancellationRequested() },

--- a/test/Elastic.Apm.Tests/HelpersTests/LazyContextualInitTests.cs
+++ b/test/Elastic.Apm.Tests/HelpersTests/LazyContextualInitTests.cs
@@ -14,7 +14,7 @@ namespace Elastic.Apm.Tests.HelpersTests
 {
 	public class LazyContextualInitTests
 	{
-		public static TheoryData WaysToCallInit = new TheoryData<string, Func<LazyContextualInit, Action, bool>>
+		public static readonly TheoryData WaysToCallInit = new TheoryData<string, Func<LazyContextualInit, Action, bool>>()
 		{
 			{ "IfNotInited?.Init ?? false", (lazyCtxInit, initAction) => lazyCtxInit.IfNotInited?.Init(initAction) ?? false },
 			{ "Init", (lazyCtxInit, initAction) => lazyCtxInit.Init(initAction) }
@@ -22,8 +22,8 @@ namespace Elastic.Apm.Tests.HelpersTests
 
 		[Theory]
 		[MemberData(nameof(WaysToCallInitOrGetString))]
-		internal void with_result_initialized_only_once_on_first_call(string dbgWayToCallDesc
-			, Func<LazyContextualInit<string>, Func<string>, string> wayToCall
+		internal void with_result_initialized_only_once_on_first_call(string dbgWayToCallDesc,
+			Func<LazyContextualInit<string>, Func<string>, string> wayToCall
 		)
 		{
 			var counter = new ThreadSafeIntCounter();
@@ -58,7 +58,9 @@ namespace Elastic.Apm.Tests.HelpersTests
 		}
 
 		[Theory]
+#pragma warning disable xUnit1037 // There are fewer theory data type arguments than required by the parameters of the test method
 		[MemberData(nameof(WaysToCallInit))]
+#pragma warning restore xUnit1037 // There are fewer theory data type arguments than required by the parameters of the test method
 		internal void no_result_initialized_only_once_on_first_call(string dbgWayToCallDesc, Func<LazyContextualInit, Action, bool> wayToCall)
 		{
 			var counter = new ThreadSafeIntCounter();
@@ -81,7 +83,9 @@ namespace Elastic.Apm.Tests.HelpersTests
 		}
 
 		[Theory]
+#pragma warning disable xUnit1037 // There are fewer theory data type arguments than required by the parameters of the test method
 		[MemberData(nameof(WaysToCallInit))]
+#pragma warning restore xUnit1037 // There are fewer theory data type arguments than required by the parameters of the test method
 		internal void no_result_multiple_threads(string dbgWayToCallDesc, Func<LazyContextualInit, Action, bool> wayToCall)
 		{
 			var counter = new ThreadSafeIntCounter();

--- a/test/Elastic.Apm.Tests/HelpersTests/LazyContextualInitTestsHelpers.cs
+++ b/test/Elastic.Apm.Tests/HelpersTests/LazyContextualInitTestsHelpers.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using Elastic.Apm.Helpers;
+using Xunit;
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+internal static class LazyContextualInitTestsHelpers
+{
+	public static TheoryData<string, Func<LazyContextualInit, Action, bool>> WaysToCallInit = new()
+		{
+			{ "IfNotInited?.Init ?? false", (lazyCtxInit, initAction) => lazyCtxInit.IfNotInited?.Init(initAction) ?? false },
+			{ "Init", (lazyCtxInit, initAction) => lazyCtxInit.Init(initAction) }
+		};
+}

--- a/test/Elastic.Apm.Tests/HelpersTests/LazyContextualInitTestsHelpers.cs
+++ b/test/Elastic.Apm.Tests/HelpersTests/LazyContextualInitTestsHelpers.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using Elastic.Apm.Helpers;
 using Xunit;
 // Licensed to Elasticsearch B.V under one or more agreements.

--- a/test/Elastic.Apm.Tests/HelpersTests/TimeUtilsTests.cs
+++ b/test/Elastic.Apm.Tests/HelpersTests/TimeUtilsTests.cs
@@ -14,7 +14,7 @@ namespace Elastic.Apm.Tests.HelpersTests
 	{
 		private static readonly DateTime UnixEpochDateTime = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
 
-		public static TheoryData TimestampAndDateTimeVariantsToTest => new TheoryData<long, DateTime>
+		public static TheoryData<long, DateTime> TimestampAndDateTimeVariantsToTest => new TheoryData<long, DateTime>
 		{
 			{ 0, UnixEpochDateTime },
 			{ 1, UnixEpochDateTime + TimeUtils.TimeSpanFromFractionalMilliseconds(0.001) },

--- a/test/Elastic.Apm.Tests/SamplerTests.cs
+++ b/test/Elastic.Apm.Tests/SamplerTests.cs
@@ -16,7 +16,7 @@ namespace Elastic.Apm.Tests
 	public class SamplerTests
 	{
 		// ReSharper disable once MemberCanBePrivate.Global
-		public static TheoryData RateVariantsToTest => new TheoryData<double>
+		public static TheoryData<double> RateVariantsToTest => new TheoryData<double>
 		{
 			0,
 			0.0001,

--- a/test/Elastic.Apm.Tests/SerializationTests.cs
+++ b/test/Elastic.Apm.Tests/SerializationTests.cs
@@ -31,7 +31,7 @@ namespace Elastic.Apm.Tests
 			_payloadItemSerializer = new PayloadItemSerializer();
 
 		// ReSharper disable once MemberCanBePrivate.Global
-		public static TheoryData SerializationUtilsTrimToPropertyMaxLengthVariantsToTest => new TheoryData<string, string>
+		public static TheoryData<string, string> SerializationUtilsTrimToPropertyMaxLengthVariantsToTest => new TheoryData<string, string>
 		{
 			{ "", "" },
 			{ "A", "A" },

--- a/test/iis/Elastic.Apm.AspNetFullFramework.Tests/TestsBase.cs
+++ b/test/iis/Elastic.Apm.AspNetFullFramework.Tests/TestsBase.cs
@@ -322,7 +322,7 @@ namespace Elastic.Apm.AspNetFullFramework.Tests
 					(int)response.StatusCode, response.StatusCode);
 			try
 			{
-				response.StatusCode.Should().Be(expectedStatusCode);
+				response.StatusCode.Should().Be((HttpStatusCode)expectedStatusCode);
 			}
 			catch (XunitException ex)
 			{

--- a/test/integrations/Elastic.Apm.AspNetCore.Tests/BodyCapturingTests.cs
+++ b/test/integrations/Elastic.Apm.AspNetCore.Tests/BodyCapturingTests.cs
@@ -95,7 +95,7 @@ namespace Elastic.Apm.AspNetCore.Tests
 			var result = await sutEnv.HttpClient.PostAsync("api/Home/Send", new StringContent(body, Encoding.UTF8, "application/json"));
 
 			// make sure the sample app received the data
-			result.StatusCode.Should().Be(200);
+			result.StatusCode.Should().Be((HttpStatusCode)200);
 
 			// and make sure the data is captured by the agent
 			sutEnv.MockPayloadSender.FirstTransaction.Should().NotBeNull();

--- a/test/profiler/Elastic.Apm.Profiler.Managed.Tests/AspNetCore/AspNetCoreTests.cs
+++ b/test/profiler/Elastic.Apm.Profiler.Managed.Tests/AspNetCore/AspNetCoreTests.cs
@@ -26,7 +26,7 @@ namespace Elastic.Apm.Profiler.Managed.Tests.AspNetCore
 		/// <param name="framework"></param>
 		[Theory]
 		[InlineData("net8.0")]
-		public async void AspNetCoreTest(string framework)
+		public async System.Threading.Tasks.Task AspNetCoreTest(string framework)
 		{
 			var apmLogger = new InMemoryBlockingLogger(Logging.LogLevel.Error);
 			var apmServer = new MockApmServer(apmLogger, nameof(AspNetCoreTests));

--- a/test/startuphook/Elastic.Apm.StartupHook.Tests/DotnetProject.cs
+++ b/test/startuphook/Elastic.Apm.StartupHook.Tests/DotnetProject.cs
@@ -74,7 +74,7 @@ namespace Elastic.Apm.StartupHook.Tests
 				var startArgs = new StartArguments("dotnet", args)
 				{
 					WorkingDirectory = workingDirectory,
-					Timeout= TimeSpan.FromSeconds(30)
+					Timeout = TimeSpan.FromSeconds(30)
 				};
 
 				var publishResult = Proc.Start(startArgs);

--- a/test/startuphook/Elastic.Apm.StartupHook.Tests/DotnetProject.cs
+++ b/test/startuphook/Elastic.Apm.StartupHook.Tests/DotnetProject.cs
@@ -73,10 +73,11 @@ namespace Elastic.Apm.StartupHook.Tests
 
 				var startArgs = new StartArguments("dotnet", args)
 				{
-					WorkingDirectory = workingDirectory
+					WorkingDirectory = workingDirectory,
+					Timeout= TimeSpan.FromSeconds(30)
 				};
 
-				var publishResult = Proc.Start(startArgs, TimeSpan.FromSeconds(30));
+				var publishResult = Proc.Start(startArgs);
 
 				foreach (var line in publishResult.ConsoleOut)
 				{
@@ -193,8 +194,9 @@ namespace Elastic.Apm.StartupHook.Tests
 
 			var result = Proc.Start(new StartArguments("dotnet", args)
 			{
-				WorkingDirectory = directory
-			}, TimeSpan.FromSeconds(30));
+				WorkingDirectory = directory,
+				Timeout = TimeSpan.FromSeconds(30)
+			});
 
 			if (result.Completed)
 			{


### PR DESCRIPTION
Updates to the latest test runners and dependencies. This may improve the stability of the integration tests and is a move toward updating to the .NET 9 SDK.