### PR TITLE
Ship managed profiler for net8.0

### DIFF
--- a/src/profiler/Elastic.Apm.Profiler.Managed.Loader/Startup.NetCore.cs
+++ b/src/profiler/Elastic.Apm.Profiler.Managed.Loader/Startup.NetCore.cs
@@ -22,10 +22,13 @@ namespace Elastic.Apm.Profiler.Managed.Loader
         private static string ResolveDirectory()
         {
 			var version = Environment.Version;
-			// use netcoreapp3.1 for netcoreapp3.1 and later
-			var framework = version.Major == 3 && version.Minor >= 1 || version.Major >= 6
-				? "netstandard2.1"
-				: "netstandard2.0";
+			string framework;
+			if (version.Major >= 8)
+				framework = "net8.0";
+			else if ((version.Major == 3 && version.Minor >= 1) || version.Major >= 5)
+				framework = "netstandard2.1";
+			else
+				framework = "netstandard2.0";
 
             var directory = ReadEnvironmentVariable("ELASTIC_APM_PROFILER_HOME") ?? string.Empty;
 			Logger.Log(LogLevel.Debug, "Resolving assemblies from {0}", directory);

--- a/src/profiler/Elastic.Apm.Profiler.Managed/CallTarget/Handlers/Continuations/ContinuationGenerator.cs
+++ b/src/profiler/Elastic.Apm.Profiler.Managed/CallTarget/Handlers/Continuations/ContinuationGenerator.cs
@@ -20,7 +20,7 @@ namespace Elastic.Apm.Profiler.Managed.CallTarget.Handlers.Continuations
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
 		protected static TReturn ToTReturn<TFrom>(TFrom returnValue)
 		{
-#if NETSTANDARD2_1_OR_GREATER
+#if NETSTANDARD2_1_OR_GREATER || NET
 			return Unsafe.As<TFrom, TReturn>(ref returnValue);
 #else
 			return ContinuationsHelper.Convert<TFrom, TReturn>(returnValue);
@@ -30,7 +30,7 @@ namespace Elastic.Apm.Profiler.Managed.CallTarget.Handlers.Continuations
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
 		protected static TTo FromTReturn<TTo>(TReturn returnValue)
 		{
-#if NETSTANDARD2_1_OR_GREATER
+#if NETSTANDARD2_1_OR_GREATER || NET
 			return Unsafe.As<TReturn, TTo>(ref returnValue);
 #else
 			return ContinuationsHelper.Convert<TReturn, TTo>(returnValue);

--- a/src/profiler/Elastic.Apm.Profiler.Managed/CallTarget/Handlers/Continuations/ContinuationsHelper.cs
+++ b/src/profiler/Elastic.Apm.Profiler.Managed/CallTarget/Handlers/Continuations/ContinuationsHelper.cs
@@ -39,7 +39,7 @@ namespace Elastic.Apm.Profiler.Managed.CallTarget.Handlers.Continuations
 			return typeof(object);
 		}
 
-#if NETSTANDARD2_1_OR_GREATER
+#if NETSTANDARD2_1_OR_GREATER || NET
 #else
 		internal static TTo Convert<TFrom, TTo>(TFrom value) => Converter<TFrom, TTo>.Convert(value);
 

--- a/src/profiler/Elastic.Apm.Profiler.Managed/CallTarget/Handlers/Continuations/ValueTaskContinuationGenerator.cs
+++ b/src/profiler/Elastic.Apm.Profiler.Managed/CallTarget/Handlers/Continuations/ValueTaskContinuationGenerator.cs
@@ -12,7 +12,7 @@ using System.Threading.Tasks;
 
 namespace Elastic.Apm.Profiler.Managed.CallTarget.Handlers.Continuations
 {
-#if NETSTANDARD2_1_OR_GREATER
+#if NETSTANDARD2_1_OR_GREATER || NET
 	internal class ValueTaskContinuationGenerator<TIntegration, TTarget, TReturn> : ContinuationGenerator<TTarget, TReturn>
 	{
 		private static readonly Func<TTarget, object, Exception, CallTargetState, object> _continuation;

--- a/src/profiler/Elastic.Apm.Profiler.Managed/CallTarget/Handlers/Continuations/ValueTaskContinuationGenerator`1.cs
+++ b/src/profiler/Elastic.Apm.Profiler.Managed/CallTarget/Handlers/Continuations/ValueTaskContinuationGenerator`1.cs
@@ -14,7 +14,7 @@ using System.Threading.Tasks;
 
 namespace Elastic.Apm.Profiler.Managed.CallTarget.Handlers.Continuations
 {
-#if NETSTANDARD2_1_OR_GREATER
+#if NETSTANDARD2_1_OR_GREATER || NET
 	internal class ValueTaskContinuationGenerator<TIntegration, TTarget, TReturn, TResult> : ContinuationGenerator<TTarget, TReturn>
 	{
 		private static readonly Func<TTarget, TResult, Exception, CallTargetState, TResult> _continuation;

--- a/src/profiler/Elastic.Apm.Profiler.Managed/CallTarget/Handlers/EndMethodHandler`1.cs
+++ b/src/profiler/Elastic.Apm.Profiler.Managed/CallTarget/Handlers/EndMethodHandler`1.cs
@@ -46,7 +46,7 @@ namespace Elastic.Apm.Profiler.Managed.CallTarget.Handlers
 						typeof(TaskContinuationGenerator<,,,>).MakeGenericType(typeof(TIntegration), typeof(TTarget), returnType,
 							ContinuationsHelper.GetResultType(returnType)));
 				}
-#if NETSTANDARD2_1_OR_GREATER
+#if NETSTANDARD2_1_OR_GREATER || NET
 				else if (genericReturnType == typeof(ValueTask<>))
 				{
 					// The type is a ValueTask<>
@@ -63,7 +63,7 @@ namespace Elastic.Apm.Profiler.Managed.CallTarget.Handlers
 					// The type is a Task
 					_continuationGenerator = new TaskContinuationGenerator<TIntegration, TTarget, TReturn>();
 				}
-#if NETSTANDARD2_1_OR_GREATER
+#if NETSTANDARD2_1_OR_GREATER || NET
 				else if (returnType == typeof(ValueTask))
 				{
 					// The type is a ValueTask

--- a/src/profiler/Elastic.Apm.Profiler.Managed/DuckTyping/DuckType.cs
+++ b/src/profiler/Elastic.Apm.Profiler.Managed/DuckTyping/DuckType.cs
@@ -114,8 +114,10 @@ namespace Elastic.Apm.Profiler.Managed.DuckTyping
 						// If the proxy type definition is an interface we create an struct proxy
 						// If the proxy type definition is an struct then we use that struct to copy the values from the target type
 						parentType = typeof(ValueType);
+#pragma warning disable SYSLIB0050
 						typeAttributes = TypeAttributes.Public | TypeAttributes.AnsiClass | TypeAttributes.BeforeFieldInit
 							| TypeAttributes.SequentialLayout | TypeAttributes.Sealed | TypeAttributes.Serializable;
+#pragma warning restore SYSLIB0050
 						if (proxyDefinitionType.IsInterface)
 							interfaceTypes = new[] { proxyDefinitionType, typeof(IDuckType) };
 						else

--- a/src/profiler/Elastic.Apm.Profiler.Managed/Elastic.Apm.Profiler.Managed.csproj
+++ b/src/profiler/Elastic.Apm.Profiler.Managed/Elastic.Apm.Profiler.Managed.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net462;netstandard2.0;netstandard2.1</TargetFrameworks>
+    <TargetFrameworks>net462;netstandard2.0;netstandard2.1;net8.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <DefineConstants>$(DefineConstants);PROFILER_MANAGED</DefineConstants>
   </PropertyGroup>


### PR DESCRIPTION
Fixes #2744

This ensures some optimisations on newer runtimes are available when using the profiler installation mechanism.