### PR TITLE
[DOCS] Changelog test

### DIFF
--- a/docs/changelog.yml
+++ b/docs/changelog.yml
@@ -186,10 +186,11 @@ bundle:
   profiles:
     # Fetch the PR list from GitHub release notes
     gh-release:
-    #   # Output filename ({version} is substituted at runtime)
+      source: github_release
+      # Output filename ({version} is substituted at runtime)
       output: "apm-agent-dotnet-{version}.yaml"
-    #   # Optional: override the products array written to the bundle output.
-    #   # Useful when the bundle should advertise a different lifecycle than was used for filtering.
+      # Optional: override the products array written to the bundle output.
+      # Useful when the bundle should advertise a different lifecycle than was used for filtering.
       output_products: "apm-agent-dotnet {version} {lifecycle}"
 
     # Example: Serverless release profile (product ID "cloud-serverless" differs from repo "cloud")

--- a/docs/changelog.yml
+++ b/docs/changelog.yml
@@ -1,0 +1,211 @@
+# Changelog Configuration
+# This file configures the valid values for changelog fields using the pivot structure.
+# Place this file as `changelog.yml` in the `docs/` directory
+#
+# NOTE: All list-like fields accept BOTH forms:
+#   - Comma-separated string: "value1, value2, value3"
+#   - YAML list:
+#     - value1
+#     - value2
+#     - value3
+# Both forms produce the same result. Choose whichever is more readable for your use case.
+
+# Products configuration (optional)
+# If not specified, all products from products.yml are allowed
+products:
+  # List of available product IDs (empty = all from products.yml)
+  # Accepts string or list: "elasticsearch, kibana" or [elasticsearch, kibana]
+  available:
+    - apm-agent-dotnet
+  # Default products when --products not specified
+  default:
+    - product: apm-agent-dotnet
+      lifecycle: ga
+
+# Extraction configuration
+# Controls automatic extraction of information from PR descriptions
+extract:
+  # Auto-extract release notes from PR descriptions (default: true)
+  # Can be overridden by CLI --no-extract-release-notes
+  release_notes: true
+  # Auto-extract linked references (default: true)
+  # When using --prs: looks for patterns like "Fixes #123", "Closes #456" in PR body to derive issues.
+  # When using --issues: looks for patterns like "Fixed by #123" in issue body to derive PRs.
+  # Can be overridden by CLI --no-extract-issues
+  issues: true
+
+# Available lifecycle values (strongly typed: preview, beta, ga)
+# Accepts string or list: "preview, beta, ga" or a YAML list
+lifecycles:
+  - preview
+  - beta
+  - ga
+
+# Pivot configuration for types, subtypes, and areas with label mappings.
+# By default we render entries grouped by type > subtype > area.
+# NOTE: subtype and area are optional and either may be omitted.
+# Labels are specified in a "label -> value" format
+pivot:
+  # Type definitions with optional labels
+  # At a minimum, feature, bug-fix, and breaking-change must be configured.
+  # Keys are type names, values can be:
+  #   - simple string: comma-separated label list (e.g., ">bug, >fix")
+  #   - YAML list: [">bug", ">fix"]
+  #   - empty/null: no labels for this type
+  #   - object: { labels: "...", subtypes: {...} } for breaking-change type only
+  #     (labels and subtype values also accept string or list)
+  types:
+    # Complex object form with subtypes (ONLY allowed for breaking-change)
+    # Subtypes help categorize breaking changes by their nature
+    # Both labels and subtype values accept string or list form
+    breaking-change:
+      labels: "breaking change"
+      # Equivalent list form:
+      # labels:
+      #   - ">breaking"
+      #   - ">bc"
+      # subtypes:
+      #   api: ">api-breaking"
+      #   behavioral: ">behavioral-breaking"
+      #   configuration: ">config-breaking"
+      #   dependency: ">dependency-breaking"
+      #   subscription: ">subscription-breaking"
+      #   plugin: ">plugin-breaking"
+      #   security: ">security-breaking"
+      #   other:
+    # Simple string form: labels as comma-separated string
+    bug-fix: "bug"
+    deprecation: "deprecation"
+    feature:
+    enhancement: "enhancement"
+    docs: "docs"
+    known-issue:
+    other:
+    regression:
+    security: "security"
+
+  # Labels that trigger the highlight flag (accepts string or list)
+  # String form: highlight: ">highlight, >release-highlight"
+  # List form:
+  # highlight:
+  #   - ">highlight"
+  #   - ">release-highlight"
+
+  # Area definitions with labels
+  # Keys are area display names, values are label strings or lists
+  # String form: "label1, label2" | List form: [label1, label2]
+  # areas:
+    # Example mappings - customize based on your label naming conventions
+    # Autoscaling: ":Distributed Coordination/Autoscaling"
+    # Search: ":Search/Search"
+    # Security: ":Security/Security"
+    # Watcher: ":Data Management/Watcher"
+    # List form example:
+    # Search:
+    #   - ":Search/Search"
+    #   - ":Search/Ranking"
+
+# Rules configuration — controls which PRs create changelogs and which entries are published.
+# All list-like fields (exclude, include, exclude_types, etc.) accept BOTH forms:
+#   - Comma-separated string: "value1, value2, value3"
+#   - YAML list: [value1, value2, value3]
+#
+# Global match default for multi-valued fields (labels, areas).
+#   any (default) = match if ANY item matches the list
+#   all           = match only if ALL items match the list
+# Inherited by create, publish, and all product overrides.
+rules:
+  # match: any
+
+  # Create — controls which PRs generate changelog entries.
+  #   exclude: block PRs with these labels (string or list)
+  #   include: only create changelogs for PRs with these labels (string or list)
+  # Cannot specify both.
+  #
+  # create:
+  #   exclude: ">non-issue, >test"
+  #   # Or equivalently:
+  #   # exclude:
+  #   #   - ">non-issue"
+  #   #   - ">test"
+  #   # match: any
+  #   products:
+  #     'elasticsearch, kibana':
+  #       exclude: ">test"
+  #     'cloud-serverless':
+  #       exclude: "ILM"
+
+  # Publish — controls which entries appear in rendered output.
+  #   exclude_types / include_types (string or list)
+  #   exclude_areas / include_areas (string or list)
+  # Cannot mix exclude_ and include_ for the same field.
+  #
+  # match_areas inherits from rules.match if not specified.
+  #
+  # publish:
+  #   # match_areas: any
+  #   exclude_types: "deprecation, known-issue"
+  #   # Or equivalently:
+  #   # exclude_types:
+  #   #   - deprecation
+  #   #   - known-issue
+  #   exclude_areas:
+  #     - "Internal"
+  #   products:
+  #     'elasticsearch, kibana':
+  #       exclude_types:
+  #         - docs
+  #     'cloud-serverless':
+  #       # match_areas: any
+  #       include_areas:
+  #         - "Search"
+  #         - "Monitoring"
+
+# Bundle configuration (profiles and defaults)
+bundle:
+  # Input directory containing changelog YAML files
+  directory: docs/changelog
+  # Output directory for bundled changelog files
+  output_directory: docs/releases
+  # Whether to resolve (copy contents) by default
+  resolve: true
+  # Optional: default GitHub repo name applied to all profiles that do not specify their own.
+  # Used by the {changelog} directive to generate correct PR/issue links when the product ID
+  # differs from the GitHub repository name. Can be overridden per profile.
+  # repo: elasticsearch
+  # Optional: default GitHub owner applied to all profiles that do not specify their own.
+  # owner: elastic
+
+  # Named bundle profiles for different release scenarios.
+  # Profiles can be used with both 'changelog bundle' and 'changelog remove':
+  #   docs-builder changelog bundle elasticsearch-release 9.2.0
+  #   docs-builder changelog remove elasticsearch-release 9.2.0
+  # When used with 'changelog remove', only the 'products' field is applied.
+  # The 'output', 'output_products', 'repo', 'owner', and 'hide_features' fields are
+  # bundle-specific and are ignored for removal.
+  profiles:
+    # Example: Elasticsearch release profile
+    # elasticsearch-release:
+    #   # Filter: which input changelogs to include ({version} and {lifecycle} are substituted at runtime)
+    #   products: "elasticsearch {version} {lifecycle}"
+    #   # Output filename ({version} is substituted at runtime)
+    #   output: "elasticsearch-{version}.yaml"
+    #   # Optional: override the products array written to the bundle output.
+    #   # Useful when the bundle should advertise a different lifecycle than was used for filtering.
+    #   # output_products: "elasticsearch {version} ga"
+    #   # Optional: profile-specific GitHub repo name (overrides bundle.repo if set).
+    #   # Only needed when this profile's product ID differs from the repository name.
+    #   # repo: elasticsearch
+    #   # Optional: profile-specific GitHub owner (overrides bundle.owner if set).
+    #   # owner: elastic
+
+    # Example: Serverless release profile (product ID "cloud-serverless" differs from repo "cloud")
+    # serverless-release:
+    #   products: "cloud-serverless {version} *"
+    #   output: "serverless-{version}.yaml"
+    #   # repo overrides the bundle-level default for this profile only
+    #   # repo: cloud
+    #   # Feature IDs to hide when bundling with this profile (accepts string or list)
+    #   hide_features:
+    #     - feature-flag-1
+    #     - feature-flag-2

