### PR TITLE
Add traceStateValue parameter to DistributedTracingData.TryDeserializ…

### DIFF
--- a/src/Elastic.Apm/Api/DistributedTracingData.cs
+++ b/src/Elastic.Apm/Api/DistributedTracingData.cs
@@ -49,10 +49,11 @@ namespace Elastic.Apm.Api
 		/// <see cref="ITracer.StartTransaction" />.
 		/// </summary>
 		/// <param name="serialized">should be a return value from a call to <see cref="SerializeToString" />.</param>
+		/// <param name="traceStateValue">should be a return value from a call to <see cref="DistributedTracing.TraceState.ToTextHeader"/>.</param>
 		/// <returns>
 		/// Instance deserialized from <paramref name="serialized" />.
 		/// </returns>
-		public static DistributedTracingData TryDeserializeFromString(string serialized) => TraceContext.TryExtractTracingData(serialized);
+		public static DistributedTracingData TryDeserializeFromString(string serialized, string traceStateValue = null) => TraceContext.TryExtractTracingData(serialized, traceStateValue);
 
 		public override string ToString() => new ToStringBuilder(nameof(DistributedTracingData))
 		{

--- a/src/Elastic.Apm/Api/DistributedTracingData.cs
+++ b/src/Elastic.Apm/Api/DistributedTracingData.cs
@@ -33,15 +33,24 @@ namespace Elastic.Apm.Api
 		internal TraceState TraceState { get; }
 
 		/// <summary>
-		/// Serializes this instance to a string.
-		/// This method should be used at the caller side and the return value should be passed to the (possibly remote) callee
-		/// side.
-		/// <see cref="TryDeserializeFromString" /> should be used to deserialize the instance at the callee side.
+		/// Serializes this instance to a traceparent string.
+		/// This method should be used at the caller side in pairs with <see cref="SerializeTraceStateToString" />,
+		/// and the return value should be passed to the (possibly remote) callee side.
+		/// <see cref="Create" /> should be used to deserialize the instance at the callee side.
 		/// </summary>
 		/// <returns>
-		/// String containing the instance in serialized form.
+		/// String containing the traceparent data in serialized form.
 		/// </returns>
 		public string SerializeToString() => TraceContext.BuildTraceparent(this);
+
+		/// <summary>
+		/// Serializes this instance to a tracestate string.
+		/// This method should be used at the caller side in pairs with <see cref="SerializeToString" />,
+		/// and the return value should be passed to the (possibly remote) callee side.
+		/// <see cref="Create" /> should be used to deserialize the instance at the callee side.
+		/// </summary>
+		/// <returns>The string representation of the tracestate header, or null if there is no tracestate.</returns>
+		public string SerializeTraceStateToString() => TraceState?.ToTextHeader();
 
 		/// <summary>
 		/// Deserializes an instance from a string.
@@ -49,11 +58,23 @@ namespace Elastic.Apm.Api
 		/// <see cref="ITracer.StartTransaction" />.
 		/// </summary>
 		/// <param name="serialized">should be a return value from a call to <see cref="SerializeToString" />.</param>
-		/// <param name="traceStateValue">should be a return value from a call to <see cref="DistributedTracing.TraceState.ToTextHeader"/>.</param>
 		/// <returns>
 		/// Instance deserialized from <paramref name="serialized" />.
 		/// </returns>
-		public static DistributedTracingData TryDeserializeFromString(string serialized, string traceStateValue = null) => TraceContext.TryExtractTracingData(serialized, traceStateValue);
+		public static DistributedTracingData TryDeserializeFromString(string serialized) => TraceContext.TryExtractTracingData(serialized);
+
+		/// <summary>
+		/// Creates an instance from a treceparent and tracestate strings.
+		/// This method should be used at the callee side, and the created instance can be passed to
+		/// <see cref="ITracer.StartTransaction" />.
+		/// </summary>
+		/// <param name="traceParent">should be a return value from a call to <see cref="SerializeToString" />.</param>
+		/// <param name="traceState">should be a return value from a call to <see cref="SerializeTraceStateToString"/>.</param>
+		/// <returns>
+		/// Instance deserialized from <paramref name="traceParent" /> and <paramref name="traceState" /> .
+		/// </returns>
+		public static DistributedTracingData Create(string traceParent, string traceState) =>
+			TraceContext.TryExtractTracingData(traceParent, traceState);
 
 		public override string ToString() => new ToStringBuilder(nameof(DistributedTracingData))
 		{


### PR DESCRIPTION
We pass the 'traceparent' value in our asynchronous message communication.
We follow the instructions at https://www.elastic.co/guide/en/apm/get-started/7.10/distributed-tracing.html#_manual_distributed_tracing.
However, it is not possible to restore the 'tracestate' as it is for the Go agent implementation.

In pair 'restart_external' TraceContinuationStrategy, it is not possible to search the logs across services using the original traceid, as each message handling generates anew traceid due to the absence of a tracestate.

The PR suggests a possible solution.