### PR TITLE
Improve and correct supported technologies

### DIFF
--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -13,7 +13,7 @@ applies_to:
 
 # APM .NET agent [intro]
 
-The Elastic APM .NET Agent automatically measures the performance of your application and tracks errors. It has built-in support observing traces and metrics for many popular frameworks, as well as an [API](/reference/public-api.md) which allows you to instrument any application.
+The Elastic APM .NET Agent automatically measures the performance of your application and tracks errors. It has built-in support for observing traces and metrics for many popular frameworks, as well as an [API](/reference/public-api.md) which allows you to instrument any application.
 
 Before you begin, review the [supported technologies](/reference/supported-technologies.md) to
 check if your framework and libraries are compatible.

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -13,10 +13,13 @@ applies_to:
 
 # APM .NET agent [intro]
 
-The Elastic APM .NET Agent automatically measures the performance of your application and tracks errors. It has built-in support for the most popular frameworks, as well as a basic API which allows you to instrument any application.
+The Elastic APM .NET Agent automatically measures the performance of your application and tracks errors. It has built-in support observing traces and metrics for many popular frameworks, as well as an API(/reference/public-api.md) which allows you to instrument any application.
+
+Before you begin, review the [supported technologies](/reference/supported-technologies.md) to
+check if your framework and libraries are compatible.
 
 :::::{note}
