### PR TITLE
Update System.Diagnostics.PerformanceCounter to remove System.Drawing.Common transitive dependency

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -125,7 +125,7 @@
     <PackageVersion Include="System.Data.SQLite" Version="1.0.112" />
     <PackageVersion Include="System.Data.SqlClient" Version="4.8.6" />
     <PackageVersion Include="System.Diagnostics.DiagnosticSource" Version="8.0.1" />
-    <PackageVersion Include="System.Diagnostics.PerformanceCounter" Version="6.0.1" />
+    <PackageVersion Include="System.Diagnostics.PerformanceCounter" Version="8.0.1" />
     <PackageVersion Include="System.IO.FileSystem.AccessControl" Version="4.7.0" />
     <PackageVersion Include="System.Reflection.Emit" Version="4.3.0" />
     <PackageVersion Include="System.Reflection.Emit.Lightweight" Version="4.3.0" />

--- a/src/Elastic.Apm/Elastic.Apm.csproj
+++ b/src/Elastic.Apm/Elastic.Apm.csproj
@@ -114,11 +114,9 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0' or '$(TargetFramework)'=='netstandard2.1'">
-    <PackageReference Include="System.Diagnostics.PerformanceCounter" VersionOverride="4.5.0" />
     <!-- Used by Ben.Demystifier -->
     <PackageReference Include="System.Reflection.Metadata" />
     <PackageReference Include="System.Threading.Tasks.Extensions" />
-
     <PackageReference Include="System.Threading.Tasks.Dataflow" />
   </ItemGroup>
 

--- a/src/Elastic.Apm/Elastic.Apm.csproj
+++ b/src/Elastic.Apm/Elastic.Apm.csproj
@@ -108,9 +108,7 @@
     <!-- Used by Ben.Demystifier -->
     <PackageReference Include="System.Reflection.Metadata" />
     <PackageReference Include="System.Threading.Tasks.Extensions" />
-
     <PackageReference Include="System.Threading.Tasks.Dataflow" />
-    <PackageReference Include="System.Diagnostics.PerformanceCounter" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0' or '$(TargetFramework)'=='netstandard2.1'">
@@ -120,7 +118,7 @@
     <PackageReference Include="System.Threading.Tasks.Dataflow" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
+  <ItemGroup>
     <PackageReference Include="System.Diagnostics.PerformanceCounter" />
   </ItemGroup>
 


### PR DESCRIPTION
Fixes #2779

## Summary

Bumping to 8.0.1 removes the `System.Drawing.Common` transitive chain (`Security.Permissions` -> `Windows.Extensions` -> `Drawing.Common`) from all resolved dependency graphs. This is safe for all supported TFMs and runtimes.