### PR TITLE
Add proxy apmserver

### DIFF
--- a/src/Elastic.Apm/BackendComm/BackendCommUtils.cs
+++ b/src/Elastic.Apm/BackendComm/BackendCommUtils.cs
@@ -238,6 +238,9 @@ namespace Elastic.Apm.BackendComm
 			// apply to the whole AppDomain and that may not be desired. A consumer can set this themselves if they
 			// need custom validation behaviour.
 #endif
+
+			ConfigureHttpProxy(httpClientHandler, configuration);
+
 			return httpClientHandler;
 		}
 
@@ -288,6 +291,23 @@ namespace Elastic.Apm.BackendComm
 
 			// Replace invalid characters by underscore. All invalid characters can be found at
 			// https://github.com/dotnet/corefx/blob/e64cac6dcacf996f98f0b3f75fb7ad0c12f588f7/src/System.Net.Http/src/System/Net/Http/HttpRuleParser.cs#L41
+		}
+
+		private static void ConfigureHttpProxy(HttpClientHandler httpClientHandler, IConfiguration configuration)
+		{
+			var proxyOption = configuration.ProxyOption;
+
+			if (proxyOption.IsEnabled)
+			{
+				var proxy = new WebProxy(proxyOption.Url)
+				{
+					Credentials = new NetworkCredential(proxyOption.UserName, proxyOption.Password),
+
+				};
+
+				httpClientHandler.UseProxy = true;
+				httpClientHandler.Proxy = proxy;
+			}
 		}
 
 		private static string GetUserAgent(Service service)

--- a/src/Elastic.Apm/BackendComm/CentralConfig/CentralConfiguration.cs
+++ b/src/Elastic.Apm/BackendComm/CentralConfig/CentralConfiguration.cs
@@ -100,6 +100,12 @@ namespace Elastic.Apm.BackendComm.CentralConfig
 
 		internal double? TransactionSampleRate { get; private set; }
 
+		internal string ProxyUrl { get; private set; }
+
+		internal string ProxyUserName { get; private set; }
+
+		internal string ProxyPassword { get; private set; }
+
 		internal bool? UsePathAsTransactionName { get; private set; }
 
 		private CentralConfigurationKeyValue BuildKv(DynamicConfigurationOption option, string value) => new(option, value, Description);

--- a/src/Elastic.Apm/BackendComm/CentralConfig/RuntimeConfigurationSnapshot.cs
+++ b/src/Elastic.Apm/BackendComm/CentralConfig/RuntimeConfigurationSnapshot.cs
@@ -129,5 +129,7 @@ namespace Elastic.Apm.BackendComm.CentralConfig
 		public bool UsePathAsTransactionName => _dynamicConfiguration?.UsePathAsTransactionName ?? _mainConfiguration.UsePathAsTransactionName;
 
 		public bool VerifyServerCert => _mainConfiguration.VerifyServerCert;
+
+		public ProxyOption ProxyOption => _mainConfiguration.ProxyOption;
 	}
 }

--- a/src/Elastic.Apm/Config/AbstractConfigurationReader.cs
+++ b/src/Elastic.Apm/Config/AbstractConfigurationReader.cs
@@ -338,6 +338,21 @@ namespace Elastic.Apm.Config
 			return DefaultValues.ServerUri;
 		}
 
+		protected Uri ParseProxyServerUrl(ConfigurationKeyValue kv)
+		{
+			if (kv == null || string.IsNullOrEmpty(kv.Value))
+			{
+				return null;
+			}
+
+			if (TryParseUri(kv.Value, out var uri))
+				return uri;
+
+			_logger?.Error()?.Log("Failed parsing server URL for proxy from {Origin}: {Key}, value: {Value}", kv.ReadFrom, kv.Key, kv.Value);
+
+			return null;
+		}
+
 		protected IReadOnlyList<Uri> ParseServerUrls(ConfigurationKeyValue kv)
 		{
 			var list = new List<Uri>();

--- a/src/Elastic.Apm/Config/ConfigurationKeyValue.cs
+++ b/src/Elastic.Apm/Config/ConfigurationKeyValue.cs
@@ -18,6 +18,8 @@ namespace Elastic.Apm.Config
 			{
 				ApiKey => true,
 				SecretToken => true,
+				ProxyUserName => true,
+				ProxyPassword => true,
 				_ => false
 			};
 		}