--- a/docs/changelog.yml
+++ b/docs/changelog.yml
@@ -184,20 +184,13 @@ bundle:
   # The 'output', 'output_products', 'repo', 'owner', and 'hide_features' fields are
   # bundle-specific and are ignored for removal.
   profiles:
-    # Example: Elasticsearch release profile
-    # elasticsearch-release:
-    #   # Filter: which input changelogs to include ({version} and {lifecycle} are substituted at runtime)
-    #   products: "elasticsearch {version} {lifecycle}"
+    # Fetch the PR list from GitHub release notes
+    gh-release:
     #   # Output filename ({version} is substituted at runtime)
-    #   output: "elasticsearch-{version}.yaml"
+      output: "apm-agent-dotnet-{version}.yaml"
     #   # Optional: override the products array written to the bundle output.
     #   # Useful when the bundle should advertise a different lifecycle than was used for filtering.
-    #   # output_products: "elasticsearch {version} ga"
-    #   # Optional: profile-specific GitHub repo name (overrides bundle.repo if set).
-    #   # Only needed when this profile's product ID differs from the repository name.
-    #   # repo: elasticsearch
-    #   # Optional: profile-specific GitHub owner (overrides bundle.owner if set).
-    #   # owner: elastic
+      output_products: "apm-agent-dotnet {version} {lifecycle}"
 
     # Example: Serverless release profile (product ID "cloud-serverless" differs from repo "cloud")
     # serverless-release:

