### PR TITLE
ci: spin-up ephemeral ESS clusters to run some system tests

### DIFF
--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -207,7 +207,7 @@ jobs:
           github-token: ${{ steps.get_token.outputs.token }}
 
       - name: Setup ephemeral cluster
-        uses: elastic/oblt-actions/oblt-cli/cluster-create-ccs@feature/wait-return-cluster-name
+        uses: elastic/oblt-actions/oblt-cli/cluster-create-ccs@v1
         id: cluster_create
         with:
           github-token: ${{ steps.get_token.outputs.token }}


### PR DESCRIPTION
#### What

Using the production environment for this makes sense to ensure we are testing against released APM features.

In the subsequent tests, we'd need to access the APM endpoint and ApiKey to push APM data from the test applications. In the test projects, we'd need access to an API key with permissions to query Elasticsearch observability data streams to validate the received data.

As a stretch feature, although not critical from day one, it would be helpful to have programmatic access to query APM server logs from the project to log any errors that might occur during intake. This is one advantage to the in-memory mocked APM server we have today.

#### Summary steps:

1. Create an Observability Serverless project as part of the CI workflow
2. Provide access to specific credentials for that project in the following workflow steps (test projects)
3. Destroy the project when the CI has finished

#### Tasks

- [x] Enable OIDC
- [ ] Confirm what environment needs to be used (edge-oblt, dev-oblt, release-oblt)
- [x] Configure the tests to use the current set of [credentials](https://github.com/elastic/oblt-actions/tree/v1/oblt-cli/cluster-credentials#exported-environment-variables)
- [x] Requires https://github.com/elastic/oblt-actions/pull/226