### PR TITLE
Eliminate enumerator boxing in `TransactionNameGroups`

### DIFF
--- a/src/Elastic.Apm/BackendComm/CentralConfig/CentralConfiguration.cs
+++ b/src/Elastic.Apm/BackendComm/CentralConfig/CentralConfiguration.cs
@@ -94,7 +94,7 @@ namespace Elastic.Apm.BackendComm.CentralConfig
 
 		internal IReadOnlyList<WildcardMatcher> TransactionIgnoreUrls { get; private set; }
 
-		internal IReadOnlyCollection<WildcardMatcher> TransactionNameGroups { get; private set; }
+		internal IReadOnlyList<WildcardMatcher> TransactionNameGroups { get; private set; }
 
 		internal int? TransactionMaxSpans { get; private set; }
 

--- a/src/Elastic.Apm/BackendComm/CentralConfig/RuntimeConfigurationSnapshot.cs
+++ b/src/Elastic.Apm/BackendComm/CentralConfig/RuntimeConfigurationSnapshot.cs
@@ -117,8 +117,8 @@ namespace Elastic.Apm.BackendComm.CentralConfig
 		public IReadOnlyList<WildcardMatcher> TransactionIgnoreUrls =>
 			_dynamicConfiguration?.TransactionIgnoreUrls ?? _mainConfiguration.TransactionIgnoreUrls;
 
-		public IReadOnlyCollection<WildcardMatcher> TransactionNameGroups =>
-			 _dynamicConfiguration?.TransactionNameGroups ?? _mainConfiguration.TransactionNameGroups;
+		public IReadOnlyList<WildcardMatcher> TransactionNameGroups =>
+			_dynamicConfiguration?.TransactionNameGroups ?? _mainConfiguration.TransactionNameGroups;
 
 		public int TransactionMaxSpans => _dynamicConfiguration?.TransactionMaxSpans ?? _mainConfiguration.TransactionMaxSpans;
 

--- a/src/Elastic.Apm/Config/AbstractConfigurationReader.cs
+++ b/src/Elastic.Apm/Config/AbstractConfigurationReader.cs
@@ -514,7 +514,7 @@ namespace Elastic.Apm.Config
 			}
 		}
 
