### PR TITLE
Fixed log template resulting in nullreference exception

### DIFF
--- a/src/Elastic.Apm/Agent.cs
+++ b/src/Elastic.Apm/Agent.cs
@@ -81,7 +81,7 @@ namespace Elastic.Apm
 				TransactionFilters.ForEach(f => sender.AddFilter(f));
 				SpanFilters.ForEach(f => sender.AddFilter(f));
 				agent.Logger?.Trace()
-					?.Log(@"Initialization - Added filters to agent (errors:{{ErrorFilters}}, transactions:{TransactionFilters} spans:{SpanFilters}",
+					?.Log(@"Initialization - Added filters to agent (errors:{ErrorFilters}, transactions:{TransactionFilters} spans:{SpanFilters}",
 						ErrorFilters.Count, TransactionFilters.Count, SpanFilters.Count);
 
 				return agent;


### PR DESCRIPTION
The escaped log template does not match the log arguments. This causes a nullreference exception with serilog, since the `LogValuesFormatter` creates a `LogValues` where the last item is null.

https://github.com/elastic/apm-agent-dotnet/blob/36670d5760fe0128e2082dc6918be4c40a3f0efc/src/Elastic.Apm/Logging/LogValuesFormatter.cs#L182C3-L198C4