--- a/docs/changelog.yml
+++ b/docs/changelog.yml
@@ -172,9 +172,9 @@ bundle:
   # Optional: default GitHub repo name applied to all profiles that do not specify their own.
   # Used by the {changelog} directive to generate correct PR/issue links when the product ID
   # differs from the GitHub repository name. Can be overridden per profile.
-  # repo: elasticsearch
+  repo: apm-agent-dotnet
   # Optional: default GitHub owner applied to all profiles that do not specify their own.
-  # owner: elastic
+  owner: elastic
 
   # Named bundle profiles for different release scenarios.
   # Profiles can be used with both 'changelog bundle' and 'changelog remove':

--- a/docs/changelog/2643-other-add-support-for-configuring-proxy-url.yaml
+++ b/docs/changelog/2643-other-add-support-for-configuring-proxy-url.yaml
@@ -1,0 +1,8 @@
+﻿prs:
+- https://github.com/elastic/apm-agent-dotnet/pull/2643
+type: other
+products:
+- product: apm-agent-dotnet
+  target: 1.34.0
+  lifecycle: ga
+title: Add support for configuring proxy URL, username and password

--- a/docs/changelog/2644-other-remove-post-release-step-to-backport.yaml
+++ b/docs/changelog/2644-other-remove-post-release-step-to-backport.yaml
@@ -1,0 +1,8 @@
+﻿prs:
+- https://github.com/elastic/apm-agent-dotnet/pull/2644
+type: other
+products:
+- product: apm-agent-dotnet
+  target: 1.34.0
+  lifecycle: ga
+title: Remove post release step to backport docs to 1.x

