### PR TITLE
Add terraform install for linux CI test yaml

### DIFF
--- a/.github/workflows/install-dependencies/action.yml
+++ b/.github/workflows/install-dependencies/action.yml
@@ -47,6 +47,12 @@
         if: "${{ inputs.rust == 'true' && runner.os == 'Linux' }}"
         shell: bash
         run: cargo install --force cargo-zigbuild
+
+      - name: Install terraform
+        if: "${{ runner.os == 'Linux' }}"
+        uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3
+        with:
+          terraform_version: 1.11.2
       
       - uses: Swatinem/rust-cache@v2
         if: "${{ inputs.rust == 'true' }}"


### PR DESCRIPTION
Linux Azure tests have been failing for a year.

Adding the terraform installation into the linux yaml for CI Linux tests seems to fix the problem 