### PR TITLE
update MongoDB.Driver PackageReference to 3.3

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -38,7 +38,7 @@
     <PackageVersion Include="Grpc.Tools" Version="2.62.0" PrivateAssets="All" IncludeAssets="runtime; build; native; contentfiles; analyzers; buildtransitive" />
     <PackageVersion Include="JetBrains.Profiler.Api" Version="1.4.0" />
     <PackageVersion Include="JunitXml.TestLogger" Version="4.1.0" PrivateAssets="All" />
-    <PackageVersion Include="MongoDB.Driver" Version="3.3.0" />
+    <PackageVersion Include="MongoDB.Driver" Version="3.0.0" />
     <PackageVersion Include="Moq" Version="4.20.72" />
     <PackageVersion Include="MySql.Data" Version="8.0.32.1" />
     <PackageVersion Include="MySql.Data.EntityFrameworkCore" Version="8.0.22" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -38,8 +38,7 @@
     <PackageVersion Include="Grpc.Tools" Version="2.62.0" PrivateAssets="All" IncludeAssets="runtime; build; native; contentfiles; analyzers; buildtransitive" />
     <PackageVersion Include="JetBrains.Profiler.Api" Version="1.4.0" />
     <PackageVersion Include="JunitXml.TestLogger" Version="4.1.0" PrivateAssets="All" />
-    <PackageVersion Include="MongoDB.Driver" Version="2.28.0" />
-    <PackageVersion Include="MongoDB.Driver.Core" Version="2.28.0" />
+    <PackageVersion Include="MongoDB.Driver" Version="3.3.0" />
     <PackageVersion Include="Moq" Version="4.20.72" />
     <PackageVersion Include="MySql.Data" Version="8.0.32.1" />
     <PackageVersion Include="MySql.Data.EntityFrameworkCore" Version="8.0.22" />

--- a/src/instrumentations/Elastic.Apm.MongoDb/Elastic.Apm.MongoDb.csproj
+++ b/src/instrumentations/Elastic.Apm.MongoDb/Elastic.Apm.MongoDb.csproj
@@ -26,7 +26,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="MongoDB.Driver.Core" />
+    <PackageReference Include="MongoDB.Driver" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
update MongoDB.Driver PackageReference to 3.3
in this version package MongoDB.Driver.Core was merged with the main package and so was removed