--- a/docs/changelog/2645-other-update-and-fix-release-notes.yaml
+++ b/docs/changelog/2645-other-update-and-fix-release-notes.yaml
@@ -1,0 +1,8 @@
+﻿prs:
+- https://github.com/elastic/apm-agent-dotnet/pull/2645
+type: other
+products:
+- product: apm-agent-dotnet
+  target: 1.34.0
+  lifecycle: ga
+title: Update and fix release notes + breaking changes

--- a/docs/changelog/2646-other-fix-mongodb-test-failure-in-integration.yaml
+++ b/docs/changelog/2646-other-fix-mongodb-test-failure-in-integration.yaml
@@ -1,0 +1,8 @@
+﻿prs:
+- https://github.com/elastic/apm-agent-dotnet/pull/2646
+type: other
+products:
+- product: apm-agent-dotnet
+  target: 1.34.1
+  lifecycle: ga
+title: Fix MongoDb test failure in integration tests

--- a/docs/changelog/2647-docs-docs-replace-placeholder-urls.yaml
+++ b/docs/changelog/2647-docs-docs-replace-placeholder-urls.yaml
@@ -1,0 +1,8 @@
+﻿prs:
+- https://github.com/elastic/apm-agent-dotnet/pull/2647
+type: docs
+products:
+- product: apm-agent-dotnet
+  target: 1.34.0
+  lifecycle: ga
+title: '[docs] Replace placeholder URLs'

--- a/docs/changelog/2656-other-ensure-we-always-start-an-activity.yaml
+++ b/docs/changelog/2656-other-ensure-we-always-start-an-activity.yaml
@@ -1,0 +1,8 @@
+﻿prs:
+- https://github.com/elastic/apm-agent-dotnet/pull/2656
+type: other
+products:
+- product: apm-agent-dotnet
+  target: 1.34.1
+  lifecycle: ga
+title: Ensure we always start an Activity even when OTelBridge disabled

--- a/docs/changelog/2661-other-add-the-target-framework-moniker-to.yaml
+++ b/docs/changelog/2661-other-add-the-target-framework-moniker-to.yaml
@@ -1,0 +1,8 @@
+﻿prs:
+- https://github.com/elastic/apm-agent-dotnet/pull/2661
+type: other
+products:
+- product: apm-agent-dotnet
+  target: 1.34.1
+  lifecycle: ga
+title: Add the target framework moniker to the preamble logs

--- a/docs/changelog/2662-other-remove-redundant-println-from-profiler.yaml
+++ b/docs/changelog/2662-other-remove-redundant-println-from-profiler.yaml
@@ -1,0 +1,8 @@
+﻿prs:
+- https://github.com/elastic/apm-agent-dotnet/pull/2662
+type: other
+products:
+- product: apm-agent-dotnet
+  target: 1.34.1
+  lifecycle: ga
+title: Remove redundant println from profiler

--- a/docs/releases/apm-agent-dotnet-1.34.1.yaml
+++ b/docs/releases/apm-agent-dotnet-1.34.1.yaml
@@ -1,0 +1,51 @@
+﻿products:
+- product: apm-agent-dotnet
+  target: 1.34.1
+  lifecycle: ga
+  repo: apm-agent-dotnet
+  owner: elastic
+entries:
+- file:
+    name: 2662-other-remove-redundant-println-from-profiler.yaml
+    checksum: d83a5ab0f429bdf65a86fcbda3c364a1f3e55f70
+  type: other
+  title: Remove redundant println from profiler
+  products:
+  - product: apm-agent-dotnet
+    target: 1.34.1
+    lifecycle: ga
+  prs:
+  - https://github.com/elastic/apm-agent-dotnet/pull/2662
+- file:
+    name: 2646-other-fix-mongodb-test-failure-in-integration.yaml
+    checksum: 28e545a1417b77ce052f8c3e22c533097a7eb1dd
+  type: other
+  title: Fix MongoDb test failure in integration tests
+  products:
+  - product: apm-agent-dotnet
+    target: 1.34.1
+    lifecycle: ga
+  prs:
+  - https://github.com/elastic/apm-agent-dotnet/pull/2646
+- file:
+    name: 2661-other-add-the-target-framework-moniker-to.yaml
+    checksum: 2795e076a85d7a16c8eee00457ceed6af5e77a87
+  type: other
+  title: Add the target framework moniker to the preamble logs
+  products:
+  - product: apm-agent-dotnet
+    target: 1.34.1
+    lifecycle: ga
+  prs:
+  - https://github.com/elastic/apm-agent-dotnet/pull/2661
+- file:
+    name: 2656-other-ensure-we-always-start-an-activity.yaml
+    checksum: a04bdb33f55cb456aacaafaf03c80b76c14374bb
+  type: other
+  title: Ensure we always start an Activity even when OTelBridge disabled
+  products:
+  - product: apm-agent-dotnet
+    target: 1.34.1
+    lifecycle: ga
+  prs:
+  - https://github.com/elastic/apm-agent-dotnet/pull/2656