--- a/src/Elastic.Apm/Config/ConfigurationOption.cs
+++ b/src/Elastic.Apm/Config/ConfigurationOption.cs
@@ -102,6 +102,18 @@ namespace Elastic.Apm.Config
 		VerifyServerCert,
 		/// <inheritdoc cref="IConfigurationReader.ServerUrls"/>
 		ServerUrls,
+		/// <summary>
+		/// The proxy URL for the APM server.
+		/// </summary>
+		ProxyUrl,
+		/// <summary>
+		/// The proxy user name for the APM server.
+		/// </summary>
+		ProxyUserName,
+		/// <summary>
+		/// The proxy password for the APM server.
+		/// </summary>
+		ProxyPassword,
 		/// <inheritdoc cref="IConfigurationReader.SpanFramesMinDurationInMilliseconds"/>
 		SpanFramesMinDuration,
 		/// <inheritdoc cref="IConfigurationReader.TraceContextIgnoreSampledFalse"/>
@@ -190,6 +202,9 @@ namespace Elastic.Apm.Config
 				UsePathAsTransactionName => EnvPrefix + "USE_PATH_AS_TRANSACTION_NAME",
 				VerifyServerCert => EnvPrefix + "VERIFY_SERVER_CERT",
 				FullFrameworkConfigurationReaderType => EnvPrefix + "FULL_FRAMEWORK_CONFIGURATION_READER_TYPE",
+				ProxyUrl => EnvPrefix + "PROXY_URL",
+				ProxyUserName => EnvPrefix + "PROXY_USERNAME",
+				ProxyPassword => EnvPrefix + "PROXY_PASSWORD",
 				_ => throw new ArgumentOutOfRangeException(nameof(option), option, null)
 			};
 
@@ -244,6 +259,9 @@ namespace Elastic.Apm.Config
 				SpanFramesMinDuration => KeyPrefix + nameof(SpanFramesMinDuration),
 				TraceContextIgnoreSampledFalse => KeyPrefix + nameof(TraceContextIgnoreSampledFalse),
 				FullFrameworkConfigurationReaderType => KeyPrefix + nameof(FullFrameworkConfigurationReaderType),
+				ProxyUrl => KeyPrefix + nameof(ProxyUrl),
+				ProxyUserName => KeyPrefix + nameof(ProxyUserName),
+				ProxyPassword => KeyPrefix + nameof(ProxyPassword),
 				_ => throw new ArgumentOutOfRangeException(nameof(option), option, null)
 			};
 	}

--- a/src/Elastic.Apm/Config/FallbackToEnvironmentConfigurationBase.cs
+++ b/src/Elastic.Apm/Config/FallbackToEnvironmentConfigurationBase.cs
@@ -146,6 +146,15 @@ namespace Elastic.Apm.Config
 			ServerUrls = ParseServerUrls(!string.IsNullOrEmpty(urlsConfig.Value) ? urlsConfig : urlConfig);
 			ServerUrl = !string.IsNullOrEmpty(urlConfig.Value) ? ParseServerUrl(urlConfig) : ServerUrls.FirstOrDefault();
 #pragma warning restore CS0618
+
+			var proxyUrl = ParseProxyServerUrl(Lookup(ConfigurationOption.ProxyUrl));
+			var proxyUserName = Lookup(ConfigurationOption.ProxyUserName)?.Value;
+			var proxyPassword = Lookup(ConfigurationOption.ProxyPassword)?.Value;
+			ProxyOption = ProxyOption.Create(proxyUrl, proxyUserName, proxyPassword);
+
+			// Set the service name to the default if not set
+			if (string.IsNullOrEmpty(ServiceName))
+				ServiceName = defaults?.ServiceName ?? "unknown";
 		}
 
 		private IConfigurationKeyValueProvider KeyValueProvider { get; }
