### PR TITLE
[profiler] Expand tiny method header to fat when IL injection exceeds 63 bytes

### DIFF
--- a/src/profiler/elastic_apm_profiler/src/cil/method.rs
+++ b/src/profiler/elastic_apm_profiler/src/cil/method.rs
@@ -73,6 +73,9 @@ pub struct TinyMethodHeader {
 
 impl TinyMethodHeader {
     pub const MAX_STACK: u8 = 8;
+    /// The maximum code size a tiny header can encode. The code size is stored in the
+    /// upper 6 bits of the single header byte, so the largest representable value is 63.
+    pub const MAX_CODE_SIZE: u8 = 0x3F;
 }
 
 #[derive(Debug)]
@@ -564,6 +567,17 @@ impl Method {
     }
 
     fn update_header(&mut self, len: i64, stack_size: Option<i64>) -> Result<(), Error> {
+        // A tiny header can only encode a code size up to 63 bytes (the size is stored in the
+        // upper 6 bits of a single byte). If growing the method would exceed that limit, expand
+        // it to a fat header first so the new size can be represented. Without this, the header
+        // silently stayed tiny and `code_size << 2` overflowed a u8 when serialized, producing an
+        // invalid method header and an InvalidProgramException at JIT time.
+        if let MethodHeader::Tiny(header) = &self.header {
+            if header.code_size as i64 + len > TinyMethodHeader::MAX_CODE_SIZE as i64 {
+                self.expand_tiny_to_fat();
+            }
+        }
+
         // update code_size and max_stack in method_header
         match &mut self.header {
             MethodHeader::Fat(header) => {
@@ -576,8 +590,7 @@ impl Method {
             }
             MethodHeader::Tiny(header) => {
                 let size = header.code_size as i64 + len as i64;
-                header.code_size = u8::try_from(size)
-                    .or_else(|err| todo!("Expand tiny into fat header!, {:?}", err))?;
+                header.code_size = u8::try_from(size).or(Err(Error::CodeSize))?;
             }
         }
 
@@ -751,5 +764,64 @@ impl Display for Method {
         }
 
         d.finish()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cil::Instruction;
+
+    /// A tiny method whose body is exactly 60 bytes. Injecting a 5-byte `call` prelude grows
+    /// the code size to 65, which no longer fits a tiny header (max 63 bytes) and must be
+    /// expanded to a fat header.
+    ///
+    /// Regression test for a bug where the method silently stayed tiny: `update_header` only
+    /// rejected sizes above `u8::MAX` (255) instead of the tiny limit (63), so `into_bytes`
+    /// then computed `code_size << 2` on a `u8` and overflowed, emitting a corrupt header byte.
+    /// The CLR decoded that as a near-zero-length tiny method and raised
+    /// `InvalidProgramException` when JIT-compiling it (observed on the app's `Main`).
+    #[test]
+    fn insert_prelude_expands_tiny_header_to_fat_when_crossing_limit() {
+        let mut instructions: Vec<Instruction> = (0..59).map(|_| Instruction::nop()).collect();
+        instructions.push(Instruction::ret());
+        let mut method = Method::tiny(instructions).unwrap();
+        assert!(matches!(method.header, MethodHeader::Tiny(_)));
+        assert_eq!(method.header.code_size(), 60);
+
+        method
+            .insert_prelude(vec![Instruction::call(0x0A00_0001)])
+            .unwrap();
+
+        // The header must have been promoted to fat with the correct code size...
+        match &method.header {
+            MethodHeader::Fat(header) => assert_eq!(header.code_size, 65),
+            other => panic!("expected fat header after crossing tiny limit, got {:?}", other),
+        }
+
+        // ...and the serialized header must be a well-formed fat header, not a corrupted
+        // tiny byte. A fat header starts with the FatFormat flag in the low two bits.
+        let bytes = method.into_bytes();
+        assert_eq!(
+            bytes[0] & CorILMethodFlags::CorILMethod_FormatMask.bits(),
+            CorILMethodFlags::CorILMethod_FatFormat.bits()
+        );
+    }
+
+    /// A tiny method that stays within the 63-byte limit after injection must remain tiny.
+    #[test]
+    fn insert_prelude_keeps_tiny_header_when_within_limit() {
+        let mut instructions: Vec<Instruction> = (0..9).map(|_| Instruction::nop()).collect();
+        instructions.push(Instruction::ret()); // 10-byte body
+        let mut method = Method::tiny(instructions).unwrap();
+
+        method
+            .insert_prelude(vec![Instruction::call(0x0A00_0001)])
+            .unwrap(); // -> 15-byte body, still tiny
+
+        match &method.header {
+            MethodHeader::Tiny(header) => assert_eq!(header.code_size, 15),
+            other => panic!("expected tiny header to be retained, got {:?}", other),
+        }
     }
 }


### PR DESCRIPTION
## Summary

The CLR profiler can emit an invalid method header when it injects the startup
hook, causing `System.InvalidProgramException` at process start. Whether an
application is affected depends on the exact IL size of its entry point, so it
looks random: some services crash on startup while others on the same runtime
and profiler version are fine.

This fixes the tiny→fat method-header transition in the IL rewriter.

## Symptom

```
Unhandled exception. System.InvalidProgramException: Common Language Runtime detected an invalid program.
   at Program.Main(String[] args)
```

Setting `CORECLR_ENABLE_PROFILING=0` makes it disappear.

## Steps to reproduce

Fully self-contained: official .NET image + the published profiler release. No
application code beyond the snippet below. Reproduces on **.NET 8**, a supported
target — this is not specific to any newer runtime.

**1. Get the published profiler**

```bash
curl -sLO https://github.com/elastic/apm-agent-dotnet/releases/download/v1.34.5/elastic_apm_profiler_1.34.5-linux-x64.zip
unzip -q elastic_apm_profiler_1.34.5-linux-x64.zip -d prof
```

**2. Build a console app whose `Main` body is 61 bytes of IL**

Six `WriteLine` calls: each is `ldstr` + `call` = 10 bytes, plus `ret` = 61.

```csharp
public class Program
{
    public static void Main(string[] args)
    {
        System.Console.WriteLine("1");
        System.Console.WriteLine("2");
        System.Console.WriteLine("3");
        System.Console.WriteLine("4");
        System.Console.WriteLine("5");
        System.Console.WriteLine("6");
    }
}
```

```xml
<Project Sdk="Microsoft.NET.Sdk">
  <PropertyGroup>
    <OutputType>Exe</OutputType>
    <TargetFramework>net8.0</TargetFramework>
    <AssemblyName>app</AssemblyName>
    <ImplicitUsings>disable</ImplicitUsings>
  </PropertyGroup>
</Project>
```

```bash
dotnet publish -c Release -o out
# verify the IL size — "Code size 61 (0x3d)" for Program::Main
ildasm out/app.dll | grep -A2 "Main(string\[\]"
```

**3. Run it under the profiler**

```bash
docker run --rm --platform linux/amd64 \
  -v "$PWD/prof":/prof:ro -v "$PWD/out":/app:ro \
  -e CORECLR_ENABLE_PROFILING=1 \
  -e CORECLR_PROFILER='{FA65FE15-F085-4681-9B20-95E04F6C03CC}' \
  -e CORECLR_PROFILER_PATH=/prof/libelastic_apm_profiler.so \
  -e ELASTIC_APM_PROFILER_HOME=/prof \
  -e ELASTIC_APM_PROFILER_INTEGRATIONS=/prof/integrations.yml \
  mcr.microsoft.com/dotnet/runtime:8.0 dotnet /app/app.dll
```

**Result**

| | |
|---|---|
| 61-byte `Main`, profiling **on** | ❌ `InvalidProgramException` |
| 61-byte `Main`, profiling **off** (`CORECLR_ENABLE_PROFILING=0`) | ✅ prints 1–6 |
| 51-byte `Main` (five `WriteLine`s), profiling **on** | ✅ prints 1–5 |

**4. The affected range is exactly 59–63 bytes**

Varying only the IL size of `Main` (same image, same profiler, `net8.0`):

| `Main` IL size | Result |
|---|---|
| 57, 58 | ✅ ok |
| **59, 60, 63** | ❌ `InvalidProgramException` |
| 64, 65 | ✅ ok |

With `ELASTIC_APM_PROFILER_LOG=trace`, the crash is preceded by:

```
JITCompilationStarted: name=Program.Main()
Startup hook registered in function_id=... name=Program.Main()
generate_void_il_startup_method: sucessfully injected Elastic.Apm.Profiler.Managed.Loader.Startup
```

## Root cause

`src/profiler/elastic_apm_profiler/src/cil/method.rs`.

`run_il_startup_hook` injects a 5-byte `call` via `Method::insert_prelude`, which
delegates to `update_header`. A **tiny** method header stores the code size in the
**upper 6 bits of a single byte** — max **63**. But the tiny branch checked the
size with `u8::try_from` (max **255**), and the expansion path was an
unimplemented `todo!()`:

```rust
MethodHeader::Tiny(header) => {
    let size = header.code_size as i64 + len as i64;
    header.code_size = u8::try_from(size)
        .or_else(|err| todo!("Expand tiny into fat header!, {:?}", err))?;
}
```

`insert_prelude` never calls `expand_tiny_to_fat` (unlike the calltarget paths in
`process.rs` / `rejit.rs`). So a method whose size after injection lands in
`64..=255` **stays tiny**, and `MethodHeader::into_bytes` then computes
`code_size << 2` on a `u8`, which overflows and drops the high bits:

```rust
MethodHeader::Tiny(header) => {
    let byte = header.code_size << 2 | CorILMethod_TinyFormat; // 65u8 << 2 overflows to 4
    vec![byte]
}
```

For a 60-byte `Main`: 60 + 5 = 65 → stays tiny → `65u8 << 2` = 4 → header byte
`0x06` → the CLR decodes "tiny method, code size 1" while 65 bytes of IL follow →
invalid program.

This explains the 59–63 range exactly. Bodies ≤58 bytes still fit after injection;
bodies ≥64 bytes are already emitted with a **fat** header by the compiler and take
the correct `Fat` branch. Only 59–63 start tiny *and* cross the limit. It lands on
`Main` because that is the first method JIT-compiled, which is where the startup
hook is injected.

## Fix

Promote a tiny header to fat (via the existing `expand_tiny_to_fat`) whenever the
updated code size would exceed 63 bytes, and replace the misleading `todo!()` with
a normal `Error::CodeSize`. This also covers `insert` and `replace`, which share
`update_header`.

## Tests

Adds two regression tests to `cil::method`:

- `insert_prelude_expands_tiny_header_to_fat_when_crossing_limit` — a 60-byte tiny
  method + 5-byte `call` prelude must become a valid **fat** header. Fails on the
  current code with `expected fat header after crossing tiny limit, got
  Tiny(TinyMethodHeader { code_size: 65 })`.
- `insert_prelude_keeps_tiny_header_when_within_limit` — a small method stays tiny.

`cargo test --lib` → 12 passed (2 new + 10 existing), no regressions.

## Notes

- No public API change; the behavior change is limited to which header format is
  chosen during IL rewriting.
- Reproduced against `v1.34.5`; the same code is still present on `main`.