--- a/docs/releases/changelog-bundle.yaml
+++ b/docs/releases/changelog-bundle.yaml
@@ -1,0 +1,51 @@
+﻿products:
+- product: apm-agent-dotnet
+  target: 1.34.0
+  lifecycle: ga
+  repo: apm-agent-dotnet
+  owner: elastic
+entries:
+- file:
+    name: 2647-docs-docs-replace-placeholder-urls.yaml
+    checksum: 72333356c8bdd5d8714dd77c207f2f30e6c1ee95
+  type: docs
+  title: '[docs] Replace placeholder URLs'
+  products:
+  - product: apm-agent-dotnet
+    target: 1.34.0
+    lifecycle: ga
+  prs:
+  - https://github.com/elastic/apm-agent-dotnet/pull/2647
+- file:
+    name: 2645-other-update-and-fix-release-notes.yaml
+    checksum: 4680f15bec969f169684609c4ebbc640ffb181dc
+  type: other
+  title: Update and fix release notes + breaking changes
+  products:
+  - product: apm-agent-dotnet
+    target: 1.34.0
+    lifecycle: ga
+  prs:
+  - https://github.com/elastic/apm-agent-dotnet/pull/2645
+- file:
+    name: 2644-other-remove-post-release-step-to-backport.yaml
+    checksum: d14a5edd412f0a8a736e3fa58a4cf53c14f95429
+  type: other
+  title: Remove post release step to backport docs to 1.x
+  products:
+  - product: apm-agent-dotnet
+    target: 1.34.0
+    lifecycle: ga
+  prs:
+  - https://github.com/elastic/apm-agent-dotnet/pull/2644
+- file:
+    name: 2643-other-add-support-for-configuring-proxy-url.yaml
+    checksum: 9cbd61e9459d5baede8d2b5282bf64df40266740
+  type: other
+  title: Add support for configuring proxy URL, username and password
+  products:
+  - product: apm-agent-dotnet
+    target: 1.34.0
+    lifecycle: ga
+  prs:
+  - https://github.com/elastic/apm-agent-dotnet/pull/2643


### PR DESCRIPTION
This PR is just for testing purposes.
It tests the `docs-builder changelog` commands, for example with https://github.com/elastic/docs-builder/pull/2843 checked out:

1. Check out https://github.com/elastic/docs-builder/pull/2843 
1. Refresh the tooling. In the `docs-builder` repo, run:
    ```sh
    ./build.sh clean
    ./build.sh publishbinaries
    ```
1. In the apm-agent-dotnet repo, set up the changelog configuration file:
    ```sh
     /path/to/GitHub/docs-builder/.artifacts/publish/docs-builder/release/docs-builder changelog init
     ```
     Fill in the relevant fields, like the default product ID, bundle directory, bundle repo and owner, etc.
1. Generate changelogs for the PRs mentioned in the GitHub release. For example:
    ```sh
    /path/to/GitHub/docs-builder/.artifacts/publish/docs-builder/release/docs-builder \
    changelog add --release-version v1.34.0 \
    --repo apm-agent-dotnet --owner elastic \
    --output ./docs/changelog --config ./docs/changelog.yml
    ```
1. Generate a changelog bundle. For example:
    ```sh
    /path/to/GitHub/docs-builder/.artifacts/publish/docs-builder/release/docs-builder changelog bundle --release-version v1.34.0
    ```
