### PR TITLE
Replace mlugg/setup-zig action with direct download, update cargo-make to 0.37

### DIFF
--- a/.github/workflows/install-dependencies/action.yml
+++ b/.github/workflows/install-dependencies/action.yml
@@ -22,9 +22,13 @@
       # ZIG
       - name: Zig
         if: "${{ inputs.rust == 'true' && runner.os == 'Linux' }}"
-        uses: mlugg/setup-zig@v1
-        with:
-          version: "0.13.0"
+        shell: bash
+        run: |
+          ZIG_DIR="zig-linux-x86_64-0.13.0"
+          wget -q "https://ziglang.org/download/0.13.0/${ZIG_DIR}.tar.xz"
+          tar -xf "${ZIG_DIR}.tar.xz"
+          echo "${GITHUB_WORKSPACE}/${ZIG_DIR}" >> "${GITHUB_PATH}"
+          rm "${ZIG_DIR}.tar.xz"
   
       # RUST
       - name: Rustup
@@ -42,7 +46,7 @@
         uses: baptiste0928/cargo-install@v3
         with:
           crate: cargo-make
-          version: "^0.36.8"
+          version: "^0.37"
   
       - name: Install cargo zigbuild
         if: "${{ inputs.rust == 'true' && runner.os == 'Linux' }}"


### PR DESCRIPTION
The setup-zig action uses node20 which GitHub Actions will force to node24 from June 2026. The latest release still declares node20 with no fix imminent (the project has moved to Codeberg). Replaced with a direct wget from ziglang.org, pinned to 0.13.0 — removing the JS runtime dependency entirely.

Also updated cargo-make constraint from ^0.36.8 to ^0.37. The 0.37.0 breaking change (duckscript 0.8 upgrade) doesn't affect this project as no duckscript tasks are used.