-		protected IReadOnlyCollection<WildcardMatcher> ParseTransactionNameGroups(ConfigurationKeyValue kv)
+		protected IReadOnlyList<WildcardMatcher> ParseTransactionNameGroups(ConfigurationKeyValue kv)
 		{
 			if (kv?.Value == null)
 				return DefaultValues.TransactionNameGroups;

--- a/src/Elastic.Apm/Config/ConfigConsts.cs
+++ b/src/Elastic.Apm/Config/ConfigConsts.cs
@@ -78,7 +78,7 @@ namespace Elastic.Apm.Config
 
 			public static readonly IReadOnlyList<WildcardMatcher> TransactionIgnoreUrls;
 
-			public static readonly IReadOnlyCollection<WildcardMatcher> TransactionNameGroups = new List<WildcardMatcher>().AsReadOnly();
+			public static readonly IReadOnlyList<WildcardMatcher> TransactionNameGroups = new List<WildcardMatcher>().AsReadOnly();
 
 			static DefaultValues()
 			{

--- a/src/Elastic.Apm/Config/FallbackToEnvironmentConfigurationBase.cs
+++ b/src/Elastic.Apm/Config/FallbackToEnvironmentConfigurationBase.cs
@@ -245,7 +245,7 @@ namespace Elastic.Apm.Config
 
 		public IReadOnlyList<WildcardMatcher> TransactionIgnoreUrls { get; }
 
-		public IReadOnlyCollection<WildcardMatcher> TransactionNameGroups { get; }
+		public IReadOnlyList<WildcardMatcher> TransactionNameGroups { get; }
 
 		public int TransactionMaxSpans { get; }
 

--- a/src/Elastic.Apm/Config/IConfigurationReader.cs
+++ b/src/Elastic.Apm/Config/IConfigurationReader.cs
@@ -390,7 +390,7 @@ namespace Elastic.Apm.Config
 		///	name cardinality."
 		/// </para>
 		/// </remarks>
-		IReadOnlyCollection<WildcardMatcher> TransactionNameGroups { get; }
+		IReadOnlyList<WildcardMatcher> TransactionNameGroups { get; }
 
 		/// <summary>
 		/// The number of spans that are recorded per transaction.

--- a/src/Elastic.Apm/Helpers/WildcardMatcher.cs
+++ b/src/Elastic.Apm/Helpers/WildcardMatcher.cs
@@ -108,15 +108,15 @@ namespace Elastic.Apm.Helpers
 		/// <param name="firstPart"> The first part of the string to match against.</param>
 		/// <param name="secondPart"> The second part of the string to match against.</param>
 		/// <returns>The first matching <see cref="WildcardMatcher" />, or <code>null</code> if none match.</returns>
-		internal static WildcardMatcher AnyMatch(IReadOnlyCollection<WildcardMatcher> matchers, string firstPart, string secondPart)
+		internal static WildcardMatcher AnyMatch(IReadOnlyList<WildcardMatcher> matchers, string firstPart, string secondPart)
 		{
 			if (matchers is null)
 				return null;
 
-			foreach (var m in matchers)
+			for (var i = 0; i < matchers.Count; i++)
 			{
-				if (m.Matches(firstPart, secondPart))
-					return m;
+				if (matchers[i].Matches(firstPart, secondPart))
+					return matchers[i];
 			}
 
 			return null;

--- a/test/Elastic.Apm.Feature.Tests/TestConfiguration.cs
+++ b/test/Elastic.Apm.Feature.Tests/TestConfiguration.cs
@@ -66,7 +66,7 @@ namespace Elastic.Apm.Feature.Tests
 		public string TraceContinuationStrategy { get; } = DefaultValues.TraceContinuationStrategy;
 		public IReadOnlyList<WildcardMatcher> TransactionIgnoreUrls { get; set; } = DefaultValues.TransactionIgnoreUrls;
 		public int TransactionMaxSpans { get; set; } = DefaultValues.TransactionMaxSpans;
-		public IReadOnlyCollection<WildcardMatcher> TransactionNameGroups { get; set; } = DefaultValues.TransactionNameGroups;
+		public IReadOnlyList<WildcardMatcher> TransactionNameGroups { get; set; } = DefaultValues.TransactionNameGroups;
 		public double TransactionSampleRate { get; set; } = DefaultValues.TransactionSampleRate;
 		public bool UseElasticTraceparentHeader { get; set; } = DefaultValues.UseElasticTraceparentHeader;
 		public bool UsePathAsTransactionName { get; set; } = DefaultValues.UsePathAsTransactionName;

--- a/test/Elastic.Apm.Tests/ConstructorTests.cs
+++ b/test/Elastic.Apm.Tests/ConstructorTests.cs
@@ -150,7 +150,7 @@ public class ConstructorTests
 
 		public int TransactionMaxSpans => ConfigConsts.DefaultValues.TransactionMaxSpans;
 
-		public IReadOnlyCollection<WildcardMatcher> TransactionNameGroups =>
+		public IReadOnlyList<WildcardMatcher> TransactionNameGroups =>
 			ConfigConsts.DefaultValues.TransactionNameGroups;
 
 		public bool UsePathAsTransactionName => ConfigConsts.DefaultValues.UsePathAsTransactionName;


### PR DESCRIPTION
Follow-up to #2791, which introduced a `for` loop in `AnyMatch` but left the parameter typed as `IReadOnlyCollection<WildcardMatcher>`. Because the compiler must call `IEnumerable<T>.GetEnumerator()` through the interface, it boxes the underlying struct enumerator into a heap allocation on every invocation.

This change widens `TransactionNameGroups` from `IReadOnlyCollection` to `IReadOnlyList` (consistent with `SanitizeFieldNames`, `TransactionIgnoreUrls`, and `IgnoreMessageQueues`). `ReadOnlyCollection<T>` already implements `IReadOnlyList<T>`, so all existing implementations and call sites are unaffected.