-Elastic supports OpenTelemetry, which allows logs, metrics, and trace signal collection for many of the [supported technologies](/reference/supported-technologies.md) below. Consider using the [EDOT .NET SDK](elastic-otel-dotnet://reference/edot-dotnet/index.md) for observability data so you continue to get the full power of Elastic's platform.
+Elastic supports OpenTelemetry, which allows logs, metrics, and trace signal collection for many of the [supported technologies](/reference/supported-technologies.md). Consider using the [EDOT .NET SDK](elastic-otel-dotnet://reference/edot-dotnet/index.md) for observability data so you continue to get the full power of Elastic's platform.
 :::::
 
 ## How does the Agent work? [how-it-works]

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -13,7 +13,7 @@ applies_to:
 
 # APM .NET agent [intro]
 
-The Elastic APM .NET Agent automatically measures the performance of your application and tracks errors. It has built-in support observing traces and metrics for many popular frameworks, as well as an API(/reference/public-api.md) which allows you to instrument any application.
+The Elastic APM .NET Agent automatically measures the performance of your application and tracks errors. It has built-in support observing traces and metrics for many popular frameworks, as well as an [API](/reference/public-api.md) which allows you to instrument any application.
 
 Before you begin, review the [supported technologies](/reference/supported-technologies.md) to
 check if your framework and libraries are compatible.

--- a/docs/reference/supported-technologies.md
+++ b/docs/reference/supported-technologies.md
@@ -26,7 +26,7 @@ If you are already using OpenTelemetry, consider the [EDOT .NET SDK](elastic-ote
 
 The APM Agent for .NET libraries and components target .NET Standard 2.0 or .NET Standard 2.1.
 
-We support .NET runtimes ≤10.0.x and .NET Framework runtimes from 4.6.2 to 4.8.1 for as long as they receive active support from Microsoft per the [.NET support policy](https://dotnet.microsoft.com/platform/support/policy/dotnet-core) and [.NET Framework support policy](https://dotnet.microsoft.com/platform/support/policy/dotnet-framework). When Microsoft ends support for a runtime version, we do too. Issues reported against unsupported runtimes will not be acted on unless they also affect a supported runtime.
+We support .NET runtimes ≤10.0.x and .NET Framework runtimes from 4.6.2 to 4.8.1 for as long as they receive active support from Microsoft per the [.NET support policy](https://dotnet.microsoft.com/platform/support/policy/dotnet-core) and [.NET Framework support policy](https://dotnet.microsoft.com/platform/support/policy/dotnet-framework). When Microsoft ends support for a runtime version, so does Elastic. Issues reported against unsupported runtimes will only be acted on if they also affect a supported runtime.
 
 ::::{warning}
 Native AOT is not supported. The agent relies on reflection, runtime IL emit, and embedded libraries that are incompatible with AOT compilation. Attempting to use the agent in a Native AOT-published application will fail at runtime.

--- a/docs/reference/supported-technologies.md
+++ b/docs/reference/supported-technologies.md
@@ -11,7 +11,14 @@ applies_to:
 
 # Supported technologies [supported-technologies]
 
-The tables below summarize the technologies the APM Agent for .NET supports, the package or runtime versions we test, and which installation methods work for each one. Versions beyond the listed upper bound have not been tested and are not supported, but may work.
+The tables below summarize the technologies the APM Agent for .NET supports, the package or runtime versions we test, and which installation methods work for each one. Versions beyond the listed upper bound have not been tested and are not supported, but might work.
+
+Use this page as a compatibility matrix:
+
+1. Find the framework or library you use.
+2. Check that your package or runtime version falls within the supported range.
+3. Check the installation method you plan to use: Profiler, NuGet, or OpenTelemetry Bridge.
+4. Read any footnotes or notes directly below that table for important limitations or setup requirements.
 
 If you are already using OpenTelemetry, consider the [EDOT .NET SDK](elastic-otel-dotnet://reference/edot-dotnet/index.md) for traces, metrics, and logs. It covers many of these technologies and fits naturally with Elastic's observability platform.
 
@@ -34,9 +41,11 @@ Native AOT is not supported. The agent relies on reflection, runtime IL emit, an
 Each table below shows which installation methods apply to each technology. A checkmark (✓) means the technology is supported via that installation method for the listed version range. Where a cell shows a version qualifier such as `(≥3.7.0)`, only that narrower range is covered by that method.
 
 ::::{note}
-The **OpenTelemetry Bridge** column requires .NET 8+ and APM Server ≥7.16. A checkmark there means the library's native OpenTelemetry spans are captured by the agent regardless of whether the agent was installed via the Profiler or a NuGet package — no additional Elastic integration package is needed for that coverage.
+The **OpenTelemetry Bridge** column requires .NET 8+ and APM Server ≥7.16. A checkmark there means the technology is covered through the built-in OpenTelemetry Bridge, whether the agent was installed via the Profiler or a NuGet package.
 
-The startup hook used by the profiler on .NET 8+ is not available on .NET Framework. Technologies that depend on the startup hook or the OpenTelemetry Bridge therefore need the NuGet install method on .NET Framework. Technologies with no Elastic APM NuGet package, such as `Elastic.Clients.Elasticsearch`, are not supported on .NET Framework.
+On .NET Framework, technologies that depend on the startup hook or the OpenTelemetry Bridge need the NuGet install method instead.
+
+If no Elastic APM NuGet package exists for that technology, such as `Elastic.Clients.Elasticsearch`, it is not supported on .NET Framework.
 ::::
 
 | Column | Meaning |
@@ -92,7 +101,7 @@ Streaming is not supported — the agent does not create transactions or spans f
 ¹ Via startup hook on .NET.
 
 ::::{note}
-`Grpc.Net.Client` ≥2.57.0 emits native OpenTelemetry spans. The OpenTelemetry Bridge provides automatic coverage when using the profiler without the NuGet package. When the NuGet package is installed, the dedicated subscriber takes precedence and the bridge is suppressed to prevent duplicate spans.
+`Grpc.Net.Client` ≥2.57.0 emits native OpenTelemetry spans. When using the profiler without the NuGet package, the OpenTelemetry Bridge captures them automatically. When the NuGet package is installed, the dedicated subscriber takes precedence to prevent duplicate spans.
 ::::
 
 ## Data access technologies [supported-data-access-technologies]
@@ -136,13 +145,13 @@ MongoDB.Driver ≥3.7.0 emits native OpenTelemetry spans. When running without t
 | --- | --- | :---: | :---: | :---: |
 | Azure Service Bus {applies_to}`apm_agent_dotnet: ga 1.10` | Azure.Messaging.ServiceBus ≥7.0.0 <8.0.0 | [✓](/reference/setup-auto-instrumentation.md) | [✓](/reference/setup-azure-servicebus.md) | [✓](/reference/opentelemetry-bridge.md) |
 | Azure Service Bus, legacy {applies_to}`apm_agent_dotnet: ga 1.10` | Microsoft.Azure.ServiceBus ≥3.0.0 <6.0.0 | — | [✓](/reference/setup-azure-servicebus.md) | — |
-| Kafka {applies_to}`apm_agent_dotnet: ga 1.12` | Confluent.Kafka ≥1.4.0 <3.0.0 | [✓](/reference/setup-auto-instrumentation.md) | — | [✓ ¹](/reference/setup-kafka.md) |
+| Kafka {applies_to}`apm_agent_dotnet: ga 1.12` | Confluent.Kafka ≥1.4.0 <3.0.0 | [✓](/reference/setup-auto-instrumentation.md) | — | [✓ via adapter ¹](/reference/setup-kafka.md) |
 | RabbitMQ {applies_to}`apm_agent_dotnet: ga 1.12` | RabbitMQ.Client ≥3.6.9 <7.0.0 | [✓](/reference/setup-auto-instrumentation.md) | — | — |
 
-¹ Requires [`Confluent.Kafka.Extensions.Diagnostics`](https://www.nuget.org/packages/Confluent.Kafka.Extensions.Diagnostics) to wrap producers and consumers to emit spans captured by the OpenTelemetry Bridge. Code changes are required — see the [setup page](/reference/setup-kafka.md).
+¹ Requires adding [`Confluent.Kafka.Extensions.Diagnostics`](https://www.nuget.org/packages/Confluent.Kafka.Extensions.Diagnostics) which wraps producers and consumers so they emit spans for the OpenTelemetry Bridge to capture. Code changes are required — see the [setup page](/reference/setup-kafka.md).
 
 ::::{note}
-`Azure.Messaging.ServiceBus` emits native OpenTelemetry spans. The OpenTelemetry Bridge provides automatic coverage when using the profiler without the NuGet package. When the NuGet package is installed, the dedicated subscriber takes precedence and the bridge is suppressed to prevent duplicate spans.
+`Azure.Messaging.ServiceBus` emits native OpenTelemetry spans. When using the profiler without the NuGet package, the OpenTelemetry Bridge captures them automatically. When the NuGet package is installed, the dedicated subscriber takes precedence to prevent duplicate spans.
 
 The legacy `Microsoft.Azure.ServiceBus` package does not emit native OpenTelemetry spans and requires the NuGet package.
 ::::
@@ -156,7 +165,7 @@ The legacy `Microsoft.Azure.ServiceBus` package does not emit native OpenTelemet
 | Azure File Share Storage {applies_to}`apm_agent_dotnet: ga 1.10` | Azure.Storage.Files.Shares ≥12.6.0 <13.0.0 | [✓](/reference/setup-auto-instrumentation.md) | [✓](/reference/setup-azure-storage.md) | [✓](/reference/opentelemetry-bridge.md) |
 
 ::::{note}
-For Azure Storage services, the OpenTelemetry Bridge provides automatic coverage when using the profiler without the NuGet package. When the NuGet package is installed, the dedicated subscriber takes precedence and the bridge is suppressed to prevent duplicate spans.
+Azure Storage SDKs emit native OpenTelemetry spans. When using the profiler without the NuGet package, the OpenTelemetry Bridge captures them automatically. When the NuGet package is installed, the dedicated subscriber takes precedence to prevent duplicate spans.
 ::::
 
 ## Networking client-side technologies [supported-networking-client-side-technologies]

--- a/docs/reference/supported-technologies.md
+++ b/docs/reference/supported-technologies.md
@@ -26,7 +26,7 @@ If you are already using OpenTelemetry, consider the [EDOT .NET SDK](elastic-ote
 
 The APM Agent for .NET libraries and components target .NET Standard 2.0 or .NET Standard 2.1.
 
-We support .NET runtimes<br>≤10.0.x and .NET Framework runtimes from 4.6.2 to 4.8.1 for as long as they receive active support from Microsoft per the [.NET support policy](https://dotnet.microsoft.com/platform/support/policy/dotnet-core) and [.NET Framework support policy](https://dotnet.microsoft.com/platform/support/policy/dotnet-framework). When Microsoft ends support for a runtime version, we do too. Issues reported against unsupported runtimes will not be acted on unless they also affect a supported runtime.
+We support .NET runtimes ≤10.0.x and .NET Framework runtimes from 4.6.2 to 4.8.1 for as long as they receive active support from Microsoft per the [.NET support policy](https://dotnet.microsoft.com/platform/support/policy/dotnet-core) and [.NET Framework support policy](https://dotnet.microsoft.com/platform/support/policy/dotnet-framework). When Microsoft ends support for a runtime version, we do too. Issues reported against unsupported runtimes will not be acted on unless they also affect a supported runtime.
 
 ::::{warning}
 Native AOT is not supported. The agent relies on reflection, runtime IL emit, and embedded libraries that are incompatible with AOT compilation. Attempting to use the agent in a Native AOT-published application will fail at runtime.

--- a/docs/reference/supported-technologies.md
+++ b/docs/reference/supported-technologies.md
@@ -109,7 +109,7 @@ Streaming is not supported - the agent does not create transactions or spans for
 | SQLite<br>`Microsoft.Data.Sqlite`<br>{applies_to}`apm_agent_dotnet: ga 1.12` | ≥2.0.0<br><9.0.0 | [✓](/reference/setup-auto-instrumentation.md) | ✗ | ✗ |
 | SQLite<br>`System.Data.SQLite`<br>{applies_to}`apm_agent_dotnet: ga 1.12` | ≥1.0.0<br><3.0.0 | [✓](/reference/setup-auto-instrumentation.md) | ✗ | ✗ |
 
-¹ Via startup hook on .NET.
+¹ Using a startup hook on .NET.
 
 ² Requires calling `connection.UseElasticApm()` on each `IConnectionMultiplexer` instance - see the [setup page](/reference/setup-stackexchange-redis.md).
 

--- a/docs/reference/supported-technologies.md
+++ b/docs/reference/supported-technologies.md
@@ -129,7 +129,7 @@ Streaming is not supported - the agent does not create transactions or spans for
 | --- | --- | :---: | :---: | :---: |
 | Azure Service Bus<br>`Azure.Messaging.ServiceBus`<br>{applies_to}`apm_agent_dotnet: ga 1.10` | ≥7.0.0<br><8.0.0 | [✓](/reference/setup-auto-instrumentation.md) | [✓](/reference/setup-azure-servicebus.md) | [✓](/reference/opentelemetry-bridge.md) |
 | Azure Service Bus (legacy)<br>`Microsoft.Azure.ServiceBus`<br>{applies_to}`apm_agent_dotnet: ga 1.10` | ≥3.0.0<br><6.0.0 | ✗ | [✓](/reference/setup-azure-servicebus.md) | ✗ |
-| Kafka<br>`Confluent.Kafka`<br>{applies_to}`apm_agent_dotnet: ga 1.12` | ≥1.4.0<br><3.0.0 | [✓](/reference/setup-auto-instrumentation.md) | ✗ | [✓ via adapter ¹](/reference/setup-kafka.md) |
+| Kafka<br>`Confluent.Kafka`<br>{applies_to}`apm_agent_dotnet: ga 1.12` | ≥1.4.0<br><3.0.0 | [✓](/reference/setup-auto-instrumentation.md) | ✗ | [✓ using an adapter ¹](/reference/setup-kafka.md) |
 | RabbitMQ<br>`RabbitMQ.Client`<br>{applies_to}`apm_agent_dotnet: ga 1.12` | ≥3.6.9<br><7.0.0 | [✓](/reference/setup-auto-instrumentation.md) | ✗ | ✗ |
 
 ¹ Requires adding [`Confluent.Kafka.Extensions.Diagnostics`](https://www.nuget.org/packages/Confluent.Kafka.Extensions.Diagnostics) which wraps producers and consumers so they emit spans for the OpenTelemetry Bridge to capture. Code changes are required - see the [setup page](/reference/setup-kafka.md).

--- a/docs/reference/supported-technologies.md
+++ b/docs/reference/supported-technologies.md
@@ -11,7 +11,7 @@ applies_to:
 
 # Supported technologies [supported-technologies]
 
-This page summarizes the technologies the APM Agent for .NET supports, the package or runtime versions we test, and which installation methods work for each one. Versions beyond the listed upper bound have not been tested and are not supported, but might work.
+This page details the technologies the APM Agent for .NET supports, the package or runtime versions we test, and which installation methods work for each one. Versions beyond the listed upper bound have not been tested and are not supported, but might work.
 
 Use this page as a compatibility matrix:
 
@@ -173,5 +173,5 @@ For supported networking client-side technologies, the agent creates an HTTP spa
 
 | Framework | Supported versions | [Profiler](/reference/setup-auto-instrumentation.md) | NuGet | OpenTelemetry Bridge |
 | --- | --- | :---: | :---: | :---: |
-| System.Net.Http.HttpClient<br>{applies_to}`apm_agent_dotnet: ga 1.0` | *built-in (.NET)* | [✓](/reference/setup-auto-instrumentation.md) | [✓](/reference/public-api.md#setup-http) | ✗ |
-| System.Net.HttpWebRequest<br>{applies_to}`apm_agent_dotnet: ga 1.1` | *built-in (.NET)* | [✓](/reference/setup-auto-instrumentation.md) | [✓](/reference/public-api.md#setup-http) | ✗ |
+| HttpClient<br>`System.Net.Http.HttpClient`<br>{applies_to}`apm_agent_dotnet: ga 1.0` | *built-in (.NET)* | [✓](/reference/setup-auto-instrumentation.md) | [✓](/reference/public-api.md#setup-http) | ✗ |
+| HttpWebRequest<br>`System.Net.HttpWebRequest`<br>{applies_to}`apm_agent_dotnet: ga 1.1` | *built-in (.NET)* | [✓](/reference/setup-auto-instrumentation.md) | [✓](/reference/public-api.md#setup-http) | ✗ |

--- a/docs/reference/supported-technologies.md
+++ b/docs/reference/supported-technologies.md
@@ -1,6 +1,7 @@
 ---
 mapped_pages:
   - https://www.elastic.co/guide/en/apm/agent/dotnet/current/supported-technologies.html
+description: "Compatibility matrix listing the frameworks, runtimes, data access libraries, and messaging systems supported by the Elastic APM Agent for .NET, with supported version ranges and installation methods."
 applies_to:
   stack:
   serverless:

--- a/docs/reference/supported-technologies.md
+++ b/docs/reference/supported-technologies.md
@@ -71,21 +71,6 @@ We support ASP.NET on IIS 10 versions supported by Microsoft per their [IIS supp
 The profiler does not support the Web Garden (multi-worker process) mode of IIS.
 ::::
 
-## Azure Functions [supported-azure-functions]
-
-For supported Azure Functions hosting models, the agent creates one transaction per HTTP-triggered invocation.
-
-| Hosting model | Supported versions | [Profiler](/reference/setup-auto-instrumentation.md) | NuGet | OpenTelemetry Bridge |
-| --- | --- | :---: | :---: | :---: |
-| Azure Functions isolated worker {applies_to}`apm_agent_dotnet: ga 1.19` | `Microsoft.Azure.Functions.Worker` ≥2.0.0 | ✗ | [✓](/reference/setup-azure-functions.md) | ✗ |
-| Azure Functions in-process {applies_to}`apm_agent_dotnet: ga 1.24` | `Microsoft.Azure.Functions.Extensions` ≥1.1.0 | ✗ | [✓](/reference/setup-azure-functions.md) | ✗ |
-
-::::{note}
-Only HTTP-triggered invocations are traced. System metrics are not collected because of a concern with unintentionally increasing Azure Functions costs on Consumption plans.
-
-The isolated worker model requires .NET 8+. The in-process model is [deprecated by Microsoft](https://learn.microsoft.com/en-us/azure/azure-functions/migrate-dotnet-in-process-to-isolated) - new apps should use the isolated worker model.
-::::
-
 ## RPC frameworks [supported-rpc-frameworks]
 
 For supported gRPC frameworks, the agent automatically captures both client-side and server-side calls.
@@ -94,8 +79,8 @@ Streaming is not supported - the agent does not create transactions or spans for
 
 | Framework | Supported versions | [Profiler](/reference/setup-auto-instrumentation.md) | NuGet | OpenTelemetry Bridge |
 | --- | --- | :---: | :---: | :---: |
-| gRPC client {applies_to}`apm_agent_dotnet: ga 1.7` | `Grpc.Net.Client` ≥2.23.2 <3.0.0 | [✓ ¹](/reference/setup-auto-instrumentation.md) | [✓](/reference/setup-grpc.md) | [✓ (≥2.57.0)](/reference/opentelemetry-bridge.md) |
 | gRPC server (ASP.NET Core) {applies_to}`apm_agent_dotnet: ga 1.7` | ≥8.0.0 ≤10.0.x | [✓ ¹](/reference/setup-auto-instrumentation.md) | [✓](/reference/setup-asp-net-core.md) | ✗ |
+| gRPC client<br>`Grpc.Net.Client` {applies_to}`apm_agent_dotnet: ga 1.7` | ≥2.23.2 <3.0.0 | [✓ ¹](/reference/setup-auto-instrumentation.md) | [✓](/reference/setup-grpc.md) | [✓ (≥2.57.0)](/reference/opentelemetry-bridge.md) |
 
 ¹ Via startup hook on .NET.
 
@@ -107,21 +92,21 @@ Streaming is not supported - the agent does not create transactions or spans for
 
 | Data access technology | Supported versions | [Profiler](/reference/setup-auto-instrumentation.md) | NuGet | OpenTelemetry Bridge |
 | --- | --- | :---: | :---: | :---: |
-| Azure CosmosDB {applies_to}`apm_agent_dotnet: ga 1.11` | `Microsoft.Azure.Cosmos` ≥3.0.0 <4.0.0 | ✗ | [✓](/reference/setup-azure-cosmosdb.md) | ✗ |
-| Azure DocumentDB, legacy {applies_to}`apm_agent_dotnet: ga 1.11` | `Microsoft.Azure.DocumentDB.Core`\* ≥2.4.1 <3.0.0; `Microsoft.Azure.DocumentDB`\* ≥2.4.1 <3.0.0 | ✗ | [✓](/reference/setup-azure-cosmosdb.md) | ✗ |
-| Elasticsearch {applies_to}`apm_agent_dotnet: ga 1.23` | `Elastic.Clients.Elasticsearch` ≥8.0.0 <10.0.0 | [✓](/reference/setup-auto-instrumentation.md) | ✗ | [✓](/reference/opentelemetry-bridge.md) |
-| Elasticsearch, legacy {applies_to}`apm_agent_dotnet: ga 1.6` | `Elasticsearch.Net` / `NEST` ≥7.6.0 <8.0.0 | [✓ ¹](/reference/setup-auto-instrumentation.md) | [✓](/reference/setup-elasticsearch.md) | ✗ |
-| Entity Framework Core {applies_to}`apm_agent_dotnet: ga 1.0` | `Microsoft.EntityFrameworkCore` ≥8.0.0 ≤10.0.x | [✓ ¹](/reference/setup-auto-instrumentation.md) | [✓](/reference/setup-ef-core.md) | ✗ |
-| Entity Framework 6 {applies_to}`apm_agent_dotnet: ga 1.2` | `EntityFramework` ≥6.2 ≤6.5.2 | ✗ | [✓](/reference/setup-ef6.md) | ✗ |
-| MongoDB {applies_to}`apm_agent_dotnet: ga 1.9` | `MongoDB.Driver` ≥3.0.0 <4.0.0 | [✓ (≥3.7.0)](/reference/setup-auto-instrumentation.md) | [✓](/reference/setup-mongo-db.md) | [✓ (≥3.7.0)](/reference/opentelemetry-bridge.md) |
-| MySQL {applies_to}`apm_agent_dotnet: ga 1.12` | `MySql.Data` ≥6.7.0 <9.0.0 | [✓](/reference/setup-auto-instrumentation.md) | ✗ | ✗ |
-| Oracle.ManagedDataAccess {applies_to}`apm_agent_dotnet: ga 1.12` | `Oracle.ManagedDataAccess` 4.122.x | [✓](/reference/setup-auto-instrumentation.md) | ✗ | ✗ |
-| Oracle.ManagedDataAccess.Core {applies_to}`apm_agent_dotnet: ga 1.12` | `Oracle.ManagedDataAccess.Core` ≥2.0.0 <4.0.0 | [✓](/reference/setup-auto-instrumentation.md) | ✗ | ✗ |
-| PostgreSQL {applies_to}`apm_agent_dotnet: ga 1.12` | `Npgsql` ≥4.0.0 <8.0.0 | [✓](/reference/setup-auto-instrumentation.md) | ✗ | ✗ |
-| Redis {applies_to}`apm_agent_dotnet: ga 1.8` | `StackExchange.Redis` ≥2.0.495 <3.0.0 | ✗ | [✓ ²](/reference/setup-stackexchange-redis.md) | ✗ |
-| SqlClient {applies_to}`apm_agent_dotnet: ga 1.0` | `System.Data.SqlClient` ≥4.0.0 <5.0.0; `Microsoft.Data.SqlClient` ≥1.0.0 <6.0.0 | [✓](/reference/setup-auto-instrumentation.md) | [✓](/reference/setup-sqlclient.md) | ✗ |
-| Microsoft.Data.Sqlite {applies_to}`apm_agent_dotnet: ga 1.12` | `Microsoft.Data.Sqlite` ≥2.0.0 <9.0.0 | [✓](/reference/setup-auto-instrumentation.md) | ✗ | ✗ |
-| System.Data.SQLite {applies_to}`apm_agent_dotnet: ga 1.12` | `System.Data.SQLite` ≥1.0.0 <3.0.0 | [✓](/reference/setup-auto-instrumentation.md) | ✗ | ✗ |
+| Azure CosmosDB<br>`Microsoft.Azure.Cosmos` {applies_to}`apm_agent_dotnet: ga 1.11` | ≥3.0.0 <4.0.0 | ✗ | [✓](/reference/setup-azure-cosmosdb.md) | ✗ |
+| Azure DocumentDB, legacy<br>`Microsoft.Azure.DocumentDB.Core`\* / `Microsoft.Azure.DocumentDB`\* {applies_to}`apm_agent_dotnet: ga 1.11` | ≥2.4.1 <3.0.0 | ✗ | [✓](/reference/setup-azure-cosmosdb.md) | ✗ |
+| Elasticsearch<br>`Elastic.Clients.Elasticsearch` {applies_to}`apm_agent_dotnet: ga 1.23` | ≥8.0.0 <10.0.0 | [✓](/reference/setup-auto-instrumentation.md) | ✗ | [✓](/reference/opentelemetry-bridge.md) |
+| Elasticsearch, legacy<br>`Elasticsearch.Net` / `NEST` {applies_to}`apm_agent_dotnet: ga 1.6` | ≥7.6.0 <8.0.0 | [✓ ¹](/reference/setup-auto-instrumentation.md) | [✓](/reference/setup-elasticsearch.md) | ✗ |
+| Entity Framework Core<br>`Microsoft.EntityFrameworkCore` {applies_to}`apm_agent_dotnet: ga 1.0` | ≥8.0.0 ≤10.0.x | [✓ ¹](/reference/setup-auto-instrumentation.md) | [✓](/reference/setup-ef-core.md) | ✗ |
+| Entity Framework 6<br>`EntityFramework` {applies_to}`apm_agent_dotnet: ga 1.2` | ≥6.2 ≤6.5.2 | ✗ | [✓](/reference/setup-ef6.md) | ✗ |
+| MongoDB<br>`MongoDB.Driver` {applies_to}`apm_agent_dotnet: ga 1.9` | ≥3.0.0 <4.0.0 | [✓ (≥3.7.0)](/reference/setup-auto-instrumentation.md) | [✓](/reference/setup-mongo-db.md) | [✓ (≥3.7.0)](/reference/opentelemetry-bridge.md) |
+| MySQL<br>`MySql.Data` {applies_to}`apm_agent_dotnet: ga 1.12` | ≥6.7.0 <9.0.0 | [✓](/reference/setup-auto-instrumentation.md) | ✗ | ✗ |
+| Oracle.ManagedDataAccess {applies_to}`apm_agent_dotnet: ga 1.12` | 4.122.x | [✓](/reference/setup-auto-instrumentation.md) | ✗ | ✗ |
+| Oracle.ManagedDataAccess.Core {applies_to}`apm_agent_dotnet: ga 1.12` | ≥2.0.0 <4.0.0 | [✓](/reference/setup-auto-instrumentation.md) | ✗ | ✗ |
+| PostgreSQL<br>`Npgsql` {applies_to}`apm_agent_dotnet: ga 1.12` | ≥4.0.0 <8.0.0 | [✓](/reference/setup-auto-instrumentation.md) | ✗ | ✗ |
+| Redis<br>`StackExchange.Redis` {applies_to}`apm_agent_dotnet: ga 1.8` | ≥2.0.495 <3.0.0 | ✗ | [✓ ²](/reference/setup-stackexchange-redis.md) | ✗ |
+| SqlClient<br>`System.Data.SqlClient` / `Microsoft.Data.SqlClient` {applies_to}`apm_agent_dotnet: ga 1.0` | ≥4.0.0 <5.0.0;<br>≥1.0.0 <6.0.0 | [✓](/reference/setup-auto-instrumentation.md) | [✓](/reference/setup-sqlclient.md) | ✗ |
+| Microsoft.Data.Sqlite {applies_to}`apm_agent_dotnet: ga 1.12` | ≥2.0.0 <9.0.0 | [✓](/reference/setup-auto-instrumentation.md) | ✗ | ✗ |
+| System.Data.SQLite {applies_to}`apm_agent_dotnet: ga 1.12` | ≥1.0.0 <3.0.0 | [✓](/reference/setup-auto-instrumentation.md) | ✗ | ✗ |
 
 ¹ Via startup hook on .NET.
 ² Requires calling `connection.UseElasticApm()` on each `IConnectionMultiplexer` instance - see the [setup page](/reference/setup-stackexchange-redis.md).
@@ -142,10 +127,10 @@ Streaming is not supported - the agent does not create transactions or spans for
 
 | Messaging system | Supported versions | [Profiler](/reference/setup-auto-instrumentation.md) | NuGet | OpenTelemetry Bridge |
 | --- | --- | :---: | :---: | :---: |
-| Azure Service Bus {applies_to}`apm_agent_dotnet: ga 1.10` | `Azure.Messaging.ServiceBus` ≥7.0.0 <8.0.0 | [✓](/reference/setup-auto-instrumentation.md) | [✓](/reference/setup-azure-servicebus.md) | [✓](/reference/opentelemetry-bridge.md) |
-| Azure Service Bus, legacy {applies_to}`apm_agent_dotnet: ga 1.10` | `Microsoft.Azure.ServiceBus` ≥3.0.0 <6.0.0 | ✗ | [✓](/reference/setup-azure-servicebus.md) | ✗ |
-| Kafka {applies_to}`apm_agent_dotnet: ga 1.12` | `Confluent.Kafka` ≥1.4.0 <3.0.0 | [✓](/reference/setup-auto-instrumentation.md) | ✗ | [✓ via adapter ¹](/reference/setup-kafka.md) |
-| RabbitMQ {applies_to}`apm_agent_dotnet: ga 1.12` | `RabbitMQ.Client` ≥3.6.9 <7.0.0 | [✓](/reference/setup-auto-instrumentation.md) | ✗ | ✗ |
+| Azure Service Bus<br>`Azure.Messaging.ServiceBus` {applies_to}`apm_agent_dotnet: ga 1.10` | ≥7.0.0 <8.0.0 | [✓](/reference/setup-auto-instrumentation.md) | [✓](/reference/setup-azure-servicebus.md) | [✓](/reference/opentelemetry-bridge.md) |
+| Azure Service Bus, legacy<br>`Microsoft.Azure.ServiceBus` {applies_to}`apm_agent_dotnet: ga 1.10` | ≥3.0.0 <6.0.0 | ✗ | [✓](/reference/setup-azure-servicebus.md) | ✗ |
+| Kafka<br>`Confluent.Kafka` {applies_to}`apm_agent_dotnet: ga 1.12` | ≥1.4.0 <3.0.0 | [✓](/reference/setup-auto-instrumentation.md) | ✗ | [✓ via adapter ¹](/reference/setup-kafka.md) |
+| RabbitMQ<br>`RabbitMQ.Client` {applies_to}`apm_agent_dotnet: ga 1.12` | ≥3.6.9 <7.0.0 | [✓](/reference/setup-auto-instrumentation.md) | ✗ | ✗ |
 
 ¹ Requires adding [`Confluent.Kafka.Extensions.Diagnostics`](https://www.nuget.org/packages/Confluent.Kafka.Extensions.Diagnostics) which wraps producers and consumers so they emit spans for the OpenTelemetry Bridge to capture. Code changes are required - see the [setup page](/reference/setup-kafka.md).
 
@@ -155,13 +140,28 @@ Streaming is not supported - the agent does not create transactions or spans for
 The legacy `Microsoft.Azure.ServiceBus` package does not emit native OpenTelemetry spans and requires the NuGet package.
 ::::
 
+## Azure Functions [supported-azure-functions]
+
+For supported Azure Functions hosting models, the agent creates one transaction per HTTP-triggered invocation.
+
+| Hosting model | Supported versions | [Profiler](/reference/setup-auto-instrumentation.md) | NuGet | OpenTelemetry Bridge |
+| --- | --- | :---: | :---: | :---: |
+| Azure Functions isolated worker<br>`Microsoft.Azure.Functions.Worker` {applies_to}`apm_agent_dotnet: ga 1.19` | ≥2.0.0 <3.0.0 | ✗ | [✓](/reference/setup-azure-functions.md) | ✗ |
+| Azure Functions in-process<br>`Microsoft.Azure.Functions.Extensions` {applies_to}`apm_agent_dotnet: ga 1.24` | ≥1.1.0 <2.0.0 | ✗ | [✓](/reference/setup-azure-functions.md) | ✗ |
+
+::::{note}
+Only HTTP-triggered invocations are traced. System metrics are not collected because of a concern with unintentionally increasing Azure Functions costs on Consumption plans.
+
+The isolated worker model requires .NET 8+. The in-process model is [deprecated by Microsoft](https://learn.microsoft.com/en-us/azure/azure-functions/migrate-dotnet-in-process-to-isolated) - new apps should use the isolated worker model.
+::::
+
 ## Azure Storage [supported-azure-storage]
 
 | Storage service | Supported versions | [Profiler](/reference/setup-auto-instrumentation.md) | NuGet | OpenTelemetry Bridge |
 | --- | --- | :---: | :---: | :---: |
-| Azure Blob Storage {applies_to}`apm_agent_dotnet: ga 1.10` | `Azure.Storage.Blobs` ≥12.8.0 <13.0.0 | [✓](/reference/setup-auto-instrumentation.md) | [✓](/reference/setup-azure-storage.md) | [✓](/reference/opentelemetry-bridge.md) |
-| Azure Queue Storage {applies_to}`apm_agent_dotnet: ga 1.10` | `Azure.Storage.Queues` ≥12.6.0 <13.0.0 | [✓](/reference/setup-auto-instrumentation.md) | [✓](/reference/setup-azure-storage.md) | [✓](/reference/opentelemetry-bridge.md) |
-| Azure File Share Storage {applies_to}`apm_agent_dotnet: ga 1.10` | `Azure.Storage.Files.Shares` ≥12.6.0 <13.0.0 | [✓](/reference/setup-auto-instrumentation.md) | [✓](/reference/setup-azure-storage.md) | [✓](/reference/opentelemetry-bridge.md) |
+| Azure Blob Storage<br>`Azure.Storage.Blobs` {applies_to}`apm_agent_dotnet: ga 1.10` | ≥12.8.0 <13.0.0 | [✓](/reference/setup-auto-instrumentation.md) | [✓](/reference/setup-azure-storage.md) | [✓](/reference/opentelemetry-bridge.md) |
+| Azure Queue Storage<br>`Azure.Storage.Queues` {applies_to}`apm_agent_dotnet: ga 1.10` | ≥12.6.0 <13.0.0 | [✓](/reference/setup-auto-instrumentation.md) | [✓](/reference/setup-azure-storage.md) | [✓](/reference/opentelemetry-bridge.md) |
+| Azure File Share Storage<br>`Azure.Storage.Files.Shares` {applies_to}`apm_agent_dotnet: ga 1.10` | ≥12.6.0 <13.0.0 | [✓](/reference/setup-auto-instrumentation.md) | [✓](/reference/setup-azure-storage.md) | [✓](/reference/opentelemetry-bridge.md) |
 
 ::::{note}
 Azure Storage SDKs emit native OpenTelemetry spans. When using the profiler without the NuGet package, the OpenTelemetry Bridge captures them automatically. When the NuGet package is installed, the dedicated subscriber takes precedence to prevent duplicate spans.

--- a/docs/reference/supported-technologies.md
+++ b/docs/reference/supported-technologies.md
@@ -26,7 +26,7 @@ If you are already using OpenTelemetry, consider the [EDOT .NET SDK](elastic-ote
 
 The APM Agent for .NET libraries and components target .NET Standard 2.0 or .NET Standard 2.1.
 
-We support .NET runtimes ≤10.0.x and .NET Framework runtimes from 4.6.2 to 4.8.1 for as long as they receive active support from Microsoft per the [.NET support policy](https://dotnet.microsoft.com/platform/support/policy/dotnet-core) and [.NET Framework support policy](https://dotnet.microsoft.com/platform/support/policy/dotnet-framework). When Microsoft ends support for a runtime version, we do too. Issues reported against unsupported runtimes will not be acted on unless they also affect a supported runtime.
+We support .NET runtimes<br>≤10.0.x and .NET Framework runtimes from 4.6.2 to 4.8.1 for as long as they receive active support from Microsoft per the [.NET support policy](https://dotnet.microsoft.com/platform/support/policy/dotnet-core) and [.NET Framework support policy](https://dotnet.microsoft.com/platform/support/policy/dotnet-framework). When Microsoft ends support for a runtime version, we do too. Issues reported against unsupported runtimes will not be acted on unless they also affect a supported runtime.
 
 ::::{note}
 On .NET Framework, we strongly recommend at least .NET Framework 4.7.2 because of binding issues introduced by Microsoft.
@@ -60,8 +60,8 @@ For supported web frameworks, the agent creates one transaction per incoming req
 
 | Framework | Supported versions | [Profiler](/reference/setup-auto-instrumentation.md) | NuGet | OpenTelemetry Bridge |
 | --- | --- | :---: | :---: | :---: |
-| ASP.NET Core {applies_to}`apm_agent_dotnet: ga 1.0` | ≥8.0.0 ≤10.0.x | [✓ ¹](/reference/setup-auto-instrumentation.md) | [✓](/reference/setup-asp-net-core.md) | ✗ |
-| ASP.NET (.NET Framework) in IIS {applies_to}`apm_agent_dotnet: ga 1.1` | 4.6.2–4.8.1 (IIS 10) | [✓](/reference/setup-auto-instrumentation.md) | [✓](/reference/setup-asp-dot-net.md) | ✗ |
+| ASP.NET Core<br>{applies_to}`apm_agent_dotnet: ga 1.0` | ≥8.0.0<br>≤10.0.x | [✓ ¹](/reference/setup-auto-instrumentation.md) | [✓](/reference/setup-asp-net-core.md) | ✗ |
+| ASP.NET (.NET Framework) in IIS<br>{applies_to}`apm_agent_dotnet: ga 1.1` | 4.6.2–4.8.1 (IIS 10) | [✓](/reference/setup-auto-instrumentation.md) | [✓](/reference/setup-asp-dot-net.md) | ✗ |
 
 ¹ Via startup hook on .NET.
 
@@ -79,8 +79,8 @@ Streaming is not supported - the agent does not create transactions or spans for
 
 | Framework | Supported versions | [Profiler](/reference/setup-auto-instrumentation.md) | NuGet | OpenTelemetry Bridge |
 | --- | --- | :---: | :---: | :---: |
-| gRPC server (ASP.NET Core) {applies_to}`apm_agent_dotnet: ga 1.7` | ≥8.0.0 ≤10.0.x | [✓ ¹](/reference/setup-auto-instrumentation.md) | [✓](/reference/setup-asp-net-core.md) | ✗ |
-| gRPC client<br>`Grpc.Net.Client` {applies_to}`apm_agent_dotnet: ga 1.7` | ≥2.23.2 <3.0.0 | [✓ ¹](/reference/setup-auto-instrumentation.md) | [✓](/reference/setup-grpc.md) | [✓ (≥2.57.0)](/reference/opentelemetry-bridge.md) |
+| gRPC server (ASP.NET Core)<br>{applies_to}`apm_agent_dotnet: ga 1.7` | ≥8.0.0<br>≤10.0.x | [✓ ¹](/reference/setup-auto-instrumentation.md) | [✓](/reference/setup-asp-net-core.md) | ✗ |
+| gRPC client<br>`Grpc.Net.Client`<br>{applies_to}`apm_agent_dotnet: ga 1.7` | ≥2.23.2<br><3.0.0 | [✓ ¹](/reference/setup-auto-instrumentation.md) | [✓](/reference/setup-grpc.md) | [✓ (≥2.57.0)](/reference/opentelemetry-bridge.md) |
 
 ¹ Via startup hook on .NET.
 
@@ -92,21 +92,24 @@ Streaming is not supported - the agent does not create transactions or spans for
 
 | Data access technology | Supported versions | [Profiler](/reference/setup-auto-instrumentation.md) | NuGet | OpenTelemetry Bridge |
 | --- | --- | :---: | :---: | :---: |
-| Azure CosmosDB<br>`Microsoft.Azure.Cosmos` {applies_to}`apm_agent_dotnet: ga 1.11` | ≥3.0.0 <4.0.0 | ✗ | [✓](/reference/setup-azure-cosmosdb.md) | ✗ |
-| Azure DocumentDB, legacy<br>`Microsoft.Azure.DocumentDB.Core`\* / `Microsoft.Azure.DocumentDB`\* {applies_to}`apm_agent_dotnet: ga 1.11` | ≥2.4.1 <3.0.0 | ✗ | [✓](/reference/setup-azure-cosmosdb.md) | ✗ |
-| Elasticsearch<br>`Elastic.Clients.Elasticsearch` {applies_to}`apm_agent_dotnet: ga 1.23` | ≥8.0.0 <10.0.0 | [✓](/reference/setup-auto-instrumentation.md) | ✗ | [✓](/reference/opentelemetry-bridge.md) |
-| Elasticsearch, legacy<br>`Elasticsearch.Net` / `NEST` {applies_to}`apm_agent_dotnet: ga 1.6` | ≥7.6.0 <8.0.0 | [✓ ¹](/reference/setup-auto-instrumentation.md) | [✓](/reference/setup-elasticsearch.md) | ✗ |
-| Entity Framework Core<br>`Microsoft.EntityFrameworkCore` {applies_to}`apm_agent_dotnet: ga 1.0` | ≥8.0.0 ≤10.0.x | [✓ ¹](/reference/setup-auto-instrumentation.md) | [✓](/reference/setup-ef-core.md) | ✗ |
-| Entity Framework 6<br>`EntityFramework` {applies_to}`apm_agent_dotnet: ga 1.2` | ≥6.2 ≤6.5.2 | ✗ | [✓](/reference/setup-ef6.md) | ✗ |
-| MongoDB<br>`MongoDB.Driver` {applies_to}`apm_agent_dotnet: ga 1.9` | ≥3.0.0 <4.0.0 | [✓ (≥3.7.0)](/reference/setup-auto-instrumentation.md) | [✓](/reference/setup-mongo-db.md) | [✓ (≥3.7.0)](/reference/opentelemetry-bridge.md) |
-| MySQL<br>`MySql.Data` {applies_to}`apm_agent_dotnet: ga 1.12` | ≥6.7.0 <9.0.0 | [✓](/reference/setup-auto-instrumentation.md) | ✗ | ✗ |
-| Oracle.ManagedDataAccess {applies_to}`apm_agent_dotnet: ga 1.12` | 4.122.x | [✓](/reference/setup-auto-instrumentation.md) | ✗ | ✗ |
-| Oracle.ManagedDataAccess.Core {applies_to}`apm_agent_dotnet: ga 1.12` | ≥2.0.0 <4.0.0 | [✓](/reference/setup-auto-instrumentation.md) | ✗ | ✗ |
-| PostgreSQL<br>`Npgsql` {applies_to}`apm_agent_dotnet: ga 1.12` | ≥4.0.0 <8.0.0 | [✓](/reference/setup-auto-instrumentation.md) | ✗ | ✗ |
-| Redis<br>`StackExchange.Redis` {applies_to}`apm_agent_dotnet: ga 1.8` | ≥2.0.495 <3.0.0 | ✗ | [✓ ²](/reference/setup-stackexchange-redis.md) | ✗ |
-| SqlClient<br>`System.Data.SqlClient` / `Microsoft.Data.SqlClient` {applies_to}`apm_agent_dotnet: ga 1.0` | ≥4.0.0 <5.0.0;<br>≥1.0.0 <6.0.0 | [✓](/reference/setup-auto-instrumentation.md) | [✓](/reference/setup-sqlclient.md) | ✗ |
-| Microsoft.Data.Sqlite {applies_to}`apm_agent_dotnet: ga 1.12` | ≥2.0.0 <9.0.0 | [✓](/reference/setup-auto-instrumentation.md) | ✗ | ✗ |
-| System.Data.SQLite {applies_to}`apm_agent_dotnet: ga 1.12` | ≥1.0.0 <3.0.0 | [✓](/reference/setup-auto-instrumentation.md) | ✗ | ✗ |
+| Azure CosmosDB<br>`Microsoft.Azure.Cosmos`<br>{applies_to}`apm_agent_dotnet: ga 1.11` | ≥3.0.0<br><4.0.0 | ✗ | [✓](/reference/setup-azure-cosmosdb.md) | ✗ |
+| Azure DocumentDB.Core, legacy<br>`Microsoft.Azure.DocumentDB.Core`<br>{applies_to}`apm_agent_dotnet: ga 1.11` | ≥2.4.1<br><3.0.0 | ✗ | [✓](/reference/setup-azure-cosmosdb.md) | ✗ |
+| Azure DocumentDB, legacy<br>`Microsoft.Azure.DocumentDB`<br>{applies_to}`apm_agent_dotnet: ga 1.11` | ≥2.4.1<br><3.0.0 | ✗ | [✓](/reference/setup-azure-cosmosdb.md) | ✗ |
+| Elasticsearch<br>`Elastic.Clients.Elasticsearch`<br>{applies_to}`apm_agent_dotnet: ga 1.23` | ≥8.0.0<br><10.0.0 | [✓](/reference/setup-auto-instrumentation.md) | ✗ | [✓](/reference/opentelemetry-bridge.md) |
+| Elasticsearch.Net<br>{applies_to}`apm_agent_dotnet: ga 1.6` | ≥7.6.0<br><8.0.0 | [✓ ¹](/reference/setup-auto-instrumentation.md) | [✓](/reference/setup-elasticsearch.md) | ✗ |
+| NEST<br>{applies_to}`apm_agent_dotnet: ga 1.6` | ≥7.6.0<br><8.0.0 | [✓ ¹](/reference/setup-auto-instrumentation.md) | [✓](/reference/setup-elasticsearch.md) | ✗ |
+| Entity Framework Core<br>`Microsoft.EntityFrameworkCore`<br>{applies_to}`apm_agent_dotnet: ga 1.0` | ≥8.0.0<br>≤10.0.x | [✓ ¹](/reference/setup-auto-instrumentation.md) | [✓](/reference/setup-ef-core.md) | ✗ |
+| Entity Framework 6<br>`EntityFramework`<br>{applies_to}`apm_agent_dotnet: ga 1.2` | ≥6.2<br>≤6.5.2 | ✗ | [✓](/reference/setup-ef6.md) | ✗ |
+| MongoDB<br>`MongoDB.Driver`<br>{applies_to}`apm_agent_dotnet: ga 1.9` | ≥3.0.0<br><4.0.0 | [✓ (≥3.7.0)](/reference/setup-auto-instrumentation.md) | [✓](/reference/setup-mongo-db.md) | [✓ (≥3.7.0)](/reference/opentelemetry-bridge.md) |
+| MySQL<br>`MySql.Data`<br>{applies_to}`apm_agent_dotnet: ga 1.12` | ≥6.7.0<br><9.0.0 | [✓](/reference/setup-auto-instrumentation.md) | ✗ | ✗ |
+| Oracle.ManagedDataAccess<br>{applies_to}`apm_agent_dotnet: ga 1.12` | 4.122.x | [✓](/reference/setup-auto-instrumentation.md) | ✗ | ✗ |
+| Oracle.ManagedDataAccess.Core<br>{applies_to}`apm_agent_dotnet: ga 1.12` | ≥2.0.0<br><4.0.0 | [✓](/reference/setup-auto-instrumentation.md) | ✗ | ✗ |
+| PostgreSQL<br>`Npgsql`<br>{applies_to}`apm_agent_dotnet: ga 1.12` | ≥4.0.0<br><8.0.0 | [✓](/reference/setup-auto-instrumentation.md) | ✗ | ✗ |
+| Redis<br>`StackExchange.Redis`<br>{applies_to}`apm_agent_dotnet: ga 1.8` | ≥2.0.495<br><3.0.0 | ✗ | [✓ ²](/reference/setup-stackexchange-redis.md) | ✗ |
+| System.Data.SqlClient<br>{applies_to}`apm_agent_dotnet: ga 1.0` | ≥4.0.0<br><5.0.0 | [✓](/reference/setup-auto-instrumentation.md) | [✓](/reference/setup-sqlclient.md) | ✗ |
+| Microsoft.Data.SqlClient<br>{applies_to}`apm_agent_dotnet: ga 1.0` | ≥1.0.0<br><6.0.0 | [✓](/reference/setup-auto-instrumentation.md) | [✓](/reference/setup-sqlclient.md) | ✗ |
+| Microsoft.Data.Sqlite<br>{applies_to}`apm_agent_dotnet: ga 1.12` | ≥2.0.0<br><9.0.0 | [✓](/reference/setup-auto-instrumentation.md) | ✗ | ✗ |
+| System.Data.SQLite<br>{applies_to}`apm_agent_dotnet: ga 1.12` | ≥1.0.0<br><3.0.0 | [✓](/reference/setup-auto-instrumentation.md) | ✗ | ✗ |
 
 ¹ Via startup hook on .NET.
 ² Requires calling `connection.UseElasticApm()` on each `IConnectionMultiplexer` instance - see the [setup page](/reference/setup-stackexchange-redis.md).
@@ -127,10 +130,10 @@ Streaming is not supported - the agent does not create transactions or spans for
 
 | Messaging system | Supported versions | [Profiler](/reference/setup-auto-instrumentation.md) | NuGet | OpenTelemetry Bridge |
 | --- | --- | :---: | :---: | :---: |
-| Azure Service Bus<br>`Azure.Messaging.ServiceBus` {applies_to}`apm_agent_dotnet: ga 1.10` | ≥7.0.0 <8.0.0 | [✓](/reference/setup-auto-instrumentation.md) | [✓](/reference/setup-azure-servicebus.md) | [✓](/reference/opentelemetry-bridge.md) |
-| Azure Service Bus, legacy<br>`Microsoft.Azure.ServiceBus` {applies_to}`apm_agent_dotnet: ga 1.10` | ≥3.0.0 <6.0.0 | ✗ | [✓](/reference/setup-azure-servicebus.md) | ✗ |
-| Kafka<br>`Confluent.Kafka` {applies_to}`apm_agent_dotnet: ga 1.12` | ≥1.4.0 <3.0.0 | [✓](/reference/setup-auto-instrumentation.md) | ✗ | [✓ via adapter ¹](/reference/setup-kafka.md) |
-| RabbitMQ<br>`RabbitMQ.Client` {applies_to}`apm_agent_dotnet: ga 1.12` | ≥3.6.9 <7.0.0 | [✓](/reference/setup-auto-instrumentation.md) | ✗ | ✗ |
+| Azure Service Bus<br>`Azure.Messaging.ServiceBus`<br>{applies_to}`apm_agent_dotnet: ga 1.10` | ≥7.0.0<br><8.0.0 | [✓](/reference/setup-auto-instrumentation.md) | [✓](/reference/setup-azure-servicebus.md) | [✓](/reference/opentelemetry-bridge.md) |
+| Azure Service Bus, legacy<br>`Microsoft.Azure.ServiceBus`<br>{applies_to}`apm_agent_dotnet: ga 1.10` | ≥3.0.0<br><6.0.0 | ✗ | [✓](/reference/setup-azure-servicebus.md) | ✗ |
+| Kafka<br>`Confluent.Kafka`<br>{applies_to}`apm_agent_dotnet: ga 1.12` | ≥1.4.0<br><3.0.0 | [✓](/reference/setup-auto-instrumentation.md) | ✗ | [✓ via adapter ¹](/reference/setup-kafka.md) |
+| RabbitMQ<br>`RabbitMQ.Client`<br>{applies_to}`apm_agent_dotnet: ga 1.12` | ≥3.6.9<br><7.0.0 | [✓](/reference/setup-auto-instrumentation.md) | ✗ | ✗ |
 
 ¹ Requires adding [`Confluent.Kafka.Extensions.Diagnostics`](https://www.nuget.org/packages/Confluent.Kafka.Extensions.Diagnostics) which wraps producers and consumers so they emit spans for the OpenTelemetry Bridge to capture. Code changes are required - see the [setup page](/reference/setup-kafka.md).
 
@@ -146,8 +149,8 @@ For supported Azure Functions hosting models, the agent creates one transaction 
 
 | Hosting model | Supported versions | [Profiler](/reference/setup-auto-instrumentation.md) | NuGet | OpenTelemetry Bridge |
 | --- | --- | :---: | :---: | :---: |
-| Azure Functions isolated worker<br>`Microsoft.Azure.Functions.Worker` {applies_to}`apm_agent_dotnet: ga 1.19` | ≥2.0.0 <3.0.0 | ✗ | [✓](/reference/setup-azure-functions.md) | ✗ |
-| Azure Functions in-process<br>`Microsoft.Azure.Functions.Extensions` {applies_to}`apm_agent_dotnet: ga 1.24` | ≥1.1.0 <2.0.0 | ✗ | [✓](/reference/setup-azure-functions.md) | ✗ |
+| Azure Functions isolated worker<br>`Microsoft.Azure.Functions.Worker`<br>{applies_to}`apm_agent_dotnet: ga 1.19` | ≥2.0.0<br><3.0.0 | ✗ | [✓](/reference/setup-azure-functions.md) | ✗ |
+| Azure Functions in-process<br>`Microsoft.Azure.Functions.Extensions`<br>{applies_to}`apm_agent_dotnet: ga 1.24` | ≥1.1.0<br><2.0.0 | ✗ | [✓](/reference/setup-azure-functions.md) | ✗ |
 
 ::::{note}
 Only HTTP-triggered invocations are traced. System metrics are not collected because of a concern with unintentionally increasing Azure Functions costs on Consumption plans.
@@ -159,9 +162,9 @@ The isolated worker model requires .NET 8+. The in-process model is [deprecated 
 
 | Storage service | Supported versions | [Profiler](/reference/setup-auto-instrumentation.md) | NuGet | OpenTelemetry Bridge |
 | --- | --- | :---: | :---: | :---: |
-| Azure Blob Storage<br>`Azure.Storage.Blobs` {applies_to}`apm_agent_dotnet: ga 1.10` | ≥12.8.0 <13.0.0 | [✓](/reference/setup-auto-instrumentation.md) | [✓](/reference/setup-azure-storage.md) | [✓](/reference/opentelemetry-bridge.md) |
-| Azure Queue Storage<br>`Azure.Storage.Queues` {applies_to}`apm_agent_dotnet: ga 1.10` | ≥12.6.0 <13.0.0 | [✓](/reference/setup-auto-instrumentation.md) | [✓](/reference/setup-azure-storage.md) | [✓](/reference/opentelemetry-bridge.md) |
-| Azure File Share Storage<br>`Azure.Storage.Files.Shares` {applies_to}`apm_agent_dotnet: ga 1.10` | ≥12.6.0 <13.0.0 | [✓](/reference/setup-auto-instrumentation.md) | [✓](/reference/setup-azure-storage.md) | [✓](/reference/opentelemetry-bridge.md) |
+| Azure Blob Storage<br>`Azure.Storage.Blobs`<br>{applies_to}`apm_agent_dotnet: ga 1.10` | ≥12.8.0<br><13.0.0 | [✓](/reference/setup-auto-instrumentation.md) | [✓](/reference/setup-azure-storage.md) | [✓](/reference/opentelemetry-bridge.md) |
+| Azure Queue Storage<br>`Azure.Storage.Queues`<br>{applies_to}`apm_agent_dotnet: ga 1.10` | ≥12.6.0<br><13.0.0 | [✓](/reference/setup-auto-instrumentation.md) | [✓](/reference/setup-azure-storage.md) | [✓](/reference/opentelemetry-bridge.md) |
+| Azure File Share Storage<br>`Azure.Storage.Files.Shares`<br>{applies_to}`apm_agent_dotnet: ga 1.10` | ≥12.6.0<br><13.0.0 | [✓](/reference/setup-auto-instrumentation.md) | [✓](/reference/setup-azure-storage.md) | [✓](/reference/opentelemetry-bridge.md) |
 
 ::::{note}
 Azure Storage SDKs emit native OpenTelemetry spans. When using the profiler without the NuGet package, the OpenTelemetry Bridge captures them automatically. When the NuGet package is installed, the dedicated subscriber takes precedence to prevent duplicate spans.
@@ -173,5 +176,5 @@ For supported networking client-side technologies, the agent creates an HTTP spa
 
 | Framework | Supported versions | [Profiler](/reference/setup-auto-instrumentation.md) | NuGet | OpenTelemetry Bridge |
 | --- | --- | :---: | :---: | :---: |
-| System.Net.Http.HttpClient {applies_to}`apm_agent_dotnet: ga 1.0` | *built-in (.NET)* | [✓](/reference/setup-auto-instrumentation.md) | [✓](/reference/public-api.md#setup-http) | ✗ |
-| System.Net.HttpWebRequest {applies_to}`apm_agent_dotnet: ga 1.1` | *built-in (.NET)* | [✓](/reference/setup-auto-instrumentation.md) | [✓](/reference/public-api.md#setup-http) | ✗ |
+| System.Net.Http.HttpClient<br>{applies_to}`apm_agent_dotnet: ga 1.0` | *built-in (.NET)* | [✓](/reference/setup-auto-instrumentation.md) | [✓](/reference/public-api.md#setup-http) | ✗ |
+| System.Net.HttpWebRequest<br>{applies_to}`apm_agent_dotnet: ga 1.1` | *built-in (.NET)* | [✓](/reference/setup-auto-instrumentation.md) | [✓](/reference/public-api.md#setup-http) | ✗ |

--- a/docs/reference/supported-technologies.md
+++ b/docs/reference/supported-technologies.md
@@ -106,7 +106,7 @@ Streaming is not supported - the agent does not create transactions or spans for
 | Redis<br>`StackExchange.Redis`<br>{applies_to}`apm_agent_dotnet: ga 1.8` | ≥2.0.495<br><3.0.0 | ✗ | [✓ ²](/reference/setup-stackexchange-redis.md) | ✗ |
 | MS SQL<br>`System.Data.SqlClient`<br>{applies_to}`apm_agent_dotnet: ga 1.0` | ≥4.0.0<br><5.0.0 | [✓](/reference/setup-auto-instrumentation.md) | [✓](/reference/setup-sqlclient.md) | ✗ |
 | MS SQL<br>`Microsoft.Data.SqlClient`<br>{applies_to}`apm_agent_dotnet: ga 1.0` | ≥1.0.0<br><6.0.0 | [✓](/reference/setup-auto-instrumentation.md) | [✓](/reference/setup-sqlclient.md) | ✗ |
-| SQLLite<br>`Microsoft.Data.Sqlite`<br>{applies_to}`apm_agent_dotnet: ga 1.12` | ≥2.0.0<br><9.0.0 | [✓](/reference/setup-auto-instrumentation.md) | ✗ | ✗ |
+| SQLite<br>`Microsoft.Data.Sqlite`<br>{applies_to}`apm_agent_dotnet: ga 1.12` | ≥2.0.0<br><9.0.0 | [✓](/reference/setup-auto-instrumentation.md) | ✗ | ✗ |
 | SQLLite<br>`System.Data.SQLite`<br>{applies_to}`apm_agent_dotnet: ga 1.12` | ≥1.0.0<br><3.0.0 | [✓](/reference/setup-auto-instrumentation.md) | ✗ | ✗ |
 
 ¹ Via startup hook on .NET.

--- a/docs/reference/supported-technologies.md
+++ b/docs/reference/supported-technologies.md
@@ -11,7 +11,7 @@ applies_to:
 
 # Supported technologies [supported-technologies]
 
-The tables below summarize the technologies the APM Agent for .NET supports, the package or runtime versions we test, and which installation methods work for each one. Versions beyond the listed upper bound have not been tested and are not supported, but might work.
+This page summarizes the technologies the APM Agent for .NET supports, the package or runtime versions we test, and which installation methods work for each one. Versions beyond the listed upper bound have not been tested and are not supported, but might work.
 
 Use this page as a compatibility matrix:
 
@@ -20,7 +20,7 @@ Use this page as a compatibility matrix:
 3. Check the installation method you plan to use: Profiler, NuGet, or OpenTelemetry Bridge.
 4. Read any footnotes or notes directly below that table for important limitations or setup requirements.
 
-If you are already using OpenTelemetry, consider the [EDOT .NET SDK](elastic-otel-dotnet://reference/edot-dotnet/index.md) for traces, metrics, and logs. It covers many of these technologies and fits naturally with Elastic's observability platform.
+If you are already using OpenTelemetry, consider the [EDOT .NET SDK](elastic-otel-dotnet://reference/edot-dotnet/index.md) for traces, metrics, and logs. It covers many of the same technologies (and more) and integrates naturally with Elastic's observability platform.
 
 ## Supported .NET runtimes [supported-dotnet-runtimes]
 
@@ -38,7 +38,7 @@ Native AOT is not supported. The agent relies on reflection, runtime IL emit, an
 
 ## Installation methods [supported-installation-methods]
 
-Each table below shows which installation methods apply to each technology. A checkmark (✓) means the technology is supported via that installation method for the listed version range. Where a cell shows a version qualifier such as `(≥3.7.0)`, only that narrower range is covered by that method.
+Each table below shows which installation methods apply to each technology. A checkmark (✓) means the technology is supported via that installation method for the listed version range; a cross (✗) means it is not supported via that method. Where a cell shows a version qualifier such as `(≥3.7.0)`, only that narrower range is covered by that method.
 
 ::::{note}
 The **OpenTelemetry Bridge** column requires .NET 8+ and APM Server ≥7.16. A checkmark there means the technology is covered through the built-in OpenTelemetry Bridge, whether the agent was installed via the Profiler or a NuGet package.
@@ -53,7 +53,6 @@ If no Elastic APM NuGet package exists for that technology, such as `Elastic.Cli
 | **[Profiler](/reference/setup-auto-instrumentation.md)** | Instrumented automatically by the [Elastic APM .NET Profiler](/reference/setup-auto-instrumentation.md) with no code changes. On .NET, a startup hook loads DiagnosticSource subscribers and the built-in OpenTelemetry Bridge. On .NET Framework, the profiler uses IL rewriting instead. |
 | **NuGet** | Install the linked integration NuGet package alongside the core `Elastic.Apm` package and add the setup call to application startup. |
 | **OpenTelemetry Bridge** | The library emits native [OpenTelemetry](https://opentelemetry.io/) spans that the agent captures through its built-in [OpenTelemetry Bridge](/reference/opentelemetry-bridge.md). |
-| **—** | Not supported via this installation method. |
 
 ## Web frameworks [supported-web-frameworks]
 
@@ -61,8 +60,8 @@ For supported web frameworks, the agent creates one transaction per incoming req
 
 | Framework | Supported versions | [Profiler](/reference/setup-auto-instrumentation.md) | NuGet | OpenTelemetry Bridge |
 | --- | --- | :---: | :---: | :---: |
-| ASP.NET Core {applies_to}`apm_agent_dotnet: ga 1.0` | ≥8.0.0 ≤10.0.x | [✓ ¹](/reference/setup-auto-instrumentation.md) | [✓](/reference/setup-asp-net-core.md) | — |
-| ASP.NET (.NET Framework) in IIS {applies_to}`apm_agent_dotnet: ga 1.1` | 4.6.2–4.8.1 (IIS 10) | [✓](/reference/setup-auto-instrumentation.md) | [✓](/reference/setup-asp-dot-net.md) | — |
+| ASP.NET Core {applies_to}`apm_agent_dotnet: ga 1.0` | ≥8.0.0 ≤10.0.x | [✓ ¹](/reference/setup-auto-instrumentation.md) | [✓](/reference/setup-asp-net-core.md) | ✗ |
+| ASP.NET (.NET Framework) in IIS {applies_to}`apm_agent_dotnet: ga 1.1` | 4.6.2–4.8.1 (IIS 10) | [✓](/reference/setup-auto-instrumentation.md) | [✓](/reference/setup-asp-dot-net.md) | ✗ |
 
 ¹ Via startup hook on .NET.
 
@@ -78,25 +77,25 @@ For supported Azure Functions hosting models, the agent creates one transaction 
 
 | Hosting model | Supported versions | [Profiler](/reference/setup-auto-instrumentation.md) | NuGet | OpenTelemetry Bridge |
 | --- | --- | :---: | :---: | :---: |
-| Azure Functions isolated worker {applies_to}`apm_agent_dotnet: ga 1.19` | Microsoft.Azure.Functions.Worker ≥2.0.0 | — | [✓](/reference/setup-azure-functions.md) | — |
-| Azure Functions in-process {applies_to}`apm_agent_dotnet: ga 1.24` | Microsoft.Azure.Functions.Extensions ≥1.1.0 | — | [✓](/reference/setup-azure-functions.md) | — |
+| Azure Functions isolated worker {applies_to}`apm_agent_dotnet: ga 1.19` | `Microsoft.Azure.Functions.Worker` ≥2.0.0 | ✗ | [✓](/reference/setup-azure-functions.md) | ✗ |
+| Azure Functions in-process {applies_to}`apm_agent_dotnet: ga 1.24` | `Microsoft.Azure.Functions.Extensions` ≥1.1.0 | ✗ | [✓](/reference/setup-azure-functions.md) | ✗ |
 
 ::::{note}
 Only HTTP-triggered invocations are traced. System metrics are not collected because of a concern with unintentionally increasing Azure Functions costs on Consumption plans.
 
-The isolated worker model requires .NET 8+. The in-process model is [deprecated by Microsoft](https://learn.microsoft.com/en-us/azure/azure-functions/migrate-dotnet-in-process-to-isolated) — new apps should use the isolated worker model.
+The isolated worker model requires .NET 8+. The in-process model is [deprecated by Microsoft](https://learn.microsoft.com/en-us/azure/azure-functions/migrate-dotnet-in-process-to-isolated) - new apps should use the isolated worker model.
 ::::
 
 ## RPC frameworks [supported-rpc-frameworks]
 
 For supported gRPC frameworks, the agent automatically captures both client-side and server-side calls.
 
-Streaming is not supported — the agent does not create transactions or spans for streaming calls automatically.
+Streaming is not supported - the agent does not create transactions or spans for streaming calls automatically.
 
 | Framework | Supported versions | [Profiler](/reference/setup-auto-instrumentation.md) | NuGet | OpenTelemetry Bridge |
 | --- | --- | :---: | :---: | :---: |
-| gRPC client {applies_to}`apm_agent_dotnet: ga 1.7` | Grpc.Net.Client ≥2.23.2 <3.0.0 | [✓ ¹](/reference/setup-auto-instrumentation.md) | [✓](/reference/setup-grpc.md) | [✓ (≥2.57.0)](/reference/opentelemetry-bridge.md) |
-| gRPC server (ASP.NET Core) {applies_to}`apm_agent_dotnet: ga 1.7` | ≥8.0.0 ≤10.0.x | [✓ ¹](/reference/setup-auto-instrumentation.md) | [✓](/reference/setup-asp-net-core.md) | — |
+| gRPC client {applies_to}`apm_agent_dotnet: ga 1.7` | `Grpc.Net.Client` ≥2.23.2 <3.0.0 | [✓ ¹](/reference/setup-auto-instrumentation.md) | [✓](/reference/setup-grpc.md) | [✓ (≥2.57.0)](/reference/opentelemetry-bridge.md) |
+| gRPC server (ASP.NET Core) {applies_to}`apm_agent_dotnet: ga 1.7` | ≥8.0.0 ≤10.0.x | [✓ ¹](/reference/setup-auto-instrumentation.md) | [✓](/reference/setup-asp-net-core.md) | ✗ |
 
 ¹ Via startup hook on .NET.
 
@@ -108,27 +107,27 @@ Streaming is not supported — the agent does not create transactions or spans f
 
 | Data access technology | Supported versions | [Profiler](/reference/setup-auto-instrumentation.md) | NuGet | OpenTelemetry Bridge |
 | --- | --- | :---: | :---: | :---: |
-| Azure CosmosDB {applies_to}`apm_agent_dotnet: ga 1.11` | Microsoft.Azure.Cosmos ≥3.0.0 <4.0.0 | — | [✓](/reference/setup-azure-cosmosdb.md) | — |
-| Azure DocumentDB, legacy {applies_to}`apm_agent_dotnet: ga 1.11` | Microsoft.Azure.DocumentDB.Core\* ≥2.4.1 <3.0.0; Microsoft.Azure.DocumentDB\* ≥2.4.1 <3.0.0 | — | [✓](/reference/setup-azure-cosmosdb.md) | — |
-| Elasticsearch {applies_to}`apm_agent_dotnet: ga 1.23` | Elastic.Clients.Elasticsearch ≥8.0.0 <10.0.0 | [✓](/reference/setup-auto-instrumentation.md) | — | [✓](/reference/opentelemetry-bridge.md) |
-| Elasticsearch, legacy {applies_to}`apm_agent_dotnet: ga 1.6` | Elasticsearch.Net / NEST ≥7.6.0 <8.0.0 | [✓ ¹](/reference/setup-auto-instrumentation.md) | [✓](/reference/setup-elasticsearch.md) | — |
-| Entity Framework Core {applies_to}`apm_agent_dotnet: ga 1.0` | Microsoft.EntityFrameworkCore ≥8.0.0 ≤10.0.x | [✓ ¹](/reference/setup-auto-instrumentation.md) | [✓](/reference/setup-ef-core.md) | — |
-| Entity Framework 6 {applies_to}`apm_agent_dotnet: ga 1.2` | EntityFramework ≥6.2 ≤6.5.2 | — | [✓](/reference/setup-ef6.md) | — |
-| MongoDB {applies_to}`apm_agent_dotnet: ga 1.9` | MongoDB.Driver ≥3.0.0 <4.0.0 | [✓ (≥3.7.0)](/reference/setup-auto-instrumentation.md) | [✓](/reference/setup-mongo-db.md) | [✓ (≥3.7.0)](/reference/opentelemetry-bridge.md) |
-| MySQL {applies_to}`apm_agent_dotnet: ga 1.12` | MySql.Data ≥6.7.0 <9.0.0 | [✓](/reference/setup-auto-instrumentation.md) | — | — |
-| Oracle.ManagedDataAccess {applies_to}`apm_agent_dotnet: ga 1.12` | Oracle.ManagedDataAccess 4.122.x | [✓](/reference/setup-auto-instrumentation.md) | — | — |
-| Oracle.ManagedDataAccess.Core {applies_to}`apm_agent_dotnet: ga 1.12` | Oracle.ManagedDataAccess.Core ≥2.0.0 <4.0.0 | [✓](/reference/setup-auto-instrumentation.md) | — | — |
-| PostgreSQL {applies_to}`apm_agent_dotnet: ga 1.12` | Npgsql ≥4.0.0 <8.0.0 | [✓](/reference/setup-auto-instrumentation.md) | — | — |
-| Redis {applies_to}`apm_agent_dotnet: ga 1.8` | StackExchange.Redis ≥2.0.495 <3.0.0 | — | [✓ ²](/reference/setup-stackexchange-redis.md) | — |
-| SqlClient {applies_to}`apm_agent_dotnet: ga 1.0` | System.Data.SqlClient ≥4.0.0 <5.0.0; Microsoft.Data.SqlClient ≥1.0.0 <6.0.0 | [✓](/reference/setup-auto-instrumentation.md) | [✓](/reference/setup-sqlclient.md) | — |
-| Microsoft.Data.Sqlite {applies_to}`apm_agent_dotnet: ga 1.12` | Microsoft.Data.Sqlite ≥2.0.0 <9.0.0 | [✓](/reference/setup-auto-instrumentation.md) | — | — |
-| System.Data.SQLite {applies_to}`apm_agent_dotnet: ga 1.12` | System.Data.SQLite ≥1.0.0 <3.0.0 | [✓](/reference/setup-auto-instrumentation.md) | — | — |
+| Azure CosmosDB {applies_to}`apm_agent_dotnet: ga 1.11` | `Microsoft.Azure.Cosmos` ≥3.0.0 <4.0.0 | ✗ | [✓](/reference/setup-azure-cosmosdb.md) | ✗ |
+| Azure DocumentDB, legacy {applies_to}`apm_agent_dotnet: ga 1.11` | `Microsoft.Azure.DocumentDB.Core`\* ≥2.4.1 <3.0.0; `Microsoft.Azure.DocumentDB`\* ≥2.4.1 <3.0.0 | ✗ | [✓](/reference/setup-azure-cosmosdb.md) | ✗ |
+| Elasticsearch {applies_to}`apm_agent_dotnet: ga 1.23` | `Elastic.Clients.Elasticsearch` ≥8.0.0 <10.0.0 | [✓](/reference/setup-auto-instrumentation.md) | ✗ | [✓](/reference/opentelemetry-bridge.md) |
+| Elasticsearch, legacy {applies_to}`apm_agent_dotnet: ga 1.6` | `Elasticsearch.Net` / `NEST` ≥7.6.0 <8.0.0 | [✓ ¹](/reference/setup-auto-instrumentation.md) | [✓](/reference/setup-elasticsearch.md) | ✗ |
+| Entity Framework Core {applies_to}`apm_agent_dotnet: ga 1.0` | `Microsoft.EntityFrameworkCore` ≥8.0.0 ≤10.0.x | [✓ ¹](/reference/setup-auto-instrumentation.md) | [✓](/reference/setup-ef-core.md) | ✗ |
+| Entity Framework 6 {applies_to}`apm_agent_dotnet: ga 1.2` | `EntityFramework` ≥6.2 ≤6.5.2 | ✗ | [✓](/reference/setup-ef6.md) | ✗ |
+| MongoDB {applies_to}`apm_agent_dotnet: ga 1.9` | `MongoDB.Driver` ≥3.0.0 <4.0.0 | [✓ (≥3.7.0)](/reference/setup-auto-instrumentation.md) | [✓](/reference/setup-mongo-db.md) | [✓ (≥3.7.0)](/reference/opentelemetry-bridge.md) |
+| MySQL {applies_to}`apm_agent_dotnet: ga 1.12` | `MySql.Data` ≥6.7.0 <9.0.0 | [✓](/reference/setup-auto-instrumentation.md) | ✗ | ✗ |
+| Oracle.ManagedDataAccess {applies_to}`apm_agent_dotnet: ga 1.12` | `Oracle.ManagedDataAccess` 4.122.x | [✓](/reference/setup-auto-instrumentation.md) | ✗ | ✗ |
+| Oracle.ManagedDataAccess.Core {applies_to}`apm_agent_dotnet: ga 1.12` | `Oracle.ManagedDataAccess.Core` ≥2.0.0 <4.0.0 | [✓](/reference/setup-auto-instrumentation.md) | ✗ | ✗ |
+| PostgreSQL {applies_to}`apm_agent_dotnet: ga 1.12` | `Npgsql` ≥4.0.0 <8.0.0 | [✓](/reference/setup-auto-instrumentation.md) | ✗ | ✗ |
+| Redis {applies_to}`apm_agent_dotnet: ga 1.8` | `StackExchange.Redis` ≥2.0.495 <3.0.0 | ✗ | [✓ ²](/reference/setup-stackexchange-redis.md) | ✗ |
+| SqlClient {applies_to}`apm_agent_dotnet: ga 1.0` | `System.Data.SqlClient` ≥4.0.0 <5.0.0; `Microsoft.Data.SqlClient` ≥1.0.0 <6.0.0 | [✓](/reference/setup-auto-instrumentation.md) | [✓](/reference/setup-sqlclient.md) | ✗ |
+| Microsoft.Data.Sqlite {applies_to}`apm_agent_dotnet: ga 1.12` | `Microsoft.Data.Sqlite` ≥2.0.0 <9.0.0 | [✓](/reference/setup-auto-instrumentation.md) | ✗ | ✗ |
+| System.Data.SQLite {applies_to}`apm_agent_dotnet: ga 1.12` | `System.Data.SQLite` ≥1.0.0 <3.0.0 | [✓](/reference/setup-auto-instrumentation.md) | ✗ | ✗ |
 
 ¹ Via startup hook on .NET.
-² Requires calling `connection.UseElasticApm()` on each `IConnectionMultiplexer` instance — see the [setup page](/reference/setup-stackexchange-redis.md).
+² Requires calling `connection.UseElasticApm()` on each `IConnectionMultiplexer` instance - see the [setup page](/reference/setup-stackexchange-redis.md).
 
 ::::{note}
-\* `Microsoft.Azure.DocumentDB.Core` and `Microsoft.Azure.DocumentDB` are deprecated. The recommended replacement is the `Microsoft.Azure.Cosmos` package.
+`Microsoft.Azure.DocumentDB.Core` and `Microsoft.Azure.DocumentDB` are deprecated. The recommended replacement is the `Microsoft.Azure.Cosmos` package.
 ::::
 
 ::::{note}
@@ -136,19 +135,19 @@ Streaming is not supported — the agent does not create transactions or spans f
 ::::
 
 ::::{note}
-MongoDB.Driver ≥3.7.0 emits native OpenTelemetry spans. When running without the NuGet package (profiler-only install), these are captured automatically by the OpenTelemetry Bridge.
+`MongoDB.Driver` ≥3.7.0 emits native OpenTelemetry spans. When running without the NuGet package (profiler-only install), these are captured automatically by the OpenTelemetry Bridge.
 ::::
 
 ## Messaging systems [supported-messaging-systems]
 
 | Messaging system | Supported versions | [Profiler](/reference/setup-auto-instrumentation.md) | NuGet | OpenTelemetry Bridge |
 | --- | --- | :---: | :---: | :---: |
-| Azure Service Bus {applies_to}`apm_agent_dotnet: ga 1.10` | Azure.Messaging.ServiceBus ≥7.0.0 <8.0.0 | [✓](/reference/setup-auto-instrumentation.md) | [✓](/reference/setup-azure-servicebus.md) | [✓](/reference/opentelemetry-bridge.md) |
-| Azure Service Bus, legacy {applies_to}`apm_agent_dotnet: ga 1.10` | Microsoft.Azure.ServiceBus ≥3.0.0 <6.0.0 | — | [✓](/reference/setup-azure-servicebus.md) | — |
-| Kafka {applies_to}`apm_agent_dotnet: ga 1.12` | Confluent.Kafka ≥1.4.0 <3.0.0 | [✓](/reference/setup-auto-instrumentation.md) | — | [✓ via adapter ¹](/reference/setup-kafka.md) |
-| RabbitMQ {applies_to}`apm_agent_dotnet: ga 1.12` | RabbitMQ.Client ≥3.6.9 <7.0.0 | [✓](/reference/setup-auto-instrumentation.md) | — | — |
+| Azure Service Bus {applies_to}`apm_agent_dotnet: ga 1.10` | `Azure.Messaging.ServiceBus` ≥7.0.0 <8.0.0 | [✓](/reference/setup-auto-instrumentation.md) | [✓](/reference/setup-azure-servicebus.md) | [✓](/reference/opentelemetry-bridge.md) |
+| Azure Service Bus, legacy {applies_to}`apm_agent_dotnet: ga 1.10` | `Microsoft.Azure.ServiceBus` ≥3.0.0 <6.0.0 | ✗ | [✓](/reference/setup-azure-servicebus.md) | ✗ |
+| Kafka {applies_to}`apm_agent_dotnet: ga 1.12` | `Confluent.Kafka` ≥1.4.0 <3.0.0 | [✓](/reference/setup-auto-instrumentation.md) | ✗ | [✓ via adapter ¹](/reference/setup-kafka.md) |
+| RabbitMQ {applies_to}`apm_agent_dotnet: ga 1.12` | `RabbitMQ.Client` ≥3.6.9 <7.0.0 | [✓](/reference/setup-auto-instrumentation.md) | ✗ | ✗ |
 
-¹ Requires adding [`Confluent.Kafka.Extensions.Diagnostics`](https://www.nuget.org/packages/Confluent.Kafka.Extensions.Diagnostics) which wraps producers and consumers so they emit spans for the OpenTelemetry Bridge to capture. Code changes are required — see the [setup page](/reference/setup-kafka.md).
+¹ Requires adding [`Confluent.Kafka.Extensions.Diagnostics`](https://www.nuget.org/packages/Confluent.Kafka.Extensions.Diagnostics) which wraps producers and consumers so they emit spans for the OpenTelemetry Bridge to capture. Code changes are required - see the [setup page](/reference/setup-kafka.md).
 
 ::::{note}
 `Azure.Messaging.ServiceBus` emits native OpenTelemetry spans. When using the profiler without the NuGet package, the OpenTelemetry Bridge captures them automatically. When the NuGet package is installed, the dedicated subscriber takes precedence to prevent duplicate spans.
@@ -160,9 +159,9 @@ The legacy `Microsoft.Azure.ServiceBus` package does not emit native OpenTelemet
 
 | Storage service | Supported versions | [Profiler](/reference/setup-auto-instrumentation.md) | NuGet | OpenTelemetry Bridge |
 | --- | --- | :---: | :---: | :---: |
-| Azure Blob Storage {applies_to}`apm_agent_dotnet: ga 1.10` | Azure.Storage.Blobs ≥12.8.0 <13.0.0 | [✓](/reference/setup-auto-instrumentation.md) | [✓](/reference/setup-azure-storage.md) | [✓](/reference/opentelemetry-bridge.md) |
-| Azure Queue Storage {applies_to}`apm_agent_dotnet: ga 1.10` | Azure.Storage.Queues ≥12.6.0 <13.0.0 | [✓](/reference/setup-auto-instrumentation.md) | [✓](/reference/setup-azure-storage.md) | [✓](/reference/opentelemetry-bridge.md) |
-| Azure File Share Storage {applies_to}`apm_agent_dotnet: ga 1.10` | Azure.Storage.Files.Shares ≥12.6.0 <13.0.0 | [✓](/reference/setup-auto-instrumentation.md) | [✓](/reference/setup-azure-storage.md) | [✓](/reference/opentelemetry-bridge.md) |
+| Azure Blob Storage {applies_to}`apm_agent_dotnet: ga 1.10` | `Azure.Storage.Blobs` ≥12.8.0 <13.0.0 | [✓](/reference/setup-auto-instrumentation.md) | [✓](/reference/setup-azure-storage.md) | [✓](/reference/opentelemetry-bridge.md) |
+| Azure Queue Storage {applies_to}`apm_agent_dotnet: ga 1.10` | `Azure.Storage.Queues` ≥12.6.0 <13.0.0 | [✓](/reference/setup-auto-instrumentation.md) | [✓](/reference/setup-azure-storage.md) | [✓](/reference/opentelemetry-bridge.md) |
+| Azure File Share Storage {applies_to}`apm_agent_dotnet: ga 1.10` | `Azure.Storage.Files.Shares` ≥12.6.0 <13.0.0 | [✓](/reference/setup-auto-instrumentation.md) | [✓](/reference/setup-azure-storage.md) | [✓](/reference/opentelemetry-bridge.md) |
 
 ::::{note}
 Azure Storage SDKs emit native OpenTelemetry spans. When using the profiler without the NuGet package, the OpenTelemetry Bridge captures them automatically. When the NuGet package is installed, the dedicated subscriber takes precedence to prevent duplicate spans.
@@ -174,5 +173,5 @@ For supported networking client-side technologies, the agent creates an HTTP spa
 
 | Framework | Supported versions | [Profiler](/reference/setup-auto-instrumentation.md) | NuGet | OpenTelemetry Bridge |
 | --- | --- | :---: | :---: | :---: |
-| System.Net.Http.HttpClient {applies_to}`apm_agent_dotnet: ga 1.0` | *built-in (.NET)* | [✓](/reference/setup-auto-instrumentation.md) | [✓](/reference/public-api.md#setup-http) | — |
-| System.Net.HttpWebRequest {applies_to}`apm_agent_dotnet: ga 1.1` | *built-in (.NET)* | [✓](/reference/setup-auto-instrumentation.md) | [✓](/reference/public-api.md#setup-http) | — |
+| System.Net.Http.HttpClient {applies_to}`apm_agent_dotnet: ga 1.0` | *built-in (.NET)* | [✓](/reference/setup-auto-instrumentation.md) | [✓](/reference/public-api.md#setup-http) | ✗ |
+| System.Net.HttpWebRequest {applies_to}`apm_agent_dotnet: ga 1.1` | *built-in (.NET)* | [✓](/reference/setup-auto-instrumentation.md) | [✓](/reference/public-api.md#setup-http) | ✗ |

--- a/docs/reference/supported-technologies.md
+++ b/docs/reference/supported-technologies.md
@@ -41,7 +41,7 @@ On .NET Framework, we strongly recommend at least .NET Framework 4.7.2 because o
 Each table below shows which installation methods apply to each technology. A checkmark (✓) means the technology is supported with that installation method for the listed version range; a cross (✗) means it is not supported using that method. Where a cell shows a version qualifier such as `(≥3.7.0)`, only that narrower range is covered by that method.
 
 ::::{note}
-The **OpenTelemetry Bridge** column requires .NET 8+ and APM Server ≥7.16. A checkmark there means the technology is covered through the built-in OpenTelemetry Bridge, whether the agent was installed via the Profiler or a NuGet package.
+The **OpenTelemetry Bridge** column requires .NET 8+ and APM Server ≥7.16. A checkmark there means the technology is covered through the built-in OpenTelemetry Bridge, whether the agent was installed using the Profiler or a NuGet package.
 
 On .NET Framework, technologies that depend on the startup hook or the OpenTelemetry Bridge need the NuGet install method instead. If no Elastic APM NuGet package exists for that technology, such as `Elastic.Clients.Elasticsearch`, it is not supported on .NET Framework.
 ::::

--- a/docs/reference/supported-technologies.md
+++ b/docs/reference/supported-technologies.md
@@ -102,7 +102,7 @@ Streaming is not supported - the agent does not create transactions or spans for
 | Entity Framework 6<br>`EntityFramework`<br>{applies_to}`apm_agent_dotnet: ga 1.2` | ≥6.2<br>≤6.5.2 | ✗ | [✓](/reference/setup-ef6.md) | ✗ |
 | MongoDB<br>`MongoDB.Driver`<br>{applies_to}`apm_agent_dotnet: ga 1.9` | ≥3.0.0<br><4.0.0 | [✓ (≥3.7.0)](/reference/setup-auto-instrumentation.md) | [✓](/reference/setup-mongo-db.md) | [✓ (≥3.7.0)](/reference/opentelemetry-bridge.md) |
 | MySQL<br>`MySql.Data`<br>{applies_to}`apm_agent_dotnet: ga 1.12` | ≥6.7.0<br><9.0.0 | [✓](/reference/setup-auto-instrumentation.md) | ✗ | ✗ |
-| Oracle<br>`Oracle.ManagedDataAccess`<br>{applies_to}`apm_agent_dotnet: ga 1.12` | 4.122.x | [✓](/reference/setup-auto-instrumentation.md) | ✗ | ✗ |
+| Oracle<br>`Oracle.ManagedDataAccess`<br>{applies_to}`apm_agent_dotnet: ga 1.12` | ≥12.2.1100<br><22.0.0 | [✓](/reference/setup-auto-instrumentation.md) | ✗ | ✗ |
 | Oracle<br>`Oracle.ManagedDataAccess.Core`<br>{applies_to}`apm_agent_dotnet: ga 1.12` | ≥2.0.0<br><4.0.0 | [✓](/reference/setup-auto-instrumentation.md) | ✗ | ✗ |
 | PostgreSQL<br>`Npgsql`<br>{applies_to}`apm_agent_dotnet: ga 1.12` | ≥4.0.0<br><8.0.0 | [✓](/reference/setup-auto-instrumentation.md) | ✗ | ✗ |
 | Redis<br>`StackExchange.Redis`<br>{applies_to}`apm_agent_dotnet: ga 1.8` | ≥2.0.495<br><3.0.0 | ✗ | [✓ ²](/reference/setup-stackexchange-redis.md) | ✗ |

--- a/docs/reference/supported-technologies.md
+++ b/docs/reference/supported-technologies.md
@@ -80,7 +80,7 @@ Streaming is not supported - the agent does not create transactions or spans for
 | gRPC server (ASP.NET Core)<br>{applies_to}`apm_agent_dotnet: ga 1.7` | ≥8.0.0<br>≤10.0.x | [✓ ¹](/reference/setup-auto-instrumentation.md) | [✓](/reference/setup-asp-net-core.md) | ✗ |
 | gRPC client<br>`Grpc.Net.Client`<br>{applies_to}`apm_agent_dotnet: ga 1.7` | ≥2.23.2<br><3.0.0 | [✓ ¹](/reference/setup-auto-instrumentation.md) | [✓](/reference/setup-grpc.md) | [✓ (≥2.57.0)](/reference/opentelemetry-bridge.md) |
 
-¹ Via startup hook on .NET.
+¹ Using a startup hook on .NET.
 
 ::::{note}
 `Grpc.Net.Client` ≥2.57.0 emits native OpenTelemetry spans. When using the profiler without the NuGet package, the OpenTelemetry Bridge captures them automatically. When the NuGet package is installed, the dedicated subscriber takes precedence to prevent duplicate spans.

--- a/docs/reference/supported-technologies.md
+++ b/docs/reference/supported-technologies.md
@@ -28,12 +28,12 @@ The APM Agent for .NET libraries and components target .NET Standard 2.0 or .NET
 
 We support .NET runtimes<br>≤10.0.x and .NET Framework runtimes from 4.6.2 to 4.8.1 for as long as they receive active support from Microsoft per the [.NET support policy](https://dotnet.microsoft.com/platform/support/policy/dotnet-core) and [.NET Framework support policy](https://dotnet.microsoft.com/platform/support/policy/dotnet-framework). When Microsoft ends support for a runtime version, we do too. Issues reported against unsupported runtimes will not be acted on unless they also affect a supported runtime.
 
-::::{note}
-On .NET Framework, we strongly recommend at least .NET Framework 4.7.2 because of binding issues introduced by Microsoft.
-::::
-
 ::::{warning}
 Native AOT is not supported. The agent relies on reflection, runtime IL emit, and embedded libraries that are incompatible with AOT compilation. Attempting to use the agent in a Native AOT-published application will fail at runtime.
+::::
+
+::::{note}
+On .NET Framework, we strongly recommend at least .NET Framework 4.7.2 because of binding issues introduced by Microsoft.
 ::::
 
 ## Installation methods [supported-installation-methods]
@@ -116,13 +116,9 @@ Streaming is not supported - the agent does not create transactions or spans for
 
 ::::{note}
 `Microsoft.Azure.DocumentDB.Core` and `Microsoft.Azure.DocumentDB` are deprecated. The recommended replacement is the `Microsoft.Azure.Cosmos` package.
-::::
 
-::::{note}
-`Elastic.Clients.Elasticsearch` emits native OpenTelemetry spans. The legacy `Elasticsearch.Net` and `NEST` clients use a `DiagnosticSource`-based subscriber instead.
-::::
+`Elastic.Clients.Elasticsearch` emits native OpenTelemetry spans. The legacy (deprecated) `Elasticsearch.Net` and `NEST` clients use a `DiagnosticSource`-based subscriber instead.
 
-::::{note}
 `MongoDB.Driver` ≥3.7.0 emits native OpenTelemetry spans. When running without the NuGet package (profiler-only install), these are captured automatically by the OpenTelemetry Bridge.
 ::::
 

--- a/docs/reference/supported-technologies.md
+++ b/docs/reference/supported-technologies.md
@@ -93,23 +93,23 @@ Streaming is not supported - the agent does not create transactions or spans for
 | Data access technology | Supported versions | [Profiler](/reference/setup-auto-instrumentation.md) | NuGet | OpenTelemetry Bridge |
 | --- | --- | :---: | :---: | :---: |
 | Azure CosmosDB<br>`Microsoft.Azure.Cosmos`<br>{applies_to}`apm_agent_dotnet: ga 1.11` | ≥3.0.0<br><4.0.0 | ✗ | [✓](/reference/setup-azure-cosmosdb.md) | ✗ |
-| Azure DocumentDB.Core, legacy<br>`Microsoft.Azure.DocumentDB.Core`<br>{applies_to}`apm_agent_dotnet: ga 1.11` | ≥2.4.1<br><3.0.0 | ✗ | [✓](/reference/setup-azure-cosmosdb.md) | ✗ |
-| Azure DocumentDB, legacy<br>`Microsoft.Azure.DocumentDB`<br>{applies_to}`apm_agent_dotnet: ga 1.11` | ≥2.4.1<br><3.0.0 | ✗ | [✓](/reference/setup-azure-cosmosdb.md) | ✗ |
+| Azure DocumentDB.Core (legacy)<br>`Microsoft.Azure.DocumentDB.Core`<br>{applies_to}`apm_agent_dotnet: ga 1.11` | ≥2.4.1<br><3.0.0 | ✗ | [✓](/reference/setup-azure-cosmosdb.md) | ✗ |
+| Azure DocumentDB (legacy)<br>`Microsoft.Azure.DocumentDB`<br>{applies_to}`apm_agent_dotnet: ga 1.11` | ≥2.4.1<br><3.0.0 | ✗ | [✓](/reference/setup-azure-cosmosdb.md) | ✗ |
 | Elasticsearch<br>`Elastic.Clients.Elasticsearch`<br>{applies_to}`apm_agent_dotnet: ga 1.23` | ≥8.0.0<br><10.0.0 | [✓](/reference/setup-auto-instrumentation.md) | ✗ | [✓](/reference/opentelemetry-bridge.md) |
-| Elasticsearch.Net<br>{applies_to}`apm_agent_dotnet: ga 1.6` | ≥7.6.0<br><8.0.0 | [✓ ¹](/reference/setup-auto-instrumentation.md) | [✓](/reference/setup-elasticsearch.md) | ✗ |
-| NEST<br>{applies_to}`apm_agent_dotnet: ga 1.6` | ≥7.6.0<br><8.0.0 | [✓ ¹](/reference/setup-auto-instrumentation.md) | [✓](/reference/setup-elasticsearch.md) | ✗ |
+| Elasticsearch (legacy)<br>`Elasticsearch.Net`<br>{applies_to}`apm_agent_dotnet: ga 1.6` | ≥7.6.0<br><8.0.0 | [✓ ¹](/reference/setup-auto-instrumentation.md) | [✓](/reference/setup-elasticsearch.md) | ✗ |
+| Elasticsearch (legacy)<br>`NEST`<br>{applies_to}`apm_agent_dotnet: ga 1.6` | ≥7.6.0<br><8.0.0 | [✓ ¹](/reference/setup-auto-instrumentation.md) | [✓](/reference/setup-elasticsearch.md) | ✗ |
 | Entity Framework Core<br>`Microsoft.EntityFrameworkCore`<br>{applies_to}`apm_agent_dotnet: ga 1.0` | ≥8.0.0<br>≤10.0.x | [✓ ¹](/reference/setup-auto-instrumentation.md) | [✓](/reference/setup-ef-core.md) | ✗ |
 | Entity Framework 6<br>`EntityFramework`<br>{applies_to}`apm_agent_dotnet: ga 1.2` | ≥6.2<br>≤6.5.2 | ✗ | [✓](/reference/setup-ef6.md) | ✗ |
 | MongoDB<br>`MongoDB.Driver`<br>{applies_to}`apm_agent_dotnet: ga 1.9` | ≥3.0.0<br><4.0.0 | [✓ (≥3.7.0)](/reference/setup-auto-instrumentation.md) | [✓](/reference/setup-mongo-db.md) | [✓ (≥3.7.0)](/reference/opentelemetry-bridge.md) |
 | MySQL<br>`MySql.Data`<br>{applies_to}`apm_agent_dotnet: ga 1.12` | ≥6.7.0<br><9.0.0 | [✓](/reference/setup-auto-instrumentation.md) | ✗ | ✗ |
-| Oracle.ManagedDataAccess<br>{applies_to}`apm_agent_dotnet: ga 1.12` | 4.122.x | [✓](/reference/setup-auto-instrumentation.md) | ✗ | ✗ |
-| Oracle.ManagedDataAccess.Core<br>{applies_to}`apm_agent_dotnet: ga 1.12` | ≥2.0.0<br><4.0.0 | [✓](/reference/setup-auto-instrumentation.md) | ✗ | ✗ |
+| Oracle<br>`Oracle.ManagedDataAccess`<br>{applies_to}`apm_agent_dotnet: ga 1.12` | 4.122.x | [✓](/reference/setup-auto-instrumentation.md) | ✗ | ✗ |
+| Oracle<br>`Oracle.ManagedDataAccess.Core`<br>{applies_to}`apm_agent_dotnet: ga 1.12` | ≥2.0.0<br><4.0.0 | [✓](/reference/setup-auto-instrumentation.md) | ✗ | ✗ |
 | PostgreSQL<br>`Npgsql`<br>{applies_to}`apm_agent_dotnet: ga 1.12` | ≥4.0.0<br><8.0.0 | [✓](/reference/setup-auto-instrumentation.md) | ✗ | ✗ |
 | Redis<br>`StackExchange.Redis`<br>{applies_to}`apm_agent_dotnet: ga 1.8` | ≥2.0.495<br><3.0.0 | ✗ | [✓ ²](/reference/setup-stackexchange-redis.md) | ✗ |
-| System.Data.SqlClient<br>{applies_to}`apm_agent_dotnet: ga 1.0` | ≥4.0.0<br><5.0.0 | [✓](/reference/setup-auto-instrumentation.md) | [✓](/reference/setup-sqlclient.md) | ✗ |
-| Microsoft.Data.SqlClient<br>{applies_to}`apm_agent_dotnet: ga 1.0` | ≥1.0.0<br><6.0.0 | [✓](/reference/setup-auto-instrumentation.md) | [✓](/reference/setup-sqlclient.md) | ✗ |
-| Microsoft.Data.Sqlite<br>{applies_to}`apm_agent_dotnet: ga 1.12` | ≥2.0.0<br><9.0.0 | [✓](/reference/setup-auto-instrumentation.md) | ✗ | ✗ |
-| System.Data.SQLite<br>{applies_to}`apm_agent_dotnet: ga 1.12` | ≥1.0.0<br><3.0.0 | [✓](/reference/setup-auto-instrumentation.md) | ✗ | ✗ |
+| MS SQL<br>`System.Data.SqlClient`<br>{applies_to}`apm_agent_dotnet: ga 1.0` | ≥4.0.0<br><5.0.0 | [✓](/reference/setup-auto-instrumentation.md) | [✓](/reference/setup-sqlclient.md) | ✗ |
+| MS SQL<br>`Microsoft.Data.SqlClient`<br>{applies_to}`apm_agent_dotnet: ga 1.0` | ≥1.0.0<br><6.0.0 | [✓](/reference/setup-auto-instrumentation.md) | [✓](/reference/setup-sqlclient.md) | ✗ |
+| SQLLite<br>`Microsoft.Data.Sqlite`<br>{applies_to}`apm_agent_dotnet: ga 1.12` | ≥2.0.0<br><9.0.0 | [✓](/reference/setup-auto-instrumentation.md) | ✗ | ✗ |
+| SQLLite<br>`System.Data.SQLite`<br>{applies_to}`apm_agent_dotnet: ga 1.12` | ≥1.0.0<br><3.0.0 | [✓](/reference/setup-auto-instrumentation.md) | ✗ | ✗ |
 
 ¹ Via startup hook on .NET.
 ² Requires calling `connection.UseElasticApm()` on each `IConnectionMultiplexer` instance - see the [setup page](/reference/setup-stackexchange-redis.md).
@@ -131,7 +131,7 @@ Streaming is not supported - the agent does not create transactions or spans for
 | Messaging system | Supported versions | [Profiler](/reference/setup-auto-instrumentation.md) | NuGet | OpenTelemetry Bridge |
 | --- | --- | :---: | :---: | :---: |
 | Azure Service Bus<br>`Azure.Messaging.ServiceBus`<br>{applies_to}`apm_agent_dotnet: ga 1.10` | ≥7.0.0<br><8.0.0 | [✓](/reference/setup-auto-instrumentation.md) | [✓](/reference/setup-azure-servicebus.md) | [✓](/reference/opentelemetry-bridge.md) |
-| Azure Service Bus, legacy<br>`Microsoft.Azure.ServiceBus`<br>{applies_to}`apm_agent_dotnet: ga 1.10` | ≥3.0.0<br><6.0.0 | ✗ | [✓](/reference/setup-azure-servicebus.md) | ✗ |
+| Azure Service Bus (legacy)<br>`Microsoft.Azure.ServiceBus`<br>{applies_to}`apm_agent_dotnet: ga 1.10` | ≥3.0.0<br><6.0.0 | ✗ | [✓](/reference/setup-azure-servicebus.md) | ✗ |
 | Kafka<br>`Confluent.Kafka`<br>{applies_to}`apm_agent_dotnet: ga 1.12` | ≥1.4.0<br><3.0.0 | [✓](/reference/setup-auto-instrumentation.md) | ✗ | [✓ via adapter ¹](/reference/setup-kafka.md) |
 | RabbitMQ<br>`RabbitMQ.Client`<br>{applies_to}`apm_agent_dotnet: ga 1.12` | ≥3.6.9<br><7.0.0 | [✓](/reference/setup-auto-instrumentation.md) | ✗ | ✗ |
 

--- a/docs/reference/supported-technologies.md
+++ b/docs/reference/supported-technologies.md
@@ -107,7 +107,7 @@ Streaming is not supported - the agent does not create transactions or spans for
 | MS SQL<br>`System.Data.SqlClient`<br>{applies_to}`apm_agent_dotnet: ga 1.0` | ≥4.0.0<br><5.0.0 | [✓](/reference/setup-auto-instrumentation.md) | [✓](/reference/setup-sqlclient.md) | ✗ |
 | MS SQL<br>`Microsoft.Data.SqlClient`<br>{applies_to}`apm_agent_dotnet: ga 1.0` | ≥1.0.0<br><6.0.0 | [✓](/reference/setup-auto-instrumentation.md) | [✓](/reference/setup-sqlclient.md) | ✗ |
 | SQLite<br>`Microsoft.Data.Sqlite`<br>{applies_to}`apm_agent_dotnet: ga 1.12` | ≥2.0.0<br><9.0.0 | [✓](/reference/setup-auto-instrumentation.md) | ✗ | ✗ |
-| SQLLite<br>`System.Data.SQLite`<br>{applies_to}`apm_agent_dotnet: ga 1.12` | ≥1.0.0<br><3.0.0 | [✓](/reference/setup-auto-instrumentation.md) | ✗ | ✗ |
+| SQLite<br>`System.Data.SQLite`<br>{applies_to}`apm_agent_dotnet: ga 1.12` | ≥1.0.0<br><3.0.0 | [✓](/reference/setup-auto-instrumentation.md) | ✗ | ✗ |
 
 ¹ Via startup hook on .NET.
 

--- a/docs/reference/supported-technologies.md
+++ b/docs/reference/supported-technologies.md
@@ -38,7 +38,7 @@ On .NET Framework, we strongly recommend at least .NET Framework 4.7.2 because o
 
 ## Installation methods [supported-installation-methods]
 
-Each table below shows which installation methods apply to each technology. A checkmark (✓) means the technology is supported via that installation method for the listed version range; a cross (✗) means it is not supported via that method. Where a cell shows a version qualifier such as `(≥3.7.0)`, only that narrower range is covered by that method.
+Each table below shows which installation methods apply to each technology. A checkmark (✓) means the technology is supported with that installation method for the listed version range; a cross (✗) means it is not supported using that method. Where a cell shows a version qualifier such as `(≥3.7.0)`, only that narrower range is covered by that method.
 
 ::::{note}
 The **OpenTelemetry Bridge** column requires .NET 8+ and APM Server ≥7.16. A checkmark there means the technology is covered through the built-in OpenTelemetry Bridge, whether the agent was installed via the Profiler or a NuGet package.

--- a/docs/reference/supported-technologies.md
+++ b/docs/reference/supported-technologies.md
@@ -61,7 +61,7 @@ For supported web frameworks, the agent creates one transaction per incoming req
 | ASP.NET Core<br>{applies_to}`apm_agent_dotnet: ga 1.0` | ≥8.0.0<br>≤10.0.x | [✓ ¹](/reference/setup-auto-instrumentation.md) | [✓](/reference/setup-asp-net-core.md) | ✗ |
 | ASP.NET (.NET Framework) in IIS<br>{applies_to}`apm_agent_dotnet: ga 1.1` | 4.6.2–4.8.1 (IIS 10) | [✓](/reference/setup-auto-instrumentation.md) | [✓](/reference/setup-asp-dot-net.md) | ✗ |
 
-¹ Via startup hook on .NET.
+¹ Using a startup hook on .NET.
 
 ::::{note}
 We support ASP.NET on IIS 10 versions supported by Microsoft per their [IIS support policy](https://learn.microsoft.com/lifecycle/products/internet-information-services-iis). IIS must be installed on a [supported](https://learn.microsoft.com/windows/release-health/windows-server-release-info#windows-server-major-versions-by-servicing-option--) Windows operating system version.

--- a/docs/reference/supported-technologies.md
+++ b/docs/reference/supported-technologies.md
@@ -150,7 +150,7 @@ For supported Azure Functions hosting models, the agent creates one transaction 
 | Azure Functions in-process<br>`Microsoft.Azure.Functions.Extensions`<br>{applies_to}`apm_agent_dotnet: ga 1.24` | ≥1.1.0<br><2.0.0 | ✗ | [✓](/reference/setup-azure-functions.md) | ✗ |
 
 ::::{note}
-Only HTTP-triggered invocations are traced. System metrics are not collected because of a concern with unintentionally increasing Azure Functions costs on Consumption plans.
+Only HTTP-triggered invocations are traced. To avoid unintentionally increasing Azure Functions costs on Consumption plans, system metrics are not collected.
 
 The isolated worker model requires .NET 8+. The in-process model is [deprecated by Microsoft](https://learn.microsoft.com/en-us/azure/azure-functions/migrate-dotnet-in-process-to-isolated) - new apps should use the isolated worker model.
 ::::

--- a/docs/reference/supported-technologies.md
+++ b/docs/reference/supported-technologies.md
@@ -11,114 +11,159 @@ applies_to:
 
 # Supported technologies [supported-technologies]
 
-The APM Agent for .NET supports the technologies listed below.
+The tables below summarize the technologies the APM Agent for .NET supports, the package or runtime versions we test, and which installation methods work for each one. Versions beyond the listed upper bound have not been tested and are not supported, but may work.
 
-Elastic supports OpenTelemetry, which allows logs, metrics, and trace signal collection for many of these technologies. Consider using the [EDOT .NET SDK](elastic-otel-dotnet://reference/edot-dotnet/index.md) for observability data so you continue to get the full power of Elastic's platform.
+If you are already using OpenTelemetry, consider the [EDOT .NET SDK](elastic-otel-dotnet://reference/edot-dotnet/index.md) for traces, metrics, and logs. It covers many of these technologies and fits naturally with Elastic's observability platform.
 
-## .NET versions [supported-dotnet-flavors]
+## Supported .NET runtimes [supported-dotnet-runtimes]
 
-The APM Agent for .NET targets every .NET flavor and version that supports .NET Standard 2.0 or .NET Standard 2.1.
+The APM Agent for .NET libraries and components target .NET Standard 2.0 or .NET Standard 2.1.
 
-However, we only test and support .NET runtimes <= 10.0.x that are also supported per the [Microsoft .NET support policy](https://dotnet.microsoft.com/platform/support/policy/dotnet-core). Therefore, we always recommend you upgrade to a supported runtime before raising issues.
+We support .NET runtimes ≤10.0.x and .NET Framework runtimes from 4.6.2 to 4.8.1 for as long as they receive active support from Microsoft per the [.NET support policy](https://dotnet.microsoft.com/platform/support/policy/dotnet-core) and [.NET Framework support policy](https://dotnet.microsoft.com/platform/support/policy/dotnet-framework). When Microsoft ends support for a runtime version, we do too. Issues reported against unsupported runtimes will not be acted on unless they also affect a supported runtime.
 
 ::::{note}
-On .NET Framework, due to binding issues introduced by Microsoft, we recommend at least .NET Framework 4.7.2 for best compatibility.
+On .NET Framework, we strongly recommend at least .NET Framework 4.7.2 because of binding issues introduced by Microsoft.
 ::::
 
+::::{warning}
+Native AOT is not supported. The agent relies on reflection, runtime IL emit, and embedded libraries that are incompatible with AOT compilation. Attempting to use the agent in a Native AOT-published application will fail at runtime.
+::::
+
+## Installation methods [supported-installation-methods]
+
+Each table below shows which installation methods apply to each technology. A checkmark (✓) means the technology is supported via that installation method for the listed version range. Where a cell shows a version qualifier such as `(≥3.7.0)`, only that narrower range is covered by that method.
+
+::::{note}
+The **OpenTelemetry Bridge** column requires .NET 8+ and APM Server ≥7.16. A checkmark there means the library's native OpenTelemetry spans are captured by the agent regardless of whether the agent was installed via the Profiler or a NuGet package — no additional Elastic integration package is needed for that coverage.
+
+The startup hook used by the profiler on .NET 8+ is not available on .NET Framework. Technologies that depend on the startup hook or the OpenTelemetry Bridge therefore need the NuGet install method on .NET Framework. Technologies with no Elastic APM NuGet package, such as `Elastic.Clients.Elasticsearch`, are not supported on .NET Framework.
+::::
+
+| Column | Meaning |
+| --- | --- |
+| **[Profiler](/reference/setup-auto-instrumentation.md)** | Instrumented automatically by the [Elastic APM .NET Profiler](/reference/setup-auto-instrumentation.md) with no code changes. On .NET, a startup hook loads DiagnosticSource subscribers and the built-in OpenTelemetry Bridge. On .NET Framework, the profiler uses IL rewriting instead. |
+| **NuGet** | Install the linked integration NuGet package alongside the core `Elastic.Apm` package and add the setup call to application startup. |
+| **OpenTelemetry Bridge** | The library emits native [OpenTelemetry](https://opentelemetry.io/) spans that the agent captures through its built-in [OpenTelemetry Bridge](/reference/opentelemetry-bridge.md). |
+| **—** | Not supported via this installation method. |
 
 ## Web frameworks [supported-web-frameworks]
 
-Automatic instrumentation for a web framework means a transaction is automatically created for each incoming request and it is named after the registered route.
+For supported web frameworks, the agent creates one transaction per incoming request and names it after the registered route.
 
-Automatic instrumentation is supported for the following web frameworks
+| Framework | Supported versions | [Profiler](/reference/setup-auto-instrumentation.md) | NuGet | OpenTelemetry Bridge |
+| --- | --- | :---: | :---: | :---: |
+| ASP.NET Core {applies_to}`apm_agent_dotnet: ga 1.0` | ≥8.0.0 ≤10.0.x | [✓ ¹](/reference/setup-auto-instrumentation.md) | [✓](/reference/setup-asp-net-core.md) | — |
+| ASP.NET (.NET Framework) in IIS {applies_to}`apm_agent_dotnet: ga 1.1` | 4.6.2–4.8.1 (IIS 10) | [✓](/reference/setup-auto-instrumentation.md) | [✓](/reference/setup-asp-dot-net.md) | — |
 
-| Framework | Supported versions | Integration |
-| --- | --- | --- |
-| ASP.NET Core {applies_to}`apm_agent_dotnet: ga 1.0` | ≥8.0.0 ≤10.0.x | [NuGet package](/reference/setup-asp-net-core.md) |
-| ASP.NET (.NET Framework) in IIS  {applies_to}`apm_agent_dotnet: ga 1.1` | 4.6.2-4.8.1 (IIS 10) | [Profiler auto instrumentation](/reference/setup-auto-instrumentation.md)<br>*or*<br>[NuGet package](/reference/setup-asp-dot-net.md) |
-
-::::{note}
-We support ASP.NET on IIS 10 versions supported by Microsoft per their [IIS support policy](https://learn.microsoft.com/lifecycle/products/internet-information-services-iis).
-IIS must be installed on a [supported](https://learn.microsoft.com/windows/release-health/windows-server-release-info#windows-server-major-versions-by-servicing-option--) Windows operating system version.
-::::
+¹ Via startup hook on .NET.
 
 ::::{note}
-APM Agent auto instrumentation does not support the Web Garden (multi-worker process) mode of IIS.
+We support ASP.NET on IIS 10 versions supported by Microsoft per their [IIS support policy](https://learn.microsoft.com/lifecycle/products/internet-information-services-iis). IIS must be installed on a [supported](https://learn.microsoft.com/windows/release-health/windows-server-release-info#windows-server-major-versions-by-servicing-option--) Windows operating system version.
+
+The profiler does not support the Web Garden (multi-worker process) mode of IIS.
 ::::
 
+## Azure Functions [supported-azure-functions]
 
-## RPC Frameworks [supported-rpc-frameworks]
+For supported Azure Functions hosting models, the agent creates one transaction per HTTP-triggered invocation.
 
-The agent supports gRPC on .NET both on the client and the server side. Every gRPC call is automatically captured by the agent.
+| Hosting model | Supported versions | [Profiler](/reference/setup-auto-instrumentation.md) | NuGet | OpenTelemetry Bridge |
+| --- | --- | :---: | :---: | :---: |
+| Azure Functions isolated worker {applies_to}`apm_agent_dotnet: ga 1.19` | Microsoft.Azure.Functions.Worker ≥2.0.0 | — | [✓](/reference/setup-azure-functions.md) | — |
+| Azure Functions in-process {applies_to}`apm_agent_dotnet: ga 1.24` | Microsoft.Azure.Functions.Extensions ≥1.1.0 | — | [✓](/reference/setup-azure-functions.md) | — |
 
-Streaming is not supported; for streaming use-cases, the agent does not create transactions and spans automatically.
+::::{note}
+Only HTTP-triggered invocations are traced. System metrics are not collected because of a concern with unintentionally increasing Azure Functions costs on Consumption plans.
 
-| Framework | Supported versions | Integration |
-| --- | --- | --- |
-| gRPC {applies_to}`apm_agent_dotnet: ga 1.7` | Grpc.Net.Client ≥2.23.2 <3.0.0 *(client side)* | [NuGet package](/reference/setup-grpc.md) |
-| ASP.NET Core | ≥8.0.0 <10.0.0 *(server side)* | [NuGet package](/reference/setup-asp-net-core.md) |
+The isolated worker model requires .NET 8+. The in-process model is [deprecated by Microsoft](https://learn.microsoft.com/en-us/azure/azure-functions/migrate-dotnet-in-process-to-isolated) — new apps should use the isolated worker model.
+::::
 
+## RPC frameworks [supported-rpc-frameworks]
+
+For supported gRPC frameworks, the agent automatically captures both client-side and server-side calls.
+
+Streaming is not supported — the agent does not create transactions or spans for streaming calls automatically.
+
+| Framework | Supported versions | [Profiler](/reference/setup-auto-instrumentation.md) | NuGet | OpenTelemetry Bridge |
+| --- | --- | :---: | :---: | :---: |
+| gRPC client {applies_to}`apm_agent_dotnet: ga 1.7` | Grpc.Net.Client ≥2.23.2 <3.0.0 | [✓ ¹](/reference/setup-auto-instrumentation.md) | [✓](/reference/setup-grpc.md) | [✓ (≥2.57.0)](/reference/opentelemetry-bridge.md) |
+| gRPC server (ASP.NET Core) {applies_to}`apm_agent_dotnet: ga 1.7` | ≥8.0.0 ≤10.0.x | [✓ ¹](/reference/setup-auto-instrumentation.md) | [✓](/reference/setup-asp-net-core.md) | — |
+
+¹ Via startup hook on .NET.
+
+::::{note}
+`Grpc.Net.Client` ≥2.57.0 emits native OpenTelemetry spans. The OpenTelemetry Bridge provides automatic coverage when using the profiler without the NuGet package. When the NuGet package is installed, the dedicated subscriber takes precedence and the bridge is suppressed to prevent duplicate spans.
+::::
 
 ## Data access technologies [supported-data-access-technologies]
 
-Automatic instrumentation is supported for the following data access technologies
+| Data access technology | Supported versions | [Profiler](/reference/setup-auto-instrumentation.md) | NuGet | OpenTelemetry Bridge |
+| --- | --- | :---: | :---: | :---: |
+| Azure CosmosDB {applies_to}`apm_agent_dotnet: ga 1.11` | Microsoft.Azure.Cosmos ≥3.0.0 <4.0.0 | — | [✓](/reference/setup-azure-cosmosdb.md) | — |
+| Azure DocumentDB, legacy {applies_to}`apm_agent_dotnet: ga 1.11` | Microsoft.Azure.DocumentDB.Core\* ≥2.4.1 <3.0.0; Microsoft.Azure.DocumentDB\* ≥2.4.1 <3.0.0 | — | [✓](/reference/setup-azure-cosmosdb.md) | — |
+| Elasticsearch {applies_to}`apm_agent_dotnet: ga 1.23` | Elastic.Clients.Elasticsearch ≥8.0.0 <10.0.0 | [✓](/reference/setup-auto-instrumentation.md) | — | [✓](/reference/opentelemetry-bridge.md) |
+| Elasticsearch, legacy {applies_to}`apm_agent_dotnet: ga 1.6` | Elasticsearch.Net / NEST ≥7.6.0 <8.0.0 | [✓ ¹](/reference/setup-auto-instrumentation.md) | [✓](/reference/setup-elasticsearch.md) | — |
+| Entity Framework Core {applies_to}`apm_agent_dotnet: ga 1.0` | Microsoft.EntityFrameworkCore ≥8.0.0 ≤10.0.x | [✓ ¹](/reference/setup-auto-instrumentation.md) | [✓](/reference/setup-ef-core.md) | — |
+| Entity Framework 6 {applies_to}`apm_agent_dotnet: ga 1.2` | EntityFramework ≥6.2 ≤6.5.2 | — | [✓](/reference/setup-ef6.md) | — |
+| MongoDB {applies_to}`apm_agent_dotnet: ga 1.9` | MongoDB.Driver ≥3.0.0 <4.0.0 | [✓ (≥3.7.0)](/reference/setup-auto-instrumentation.md) | [✓](/reference/setup-mongo-db.md) | [✓ (≥3.7.0)](/reference/opentelemetry-bridge.md) |
+| MySQL {applies_to}`apm_agent_dotnet: ga 1.12` | MySql.Data ≥6.7.0 <9.0.0 | [✓](/reference/setup-auto-instrumentation.md) | — | — |
+| Oracle.ManagedDataAccess {applies_to}`apm_agent_dotnet: ga 1.12` | Oracle.ManagedDataAccess 4.122.x | [✓](/reference/setup-auto-instrumentation.md) | — | — |
+| Oracle.ManagedDataAccess.Core {applies_to}`apm_agent_dotnet: ga 1.12` | Oracle.ManagedDataAccess.Core ≥2.0.0 <4.0.0 | [✓](/reference/setup-auto-instrumentation.md) | — | — |
+| PostgreSQL {applies_to}`apm_agent_dotnet: ga 1.12` | Npgsql ≥4.0.0 <8.0.0 | [✓](/reference/setup-auto-instrumentation.md) | — | — |
+| Redis {applies_to}`apm_agent_dotnet: ga 1.8` | StackExchange.Redis ≥2.0.495 <3.0.0 | — | [✓ ²](/reference/setup-stackexchange-redis.md) | — |
+| SqlClient {applies_to}`apm_agent_dotnet: ga 1.0` | System.Data.SqlClient ≥4.0.0 <5.0.0; Microsoft.Data.SqlClient ≥1.0.0 <6.0.0 | [✓](/reference/setup-auto-instrumentation.md) | [✓](/reference/setup-sqlclient.md) | — |
+| Microsoft.Data.Sqlite {applies_to}`apm_agent_dotnet: ga 1.12` | Microsoft.Data.Sqlite ≥2.0.0 <9.0.0 | [✓](/reference/setup-auto-instrumentation.md) | — | — |
+| System.Data.SQLite {applies_to}`apm_agent_dotnet: ga 1.12` | System.Data.SQLite ≥1.0.0 <3.0.0 | [✓](/reference/setup-auto-instrumentation.md) | — | — |
 
-| Data access technology | Supported versions | Integration |
-| --- | --- | --- |
-| Azure CosmosDB {applies_to}`apm_agent_dotnet: ga 1.11` | Microsoft.Azure.Cosmos ≥3.0.0 <4.0.0 | [NuGet package](/reference/setup-azure-cosmosdb.md) |
-| Azure DocumentDb {applies_to}`apm_agent_dotnet: ga 1.11` | Microsoft.Azure.DocumentDB.Core\* ≥2.4.1 <3.0.0<br>Microsoft.Azure.DocumentDB\* ≥2.4.1 <3.0.0 | [NuGet package](/reference/setup-azure-cosmosdb.md) |
-| Entity Framework Core {applies_to}`apm_agent_dotnet: ga 1.0` | Microsoft.EntityFrameworkCore ≥8.0.0 <10.0.0 | [NuGet package](/reference/setup-ef-core.md) |
-| Entity Framework 6 {applies_to}`apm_agent_dotnet: ga 1.2` | EntityFramework 6.2-6.5.1 | [NuGet package](/reference/setup-ef6.md) |
-| Elasticsearch {applies_to}`apm_agent_dotnet: ga 1.23` | Elastic.Clients.Elasticsearch ≥8.0.0 <10.0.0 | [OpenTelemetry Bridge](/reference/opentelemetry-bridge.md) |
-| MySQL {applies_to}`apm_agent_dotnet: ga 1.12` | See profiler documentation | [Profiler auto instrumentation](/reference/setup-auto-instrumentation.md) |
-| MongoDB | MongoDB.Driver ≥3.0.0 <4.0.0 | [NuGet package](/reference/setup-mongo-db.md) |
-| Oracle {applies_to}`apm_agent_dotnet: ga 1.12` | See profiler documentation | [Profiler auto instrumentation](/reference/setup-auto-instrumentation.md) |
-| PostgreSQL {applies_to}`apm_agent_dotnet: ga 1.12` | See profiler documentation | [Profiler auto instrumentation](/reference/setup-auto-instrumentation.md) |
-| Redis {applies_to}`apm_agent_dotnet: ga 1.8` | StackExchange.Redis ≥2.0.495 <3.0.0 | [NuGet package](/reference/setup-stackexchange-redis.md) |
-| SqlClient {applies_to}`apm_agent_dotnet: ga 1.8` | System.Data.SqlClient ≥2.0.495 <5.0.0 | [NuGet package](/reference/setup-sqlclient.md) |
-| SQLite {applies_to}`apm_agent_dotnet: ga 1.12` | See profiler documentation | [Profiler auto instrumentation](/reference/setup-auto-instrumentation.md) |
-
+¹ Via startup hook on .NET.
+² Requires calling `connection.UseElasticApm()` on each `IConnectionMultiplexer` instance — see the [setup page](/reference/setup-stackexchange-redis.md).
 
 ::::{note}
 \* `Microsoft.Azure.DocumentDB.Core` and `Microsoft.Azure.DocumentDB` are deprecated. The recommended replacement is the `Microsoft.Azure.Cosmos` package.
+::::
+
+::::{note}
+`Elastic.Clients.Elasticsearch` emits native OpenTelemetry spans. The legacy `Elasticsearch.Net` and `NEST` clients use a `DiagnosticSource`-based subscriber instead.
+::::
+
+::::{note}
+MongoDB.Driver ≥3.7.0 emits native OpenTelemetry spans. When running without the NuGet package (profiler-only install), these are captured automatically by the OpenTelemetry Bridge.
 ::::
 
 ## Messaging systems [supported-messaging-systems]
 
-We support automatic instrumentation for the following messaging systems
+| Messaging system | Supported versions | [Profiler](/reference/setup-auto-instrumentation.md) | NuGet | OpenTelemetry Bridge |
+| --- | --- | :---: | :---: | :---: |
+| Azure Service Bus {applies_to}`apm_agent_dotnet: ga 1.10` | Azure.Messaging.ServiceBus ≥7.0.0 <8.0.0 | [✓](/reference/setup-auto-instrumentation.md) | [✓](/reference/setup-azure-servicebus.md) | [✓](/reference/opentelemetry-bridge.md) |
+| Azure Service Bus, legacy {applies_to}`apm_agent_dotnet: ga 1.10` | Microsoft.Azure.ServiceBus ≥3.0.0 <6.0.0 | — | [✓](/reference/setup-azure-servicebus.md) | — |
+| Kafka {applies_to}`apm_agent_dotnet: ga 1.12` | Confluent.Kafka ≥1.4.0 <3.0.0 | [✓](/reference/setup-auto-instrumentation.md) | — | [✓ ¹](/reference/setup-kafka.md) |
+| RabbitMQ {applies_to}`apm_agent_dotnet: ga 1.12` | RabbitMQ.Client ≥3.6.9 <7.0.0 | [✓](/reference/setup-auto-instrumentation.md) | — | — |
 
-| Messaging system | Supported versions | Integration |
-| --- | --- | --- |
-| Azure Service Bus {applies_to}`apm_agent_dotnet: ga 1.10` | Microsoft.Azure.ServiceBus ≥3.0.0 <6.0.0<br>Azure.Messaging.ServiceBus ≥7.0.0 <8.0.0 | [NuGet package](/reference/setup-azure-servicebus.md) |
-| Azure Queue Storage {applies_to}`apm_agent_dotnet: ga 1.10` | Azure.Storage.Queues ≥12.6.0 <13.0.0 | [NuGet package](/reference/setup-azure-storage.md) |
-| Kafka {applies_to}`apm_agent_dotnet: ga 1.12` | See profiler documentation<br>Confluent.Kafka ≥2.11.1 <3.0.0 | [Profiler auto instrumentation](/reference/setup-auto-instrumentation.md)<br>[NuGet package](/reference/setup-kafka.md) |
-| RabbitMQ {applies_to}`apm_agent_dotnet: ga 1.12` | See profiler documentation | [Profiler auto instrumentation](/reference/setup-auto-instrumentation.md) |
+¹ Requires [`Confluent.Kafka.Extensions.Diagnostics`](https://www.nuget.org/packages/Confluent.Kafka.Extensions.Diagnostics) to wrap producers and consumers to emit spans captured by the OpenTelemetry Bridge. Code changes are required — see the [setup page](/reference/setup-kafka.md).
 
+::::{note}
+`Azure.Messaging.ServiceBus` emits native OpenTelemetry spans. The OpenTelemetry Bridge provides automatic coverage when using the profiler without the NuGet package. When the NuGet package is installed, the dedicated subscriber takes precedence and the bridge is suppressed to prevent duplicate spans.
+
+The legacy `Microsoft.Azure.ServiceBus` package does not emit native OpenTelemetry spans and requires the NuGet package.
+::::
+
+## Azure Storage [supported-azure-storage]
+
+| Storage service | Supported versions | [Profiler](/reference/setup-auto-instrumentation.md) | NuGet | OpenTelemetry Bridge |
+| --- | --- | :---: | :---: | :---: |
+| Azure Blob Storage {applies_to}`apm_agent_dotnet: ga 1.10` | Azure.Storage.Blobs ≥12.8.0 <13.0.0 | [✓](/reference/setup-auto-instrumentation.md) | [✓](/reference/setup-azure-storage.md) | [✓](/reference/opentelemetry-bridge.md) |
+| Azure Queue Storage {applies_to}`apm_agent_dotnet: ga 1.10` | Azure.Storage.Queues ≥12.6.0 <13.0.0 | [✓](/reference/setup-auto-instrumentation.md) | [✓](/reference/setup-azure-storage.md) | [✓](/reference/opentelemetry-bridge.md) |
+| Azure File Share Storage {applies_to}`apm_agent_dotnet: ga 1.10` | Azure.Storage.Files.Shares ≥12.6.0 <13.0.0 | [✓](/reference/setup-auto-instrumentation.md) | [✓](/reference/setup-azure-storage.md) | [✓](/reference/opentelemetry-bridge.md) |
+
+::::{note}
+For Azure Storage services, the OpenTelemetry Bridge provides automatic coverage when using the profiler without the NuGet package. When the NuGet package is installed, the dedicated subscriber takes precedence and the bridge is suppressed to prevent duplicate spans.
+::::
 
 ## Networking client-side technologies [supported-networking-client-side-technologies]
 
-Automatic instrumentation for networking client-side technology means an HTTP span is automatically created for each outgoing HTTP request and tracing headers are propagated.
+For supported networking client-side technologies, the agent creates an HTTP span for each outgoing request and propagates tracing headers automatically.
 
-| Framework | Supported versions | Integration |
-| --- | --- | --- |
-| System.Net.Http.HttpClient {applies_to}`apm_agent_dotnet: ga 1.0` | *built-in* | [part of Elastic.Apm](/reference/public-api.md#setup-http) |
-| System.Net.HttpWebRequest {applies_to}`apm_agent_dotnet: ga 1.1` | *built-in* | [part of Elastic.Apm](/reference/public-api.md#setup-http) |
-
-
-## Cloud services [supported-cloud-services]
-
-Automatic instrumentation for the following cloud services
-
-| Cloud service | Supported versions | Integration |
-| --- | --- | --- |
-| Azure CosmosDB {applies_to}`apm_agent_dotnet: ga 1.11` | Microsoft.Azure.Cosmos ≥3.0.0 <4.0.0 | [NuGet package](/reference/setup-azure-cosmosdb.md) |
-| Azure DocumentDb {applies_to}`apm_agent_dotnet: ga 1.11` | Microsoft.Azure.DocumentDB.Core\* ≥2.4.1 <3.0.0<br>Microsoft.Azure.DocumentDB\* ≥2.4.1 <3.0.0 | [NuGet package](/reference/setup-azure-cosmosdb.md) |
-| Azure Service Bus {applies_to}`apm_agent_dotnet: ga 1.10` | Microsoft.Azure.ServiceBus ≥3.0.0 <6.0.0<br>Azure.Messaging.ServiceBus ≥7.0.0 <8.0.0 | [NuGet package](/reference/setup-azure-servicebus.md) |
-| Azure Storage {applies_to}`apm_agent_dotnet: ga 1.10` | Azure.Storage.Blobs ≥12.8.0 <13.0.0 | [NuGet package](/reference/setup-azure-storage.md) |
-| Azure Storage Queues {applies_to}`apm_agent_dotnet: ga 1.10` | Azure.Storage.Queues ≥12.6.0 <13.0.0 | [NuGet package](/reference/setup-azure-storage.md) |
-| Azure Storage Files {applies_to}`apm_agent_dotnet: ga 1.10` | Azure.Storage.Files.Shares ≥12.6.0 <13.0.0 | [NuGet package](/reference/setup-azure-storage.md) |
-
-
-::::{note}
-\* `Microsoft.Azure.DocumentDB.Core` and `Microsoft.Azure.DocumentDB` are deprecated. The recommended replacement is the `Microsoft.Azure.Cosmos` package.
-::::
+| Framework | Supported versions | [Profiler](/reference/setup-auto-instrumentation.md) | NuGet | OpenTelemetry Bridge |
+| --- | --- | :---: | :---: | :---: |
+| System.Net.Http.HttpClient {applies_to}`apm_agent_dotnet: ga 1.0` | *built-in (.NET)* | [✓](/reference/setup-auto-instrumentation.md) | [✓](/reference/public-api.md#setup-http) | — |
+| System.Net.HttpWebRequest {applies_to}`apm_agent_dotnet: ga 1.1` | *built-in (.NET)* | [✓](/reference/setup-auto-instrumentation.md) | [✓](/reference/public-api.md#setup-http) | — |

--- a/docs/reference/supported-technologies.md
+++ b/docs/reference/supported-technologies.md
@@ -43,14 +43,12 @@ Each table below shows which installation methods apply to each technology. A ch
 ::::{note}
 The **OpenTelemetry Bridge** column requires .NET 8+ and APM Server ≥7.16. A checkmark there means the technology is covered through the built-in OpenTelemetry Bridge, whether the agent was installed via the Profiler or a NuGet package.
 
-On .NET Framework, technologies that depend on the startup hook or the OpenTelemetry Bridge need the NuGet install method instead.
-
-If no Elastic APM NuGet package exists for that technology, such as `Elastic.Clients.Elasticsearch`, it is not supported on .NET Framework.
+On .NET Framework, technologies that depend on the startup hook or the OpenTelemetry Bridge need the NuGet install method instead. If no Elastic APM NuGet package exists for that technology, such as `Elastic.Clients.Elasticsearch`, it is not supported on .NET Framework.
 ::::
 
 | Column | Meaning |
 | --- | --- |
-| **[Profiler](/reference/setup-auto-instrumentation.md)** | Instrumented automatically by the [Elastic APM .NET Profiler](/reference/setup-auto-instrumentation.md) with no code changes. On .NET, a startup hook loads DiagnosticSource subscribers and the built-in OpenTelemetry Bridge. On .NET Framework, the profiler uses IL rewriting instead. |
+| **[Profiler](/reference/setup-auto-instrumentation.md)** | Instrumented automatically by the [Elastic APM .NET Profiler](/reference/setup-auto-instrumentation.md) with no code changes. On .NET, a startup hook loads `DiagnosticSource` subscribers and the built-in OpenTelemetry Bridge. On .NET Framework, the profiler uses IL rewriting instead. |
 | **NuGet** | Install the linked integration NuGet package alongside the core `Elastic.Apm` package and add the setup call to application startup. |
 | **OpenTelemetry Bridge** | The library emits native [OpenTelemetry](https://opentelemetry.io/) spans that the agent captures through its built-in [OpenTelemetry Bridge](/reference/opentelemetry-bridge.md). |
 
@@ -100,7 +98,7 @@ Streaming is not supported - the agent does not create transactions or spans for
 | Elasticsearch (legacy)<br>`NEST`<br>{applies_to}`apm_agent_dotnet: ga 1.6` | ≥7.6.0<br><8.0.0 | [✓ ¹](/reference/setup-auto-instrumentation.md) | [✓](/reference/setup-elasticsearch.md) | ✗ |
 | Entity Framework Core<br>`Microsoft.EntityFrameworkCore`<br>{applies_to}`apm_agent_dotnet: ga 1.0` | ≥8.0.0<br>≤10.0.x | [✓ ¹](/reference/setup-auto-instrumentation.md) | [✓](/reference/setup-ef-core.md) | ✗ |
 | Entity Framework 6<br>`EntityFramework`<br>{applies_to}`apm_agent_dotnet: ga 1.2` | ≥6.2<br>≤6.5.2 | ✗ | [✓](/reference/setup-ef6.md) | ✗ |
-| MongoDB<br>`MongoDB.Driver`<br>{applies_to}`apm_agent_dotnet: ga 1.9` | ≥3.0.0<br><4.0.0 | [✓ (≥3.7.0)](/reference/setup-auto-instrumentation.md) | [✓](/reference/setup-mongo-db.md) | [✓ (≥3.7.0)](/reference/opentelemetry-bridge.md) |
+| MongoDB<br>`MongoDB.Driver`<br>{applies_to}`apm_agent_dotnet: ga 1.9` | ≥3.0.0<br><4.0.0 | [✓ (≥3.7.0) ³](/reference/setup-auto-instrumentation.md) | [✓](/reference/setup-mongo-db.md) | [✓ (≥3.7.0)](/reference/opentelemetry-bridge.md) |
 | MySQL<br>`MySql.Data`<br>{applies_to}`apm_agent_dotnet: ga 1.12` | ≥6.7.0<br><9.0.0 | [✓](/reference/setup-auto-instrumentation.md) | ✗ | ✗ |
 | Oracle<br>`Oracle.ManagedDataAccess`<br>{applies_to}`apm_agent_dotnet: ga 1.12` | ≥12.2.1100<br><22.0.0 | [✓](/reference/setup-auto-instrumentation.md) | ✗ | ✗ |
 | Oracle<br>`Oracle.ManagedDataAccess.Core`<br>{applies_to}`apm_agent_dotnet: ga 1.12` | ≥2.0.0<br><4.0.0 | [✓](/reference/setup-auto-instrumentation.md) | ✗ | ✗ |
@@ -112,7 +110,10 @@ Streaming is not supported - the agent does not create transactions or spans for
 | SQLLite<br>`System.Data.SQLite`<br>{applies_to}`apm_agent_dotnet: ga 1.12` | ≥1.0.0<br><3.0.0 | [✓](/reference/setup-auto-instrumentation.md) | ✗ | ✗ |
 
 ¹ Via startup hook on .NET.
+
 ² Requires calling `connection.UseElasticApm()` on each `IConnectionMultiplexer` instance - see the [setup page](/reference/setup-stackexchange-redis.md).
+
+³ Requires the OpenTelemetry Bridge to be active. `MongoDB.Driver` ≥3.7.0 emits native OpenTelemetry spans; the profiler captures them through the bridge rather than a dedicated subscriber.
 
 ::::{note}
 `Microsoft.Azure.DocumentDB.Core` and `Microsoft.Azure.DocumentDB` are deprecated. The recommended replacement is the `Microsoft.Azure.Cosmos` package.

--- a/docs/reference/toc.yml
+++ b/docs/reference/toc.yml
@@ -1,6 +1,7 @@
 project: 'APM .NET agent reference'
 toc:
   - file: index.md
+  - file: supported-technologies.md
   - file: set-up-apm-net-agent.md
     children:
       - file: setup-auto-instrumentation.md
@@ -22,7 +23,6 @@ toc:
       - file: setup-azure-storage.md
       - file: setup-mongo-db.md
       - file: setup-kafka.md
-  - file: supported-technologies.md
   - file: configuration.md
     children:
       - file: configuration-on-asp-net-core.md


### PR DESCRIPTION
Fixes #2737

Support cases have highlighted that the supported technologies tables were hard to interpret especially when evaluating the install mechanism to choose. This redesigns the tables and updates the documentation with a view to maker it clearer, easier to scan and more approachable for new users.