### PR TITLE
Diagnostic logs for loaded assemblies and remove `dotnet` process startup hook file noise

### DIFF
--- a/src/Elastic.Apm/Logging/GlobalLogConfiguration.cs
+++ b/src/Elastic.Apm/Logging/GlobalLogConfiguration.cs
@@ -149,11 +149,11 @@ internal readonly struct GlobalLogConfiguration
 		{
 			try
 			{
-				Directory.CreateDirectory(logFileDirectory); 
+				Directory.CreateDirectory(logFileDirectory);
 			}
 			catch
-			{ 
-				/* best-effort: file logging will fail gracefully if directory can't be created */ 
+			{
+				/* best-effort: file logging will fail gracefully if directory can't be created */
 			}
 		}
 	}

--- a/src/Elastic.Apm/Logging/GlobalLogConfiguration.cs
+++ b/src/Elastic.Apm/Logging/GlobalLogConfiguration.cs
@@ -144,6 +144,18 @@ internal readonly struct GlobalLogConfiguration
 		LogFilePrefix = logFilePrefix;
 
 		AgentLogFilePath = CreateLogFileName();
+
+		if (isActive && (logTarget & GlobalLogTarget.File) == GlobalLogTarget.File)
+		{
+			try
+			{
+				Directory.CreateDirectory(logFileDirectory); 
+			}
+			catch
+			{ 
+				/* best-effort: file logging will fail gracefully if directory can't be created */ 
+			}
+		}
 	}
 
 	internal bool IsActive { get; }

--- a/src/startuphook/Elastic.Apm.StartupHook.Loader/AssemblyLoadLogger.cs
+++ b/src/startuphook/Elastic.Apm.StartupHook.Loader/AssemblyLoadLogger.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Reflection;
+using System.Threading;
 using Elastic.Apm.Logging;
 
 namespace Elastic.Apm.StartupHook.Loader;
@@ -20,6 +21,8 @@ internal static class AssemblyLoadLogger
 
 	private static readonly ConcurrentDictionary<string, byte> Logged = new(StringComparer.OrdinalIgnoreCase);
 
+	private static int _subscribed;
+
 	/// <summary>
 	/// Subscribes to <see cref="AppDomain.AssemblyLoad"/> and logs assemblies as they load.
 	/// Also scans assemblies already loaded at call time. Subscription is established first
@@ -27,6 +30,9 @@ internal static class AssemblyLoadLogger
 	/// </summary>
 	internal static void Subscribe(IApmLogger logger)
 	{
+		if (Interlocked.Exchange(ref _subscribed, 1) == 1)
+			return;
+
 		AppDomain.CurrentDomain.AssemblyLoad += (_, args) => TryLog(logger, args.LoadedAssembly);
 
 		foreach (var assembly in AppDomain.CurrentDomain.GetAssemblies())
@@ -80,7 +86,7 @@ internal static class AssemblyLoadLogger
 		}
 		catch
 		{
-			logger.Error()?.Log("Failed to log assembly load for {Assembly}", assembly.FullName);
+			logger.Error()?.Log("Failed to log loaded assembly");
 		}
 	}
 }

