### PR TITLE
Avoid NullReferenceException on 401 Unauthorized

### DIFF
--- a/src/Elastic.Apm/Report/PayloadSenderV2.cs
+++ b/src/Elastic.Apm/Report/PayloadSenderV2.cs
@@ -429,7 +429,7 @@ namespace Elastic.Apm.Report
 #else
 							var intakeResponse = _payloadItemSerializer.Deserialize<IntakeResponse>(response.Content.ReadAsStreamAsync().GetAwaiter().GetResult());
 #endif
-							if (intakeResponse.Errors.Count > 0)
+							if ((intakeResponse?.Errors?.Count ?? 0) > 0)
 								message = string.Join(", ", intakeResponse.Errors.Select(e => e.Message).Distinct());
 						}
 						_logger?.Error()


### PR DESCRIPTION
We frequently experience NullReferenceExceptions in our logging registered by the first chance exception handler.

It is caused by `intakeResponse` being not null: Accepted = 0, Errors = null, and then evaluating `intakeResponse.Errors.Count` triggering an error.

Environment:

Unauthorized 401 on https://53b082e7cfeb4d9a9c117371xxxxxxxx.apm.eu-west-1.aws.cloud.es.io/intake/v2/events

The payload returned is:

```json
{"error":"authentication failed"}\n
```

So an improvement might be to also deserialize this JSON format.