### PR TITLE
Allow use of the latest minor to accomodate newer 8.x releases

### DIFF
--- a/test/startuphook/Elastic.Apm.StartupHook.Tests/DotnetProject.cs
+++ b/test/startuphook/Elastic.Apm.StartupHook.Tests/DotnetProject.cs
@@ -170,7 +170,7 @@ namespace Elastic.Apm.StartupHook.Tests
 				"--sdk-version",
 				"8.0.404", // Fixing this specific version, for now
 				"--roll-forward",
-				"disable"
+				"LatestPatch"
 			])
 			{
 				WorkingDirectory = directory


### PR DESCRIPTION
As titled.

This fixes the failing startup hook tests. Failing Azure tests will be reviewed and fixed in a subsequent PR.