--- a/src/startuphook/Elastic.Apm.StartupHook.Loader/AssemblyLoadLogger.cs
+++ b/src/startuphook/Elastic.Apm.StartupHook.Loader/AssemblyLoadLogger.cs
@@ -1,0 +1,86 @@
+// Licensed to Elasticsearch B.V under
+// one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Reflection;
+using Elastic.Apm.Logging;
+
+namespace Elastic.Apm.StartupHook.Loader;
+
+internal static class AssemblyLoadLogger
+{
+	// Assemblies with no independent diagnostic value — their identity is already captured by
+	// the .NET runtime version string, or they are infrastructure shims.
+	private static readonly HashSet<string> SkipByName = new(StringComparer.OrdinalIgnoreCase)
+		{ "mscorlib", "netstandard", "System.Private.CoreLib", "dotnet" };
+
+	private static readonly ConcurrentDictionary<string, byte> Logged = new(StringComparer.OrdinalIgnoreCase);
+
+	/// <summary>
+	/// Subscribes to <see cref="AppDomain.AssemblyLoad"/> and logs assemblies as they load.
+	/// Also scans assemblies already loaded at call time. Subscription is established first
+	/// so no assembly loaded during the initial scan is missed.
+	/// </summary>
+	internal static void Subscribe(IApmLogger logger)
+	{
+		AppDomain.CurrentDomain.AssemblyLoad += (_, args) => TryLog(logger, args.LoadedAssembly);
+
+		foreach (var assembly in AppDomain.CurrentDomain.GetAssemblies())
+			TryLog(logger, assembly);
+	}
+
+	private static void TryLog(IApmLogger logger, Assembly assembly)
+	{
+		if (!logger.IsEnabled(LogLevel.Debug))
+			return;
+
+		try
+		{
+			var name = assembly.GetName();
+			if (string.IsNullOrEmpty(name.Name) || SkipByName.Contains(name.Name))
+				return;
+
+			// Key on name + assembly version: the same library name can appear multiple times in a
+			// process when different versions are loaded into separate AssemblyLoadContexts (e.g.
+			// plugin hosts, or the agent isolating its own dependencies). Each distinct binding
+			// version is worth logging — it is precisely these conflicts that cause support issues.
+			// Keying on assembly version (not informational version) matches the CLR binding identity.
+			var assemblyVersion = name.Version?.ToString() ?? "unknown";
+			if (!Logged.TryAdd($"{name.Name}|{assemblyVersion}", 0))
+				return;
+
+			// AssemblyInformationalVersion is the most precise — it carries the full semantic
+			// version including pre-release labels and git commit SHA for official packages.
+			// AssemblyVersion is logged separately because it is often locked to a major version
+			// for binary compatibility and may differ significantly from the actual release version.
+			var informationalVersion = assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion;
+			var location = assembly.Location;
+
+			var tokenBytes = name.GetPublicKeyToken();
+			var publicKeyToken = tokenBytes is { Length: > 0 }
+				? BitConverter.ToString(tokenBytes).Replace("-", "").ToLowerInvariant()
+				: "null";
+
+			if (informationalVersion != null)
+			{
+				logger.Debug()?.Log(
+					"Assembly loaded: {AssemblyName}, AssemblyVersion={AssemblyVersion}, InformationalVersion={InformationalVersion}, PublicKeyToken={PublicKeyToken}, Location={Location}",
+					name.Name, assemblyVersion, informationalVersion, publicKeyToken, location);
+			}
+			else
+			{
+				logger.Debug()?.Log(
+					"Assembly loaded: {AssemblyName}, AssemblyVersion={AssemblyVersion}, PublicKeyToken={PublicKeyToken}, Location={Location}",
+					name.Name, assemblyVersion, publicKeyToken, location);
+			}
+		}
+		catch
+		{
+			logger.Error()?.Log("Failed to log assembly load for {Assembly}", assembly.FullName);
+		}
+	}
+}

--- a/src/startuphook/Elastic.Apm.StartupHook.Loader/Loader.cs
+++ b/src/startuphook/Elastic.Apm.StartupHook.Loader/Loader.cs
@@ -39,6 +39,8 @@ namespace Elastic.Apm.StartupHook.Loader
 
 			HostBuilderExtensions.UpdateServiceInformation(Agent.Instance.Service);
 
+			AssemblyLoadLogger.Subscribe(logger);
+
 			static void LoadDiagnosticSubscriber(IDiagnosticsSubscriber diagnosticsSubscriber, IApmLogger logger)
 			{
 				try

--- a/src/startuphook/ElasticApmAgentStartupHook/StartupHook.cs
+++ b/src/startuphook/ElasticApmAgentStartupHook/StartupHook.cs
@@ -34,6 +34,13 @@ internal class StartupHook
 	/// </summary>
 	public static void Initialize()
 	{
+		// DOTNET_STARTUP_HOOKS applies to every .NET process in the environment, including the
+		// dotnet CLI itself when using 'dotnet run', 'dotnet build', 'dotnet watch', etc.
+		// Those CLI host processes are not user applications — bail out immediately so we don't
+		// waste resources initialising the agent in them or produce noise log files.
+		if (Assembly.GetEntryAssembly()?.GetName().Name == "dotnet")
+			return;
+
 		Logger = StartupHookLogger.Create();
 
 		if (!IsNet8OrHigher())

--- a/src/startuphook/ElasticApmAgentStartupHook/StartupHook.cs
+++ b/src/startuphook/ElasticApmAgentStartupHook/StartupHook.cs
@@ -38,7 +38,7 @@ internal class StartupHook
 		// dotnet CLI itself when using 'dotnet run', 'dotnet build', 'dotnet watch', etc.
 		// Those CLI host processes are not user applications — bail out immediately so we don't
 		// waste resources initialising the agent in them or produce noise log files.
-		if (Assembly.GetEntryAssembly()?.GetName().Name == "dotnet")
+		if (string.Equals(Assembly.GetEntryAssembly()?.GetName().Name, "dotnet", StringComparison.OrdinalIgnoreCase))
 			return;
 
 		Logger = StartupHookLogger.Create();


### PR DESCRIPTION
Skips startup hook logging for "dotnet" processes which occurs due to the startup hook mechanism and causes extra log files to be generated, adding noise and overhead.

When an application is run voa the dotnet CLI and startup hook env vars are set for the current sessions or system wide, it results in the `dotnet` process itself being instrumented, causing two log files. At termination, `dotnet stop` also runs causing two additional log files. These are noise and the instrumentation adds overhead. This change skips instrumentation of all `dotnet` processes to avoid these problems.

This change also ports (and improves) an EDOT .NET logging enhancement to track loaded assemblies which may be diagnosticly helpful for complex scenarios.