@@ -254,5 +263,7 @@ namespace Elastic.Apm.Config
 		public bool VerifyServerCert { get; }
 
 		public bool OpenTelemetryBridgeEnabled { get; }
+
+		public ProxyOption ProxyOption { get; }
 	}
 }

--- a/src/Elastic.Apm/Config/FallbackToEnvironmentConfigurationBase.cs
+++ b/src/Elastic.Apm/Config/FallbackToEnvironmentConfigurationBase.cs
@@ -151,10 +151,6 @@ namespace Elastic.Apm.Config
 			var proxyUserName = Lookup(ConfigurationOption.ProxyUserName)?.Value;
 			var proxyPassword = Lookup(ConfigurationOption.ProxyPassword)?.Value;
 			ProxyOption = ProxyOption.Create(proxyUrl, proxyUserName, proxyPassword);
-
-			// Set the service name to the default if not set
-			if (string.IsNullOrEmpty(ServiceName))
-				ServiceName = defaults?.ServiceName ?? "unknown";
 		}
 
 		private IConfigurationKeyValueProvider KeyValueProvider { get; }

--- a/src/Elastic.Apm/Config/IConfigurationReader.cs
+++ b/src/Elastic.Apm/Config/IConfigurationReader.cs
@@ -20,7 +20,7 @@ namespace Elastic.Apm.Config
 	/// <summary> A description for the configuration </summary>
 	public interface IConfigurationDescription
 	{
-		public string Description { get; }
+		string Description { get; }
 	}
 
 	/// <summary>
@@ -231,7 +231,7 @@ namespace Elastic.Apm.Config
 		/// As this is a reversible switch, agent threads are not terminated when inactivated, but they will be mostly
 		/// idle in this state, so the overhead should be negligible.
 		/// </remarks>
-		public bool Recording { get; }
+		bool Recording { get; }
 
 		/// <summary>
 		/// Sometimes it is necessary to sanitize the data sent to Elastic APM, e.g. remove sensitive data.
@@ -437,5 +437,10 @@ namespace Elastic.Apm.Config
 		/// Verification can be disabled by setting to <c>false</c>.
 		/// </summary>
 		bool VerifyServerCert { get; }
+
+		/// <summary>
+		/// The proxy configuration used by the agent to communicate with the APM server.
+		/// </summary>
+		ProxyOption ProxyOption { get; }
 	}
 }

--- a/src/Elastic.Apm/Config/ProxyOption.cs
+++ b/src/Elastic.Apm/Config/ProxyOption.cs
@@ -1,0 +1,35 @@
+// Licensed to Elasticsearch B.V under
+// one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System;
+
+namespace Elastic.Apm.Config;
+
+public sealed class ProxyOption
+{
+	private ProxyOption(bool isEnabled, Uri proxyUrl, string proxyUserName, string proxyPassword)
+	{
+		IsEnabled = isEnabled;
+		Url = proxyUrl;
+		UserName = proxyUserName;
+		Password = proxyPassword;
+	}
+
+	public bool IsEnabled { get; }
+
+	public Uri Url { get; }
+
+	public string UserName { get; }
+
+	public string Password { get; }
+
+	public static ProxyOption Create(Uri proxyUrl, string proxyUserName = null, string proxyPassword = null)
+	{
+		if (proxyUrl == null)
+			return new ProxyOption(false, null, null, null);
+
+		return new ProxyOption(true, proxyUrl, proxyUserName, proxyPassword);
+	}
+}


### PR DESCRIPTION
Add the possibility to add a server proxy for the APM server using new configurations: `ProxyUrl`, `ProxyUserName` and `ProxyPassword`.

