### PR TITLE
[docs] Fix image paths for docs-assembler

### DIFF
--- a/docs/reference/config-all-options-summary.md
+++ b/docs/reference/config-all-options-summary.md
@@ -5,7 +5,7 @@ mapped_pages:
 
 # All options summary [config-all-options-summary]
 
-| Option name | [![dynamic config](/reference/images/dynamic-config.svg "") ](/reference/configuration.md#dynamic-configuration) | Keywords |
+| Option name | [![dynamic config](images/dynamic-config.svg "") ](/reference/configuration.md#dynamic-configuration) | Keywords |
 | --- | --- | --- |
 | [`ApiKey`](/reference/config-reporter.md#config-api-key) | No | Reporter |
 | [`ApplicationNamespaces`](/reference/config-stacktrace.md#config-application-namespaces) | No | Stacktrace |

--- a/docs/reference/config-core.md
+++ b/docs/reference/config-core.md
@@ -8,7 +8,7 @@ mapped_pages:
 
 ## `Recording` ([1.7.0]) [config-recording]
 
-[![dynamic config](/reference/images/dynamic-config.svg "") ](/reference/configuration.md#dynamic-configuration)
+[![dynamic config](images/dynamic-config.svg "") ](/reference/configuration.md#dynamic-configuration)
 
 A Boolean specifying if the agent should be recording or not. When recording, the agent captures HTTP requests, tracks errors, and collects and sends metrics. When not recording, the agent works as a noop, where it does not collect data or communicate with the APM server, except for polling the central configuration endpoint. This is a reversible switch, so the agent threads are not killed when deactivated, but they will be mostly idle in this state, so the overhead should be negligible.
 
@@ -135,7 +135,7 @@ On ASP.NET Core application the agent uses [EnvironmentName from IHostingEnviron
 
 ## `TransactionSampleRate` [config-transaction-sample-rate]
 
-[![dynamic config](/reference/images/dynamic-config.svg "") ](/reference/configuration.md#dynamic-configuration)
+[![dynamic config](images/dynamic-config.svg "") ](/reference/configuration.md#dynamic-configuration)
 
 By default, the agent samples every transaction (e.g. a request to your service). To reduce overhead and storage requirements, set the sample rate to a value between 0.0 and 1.0. The agent will still record the overall time and result for unsampled transactions, but no context information, labels, or spans will be recorded.
 
@@ -157,7 +157,7 @@ This setting can be changed after the agent starts.
 
 ## `TransactionMaxSpans` (performance) ([1.1.1]) [config-transaction-max-spans]
 
-[![dynamic config](/reference/images/dynamic-config.svg "") ](/reference/configuration.md#dynamic-configuration)
+[![dynamic config](images/dynamic-config.svg "") ](/reference/configuration.md#dynamic-configuration)
 
 This limits the amount of spans that are recorded per transaction. This is helpful when a transaction creates a very high amount of spans, for example, thousands of SQL queries. Setting an upper limit helps prevent overloading the Agent and APM server in these edge cases.
 
@@ -192,7 +192,7 @@ If set to `true`, the agent makes periodic requests to the APM Server to fetch t
 
 ## `SanitizeFieldNames` ([1.2]) [config-sanitize-field-names]
 
-[![dynamic config](/reference/images/dynamic-config.svg "") ](/reference/configuration.md#dynamic-configuration)
+[![dynamic config](images/dynamic-config.svg "") ](/reference/configuration.md#dynamic-configuration)
 
 Sometimes, sanitizing, i.e., redacting sensitive data sent to Elastic APM, is necessary. This configuration accepts a comma-separated list of wildcard patterns of field names that should be sanitized. These apply to HTTP headers for requests and responses, cookies and `application/x-www-form-urlencoded` data.
 
@@ -243,7 +243,7 @@ This option requires APM Server 7.2 or later. It will have no effect on older ve
 
 ## `SpanCompressionEnabled` ([1.14]) [config-span-compression-enabled]
 
-[![dynamic config](/reference/images/dynamic-config.svg "") ](/reference/configuration.md#dynamic-configuration)
+[![dynamic config](images/dynamic-config.svg "") ](/reference/configuration.md#dynamic-configuration)
 
 Setting this option to true will enable span compression feature. Span compression reduces the collection, processing, and storage overhead, and removes clutter from the UI. The tradeoff is that some information such as DB statements of all the compressed spans will not be collected.
 
@@ -258,7 +258,7 @@ Setting this option to true will enable span compression feature. Span compressi
 
 ## `SpanCompressionExactMatchMaxDuration` ([1.14]) [config-span-compression-exact-match-max-duration]
 
-[![dynamic config](/reference/images/dynamic-config.svg "") ](/reference/configuration.md#dynamic-configuration)
+[![dynamic config](images/dynamic-config.svg "") ](/reference/configuration.md#dynamic-configuration)
 
 Consecutive spans that are exact match and that are under this threshold will be compressed into a single composite span. This option does not apply to composite spans. This reduces the collection, processing, and storage overhead, and removes clutter from the UI. The tradeoff is that the DB statements of all the compressed spans will not be collected.
 
@@ -273,7 +273,7 @@ Consecutive spans that are exact match and that are under this threshold will be
 
 ## `SpanCompressionSameKindMaxDuration` ([1.14]) [config-span-compression-same-kind-max-duration]
 
-[![dynamic config](/reference/images/dynamic-config.svg "") ](/reference/configuration.md#dynamic-configuration)
+[![dynamic config](images/dynamic-config.svg "") ](/reference/configuration.md#dynamic-configuration)
 
 Consecutive spans to the same destination that are under this threshold will be compressed into a single composite span. This option does not apply to composite spans. This reduces the collection, processing, and storage overhead, and removes clutter from the UI. The tradeoff is that the DB statements of all the compressed spans will not be collected.
 
@@ -288,7 +288,7 @@ Consecutive spans to the same destination that are under this threshold will be 
 
 ## `ExitSpanMinDuration` ([1.14]) [config-exit-span-min-duration]
 
-[![dynamic config](/reference/images/dynamic-config.svg "") ](/reference/configuration.md#dynamic-configuration)
+[![dynamic config](images/dynamic-config.svg "") ](/reference/configuration.md#dynamic-configuration)
 
 Sets the minimum duration of exit spans. Exit spans with a duration lesser than this threshold are attempted to be discarded. If the exit span is equal or greater the threshold, it should be kept. In some cases exit spans cannot be discarded. For example, spans that propagate the trace context to downstream services, such as outgoing HTTP requests, can’t be discarded. However, external calls that don’t propagate context, such as calls to a database, can be discarded using this threshold. Additionally, spans that lead to an error can’t be discarded.
 

--- a/docs/reference/config-http.md
+++ b/docs/reference/config-http.md
@@ -8,7 +8,7 @@ mapped_pages:
 
 ## `CaptureBody` (performance) ([1.0.1]) [config-capture-body]
 
-[![dynamic config](/reference/images/dynamic-config.svg "") ](/reference/configuration.md#dynamic-configuration)
+[![dynamic config](images/dynamic-config.svg "") ](/reference/configuration.md#dynamic-configuration)
 
 For transactions that are HTTP requests, the agent can optionally capture the request body, e.g., POST variables. If the request has a body and this setting is disabled, the body will be shown as [REDACTED]. This option is case-insensitive.
 
@@ -65,7 +65,7 @@ This setting can be changed after the agent starts.
 
 ## `CaptureHeaders` (performance) [config-capture-headers]
 
-[![dynamic config](/reference/images/dynamic-config.svg "") ](/reference/configuration.md#dynamic-configuration)
+[![dynamic config](images/dynamic-config.svg "") ](/reference/configuration.md#dynamic-configuration)
 
 If set to `true`, the agent will capture request and response headers, including cookies.
 
@@ -85,7 +85,7 @@ Setting this to `false` reduces memory allocations, network bandwidth, and disk 
 
 ## `TraceContinuationStrategy` (performance) ([1.17.0]) [config-trace-continuation-strategy]
 
-[![dynamic config](/reference/images/dynamic-config.svg "") ](/reference/configuration.md#dynamic-configuration)
+[![dynamic config](images/dynamic-config.svg "") ](/reference/configuration.md#dynamic-configuration)
 
 Valid options: `continue`, `restart`, `restart_external`.
 
@@ -110,7 +110,7 @@ In order to handle this properly, the agent offers trace continuation strategies
 
 ## `TransactionIgnoreUrls` (performance) [config-transaction-ignore-urls]
 
-[![dynamic config](/reference/images/dynamic-config.svg "") ](/reference/configuration.md#dynamic-configuration)
+[![dynamic config](images/dynamic-config.svg "") ](/reference/configuration.md#dynamic-configuration)
 
 This is used to restrict requests to certain URLs from being instrumented.
 
@@ -151,7 +151,7 @@ Changing this configuration will overwrite the default value.
 
 ## `TransactionNameGroups` ([1.27.0]) [config-transaction-name-groups]
 
-[![dynamic config](/reference/images/dynamic-config.svg "") ](/reference/configuration.md#dynamic-configuration)
+[![dynamic config](images/dynamic-config.svg "") ](/reference/configuration.md#dynamic-configuration)
 
 With this option, you can group transaction names that contain dynamic parts with a wildcard expression. For example, the pattern `GET /user/*/cart` would consolidate transactions, such as `GET /users/42/cart` and `GET /users/73/cart` into a single transaction name `GET /users/*/cart`, hence reducing the transaction name cardinality.
 
@@ -183,7 +183,7 @@ When this setting is `true`, the agent also adds the header `elasticapm-tracepar
 
 ## `UsePathAsTransactionName` ([1.27.0]) [config-use-path-as-transaction-name]
 
-[![dynamic config](/reference/images/dynamic-config.svg "") ](/reference/configuration.md#dynamic-configuration)
+[![dynamic config](images/dynamic-config.svg "") ](/reference/configuration.md#dynamic-configuration)
 
 If set to `true`, transaction names of unsupported or partially-supported frameworks will be in the form of `$method $path` instead of just `$method unknown route`.
 
@@ -218,7 +218,7 @@ This is useful when using windows authentication on a proxy, that routes APM age
 
 ## `BaggageToAttach` ([1.24]) [config-baggage-to-attach]
 
-[![dynamic config](/reference/images/dynamic-config.svg "") ](/reference/configuration.md#dynamic-configuration)
+[![dynamic config](images/dynamic-config.svg "") ](/reference/configuration.md#dynamic-configuration)
 
 Controls which baggage values are automatically attached to the given event (transaction, span, error). Baggage values are derived from the `baggage` header defined in the [W3C Baggage specification](https://www.w3.org/TR/baggage/). You can programmatically write and read baggage values via the [Activity API](https://learn.microsoft.com/en-us/dotnet/api/system.diagnostics.activity?view=net-6.0). For more details, see [`our documentation on how to integrate with OpenTelemetry`](/reference/opentelemetry-bridge.md#baggage-api).
 

--- a/docs/reference/config-stacktrace.md
+++ b/docs/reference/config-stacktrace.md
@@ -39,7 +39,7 @@ Namespaces are checked with `string.StartsWith()`, so "System." matches all Syst
 
 ## `StackTraceLimit` (performance) [config-stack-trace-limit]
 
-[![dynamic config](/reference/images/dynamic-config.svg "") ](/reference/configuration.md#dynamic-configuration)
+[![dynamic config](images/dynamic-config.svg "") ](/reference/configuration.md#dynamic-configuration)
 
 Setting this to `0` disables stack trace collection. Any positive integer value will be used as the maximum number of frames to collect. Setting it to -1 means that all frames will be collected.
 
@@ -59,7 +59,7 @@ If you would like to disable stack trace capturing only for spans, but still cap
 
 ### `SpanStackTraceMinDuration` (performance) [config-span-stack-trace-min-duration]
 
-[![dynamic config](/reference/images/dynamic-config.svg "") ](/reference/configuration.md#dynamic-configuration)
+[![dynamic config](images/dynamic-config.svg "") ](/reference/configuration.md#dynamic-configuration)
 
 In its default settings, the APM agent collects a stack trace for every recorded span with duration longer than `5ms`. While this is very helpful to find the exact place in your code that causes the span, collecting this stack trace does have some overhead. When setting this option to zero (regardless of the time unit), like `0ms`, stack traces are collected for all spans. Setting it to a positive value, e.g. `5ms`, limits stack trace collection to spans with durations equal to or longer than the given value, e.g. 5 milliseconds.
 

--- a/docs/reference/config-supportability.md
+++ b/docs/reference/config-supportability.md
@@ -8,7 +8,7 @@ mapped_pages:
 
 ## `LogLevel` [config-log-level]
 
-[![dynamic config](/reference/images/dynamic-config.svg "") ](/reference/configuration.md#dynamic-configuration)
+[![dynamic config](images/dynamic-config.svg "") ](/reference/configuration.md#dynamic-configuration)
 
 Sets the logging level for the agent.
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -12,7 +12,7 @@ By default, the agent uses environment variables. Additionally, on ASP.NET Core,
 
 ## Dynamic configuration [dynamic-configuration]
 
-Configuration options that are marked with the ![dynamic config](/reference/images/dynamic-config.svg "") badge can be changed at runtime when set from a supported source.
+Configuration options that are marked with the ![dynamic config](images/dynamic-config.svg "") badge can be changed at runtime when set from a supported source.
 
 The .NET Agent supports [Central configuration](docs-content://solutions/observability/apm/apm-agent-central-configuration.md), which allows you to fine-tune certain configurations via the APM app. This feature is enabled in the Agent by default, with [`CentralConfig` ([1.1])](/reference/config-core.md#config-central-config).
 

--- a/docs/reference/setup-auto-instrumentation.md
+++ b/docs/reference/setup-auto-instrumentation.md
@@ -423,6 +423,4 @@ To unblock a DLL file on Windows, you can do the following:
 * In the General tab, look for the Security section at the bottom
 * Select the Unblock check box and click OK
 
-:::{image} images/unblock-profiler-dll.png
-:alt: Unblock DLL in Windows file properties
-:::
+![Unblock DLL in Windows file properties](images/unblock-profiler-dll.png)

--- a/docs/reference/setup-azure-functions.md
+++ b/docs/reference/setup-azure-functions.md
@@ -92,9 +92,7 @@ Open *Settings > Environment variables* for your Function App in the Azure Porta
 
 For example:
 
-:::{image} images/azure-functions-configuration.png
-:alt: Configuring the APM Agent in the Azure Portal
-:::
+![Configuring the APM Agent in the Azure Portal](images/azure-functions-configuration.png)
 
 
 ## Limitations [azure-functions-limitations]


### PR DESCRIPTION
Fixes image paths to work with docs-assembler.

Notes for the reviewer:
* I was not able to get images in reference, extend, or release-notes to work using the `:::{image}` syntax because it seems to resolve differently than the Markdown `![]()` syntax. We should address this in docs-builder, but in order to get images working as soon as possible, I've used Markdown syntax and left us a `TO DO` in a code comment to add back the `screenshot` class where applicable. 
* Can you please add the appropriate labels needed for backporting? 