### PR TITLE
Fix detection of api key and secret token

### DIFF
--- a/src/Elastic.Apm/BackendComm/BackendCommUtils.cs
+++ b/src/Elastic.Apm/BackendComm/BackendCommUtils.cs
@@ -270,9 +270,9 @@ namespace Elastic.Apm.BackendComm
 				}
 			}
 
-			if (configuration.ApiKey != null)
+			if (!string.IsNullOrEmpty(configuration.ApiKey))
 				httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("ApiKey", configuration.ApiKey);
-			else if (configuration.SecretToken != null)
+			else if (!string.IsNullOrEmpty(configuration.SecretToken))
 				httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", configuration.SecretToken);
 
 			return httpClient;


### PR DESCRIPTION
When the `ApiKey == string.Empty`, a header will be added. This seems unlikely to be intended. Dito for `SecretToken`.

We have had some problems due to this handling in Summer of 2024.

Now we are making improvement, inline with other code in this file such as:

```
if (!string.IsNullOrEmpty(service.Name))
```