### PR TITLE
[docs] Replace placeholder URLs

### DIFF
--- a/docs/reference/config-http.md
+++ b/docs/reference/config-http.md
@@ -121,9 +121,9 @@ For example, in order to ignore the URLs `/foo` and `/bar`, set the configuratio
 When an incoming HTTP request is detected, its request path will be tested against each element in this list. For example, adding `/home/index` to this list would match and remove instrumentation from the following URLs:
 
 ```txt
-https://www.mycoolsite.com/home/index
+https://www.example.com/home/index
 http://localhost/home/index
-http://whatever.com/home/index?value1=123
+http://example.com/home/index?value1=123
 ```
 
 In other words, the matching always happens based on the request path—hosts and query strings are ignored.


### PR DESCRIPTION
Contributes to https://github.com/elastic/docs-content/issues/1734, https://github.com/elastic/docs-content/issues/1801

Replaces placeholder URLs with those reserved by the Internet Engineering Task Force (IETF) in RFC 2606 and RFC 6761 (e.g. `example.com`, `example.net`, `example.org`, `example.edu`,  `.example`).