### PR TITLE
Ensure we don't block TLS 1.3 negotiation

### DIFF
--- a/src/Elastic.Apm/BackendComm/BackendCommUtils.cs
+++ b/src/Elastic.Apm/BackendComm/BackendCommUtils.cs
@@ -30,6 +30,12 @@ namespace Elastic.Apm.BackendComm
 
 		private static readonly TimeSpan DnsTimeout = TimeSpan.FromMinutes(1);
 
+#if NET462
+		internal static SecurityProtocolType EnsureTls12ForExplicitSecurityProtocols(SecurityProtocolType protocols) =>
+			// SecurityProtocolType.SystemDefault is zero but is unavailable in the net462 reference assemblies.
+			protocols == 0 ? protocols : protocols | SecurityProtocolType.Tls12;
+#endif
+
 		internal static class ApmServerEndpoints
 		{
 			/// <summary>
@@ -124,7 +130,7 @@ namespace Elastic.Apm.BackendComm
 				servicePoint.ConnectionLimit = 20;
 			});
 
-		private static HttpClientHandler CreateHttpClientHandler(IConfiguration configuration, IApmLogger logger)
+		internal static HttpClientHandler CreateHttpClientHandler(IConfiguration configuration, IApmLogger logger)
 		{
 #if NET462 // SSL options are not available in .NET Framework 4.6.2
 			try
@@ -210,12 +216,24 @@ namespace Elastic.Apm.BackendComm
 				UseDefaultCredentials = configuration.UseWindowsCredentials
 			};
 
-#if NETSTANDARD || NET472
-			httpClientHandler.SslProtocols |= SslProtocols.Tls12;
-			logger.Info()?.Log("CreateHttpClientHandler - SslProtocols: {SslProtocols}", ServicePointManager.SecurityProtocol);
+#if NET462
+			// HttpClientHandler.SslProtocols requires .NET Framework 4.7.1 or later, so protocols cannot be
+			// selected for this handler alone on this target. Preserve the existing TLS 1.2 opt-in when
+			// the host uses an explicit protocol list, but do not replace the OS-managed SystemDefault value.
+			var currentProtocols = ServicePointManager.SecurityProtocol;
+			var securityProtocols = EnsureTls12ForExplicitSecurityProtocols(currentProtocols);
+			if (securityProtocols == 0)
+				logger.Info()?.Log("CreateHttpClientHandler - SecurityProtocol: SystemDefault (OS default)");
+			else
+			{
+				if (securityProtocols != currentProtocols)
+					ServicePointManager.SecurityProtocol = securityProtocols;
+				logger.Info()?.Log("CreateHttpClientHandler - SecurityProtocol: {SecurityProtocol}", securityProtocols);
+			}
 #else
-			ServicePointManager.SecurityProtocol |= SecurityProtocolType.Tls12;
-			logger.Info()?.Log("CreateHttpClientHandler - SslProtocols: {SslProtocols}", ServicePointManager.SecurityProtocol);
+			// Defer protocol selection to the operating system so newer protocols can be used automatically.
+			httpClientHandler.SslProtocols = SslProtocols.None;
+			logger.Info()?.Log("CreateHttpClientHandler - SslProtocols: {SslProtocols} (OS default)", httpClientHandler.SslProtocols);
 #endif
 
 #if !NET462

--- a/test/Elastic.Apm.Tests/BackendCommTests/BackendCommUtilsTests.cs
+++ b/test/Elastic.Apm.Tests/BackendCommTests/BackendCommUtilsTests.cs
@@ -3,7 +3,14 @@
 // See the LICENSE file in the project root for more information
 
 using System;
+#if NET462
+using System.Net;
+#else
+using System.Net.Http;
+using System.Security.Authentication;
+#endif
 using Elastic.Apm.Api;
+using Elastic.Apm.BackendComm;
 using Elastic.Apm.Tests.Utilities;
 using FluentAssertions;
 using Xunit;
@@ -18,6 +25,25 @@ namespace Elastic.Apm.Tests.BackendCommTests
 	public class BackendCommUtilsTests : LoggingTestBase
 	{
 		public BackendCommUtilsTests(ITestOutputHelper xUnitOutputHelper) : base(xUnitOutputHelper) { }
+
+#if NET462
+		[Theory]
+		[InlineData(0, 0)]
+		[InlineData((int)SecurityProtocolType.Tls, (int)(SecurityProtocolType.Tls | SecurityProtocolType.Tls12))]
+		[InlineData((int)SecurityProtocolType.Tls12, (int)SecurityProtocolType.Tls12)]
+		public void EnsureTls12ForExplicitSecurityProtocols_preserves_system_default_and_adds_tls12(int input, int expected) =>
+			BackendCommUtils.EnsureTls12ForExplicitSecurityProtocols((SecurityProtocolType)input)
+				.Should()
+				.Be((SecurityProtocolType)expected);
+#else
+		[Fact]
+		public void CreateHttpClientHandler_uses_os_default_tls_protocols()
+		{
+			using var handler = BackendCommUtils.CreateHttpClientHandler(new MockConfiguration(), new NoopLogger());
+
+			handler.SslProtocols.Should().Be(SslProtocols.None);
+		}
+#endif
 
 		[Theory]
 		[InlineData("http://1.2.3.4", "My svc", "My env", "http://1.2.3.4/config/v1/agents?service.name=My+svc&service.environment=My+env")]


### PR DESCRIPTION
Don't block TLS 1.3 negotiation on any target framework

Previously, the agent explicitly restricted outgoing HTTPS connections to TLS 1.2, which prevented TLS 1.3 from being negotiated even on operating systems that support it (e.g., Windows 11+). This affected all supported target frameworks.

This change lets the operating system pick the best available TLS protocol (matching Microsoft's recommended best practice), instead of hardcoding TLS 1.2. As a result, the agent can now use TLS 1.3 where the OS/runtime supports it, while still working the same as before everywhere else.

**Note for consumers:** environments that require TLS 1.2 as a strict minimum via OS/registry policy should ensure that's configured at the OS level, since the agent no longer forces it independently of the OS configuration.