### PR TITLE
Add the target framework moniker to the preamble logs

### DIFF
--- a/src/Elastic.Apm/Config/ConfigurationLogger.cs
+++ b/src/Elastic.Apm/Config/ConfigurationLogger.cs
@@ -80,7 +80,7 @@ namespace Elastic.Apm.Config
 #elif NETSTANDARD2_0
 				info.Log("Matched TFM: {TargetFrameworkMoniker}", "netstandard2.0");
 #elif NET472
-				info.Log("Matched TFM: {TargetFrameworkMoniker}", "net462");
+				info.Log("Matched TFM: {TargetFrameworkMoniker}", "net472");
 #elif NET462
 				info.Log("Matched TFM: {TargetFrameworkMoniker}", "net462");
 #else


### PR DESCRIPTION
Add the target framework moniker to the preamble logs to know the .Net runtime version
Fixes https://github.com/elastic/apm-agent-dotnet/issues/2529